### PR TITLE
Thread visibility scope through knowledge title-conflict recovery

### DIFF
--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -39,7 +39,7 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:463-469`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:428-430`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:6980`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:6987`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
    (`absolute_score/1`, `:7049-7054`) clears a scale-matched threshold AND beats the best retrieved
    candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:7083-7093`; the pure decision is

--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -39,7 +39,7 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:463-469`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:428-430`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:6987`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:6999`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
    (`absolute_score/1`, `:7049-7054`) clears a scale-matched threshold AND beats the best retrieved
    candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:7083-7093`; the pure decision is

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -578,17 +578,17 @@ defmodule Loopctl.Knowledge do
         end
 
       active_title_conflict?(changeset) ->
-        resolve_title_conflict(tenant_id, attrs, changeset)
+        resolve_title_conflict(tenant_id, attrs, changeset, vis)
 
       true ->
         {:error, changeset}
     end
   end
 
-  defp resolve_title_conflict(tenant_id, attrs, changeset) do
+  defp resolve_title_conflict(tenant_id, attrs, changeset, vis) do
     title = attrs[:title] || attrs["title"]
 
-    case get_active_article_by_title(tenant_id, title) do
+    case get_active_article_by_title(tenant_id, title, vis) do
       %Article{} = existing ->
         if same_content?(existing, attrs) do
           {:ok, :deduplicated, existing}
@@ -646,22 +646,28 @@ defmodule Loopctl.Knowledge do
     end)
   end
 
-  defp get_active_article_by_title(_tenant_id, title) when not is_binary(title), do: nil
+  defp get_active_article_by_title(_tenant_id, title, _vis) when not is_binary(title), do: nil
 
   # tenant_id is nil for system-scoped articles; a NULL `=` never matches, so the
   # recovery simply doesn't apply to system scope (its conflicts are slug-based).
-  defp get_active_article_by_title(nil, _title), do: nil
+  defp get_active_article_by_title(nil, _title, _vis), do: nil
 
-  defp get_active_article_by_title(tenant_id, title) do
-    AdminRepo.one(
-      from(a in Article,
-        where:
-          a.tenant_id == ^tenant_id and a.title == ^title and
-            a.status not in [:archived, :superseded],
-        order_by: [asc: a.inserted_at],
-        limit: 1
-      )
+  # `vis` (a `visibility_agent_id`) scopes the recovery SELECT to owner-visible rows,
+  # mirroring get_article_by_idempotency_key/3 (#163). Because this path uses
+  # AdminRepo (BYPASSRLS) the visibility filter MUST live in the query — RLS won't
+  # apply it. A title colliding with another agent's private/owner article returns
+  # nil here → the caller falls through to a generic uniqueness 422, with no UUID,
+  # body, or existence signal leaked.
+  defp get_active_article_by_title(tenant_id, title, vis) do
+    from(a in Article,
+      where:
+        a.tenant_id == ^tenant_id and a.title == ^title and
+          a.status not in [:archived, :superseded],
+      order_by: [asc: a.inserted_at],
+      limit: 1
     )
+    |> maybe_filter_by_visibility(vis)
+    |> AdminRepo.one()
   end
 
   # Same content == same (whitespace-normalized) body. Derived server-side from

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -547,23 +547,35 @@ defmodule Loopctl.Knowledge do
 
   # Make concurrent/retried creates safe on the (tenant_id, title) active unique
   # index. By the time the insert fails the constraint, the winning transaction
-  # has committed, so the existing row is visible (the recovery SELECT below
-  # deliberately mirrors the partial index's predicate, so the conflicting row is
-  # guaranteed visible unless it was concurrently archived). The idempotency
-  # signal is the article BODY itself (server-side, unforgeable): if the colliding
-  # payload's body equals the existing article's (after trimming leading/trailing
-  # whitespace), the conflict is a duplicate/retry -> return the existing row
-  # idempotently as `{:ok, :deduplicated, existing}` (a no-op the API answers 200).
-  # Otherwise it is a genuine different-body title collision ->
+  # has committed, so the winning row exists. The recovery SELECT
+  # (get_active_article_by_title/3) mirrors the partial index's active predicate
+  # AND is visibility-scoped by `vis` (mirroring get_article_by_idempotency_key/3,
+  # #163): it returns the winning row only when the caller may see it. The
+  # idempotency signal is the article BODY itself (server-side, unforgeable): if
+  # the colliding payload's body equals the existing article's (after trimming
+  # leading/trailing whitespace), the conflict is a duplicate/retry -> return the
+  # existing row idempotently as `{:ok, :deduplicated, existing}` (a no-op the API
+  # answers 200). Otherwise it is a genuine different-body title collision ->
   # `{:error, :duplicate_title, existing}` so the API can answer 409 (not a
   # retry-into-the-same-422). Non-(active-title) failures pass through unchanged.
   #
-  # The recovery SELECT runs after the insert's transaction has rolled back, so
-  # there is a tiny window in which a THIRD writer mutates or archives the winning
-  # row between its commit and our SELECT. That only produces a transient,
-  # self-healing outcome — a 409 (body now differs), or the original 422 (row now
-  # archived → SELECT returns nil) — which the client's next attempt resolves
-  # cleanly. We accept that rather than re-running the whole create under a lock.
+  # A nil recovery-SELECT result is an EXPECTED, intended outcome — not an
+  # impossible/transient edge — and the caller deliberately falls through to a
+  # generic uniqueness 422. Two distinct nil cases produce it:
+  #
+  #   1. Cross-agent private collision (the security invariant this path enforces):
+  #      the title collides with ANOTHER agent's private/owner article, so the
+  #      visibility filter excludes it. Falling through to a bare 422 leaks no
+  #      UUID, body, or existence signal about that private row. DO NOT drop the
+  #      visibility filter or this fallthrough to "fix" a phantom nil — doing so
+  #      silently reintroduces the private-article existence/UUID leak (#163).
+  #   2. Concurrent archival: the recovery SELECT runs after the insert's
+  #      transaction has rolled back, so a THIRD writer may mutate or archive the
+  #      winning row between its commit and our SELECT. That yields a transient,
+  #      self-healing outcome — a 409 (body now differs) or the 422 (row now
+  #      archived/superseded → SELECT returns nil) — which the client's next
+  #      attempt resolves cleanly. We accept that rather than re-running the whole
+  #      create under a lock.
   defp resolve_create_conflict(tenant_id, attrs, changeset, vis) do
     cond do
       # A single failed INSERT raises exactly one unique violation, so the

--- a/test/loopctl/knowledge_test.exs
+++ b/test/loopctl/knowledge_test.exs
@@ -224,6 +224,143 @@ defmodule Loopctl.KnowledgeTest do
     end
   end
 
+  describe "create_article/3 title-conflict recovery respects visibility scope" do
+    # The duplicate-title recovery SELECT runs via AdminRepo (BYPASSRLS), so the
+    # caller's visibility scope must be applied in the query — otherwise a title
+    # colliding with another agent's private/owner article leaks its existence (a
+    # UUID in a 409) or, on a whitespace-normalized body match, the full private
+    # article. These tests pin that the recovery is scoped to owner-visible rows,
+    # mirroring the idempotency-key path.
+    setup do
+      %{tenant: tenant} = setup_tenant()
+      owner_agent = fixture(:agent, %{tenant_id: tenant.id})
+      other_agent = fixture(:agent, %{tenant_id: tenant.id})
+
+      private =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          title: "Collide Title",
+          body: "PRIVATE BODY",
+          metadata: %{"visibility" => "private", "agent_id" => to_string(owner_agent.id)}
+        })
+
+      %{
+        tenant: tenant,
+        owner_agent: owner_agent,
+        other_agent: other_agent,
+        private: private
+      }
+    end
+
+    test "AC1: cross-agent private-title collision with a differing body yields a generic changeset error, no UUID",
+         %{tenant: tenant, other_agent: other_agent, private: private} do
+      result =
+        Knowledge.create_article(
+          tenant.id,
+          %{title: "Collide Title", body: "a different body entirely", category: :pattern},
+          visibility_agent_id: to_string(other_agent.id)
+        )
+
+      # Generic 422 shape — NOT {:error, :duplicate_title, _} (which would echo the
+      # private row) and NOT the private article struct.
+      assert {:error, %Ecto.Changeset{} = changeset} = result
+      assert Map.has_key?(errors_on(changeset), :title)
+
+      # No existence oracle: the private article's id never appears in the error.
+      refute match?({:error, :duplicate_title, _}, result)
+      refute inspect(result) =~ private.id
+    end
+
+    test "AC2: same collision with a MATCHING body does not return the private article's body/metadata/id",
+         %{tenant: tenant, other_agent: other_agent, private: private} do
+      # Body equals the private article's body after trim — the whitespace-normalized
+      # dedup path must still NOT hand back the invisible article.
+      result =
+        Knowledge.create_article(
+          tenant.id,
+          %{title: "Collide Title", body: "  PRIVATE BODY\n", category: :pattern},
+          visibility_agent_id: to_string(other_agent.id)
+        )
+
+      # The changeset carries only B's OWN submitted input; the invisible article is
+      # never handed back, so its id (the meaningful leak vector) must not surface.
+      assert {:error, %Ecto.Changeset{}} = result
+      refute match?({:ok, :deduplicated, _}, result)
+      refute inspect(result) =~ private.id
+    end
+
+    test "AC3: the OWNER (who can see its own private article) gets the normal recovery behavior",
+         %{tenant: tenant, owner_agent: owner_agent, private: private} do
+      # Owner, differing body → normal duplicate-title recovery echoing the row.
+      assert {:error, :duplicate_title, returned} =
+               Knowledge.create_article(
+                 tenant.id,
+                 %{title: "Collide Title", body: "owner's different body", category: :pattern},
+                 visibility_agent_id: to_string(owner_agent.id)
+               )
+
+      assert returned.id == private.id
+
+      # Owner, matching body → idempotent dedup returning the same row.
+      assert {:ok, :deduplicated, deduped} =
+               Knowledge.create_article(
+                 tenant.id,
+                 %{title: "Collide Title", body: "PRIVATE BODY", category: :pattern},
+                 visibility_agent_id: to_string(owner_agent.id)
+               )
+
+      assert deduped.id == private.id
+    end
+
+    test "AC3 (shared): a SHARED article collision is unchanged whether or not a vis scope is passed",
+         %{tenant: tenant, other_agent: other_agent} do
+      assert {:ok, shared} =
+               Knowledge.create_article(tenant.id, %{
+                 title: "Shared Collide",
+                 body: "shared original",
+                 category: :pattern
+               })
+
+      # Non-owning agent still sees the shared row → normal recovery.
+      assert {:error, :duplicate_title, returned} =
+               Knowledge.create_article(
+                 tenant.id,
+                 %{title: "Shared Collide", body: "shared different", category: :pattern},
+                 visibility_agent_id: to_string(other_agent.id)
+               )
+
+      assert returned.id == shared.id
+
+      assert {:ok, :deduplicated, deduped} =
+               Knowledge.create_article(
+                 tenant.id,
+                 %{title: "Shared Collide", body: "shared original", category: :pattern},
+                 visibility_agent_id: to_string(other_agent.id)
+               )
+
+      assert deduped.id == shared.id
+    end
+
+    test "AC5: a title collision across tenants does not recover and leaks nothing",
+         %{private: private} do
+      other_tenant = fixture(:tenant)
+      other_agent = fixture(:agent, %{tenant_id: other_tenant.id})
+
+      # Same title in a DIFFERENT tenant is not a conflict at all (the active-title
+      # index is per-tenant) — the create simply succeeds without touching tenant A.
+      assert {:ok, created} =
+               Knowledge.create_article(
+                 other_tenant.id,
+                 %{title: "Collide Title", body: "tenant B body", category: :pattern},
+                 visibility_agent_id: to_string(other_agent.id)
+               )
+
+      assert created.id != private.id
+      assert created.body == "tenant B body"
+    end
+  end
+
   describe "bulk_archive/3 (#136)" do
     test "archives draft/published, skips archived/superseded, reports not_found, partial-success" do
       %{tenant: tenant} = setup_tenant()


### PR DESCRIPTION
## Summary

The duplicate-title recovery path in `Knowledge.create_article/3` did not thread the caller's article visibility scope, unlike the sibling idempotency-key recovery path. Because recovery runs via `AdminRepo` (BYPASSRLS), row-level security does not apply the article visibility model there, so a title colliding with another agent's non-shared article could surface that row to a non-owning caller.

This change threads the existing `visibility_agent_id` through `resolve_title_conflict` and `get_active_article_by_title`, applying `maybe_filter_by_visibility/2` to the recovery SELECT — mirroring the already-correct `get_article_by_idempotency_key/3` pattern.

## Behavior

- When a colliding row is NOT visible to the caller, the lookup returns nil and the caller falls through to a generic uniqueness 422 — no id, body, or existence signal.
- When the caller CAN see the row (a shared article, or its own private/owner article), behavior is byte-identical to before.
- The tenant predicate is unchanged; tenant isolation holds.

## Tests

Adds a visibility-scope describe block covering:
- cross-agent non-shared title collision with a differing body (generic changeset error, no id echo)
- same collision with a whitespace-normalized matching body (no dedup, no id echo)
- the owner-visible path (normal duplicate-title recovery and dedup)
- the shared-article path unchanged with a vis scope passed
- cross-tenant isolation

Full `mix precommit` is green (5484 tests, 0 failures; format, credo --strict, dialyzer, sobelow, citation guard all pass). Also bumps a `hybrid_search/3` line citation in the knowledge-wiki skill to track the line shift.
