### PR TITLE
US-41.5: bring webhook delivery under the single egress policy

### DIFF
--- a/docs/egress-guard.md
+++ b/docs/egress-guard.md
@@ -34,7 +34,7 @@ Nothing content-carrying is documented away.
 |---|---|---|
 | `Loopctl.Provider` (`lib/loopctl/provider.ex`) | yes | **IS the model-provider chokepoint wrapper.** Consults `Egress.Policy` on every call. Allowlisted because it is the wrapper, not a bypass. |
 | `Loopctl.Webhooks.ReqDelivery` (`lib/loopctl/webhooks/req_delivery.ex`) | **yes — the payload is tenant state** | **IS the webhook chokepoint wrapper (US-41.5).** Consults the same `Egress.Policy.check/4` with purpose `:webhook` and `tenant_supplied: true`, then pins (`pinned_request_opts` + `redirect: false`). Allowlisted for the same reason `Provider` is. |
-| `Loopctl.Workers.ContentIngestionWorker` (`resolve_content/3`) | no — INBOUND content; sends no tenant data | **Under the guard, not exempt.** Not in the allowlist at all: it pins with `UrlGuard.pin/1` and then issues the fetch through `Provider.get/3` (purpose `:ingest`, `pinned_by_caller: true`), so it consults the one policy like everything else. |
+| `Loopctl.Workers.ContentIngestionWorker` (`resolve_content/3`) | no — INBOUND content; sends no tenant data | **Under the guard, not exempt.** Not in the allowlist at all: it issues the fetch through `Provider.get/3` (purpose `:ingest`, `tenant_supplied_url: true`), so the SSRF denylist AND the locality decision are both made by the ONE policy. The old unconditional `UrlGuard.pin/1` pre-gate was REMOVED (US-41.5 review): it could not see the OPERATOR deployment allowlist, so an allowlisted private host was a legal webhook destination but still refused as an ingestion source, and every fetch resolved the URL twice. |
 | `Loopctl.Workers.ScaleAlertDeliveryWorker` | no — operator-plane alerting (metric name, value, threshold) | Delivers through `ReqDelivery` with **`scope: nil`**. The URL is operator configuration, not tenant data, and there is no tenant marking to apply; the SSRF denylist still applies (the same `UrlGuard` primitive the policy composes). |
 | `Loopctl.Verification.GitHubActions` (`lib/loopctl/verification/github_actions.ex`) | no — reads commit/check-run metadata | Operator-plane, fixed vendor host, never reachable from a tenant-supplied URL. Allowlisted. |
 | `Loopctl.Secrets.FlyAdapter` (`lib/loopctl/secrets/fly_adapter.ex`) | no — operator secret management | Operator-plane against the Fly GraphQL API. Fixed host, never tenant-supplied. Allowlisted. |
@@ -79,23 +79,78 @@ it). Blocked deliveries therefore cannot build a retry backlog.
 (`block_kind/1` returns `:transient`), so the job SNOOZES without consuming an
 attempt and nothing is recorded as blocked.
 
-Stated rather than hidden: because a transient refusal consumes no attempt, it
-does NOT advance the worker's app-level 6-attempt ladder — a persistently
-unresolvable destination re-checks every `Egress.transient_snooze_seconds/0`
-instead of exhausting. That is the US-41.4 contract (`:pin_stale` /
-`:egress_unavailable` are NEVER terminal, because nothing re-enqueues a cancelled
-job after the re-pin), and it is one snoozed job per event, not a growing
-backlog — the terminal-state proof in `WebhookObanTerminalTest` covers the
-BLOCKED case, which is the one an unbounded ladder would have amplified.
+A refusal term the policy does NOT recognise is `:unrecognized` — TERMINAL, and
+handled exactly like a block. Fail-closed classification must not route an
+unknown term onto the retry path (that is how a malformed `{:refused, term}` from
+a future delivery client would become an immortal job); `Egress.oban_result/1`
+already cancels an unknown term, and `block_kind/1` now matches it.
+
+#### The transient path is BOUNDED
+
+"Transient" describes the CAUSE, not a guarantee that it ends. A destination
+whose domain lapses classifies as `:egress_unavailable` on EVERY attempt, so an
+unconditional snooze — on a `max_attempts: 1` queue where each snooze also bumps
+`max_attempts` — produced one IMMORTAL job per event: `attempts` stayed 0, the
+event stayed `pending`, `consecutive_failures` never rose, the subscription was
+never auto-disabled, and each new event added another permanent job. Events
+accumulate, so that IS a growing backlog, and it contradicts AC-41.5.2 ("NOT an
+infinite retry").
+
+So `WebhookDeliveryWorker` allows at most
+`WebhookDeliveryWorker.max_transient_snoozes/0` free (attempt-less) snoozes per
+job; after that the refusal falls through to the ordinary failure ladder —
+burning an attempt each time, reaching `:exhausted` at the 6th, incrementing
+`consecutive_failures` and reaching the auto-disable valve, exactly as an
+unreachable destination did before US-41.5. The count is DERIVED from
+`Oban.Job.attempt` minus the event's own `attempts` (Oban increments `attempt` on
+every execution), so it needs no new column. The US-41.4 contract still holds for
+the transient causes it was written for: a re-pinnable blip recovers inside the
+free window and never burns an attempt.
+
+#### A resolver failure is TRANSIENT even on a marked scope
+
+`Policy` maps every classification error — a plain NXDOMAIN, a resolver timeout —
+to `{:egress_blocked, verdict: :unclassifiable}`. Fail-closed is right; treating
+it as PERMANENT was not. It made the SAME failure asymmetric by marking: on an
+unmarked scope it is `:egress_unavailable` and retried, while on a `local_only`
+scope it terminally dropped the delivery and labelled it `locality_denied` — whose
+documented remediation ("declare the endpoint, or clear the marking") cannot fix a
+DNS outage on an endpoint that is already declared. And because
+`enable_local_only/3` and `clear_local_only/3` both invalidate the `PinCache`, a
+cold cache right after a marking change is the EXPECTED state.
+
+So `Egress.block_kind/1` classifies `:unclassifiable` **for a real host** as
+`:transient` — bounded by the free-snooze cap above, so a permanently dead host
+still exhausts and still auto-disables. A refusal with NO host is a malformed
+destination and stays permanent. `Egress.oban_result/1` is deliberately NOT
+changed: its callers hand the result straight to Oban with no snooze budget of
+their own, so snoozing there would recreate the immortal-job defect.
 
 ### Config time beats delivery time (AC-41.5.3)
 
 `Webhooks.create_webhook/3` and `update_webhook/4` reject a non-local destination
 on an already-`local_only` scope with a changeset error on `:url` carrying the
-remediation. The check runs before the `Ecto.Multi`, so nothing is persisted. It
-only fires when the URL is actually being set/changed and the changeset is
-otherwise valid — otherwise an unrelated edit (`active: false`) to a
-pre-existing, now-incompatible subscription would be un-savable, including the
+remediation. The check runs inside the write's `Ecto.Multi` (see the lock below),
+so nothing is persisted on rejection.
+
+`project_id` is validated to belong to the CALLER's tenant first. The webhooks FK
+targets `projects.id` alone and these writes go through `AdminRepo` (no RLS), so
+a foreign `project_id` was accepted — and US-41.5 makes that field the selector
+for the delivery scope, so it matched no marking of this tenant and side-stepped a
+project-scoped `local_only` marking without touching the audited, `:user`-gated
+marking row.
+
+It fires when the edit changes the EFFECTIVE EGRESS DECISION and the changeset is
+otherwise valid — that is: the `url`, the `project_id` (which IS the delivery
+scope, `Scope.new(tenant_id, project_id)`), or a `false -> true` re-activation.
+Keying it on the URL alone left it bypassable: a `PATCH` carrying only
+`project_id` re-scoped a public destination under a `local_only` project and was
+ACCEPTED — precisely the "accepted, then silently blocked at delivery time"
+outcome AC-41.5.3 exists to prevent. Re-activation is checked for the same reason
+the enable pre-flight reports INACTIVE subscriptions.
+
+An edit that changes NEITHER (`active: false`, `events: [...]`) skips the check,
+so a pre-existing, now-incompatible subscription stays savable — including by the
 edit that fixes it.
 
 ### Enabling `local_only` with incompatible subscriptions (AC-41.5.4)
@@ -115,15 +170,65 @@ marking covers only that project's subscriptions. INACTIVE subscriptions are
 included — re-activating one under an unchanged marking would otherwise produce
 a silently blocked destination.
 
+**The pre-flight and the marking write are ONE transaction, under an advisory
+lock.** The enable decides on a snapshot of the SUBSCRIPTIONS; a concurrent
+`create_webhook/3` decides on a snapshot of the MARKINGS. Interleaved without a
+lock, a subscription created after the pre-flight snapshot landed under the new
+marking: absent from `{:would_block, endpoints}`, absent from
+`acknowledged_blocked_endpoints`, silently blocked at delivery — the silent state
+change AC-41.5.4 rules out. Both writers now take
+`Egress.lock_scope_config!/2` (transaction-scoped `pg_advisory_xact_lock`, keyed
+on the tenant UUID's first four bytes rather than `:erlang.phash2/1`, whose
+hashing is not guaranteed stable across OTP releases) as the FIRST step and run
+their check inside it.
+
+**Webhook destinations in the returned list are redacted to their HOST below role
+`:user`** (`Egress.redact_blocked_endpoints/2`). `POST /api/v1/egress/local-only`
+is `role: :orchestrator`, one level under the `role: :user` gate on
+`LoopctlWeb.WebhookController`, and a webhook path is frequently the credential.
+The marking row and the audit event still record the full URL — that is
+server-side state a `:user` reads back.
+
 ### Posture (AC-41.5.5)
 
 `Egress.posture/2` gained `webhook_destinations`: one entry per subscription with
-`endpoint`, `host`, `active`, the locality `verdict` label (network-local /
-tenant-declared (unverified attestation) / non-local / denylisted),
+`host`, `active`, the locality `verdict` label (network-local / tenant-declared
+(unverified attestation) / non-local / denylisted),
 `verdict_from_deployment_allowlist` (a BOOLEAN at `:agent` — allowlist contents
-stay `:user`+) and `blocked_by_local_only`. The destination URL is not a secret
-(only the signing secret is Cloak-encrypted), so it is disclosed like the
-provider endpoints.
+stay `:user`+) and `blocked_by_local_only`.
+
+**The FULL destination URL (`endpoint`) is `:user`+ only.** A webhook destination
+is frequently a CAPABILITY URL whose PATH is the credential (Slack
+`hooks.slack.com/services/T…/B…/<token>`, Discord, Teams, Zapier, n8n), and
+`LoopctlWeb.WebhookController` is `role: :user` at module level — so emitting it
+on the un-gated posture endpoint would be a role DOWNGRADE of existing data.
+AC-41.5.5 asks for "webhook destinations and their local classification", which
+`host` + `verdict` + `blocked_by_local_only` satisfies at `:agent`; `endpoint` is
+added at `:user`+, the same boolean-vs-contents split the deployment allowlist
+already uses.
+
+**The classification pass is BOUNDED.** Both the posture report and the
+`local_only` enable pre-flight classify TENANT-SUPPLIED hosts, and a cache miss
+pays a real DNS resolve. Unbounded, a tenant could make the endpoint agents call
+before every harvest take `max_webhooks × 3s` (with `max_webhooks` itself
+tenant-settable). At most `Egress.max_classified_webhooks/0` rows are read, and
+once `Egress.classification_budget_ms/0` is spent the remaining rows are reported
+`unclassified` — which is NOT a local verdict, so the pre-flight still names them.
+
+FAILED classifications are also NEGATIVELY CACHED for
+`Egress.Policy.negative_ttl_ms/0` (short — long enough to collapse a burst, short
+enough that a resolver blip clears promptly). Previously only successes were
+cached, so a dead tenant-supplied host repaid the full multi-second resolve on
+every posture call, forever. A negative entry is a REFUSAL, never a permit, so it
+can never widen egress.
+
+### Retention
+
+`:blocked` is terminal, so `WebhookCleanupWorker` prunes it alongside
+`:delivered` and `:exhausted`. It has to: a blocked delivery deliberately does not
+increment `consecutive_failures`, so the auto-disable valve never fires and a
+`local_only` tenant with one incompatible subscription emits a blocked row per
+matching state change indefinitely.
 
 ## Tenant isolation: explicit scoping on `AdminRepo`, not RLS
 
@@ -299,12 +404,13 @@ that the guard would refuse is refused at CONFIG time, before it can be saved.
 
 #### `tenant_supplied_url: true` — the SSRF denylist on the DEFAULT path
 
-The default (non-`local_only`) path deliberately never REFUSES: an unpinnable or
-denylisted host proceeds unpinned, because the SSRF denylist "is enforced by the
-callers that own it" (ingestion pins with `UrlGuard.pin/1` first). That was sound
-while every URL on this path was a hardcoded vendor host. `chat_base_url` made one
-of them TENANT-WRITABLE, so the chat client and the probe pass
-`tenant_supplied_url: true` on `Loopctl.Provider.post/3`, and
+The default (non-`local_only`) path deliberately never REFUSES for a HARDCODED
+VENDOR host: an unpinnable one proceeds unpinned, because turning a DNS blip into
+a refusal would hand every default tenant a brand-new failure mode. That was the
+whole story while every URL on this path was a vendor host. `chat_base_url` made
+one of them TENANT-WRITABLE, so the chat client, the probe and (since the US-41.5
+review) the ingestion fetch pass `tenant_supplied_url: true` on
+`Loopctl.Provider.post/3` / `get/3`, and
 `Egress.Policy.check/4` then refuses a `:denylisted` verdict with
 `{:error, :egress_blocked, details}` for EVERY tenant, marked or not. Without it a
 role `:user` key could point loopctl at `169.254.169.254`, a `.internal` host or any

--- a/docs/egress-guard.md
+++ b/docs/egress-guard.md
@@ -1,4 +1,4 @@
-# Fail-closed no-egress guard (US-41.4)
+# Fail-closed no-egress guard (US-41.4, US-41.5)
 
 A privacy tier that depends on the operator configuring three endpoints
 correctly is not a guarantee. This is the enforcement that turns it into one an
@@ -7,19 +7,123 @@ agent can verify.
 ## What is actually guaranteed
 
 > Fail-closed `local_only` enforcement applies to **every outbound HTTP call made
-> by loopctl application code** on the MODEL-PROVIDER path.
+> by loopctl application code** on **every content-carrying path**: model-provider
+> calls, the ingestion fetch, and webhook delivery.
 
-That wording is deliberate and narrow. Three things it does **not** claim:
+US-41.5 closed the webhook gap; the wording is still deliberate and narrow. Two
+things it does **not** claim:
 
-1. **Webhook delivery is not covered yet.** `Loopctl.Webhooks.ReqDelivery`
-   bypasses this guard entirely (it has its own SSRF pin, but no locality
-   decision). Bringing it under the guard is US-41.5. Until then, neither the
-   docs nor the posture report claim total egress control.
-2. **HTTP performed inside a dependency is invisible.** The static chokepoint
+1. **HTTP performed inside a dependency is invisible.** The static chokepoint
    check is an AST scan of this repository; a library that opens its own socket
    is outside it.
-3. **The separate `mcp-server/` codebase is not scanned.** It is a different
+2. **The separate `mcp-server/` codebase is not scanned.** It is a different
    process on the agent's machine.
+
+## Outbound-path triage (US-41.5, AC-41.5.6)
+
+Every outbound path in `lib/` is enumerated below. The list is not prose: the
+`@allowed` map in `Loopctl.Egress.ChokepointScan` is the machine-checked
+inventory (`mix credo --strict`), and `Loopctl.Egress.ChokepointScanTest`
+asserts that **every allowlist entry has a row in this table** — a call site the
+static check exempts with no triage entry fails the build.
+
+The rule applied: **anything carrying tenant content is brought UNDER the guard.**
+Nothing content-carrying is documented away.
+
+| Call site | Carries tenant content? | Disposition |
+|---|---|---|
+| `Loopctl.Provider` (`lib/loopctl/provider.ex`) | yes | **IS the model-provider chokepoint wrapper.** Consults `Egress.Policy` on every call. Allowlisted because it is the wrapper, not a bypass. |
+| `Loopctl.Webhooks.ReqDelivery` (`lib/loopctl/webhooks/req_delivery.ex`) | **yes — the payload is tenant state** | **IS the webhook chokepoint wrapper (US-41.5).** Consults the same `Egress.Policy.check/4` with purpose `:webhook` and `tenant_supplied: true`, then pins (`pinned_request_opts` + `redirect: false`). Allowlisted for the same reason `Provider` is. |
+| `Loopctl.Workers.ContentIngestionWorker` (`resolve_content/3`) | no — INBOUND content; sends no tenant data | **Under the guard, not exempt.** Not in the allowlist at all: it pins with `UrlGuard.pin/1` and then issues the fetch through `Provider.get/3` (purpose `:ingest`, `pinned_by_caller: true`), so it consults the one policy like everything else. |
+| `Loopctl.Workers.ScaleAlertDeliveryWorker` | no — operator-plane alerting (metric name, value, threshold) | Delivers through `ReqDelivery` with **`scope: nil`**. The URL is operator configuration, not tenant data, and there is no tenant marking to apply; the SSRF denylist still applies (the same `UrlGuard` primitive the policy composes). |
+| `Loopctl.Verification.GitHubActions` (`lib/loopctl/verification/github_actions.ex`) | no — reads commit/check-run metadata | Operator-plane, fixed vendor host, never reachable from a tenant-supplied URL. Allowlisted. |
+| `Loopctl.Secrets.FlyAdapter` (`lib/loopctl/secrets/fly_adapter.ex`) | no — operator secret management | Operator-plane against the Fly GraphQL API. Fixed host, never tenant-supplied. Allowlisted. |
+| `Loopctl.CLI.Client` (`lib/loopctl/cli/client.ex`) | no — targets the CONFIGURED loopctl server | The loopctl CLI's own client: runs on the operator's machine, outside the server request path, and is not a tenant-content egress path to a third party. **Exempted by an explicit allowlist entry** rather than being silently unmatched by the static check. |
+
+## Webhook delivery under the guard (US-41.5)
+
+`ReqDelivery.deliver/4` takes the `Loopctl.Egress.Scope` the delivery is made on
+behalf of — `Scope.new(webhook.tenant_id, webhook.project_id)`, so a project-less
+subscription follows the TENANT marking (most-restrictive-wins, AC-41.4.2). The
+old unconditional `UrlGuard.pin/1` was REPLACED by the policy call, not wrapped
+around it: there is exactly one URL policy.
+
+Consequences worth stating:
+
+- A destination the OPERATOR allowlisted (or that the tenant declared **for the
+  `webhook` purpose**) is now **deliverable**. It was not before — the bare
+  `UrlGuard.pin/1` refused every loopback/private destination for every tenant.
+- A host declared for an Ollama **inference** box does **not** authorize POSTing
+  tenant content to it. Purpose scoping is re-derived on every read
+  (`Policy.resolve_verdict/2`).
+- A tenant declaration still carves **nothing** out of the SSRF denylist. Only
+  the operator deployment allowlist can reach a private range
+  (GHSA-jh42-wf7g-f5rg stays closed for every tenant-writable input).
+
+### `blocked` is a distinct delivery status, not a failure (AC-41.5.2)
+
+`webhook_events.status` gained `:blocked`. It is TERMINAL: the job returns `:ok`,
+burns no attempt, schedules no retry, and does **not** increment the webhook's
+`consecutive_failures` (the subscriber never failed — loopctl refused to call
+it). Blocked deliveries therefore cannot build a retry backlog.
+
+`event.error` carries `"<kind>: <Egress.refusal_reason/1>"`, where
+`Loopctl.Egress.block_kind/1` distinguishes the two block causes:
+
+| kind | cause | who can fix it |
+|---|---|---|
+| `ssrf_denied` | the destination resolves into a private/loopback/CGNAT/link-local/ULA range and is not in the operator deployment allowlist | the OPERATOR (allowlist) — a tenant declaration cannot |
+| `locality_denied` | the scope is `local_only` and the destination is not local for the `webhook` purpose | the TENANT (declare the endpoint, or clear the marking — both role `:user`) |
+
+`:pin_stale` / `:egress_unavailable` are neither: they are TRANSIENT
+(`block_kind/1` returns `:transient`), so the job SNOOZES without consuming an
+attempt and nothing is recorded as blocked.
+
+Stated rather than hidden: because a transient refusal consumes no attempt, it
+does NOT advance the worker's app-level 6-attempt ladder — a persistently
+unresolvable destination re-checks every `Egress.transient_snooze_seconds/0`
+instead of exhausting. That is the US-41.4 contract (`:pin_stale` /
+`:egress_unavailable` are NEVER terminal, because nothing re-enqueues a cancelled
+job after the re-pin), and it is one snoozed job per event, not a growing
+backlog — the terminal-state proof in `WebhookObanTerminalTest` covers the
+BLOCKED case, which is the one an unbounded ladder would have amplified.
+
+### Config time beats delivery time (AC-41.5.3)
+
+`Webhooks.create_webhook/3` and `update_webhook/4` reject a non-local destination
+on an already-`local_only` scope with a changeset error on `:url` carrying the
+remediation. The check runs before the `Ecto.Multi`, so nothing is persisted. It
+only fires when the URL is actually being set/changed and the changeset is
+otherwise valid — otherwise an unrelated edit (`active: false`) to a
+pre-existing, now-incompatible subscription would be un-savable, including the
+edit that fixes it.
+
+### Enabling `local_only` with incompatible subscriptions (AC-41.5.4)
+
+**The documented choice is REFUSE-BY-DEFAULT, then report on acknowledgement** —
+the same contract US-41.4 already used for provider endpoints, extended rather
+than duplicated. `Egress.enable_local_only/3` runs
+`blocked_webhook_subscriptions/1` in its pre-flight and returns
+`{:error, {:would_block, endpoints}}` with a `kind: :webhook` entry per offending
+subscription (carrying `webhook_id`, `endpoint`, `verdict`, `project_id`,
+`active`). Passing `acknowledge: true` completes the enable and REPORTS them in
+`blocked_endpoints` (and in the marking's `acknowledged_blocked_endpoints`).
+
+Subscriptions are never silently disabled or deleted. Coverage follows the
+marking: a tenant-scope marking covers every subscription; a project-scope
+marking covers only that project's subscriptions. INACTIVE subscriptions are
+included — re-activating one under an unchanged marking would otherwise produce
+a silently blocked destination.
+
+### Posture (AC-41.5.5)
+
+`Egress.posture/2` gained `webhook_destinations`: one entry per subscription with
+`endpoint`, `host`, `active`, the locality `verdict` label (network-local /
+tenant-declared (unverified attestation) / non-local / denylisted),
+`verdict_from_deployment_allowlist` (a BOOLEAN at `:agent` — allowlist contents
+stay `:user`+) and `blocked_by_local_only`. The destination URL is not a secret
+(only the signing secret is Cloak-encrypted), so it is disclosed like the
+provider endpoints.
 
 ## Tenant isolation: explicit scoping on `AdminRepo`, not RLS
 

--- a/lib/loopctl/egress.ex
+++ b/lib/loopctl/egress.ex
@@ -44,7 +44,10 @@ defmodule Loopctl.Egress do
   ## Mandatory pre-flight on ENABLE
 
   Because the enabling role cannot undo the transition, `enable_local_only/3`
-  classifies the scope's currently-resolved embedding and chat endpoints FIRST.
+  classifies the scope's currently-resolved embedding and chat endpoints FIRST —
+  and, since US-41.5 (AC-41.5.4), every WEBHOOK SUBSCRIPTION the marking would
+  cover (`blocked_webhook_subscriptions/1`). Subscriptions are never silently
+  disabled: they are either the reason for the refusal, or reported back.
   If any would become `egress_blocked` the operation is REFUSED with
   `{:error, {:would_block, endpoints}}` naming each offending endpoint — UNLESS
   the caller passes `acknowledge: true`, in which case it completes and REPORTS
@@ -72,6 +75,7 @@ defmodule Loopctl.Egress do
   alias Loopctl.Egress.TrustedEndpoint
   alias Loopctl.Knowledge.EmbeddingClient
   alias Loopctl.Llm
+  alias Loopctl.Webhooks.Webhook
 
   @blocked_window_seconds 60
 
@@ -240,17 +244,167 @@ defmodule Loopctl.Egress do
   end
 
   # The pre-flight. Endpoint resolution is TENANT-scoped only, so this classifies
-  # the tenant's currently-resolved embedding + chat endpoints for the scope.
+  # the tenant's currently-resolved embedding + chat endpoints for the scope, PLUS
+  # (US-41.5, AC-41.5.4) every webhook subscription the marking would cover.
   defp preflight_blocked_endpoints(%Scope{} = scope) do
-    scope
-    |> resolved_endpoints()
-    |> Enum.map(fn {kind, url} -> {kind, url, endpoint_verdict(scope, url)} end)
-    |> Enum.reject(fn {_kind, _url, verdict} ->
-      verdict in [:network_local, :tenant_declared]
+    provider =
+      scope
+      |> resolved_endpoints()
+      |> Enum.map(fn {kind, url} -> {kind, url, endpoint_verdict(scope, url, :inference)} end)
+      |> Enum.reject(fn {_kind, _url, verdict} -> local_verdict?(verdict) end)
+      |> Enum.map(fn {kind, url, verdict} ->
+        %{kind: kind, endpoint: url, verdict: to_string(verdict)}
+      end)
+
+    provider ++ blocked_webhook_subscriptions(scope)
+  end
+
+  @doc """
+  The webhook subscriptions a `local_only` marking on `scope` would REFUSE
+  (US-41.5, AC-41.5.4).
+
+  Feeds `enable_local_only/3`'s pre-flight, so enabling `local_only` while an
+  incompatible subscription exists is REFUSED with `{:error, {:would_block,
+  endpoints}}` naming each one — never a silent state change. Passing
+  `acknowledge: true` completes the enable and REPORTS them. That is the
+  DOCUMENTED choice (see `docs/egress-guard.md`): refuse by default, proceed only
+  on an explicit acknowledgement.
+
+  Coverage follows the marking, not the delivery scope: a TENANT-scope marking
+  (`project_id: nil`) covers every subscription, while a PROJECT-scope marking
+  covers only that project's subscriptions — a project marking cannot block a
+  tenant-wide (project-less) subscription, whose delivery scope it does not
+  narrow (AC-41.4.2, most-restrictive-wins).
+
+  INACTIVE subscriptions are included deliberately. They are not broken today,
+  but re-activating one under an unchanged marking would silently produce a
+  blocked destination, and "surfaced explicitly" is the whole point of the
+  pre-flight. Each entry carries `active` so a caller can weight them.
+  """
+  @spec blocked_webhook_subscriptions(Scope.t()) :: [map()]
+  def blocked_webhook_subscriptions(%Scope{tenant_id: tenant_id, project_id: project_id}) do
+    Webhook
+    |> where([w], w.tenant_id == ^tenant_id)
+    |> marking_covers_webhook(project_id)
+    |> order_by([w], asc: w.inserted_at)
+    |> AdminRepo.all()
+    |> Enum.map(fn webhook ->
+      delivery_scope = Scope.new(tenant_id, webhook.project_id)
+      {webhook, endpoint_verdict(delivery_scope, webhook.url, :webhook)}
     end)
-    |> Enum.map(fn {kind, url, verdict} ->
-      %{kind: kind, endpoint: url, verdict: to_string(verdict)}
+    |> Enum.reject(fn {_webhook, verdict} -> local_verdict?(verdict) end)
+    |> Enum.map(fn {webhook, verdict} ->
+      %{
+        kind: :webhook,
+        endpoint: webhook.url,
+        verdict: to_string(verdict),
+        webhook_id: webhook.id,
+        project_id: webhook.project_id,
+        active: webhook.active
+      }
     end)
+  end
+
+  # A TENANT marking covers every subscription; a PROJECT marking covers only that
+  # project's subscriptions.
+  defp marking_covers_webhook(query, nil), do: query
+
+  defp marking_covers_webhook(query, project_id),
+    do: where(query, [w], w.project_id == ^project_id)
+
+  @doc """
+  True when `verdict` means "local for this scope" — the ONE definition of
+  deliverable/admissible locality, shared by the guard, the pre-flight, the
+  config-time check and the posture report so they cannot drift.
+  """
+  @spec local_verdict?(atom()) :: boolean()
+  def local_verdict?(verdict), do: verdict in [:network_local, :tenant_declared]
+
+  @doc """
+  The locality verdict for a destination `url` under `scope` and `purpose`.
+
+  Purpose scoping is a SECURITY INVARIANT (AC-41.4.5 constraint 2): a host
+  declared for an Ollama inference box does NOT authorize POSTing tenant content
+  to it, so webhook callers must pass `:webhook`.
+  """
+  @spec endpoint_verdict(Scope.t(), String.t(), Policy.purpose()) :: atom()
+  def endpoint_verdict(%Scope{} = scope, url, purpose) do
+    host = URI.parse(url).host || url
+
+    case Policy.classify(scope, host, purpose) do
+      {:ok, %{verdict: verdict}} -> verdict
+      {:error, _} -> :unclassifiable
+    end
+  end
+
+  @doc """
+  The CONFIG-TIME verdict for a webhook destination (US-41.5, AC-41.5.3).
+
+  Returns `:ok` when the subscription may be created/updated, or
+  `{:error, {verdict, message}}` with a legible remediation naming the conflict.
+
+  TWO refusals, in the same order the delivery path applies them:
+
+    1. `:denylisted` — the destination resolves into a private/loopback/CGNAT/
+      link-local/ULA range and the OPERATOR deployment allowlist does not carve
+      it out. Refused for EVERY scope, marked or not (ie-02 /
+      GHSA-jh42-wf7g-f5rg). This decision moved here from
+      `Loopctl.Webhooks.Webhook.validate_url/1`, which could not see the tenant
+      and therefore refused every allowlisted destination too.
+    2. `:unclassifiable` — the host does not resolve. Reported DISTINCTLY from a
+      private address: "does not exist" and "exists but is forbidden" are
+      different problems with different fixes.
+    3. locality — the scope is `local_only` and the destination is not local for
+      the `webhook` purpose.
+
+  This is the ONLY DNS resolution performed for a webhook write: the changeset
+  above it validates SHAPE only.
+  """
+  @spec webhook_destination_check(Scope.t(), String.t()) ::
+          :ok | {:error, {atom(), String.t()}}
+  def webhook_destination_check(%Scope{} = scope, url) when is_binary(url) do
+    case endpoint_verdict(scope, url, :webhook) do
+      :denylisted ->
+        {:error, {:denylisted, denylisted_message(url)}}
+
+      :unclassifiable ->
+        {:error, {:unclassifiable, "host could not be resolved"}}
+
+      verdict ->
+        cond do
+          local_verdict?(verdict) ->
+            :ok
+
+          effective_local_only?(scope) ->
+            {:error, {verdict, webhook_remediation(scope, url, verdict)}}
+
+          true ->
+            :ok
+        end
+    end
+  end
+
+  # The legacy phrase is preserved as the PREFIX so existing API consumers that
+  # string-match it keep working; the remediation names WHO can change it, which
+  # a bare "must not target a private or loopback address" never did.
+  defp denylisted_message(url) do
+    host = URI.parse(url).host || url
+
+    "must not target a private or loopback address — #{host} resolves into a private, " <>
+      "loopback, CGNAT, link-local or ULA range. Only the OPERATOR deployment allowlist " <>
+      "can carve such a host out of the SSRF denylist; a tenant declaration cannot."
+  end
+
+  defp webhook_remediation(scope, url, verdict) do
+    host = URI.parse(url).host || url
+
+    "#{host} is #{verdict_label(verdict)} for #{Scope.key(scope)}, which is marked " <>
+      "local_only. A subscription to it would be refused at delivery time, so it is " <>
+      "rejected here instead. Either declare #{host} as a tenant-trusted endpoint FOR " <>
+      "THE 'webhook' PURPOSE (role :user — note a declaration is #{@tenant_declared_label}), " <>
+      "ask the operator to add it to the deployment allowlist if it is genuinely on the " <>
+      "deployment network, use a destination that is already local, or clear the " <>
+      "local_only marking on this scope (role :user)."
   end
 
   @doc """
@@ -272,15 +426,6 @@ defmodule Loopctl.Egress do
   @spec resolved_endpoints(Scope.t()) :: [{atom(), String.t()}]
   def resolved_endpoints(%Scope{tenant_id: tenant_id}) do
     [{:embedding, EmbeddingClient.base_url()}, {:chat, Llm.chat_base_url(tenant_id)}]
-  end
-
-  defp endpoint_verdict(scope, url) do
-    host = URI.parse(url).host || url
-
-    case Policy.classify(scope, host, :inference) do
-      {:ok, %{verdict: verdict}} -> verdict
-      {:error, _} -> :unclassifiable
-    end
   end
 
   # ---------------------------------------------------------------------------
@@ -449,6 +594,30 @@ defmodule Loopctl.Egress do
             nil -> ""
             remediation -> " remediation=#{remediation}"
           end
+    end
+  end
+
+  @doc """
+  WHICH of the two block causes a PERMANENT refusal is (US-41.5).
+
+    * `:ssrf_denied` — the destination resolves into a private/loopback/CGNAT/
+      link-local/ULA range and the OPERATOR deployment allowlist does not carve it
+      out. Unreachable for EVERY tenant, marked or not; a tenant declaration
+      cannot change it.
+    * `:locality_denied` — the destination is reachable, but the scope is
+      `local_only` and the destination is not classified local for the requested
+      purpose. A configuration conflict the TENANT can resolve.
+    * `:transient` — `:pin_stale` / `:egress_unavailable`; not a block at all.
+
+  An operator reading a blocked delivery needs the distinction: one is "ask the
+  operator", the other is "declare the endpoint or clear the marking".
+  """
+  @spec block_kind({atom(), map()} | atom()) :: :ssrf_denied | :locality_denied | :transient
+  def block_kind(term) do
+    case refusal(term) do
+      {:egress_blocked, %{verdict: :denylisted}} -> :ssrf_denied
+      {:egress_blocked, _details} -> :locality_denied
+      _other -> :transient
     end
   end
 
@@ -668,9 +837,13 @@ defmodule Loopctl.Egress do
 
   ## Scope of the guarantee
 
-  This story covers MODEL-PROVIDER egress only. Webhook delivery
-  (`Loopctl.Webhooks.ReqDelivery`) bypasses this guard and is handled in US-41.5,
-  so the report says so explicitly rather than implying total egress control.
+  Every CONTENT-CARRYING outbound path made by loopctl application code is
+  covered: the model-provider path (US-41.4), the ingestion fetch, and — since
+  US-41.5 — webhook delivery, reported per destination in `webhook_destinations`.
+  What is still NOT covered is stated rather than implied: HTTP performed inside
+  a dependency and the separate `mcp-server/` codebase are outside the static
+  chokepoint scan, and the remaining non-content outbound paths are triaged in
+  `docs/egress-guard.md`.
   """
   @spec posture(Ecto.UUID.t(), atom()) :: map()
   def posture(tenant_id, role \\ :agent) do
@@ -698,14 +871,17 @@ defmodule Loopctl.Egress do
     base = %{
       tenant_id: tenant_id,
       endpoints: endpoints,
+      webhook_destinations: webhook_destinations(tenant_id),
       declared_endpoints: declared,
       scopes: scopes,
       posture_defects: posture_defects(scopes),
       guarantee_scope:
         "Enforced for every outbound HTTP call made by loopctl application code on the " <>
-          "MODEL-PROVIDER path. Webhook delivery is NOT yet covered (US-41.5). HTTP " <>
+          "content-carrying paths: MODEL-PROVIDER calls, the ingestion fetch, and WEBHOOK " <>
+          "DELIVERY (per-destination classification in webhook_destinations). HTTP " <>
           "performed inside a dependency, and the separate mcp-server/ codebase, are " <>
-          "outside the static chokepoint check.",
+          "outside the static chokepoint check; the remaining non-content outbound paths " <>
+          "are triaged in docs/egress-guard.md.",
       tenant_declared_label: @tenant_declared_label
     }
 
@@ -750,13 +926,8 @@ defmodule Loopctl.Egress do
   end
 
   defp endpoint_posture(scope, kind, url) do
+    {verdict, from_allowlist} = classify_endpoint(scope, url, :inference)
     host = URI.parse(url).host || url
-
-    {verdict, from_allowlist} =
-      case Policy.classify(scope, host, :inference) do
-        {:ok, %{verdict: v, from_allowlist: a}} -> {v, a}
-        {:error, _} -> {:unclassifiable, false}
-      end
 
     %{
       kind: kind,
@@ -766,6 +937,47 @@ defmodule Loopctl.Egress do
       # Boolean only at :agent — the allowlist CONTENTS are operator-plane state.
       verdict_from_deployment_allowlist: from_allowlist
     }
+  end
+
+  # AC-41.5.5: the posture report covers EVERY content-carrying egress path, so a
+  # webhook destination is classified here exactly the way delivery classifies it
+  # — same policy module, same `:webhook` purpose, same DELIVERY scope
+  # (`tenant_id, webhook.project_id`). Anything else would let the report and the
+  # guard disagree, which is the failure mode the whole report exists to prevent.
+  #
+  # The destination URL is NOT a secret (only the signing secret is Cloak-encrypted),
+  # so it is disclosed at every role, exactly like the provider endpoints.
+  defp webhook_destinations(tenant_id) do
+    Webhook
+    |> where([w], w.tenant_id == ^tenant_id)
+    |> order_by([w], asc: w.inserted_at)
+    |> AdminRepo.all()
+    |> Enum.map(fn webhook ->
+      scope = Scope.new(tenant_id, webhook.project_id)
+      {verdict, from_allowlist} = classify_endpoint(scope, webhook.url, :webhook)
+      host = URI.parse(webhook.url).host || webhook.url
+
+      %{
+        webhook_id: webhook.id,
+        project_id: webhook.project_id,
+        scope: Scope.key(scope),
+        endpoint: webhook.url,
+        host: host,
+        active: webhook.active,
+        verdict: verdict_label(verdict),
+        verdict_from_deployment_allowlist: from_allowlist,
+        blocked_by_local_only: Policy.local_only?(scope) and not local_verdict?(verdict)
+      }
+    end)
+  end
+
+  defp classify_endpoint(scope, url, purpose) do
+    host = URI.parse(url).host || url
+
+    case Policy.classify(scope, host, purpose) do
+      {:ok, %{verdict: v, from_allowlist: a}} -> {v, a}
+      {:error, _} -> {:unclassifiable, false}
+    end
   end
 
   defp verdict_label(:network_local), do: "network-local"

--- a/lib/loopctl/egress.ex
+++ b/lib/loopctl/egress.ex
@@ -75,7 +75,10 @@ defmodule Loopctl.Egress do
   alias Loopctl.Egress.TrustedEndpoint
   alias Loopctl.Knowledge.EmbeddingClient
   alias Loopctl.Llm
-  alias Loopctl.Webhooks.Webhook
+  # Webhook rows are read through the OWNING context's narrow reader
+  # (`Webhooks.list_for_egress/3`), never queried here: the tenant-scoping
+  # predicate for webhooks must live in exactly one place (US-41.5 review).
+  alias Loopctl.Webhooks
 
   @blocked_window_seconds 60
 
@@ -151,15 +154,56 @@ defmodule Loopctl.Egress do
   @spec enable_local_only(Ecto.UUID.t(), Ecto.UUID.t() | nil, keyword()) ::
           {:ok, map()} | {:error, {:would_block, [map()]} | Ecto.Changeset.t()}
   def enable_local_only(tenant_id, project_id, opts \\ []) do
-    scope = Scope.new(tenant_id, project_id)
-    acknowledge = Keyword.get(opts, :acknowledge, false)
-    blocked = preflight_blocked_endpoints(scope)
+    do_enable(Scope.new(tenant_id, project_id), opts)
+  end
 
-    if blocked != [] and not acknowledge do
-      {:error, {:would_block, blocked}}
-    else
-      do_enable(scope, blocked, opts)
-    end
+  # `pg_advisory_xact_lock` takes two int4s. The NAMESPACE isolates this lock
+  # class from every other advisory lock in the app (the memory quota, the
+  # Context Retriever entity cap) so hashing a tenant here can never collide with
+  # an unrelated lock keyed on the same integer.
+  @scope_marking_lock_ns 0x4105_0001
+
+  @doc """
+  Serializes everything that reads-then-writes a tenant's egress configuration
+  (review fix), inside the caller's transaction.
+
+  `enable_local_only/3` decides on a SNAPSHOT of the tenant's webhook
+  subscriptions (the pre-flight) and then writes the marking. Concurrently,
+  `Loopctl.Webhooks.create_webhook/3` decides on a snapshot of the MARKINGS (the
+  AC-41.5.3 config-time check) and then writes a subscription. Interleaved
+  without a lock, a subscription created after the pre-flight snapshot lands
+  under the new marking: it is absent from the `{:would_block, endpoints}` list,
+  absent from `acknowledged_blocked_endpoints`, and silently blocked at delivery
+  — the "silent state change" AC-41.5.4 rules out.
+
+  Both writers take THIS lock as the FIRST step of their transaction and both run
+  their check INSIDE it, so one of the two always observes the other's committed
+  state. It is transaction-scoped, so it releases on commit/rollback with no
+  unlock path to forget.
+
+  The key is derived from the tenant UUID's first four bytes rather than
+  `:erlang.phash2/1`, whose hashing is not guaranteed stable across OTP releases
+  — during a rolling deploy two nodes must agree on the key or they do not
+  serialize at all.
+  """
+  @spec lock_scope_config!(Ecto.Repo.t(), Ecto.UUID.t()) :: :ok
+  def lock_scope_config!(repo, tenant_id) do
+    repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [
+      @scope_marking_lock_ns,
+      tenant_lock_key(tenant_id)
+    ])
+
+    :ok
+  end
+
+  @doc """
+  The STABLE signed int4 advisory-lock key for a tenant. Public so a test can
+  prove two real DB sessions derive the same key.
+  """
+  @spec tenant_lock_key(Ecto.UUID.t()) :: integer()
+  def tenant_lock_key(tenant_id) do
+    {:ok, <<key::signed-integer-32, _rest::binary>>} = Ecto.UUID.dump(tenant_id)
+    key
   end
 
   @doc """
@@ -195,34 +239,51 @@ defmodule Loopctl.Egress do
     end
   end
 
-  defp do_enable(%Scope{tenant_id: tenant_id, project_id: project_id} = scope, blocked, opts) do
+  # The pre-flight runs INSIDE the transaction, under `lock_scope_config!/2` —
+  # see that function for the race it closes. The cost is that a webhook
+  # classification (worst case a DNS resolve) happens while an `AdminRepo`
+  # connection is held; `classify_within_budget/3`'s deadline is what keeps that
+  # hold bounded, and enabling `local_only` is a rare operator write.
+  defp do_enable(%Scope{tenant_id: tenant_id, project_id: project_id} = scope, opts) do
+    acknowledge = Keyword.get(opts, :acknowledge, false)
     now = DateTime.utc_now()
 
-    attrs = %{
-      project_id: project_id,
-      local_only: true,
-      enabled_by_actor_type: Keyword.get(opts, :actor_type, "api_key"),
-      enabled_by_actor_id: Keyword.get(opts, :actor_id),
-      enabled_at: now,
-      acknowledged_blocked_endpoints: Enum.map(blocked, & &1.endpoint)
-    }
+    Multi.new()
+    |> Multi.run(:lock, fn repo, _changes ->
+      {:ok, lock_scope_config!(repo, tenant_id)}
+    end)
+    |> Multi.run(:preflight, fn _repo, _changes ->
+      blocked = preflight_blocked_endpoints(scope)
 
-    changeset =
+      if blocked != [] and not acknowledge do
+        {:error, {:would_block, blocked}}
+      else
+        {:ok, blocked}
+      end
+    end)
+    |> Multi.insert_or_update(:marking, fn %{preflight: blocked} ->
+      attrs = %{
+        project_id: project_id,
+        local_only: true,
+        enabled_by_actor_type: Keyword.get(opts, :actor_type, "api_key"),
+        enabled_by_actor_id: Keyword.get(opts, :actor_id),
+        enabled_at: now,
+        acknowledged_blocked_endpoints: Enum.map(blocked, & &1.endpoint)
+      }
+
       (get_marking(tenant_id, project_id) || %ScopeMarking{tenant_id: tenant_id})
       |> ScopeMarking.changeset(attrs)
-
-    Multi.new()
-    |> Multi.insert_or_update(:marking, changeset)
-    |> Audit.log_in_multi(:audit, fn _changes ->
+    end)
+    |> Audit.log_in_multi(:audit, fn %{preflight: blocked} ->
       audit_attrs(tenant_id, scope, "egress.local_only_enabled", opts, %{
         local_only: true,
         blocked_endpoints: Enum.map(blocked, & &1.endpoint),
-        acknowledged: Keyword.get(opts, :acknowledge, false)
+        acknowledged: acknowledge
       })
     end)
     |> AdminRepo.transaction()
     |> case do
-      {:ok, %{marking: marking}} ->
+      {:ok, %{marking: marking, preflight: blocked}} ->
         PinCache.invalidate_tenant(tenant_id)
 
         :telemetry.execute(
@@ -237,6 +298,13 @@ defmodule Loopctl.Egress do
         )
 
         {:ok, %{marking: marking, blocked_endpoints: blocked}}
+
+      # The pre-flight now REFUSES from inside the transaction, so its verdict
+      # arrives as a Multi failure. Unwrap it to the same `{:error,
+      # {:would_block, endpoints}}` the caller contract already documents —
+      # nothing was written, because the whole Multi rolled back.
+      {:error, :preflight, {:would_block, blocked}, _} ->
+        {:error, {:would_block, blocked}}
 
       {:error, _step, reason, _} ->
         {:error, reason}
@@ -283,14 +351,11 @@ defmodule Loopctl.Egress do
   """
   @spec blocked_webhook_subscriptions(Scope.t()) :: [map()]
   def blocked_webhook_subscriptions(%Scope{tenant_id: tenant_id, project_id: project_id}) do
-    Webhook
-    |> where([w], w.tenant_id == ^tenant_id)
-    |> marking_covers_webhook(project_id)
-    |> order_by([w], asc: w.inserted_at)
-    |> AdminRepo.all()
-    |> Enum.map(fn webhook ->
+    tenant_id
+    |> Webhooks.list_for_egress(project_id || :all, limit: max_classified_webhooks())
+    |> classify_within_budget(fn webhook ->
       delivery_scope = Scope.new(tenant_id, webhook.project_id)
-      {webhook, endpoint_verdict(delivery_scope, webhook.url, :webhook)}
+      endpoint_verdict(delivery_scope, webhook.url, :webhook)
     end)
     |> Enum.reject(fn {_webhook, verdict} -> local_verdict?(verdict) end)
     |> Enum.map(fn {webhook, verdict} ->
@@ -305,12 +370,86 @@ defmodule Loopctl.Egress do
     end)
   end
 
-  # A TENANT marking covers every subscription; a PROJECT marking covers only that
-  # project's subscriptions.
-  defp marking_covers_webhook(query, nil), do: query
+  @doc """
+  Redacts the pre-flight's blocked-endpoint list for `role` (review fix).
 
-  defp marking_covers_webhook(query, project_id),
-    do: where(query, [w], w.project_id == ^project_id)
+  `blocked_webhook_subscriptions/1` carries the FULL destination URL because
+  `enable_local_only/3` records it in the marking's
+  `acknowledged_blocked_endpoints` and in the audit event — server-side state a
+  `:user` reads back. But the pre-flight's list is also echoed to the CALLER, and
+  `POST /api/v1/egress/local-only` is `role: :orchestrator`, one level below the
+  `role: :user` gate on `LoopctlWeb.WebhookController`. Echoing it verbatim would
+  disclose webhook destination URLs — frequently capability URLs whose path IS the
+  credential (Slack, Discord, Teams, Zapier, n8n) — a role below the one that can
+  read them anywhere else.
+
+  So below `:user` a `:webhook` entry's `endpoint` is reduced to its HOST, which
+  is all an orchestrator needs to act on the conflict (it also carries
+  `webhook_id`). PROVIDER endpoints are left intact: they are operator/tenant
+  configuration already disclosed at `:agent` by `posture/2`.
+  """
+  @spec redact_blocked_endpoints([map()], atom()) :: [map()]
+  def redact_blocked_endpoints(blocked, role) when is_list(blocked) do
+    if role in [:user, :superadmin] do
+      blocked
+    else
+      Enum.map(blocked, &redact_blocked_endpoint/1)
+    end
+  end
+
+  defp redact_blocked_endpoint(%{kind: :webhook, endpoint: url} = entry) when is_binary(url) do
+    %{entry | endpoint: URI.parse(url).host || url}
+  end
+
+  defp redact_blocked_endpoint(entry), do: entry
+
+  @doc """
+  Rows an egress caller will classify for one tenant, and the wall-clock budget
+  it will spend doing so (US-41.5 review).
+
+  Both the posture report (role `:agent`) and the `local_only` enable pre-flight
+  classify TENANT-SUPPLIED webhook hosts, and a classification that misses the
+  `PinCache` pays a real DNS resolve (`UrlGuard`'s 3s timeout). Unbounded, a
+  tenant could make the endpoint agents are told to call BEFORE EVERY HARVEST
+  take `max_webhooks x 3s` — with `max_webhooks` itself tenant-settable.
+
+  So the work is bounded twice: at most `max_classified_webhooks/0` rows, and
+  once the budget is spent the remaining rows are reported `unclassified`
+  (cache-only, no resolve) rather than blocking the request. `unclassified` is
+  NOT a local verdict, so a budget-exhausted destination is reported as blocked
+  by the pre-flight — bounded the FAIL-CLOSED way.
+
+  Deliberately serial rather than `Task.async_stream/3`: the classifier reads the
+  DB (declared purposes) inside the caller's `Ecto` sandbox/RLS context, and this
+  bound must hold identically in a request, a worker and a test.
+  """
+  @spec classification_budget_ms() :: pos_integer()
+  def classification_budget_ms do
+    Application.get_env(:loopctl, :egress_classification_budget_ms, 2_000)
+  end
+
+  @doc "Maximum webhook rows one egress classification pass will look at."
+  @spec max_classified_webhooks() :: pos_integer()
+  def max_classified_webhooks do
+    Application.get_env(:loopctl, :egress_max_classified_webhooks, 50)
+  end
+
+  # Classifies `items` in order until the budget is spent; the rest get `skipped`.
+  # The FIRST item is always classified, so a single destination behaves exactly
+  # as it did before the bound.
+  defp classify_within_budget(items, classify_fun, skipped \\ :unclassified) do
+    deadline = System.monotonic_time(:millisecond) + classification_budget_ms()
+
+    items
+    |> Enum.with_index()
+    |> Enum.map(fn {item, index} ->
+      if index == 0 or System.monotonic_time(:millisecond) < deadline do
+        {item, classify_fun.(item)}
+      else
+        {item, skipped}
+      end
+    end)
+  end
 
   @doc """
   True when `verdict` means "local for this scope" — the ONE definition of
@@ -607,17 +746,59 @@ defmodule Loopctl.Egress do
     * `:locality_denied` — the destination is reachable, but the scope is
       `local_only` and the destination is not classified local for the requested
       purpose. A configuration conflict the TENANT can resolve.
-    * `:transient` — `:pin_stale` / `:egress_unavailable`; not a block at all.
+    * `:transient` — `:pin_stale` / `:egress_unavailable`, AND an
+      `:egress_blocked` whose verdict is `:unclassifiable` for a real host
+      (review fix, below); not a block at all.
+    * `:unrecognized` — the term is not an egress refusal at all. TERMINAL, and
+      deliberately so: this module's whole purpose is fail-closed classification,
+      so an unknown term must not be silently routed onto the retry path. A
+      malformed `{:refused, term}` from a future delivery-client change, a Mox
+      stub, or a third-party `DeliveryBehaviour` implementation therefore stops
+      loudly (a recorded, agent-readable block) instead of producing a job that
+      snoozes forever. This matches `oban_result/1`, which already cancels an
+      unrecognised term rather than snoozing it.
 
   An operator reading a blocked delivery needs the distinction: one is "ask the
   operator", the other is "declare the endpoint or clear the marking".
+
+  ## `:unclassifiable` is TRANSIENT, not `:locality_denied` (review fix)
+
+  `Policy.check_local_only/4` maps EVERY classification error — including a plain
+  NXDOMAIN or a 3s resolver timeout — to `{:egress_blocked, %{verdict:
+  :unclassifiable}}`. Fail-closed is right; calling it PERMANENT was not. It made
+  the same resolver hiccup asymmetric by marking: on an UNMARKED scope the
+  identical failure is `:egress_unavailable` and retried, while on a `local_only`
+  scope it terminally dropped the delivery — and labelled it `locality_denied`,
+  whose documented remediation ("declare the endpoint, or clear the marking")
+  cannot fix a DNS outage on an already-declared endpoint. `enable_local_only/3`
+  and `clear_local_only/3` both call `PinCache.invalidate_tenant/1`, so a cold
+  cache right after a marking change is the EXPECTED state, not an edge case.
+
+  It is transient only for a REAL host: `{:egress_blocked, %{verdict:
+  :unclassifiable, host: nil}}` is a URL with no host at all (a malformed
+  destination), which no amount of retrying fixes, so that stays permanent. The
+  retry it enables is bounded by
+  `Loopctl.Workers.WebhookDeliveryWorker.max_transient_snoozes/0`, after which the
+  ordinary failure ladder still exhausts and still auto-disables.
   """
-  @spec block_kind({atom(), map()} | atom()) :: :ssrf_denied | :locality_denied | :transient
+  @spec block_kind({atom(), map()} | atom()) ::
+          :ssrf_denied | :locality_denied | :transient | :unrecognized
   def block_kind(term) do
     case refusal(term) do
-      {:egress_blocked, %{verdict: :denylisted}} -> :ssrf_denied
-      {:egress_blocked, _details} -> :locality_denied
-      _other -> :transient
+      {:egress_blocked, %{verdict: :denylisted}} ->
+        :ssrf_denied
+
+      {:egress_blocked, %{verdict: :unclassifiable, host: host}} when is_binary(host) ->
+        :transient
+
+      {:egress_blocked, _details} ->
+        :locality_denied
+
+      {tag, _details} when tag in [:pin_stale, :egress_unavailable] ->
+        :transient
+
+      nil ->
+        :unrecognized
     end
   end
 
@@ -635,6 +816,19 @@ defmodule Loopctl.Egress do
       SILENTLY. AC-41.4.3 makes only `:egress_blocked` terminal.
     * `:egress_unavailable` → `{:snooze, _}`. A transient infrastructure failure
       reading the marking, not a privacy refusal at all.
+
+  ## Deliberately COARSER than `block_kind/1`
+
+  `block_kind/1` treats an `:egress_blocked` carrying `verdict: :unclassifiable`
+  for a real host as TRANSIENT (a resolver failure is not a locality decision).
+  This function does NOT, and the divergence is intentional rather than an
+  oversight: `oban_result/1`'s callers hand the result straight to Oban with no
+  snooze budget of their own, so snoozing an `:unclassifiable` would recreate
+  exactly the immortal-job defect the webhook worker's
+  `max_transient_snoozes/0` bound exists to prevent. `WebhookDeliveryWorker` uses
+  `block_kind/1` precisely BECAUSE it carries that bound.
+
+  A caller that wants the finer distinction must adopt a bound first.
   """
   @spec oban_result({atom(), map()} | atom()) ::
           {:cancel, String.t()} | {:snooze, pos_integer()}
@@ -835,6 +1029,11 @@ defmodule Loopctl.Egress do
   allowlist. Operator infrastructure is not disclosed to the lowest-privileged
   key of every tenant.
 
+  The same split applies to WEBHOOK DESTINATIONS: `host`, `verdict` and
+  `blocked_by_local_only` at every role; the FULL `endpoint` URL (path and query
+  included — often a capability credential) only at `:user`+, matching the
+  `role: :user` gate on `LoopctlWeb.WebhookController`.
+
   ## Scope of the guarantee
 
   Every CONTENT-CARRYING outbound path made by loopctl application code is
@@ -871,7 +1070,7 @@ defmodule Loopctl.Egress do
     base = %{
       tenant_id: tenant_id,
       endpoints: endpoints,
-      webhook_destinations: webhook_destinations(tenant_id),
+      webhook_destinations: webhook_destinations(tenant_id, role),
       declared_endpoints: declared,
       scopes: scopes,
       posture_defects: posture_defects(scopes),
@@ -945,29 +1144,45 @@ defmodule Loopctl.Egress do
   # (`tenant_id, webhook.project_id`). Anything else would let the report and the
   # guard disagree, which is the failure mode the whole report exists to prevent.
   #
-  # The destination URL is NOT a secret (only the signing secret is Cloak-encrypted),
-  # so it is disclosed at every role, exactly like the provider endpoints.
-  defp webhook_destinations(tenant_id) do
-    Webhook
-    |> where([w], w.tenant_id == ^tenant_id)
-    |> order_by([w], asc: w.inserted_at)
-    |> AdminRepo.all()
-    |> Enum.map(fn webhook ->
+  # DISCLOSURE (review fix): the full destination URL is `:user`+ only.
+  #
+  # A webhook destination is frequently a CAPABILITY URL whose PATH is the
+  # credential (Slack `hooks.slack.com/services/T.../B.../<token>`, Discord,
+  # Teams, Zapier, n8n). `LoopctlWeb.WebhookController` is `role: :user` at module
+  # level, so an `:agent` key cannot read those URLs anywhere else — emitting them
+  # here would be a role DOWNGRADE of existing data. AC-41.5.5 asks for "webhook
+  # destinations and their local classification", which `host` + `verdict` +
+  # `blocked_by_local_only` satisfies; `endpoint` is added at `:user`+, the same
+  # boolean-vs-contents split the deployment allowlist already uses.
+  defp webhook_destinations(tenant_id, role) do
+    tenant_id
+    |> Webhooks.list_for_egress(:all, limit: max_classified_webhooks())
+    |> classify_within_budget(
+      fn webhook ->
+        classify_endpoint(Scope.new(tenant_id, webhook.project_id), webhook.url, :webhook)
+      end,
+      {:unclassified, false}
+    )
+    |> Enum.map(fn {webhook, {verdict, from_allowlist}} ->
       scope = Scope.new(tenant_id, webhook.project_id)
-      {verdict, from_allowlist} = classify_endpoint(scope, webhook.url, :webhook)
       host = URI.parse(webhook.url).host || webhook.url
 
-      %{
+      base = %{
         webhook_id: webhook.id,
         project_id: webhook.project_id,
         scope: Scope.key(scope),
-        endpoint: webhook.url,
         host: host,
         active: webhook.active,
         verdict: verdict_label(verdict),
         verdict_from_deployment_allowlist: from_allowlist,
         blocked_by_local_only: Policy.local_only?(scope) and not local_verdict?(verdict)
       }
+
+      if role in [:user, :superadmin] do
+        Map.put(base, :endpoint, webhook.url)
+      else
+        base
+      end
     end)
   end
 

--- a/lib/loopctl/egress/chokepoint_scan.ex
+++ b/lib/loopctl/egress/chokepoint_scan.ex
@@ -58,14 +58,19 @@ defmodule Loopctl.Egress.ChokepointScan do
   """
 
   # {module_name => justification}. An entry here exempts only the LINT; it does
-  # NOT exempt the call from US-41.5's webhook guard or any future coverage.
+  # NOT exempt the call from the egress guard. Every entry MUST have a matching
+  # row in the `docs/egress-guard.md` triage table — a parity assertion in
+  # `Loopctl.Egress.ChokepointScanTest` fails the build otherwise (AC-41.5.6), so
+  # the doc triage and this list can never drift.
   @allowed %{
     "Loopctl.Provider" =>
       "IS the chokepoint wrapper — the one sanctioned outbound provider call site.",
     "Loopctl.Webhooks.ReqDelivery" =>
-      "Webhook delivery. Already SSRF-guarded (UrlGuard.pin + pinned_request_opts + " <>
-        "redirect: false). Bringing it under the local_only guard is US-41.5, so this " <>
-        "story's guarantee wording must NOT claim total egress control yet.",
+      "IS the webhook chokepoint wrapper (US-41.5). Content-carrying egress, and fully " <>
+        "under the guard: it consults the ONE policy (Egress.Policy.check/4, purpose " <>
+        ":webhook, tenant_supplied: true) before building the request, then keeps the " <>
+        "pin (pinned_request_opts + redirect: false). It is allowlisted for the same " <>
+        "reason Loopctl.Provider is — it is the wrapper, not a call site that bypasses one.",
     "Loopctl.Verification.GitHubActions" =>
       "Reads GitHub check-run status for verification. Operator-plane, fixed vendor " <>
         "host, carries no tenant content outbound.",

--- a/lib/loopctl/egress/pin_cache.ex
+++ b/lib/loopctl/egress/pin_cache.ex
@@ -154,8 +154,35 @@ defmodule Loopctl.Egress.PinCache do
           expires_at: integer()
         }
 
+  @typedoc """
+  The THIRD shape: a NEGATIVE entry recording that a host failed to classify
+  (`Loopctl.Egress.Policy.cache_unresolvable/5`). It exists so an unresolvable
+  tenant-supplied host does not repay a multi-second DNS resolve on every
+  `Loopctl.Egress.posture/2` call, and it carries a much shorter TTL than a
+  success (`Policy.negative_ttl_ms/0`).
+
+  It is a REFUSAL, never a permit: `Policy` short-circuits it back to
+  `{:error, reason}` BEFORE `resolve_verdict/2`, whose catch-all would otherwise
+  invent a `:non_local` verdict for an entry that has none. It has no pin, so the
+  refresher skips it.
+  """
+  @type unresolvable_entry :: %{
+          tenant_id: Ecto.UUID.t(),
+          scope_key: String.t(),
+          host: key_host(),
+          base_verdict: :unresolvable,
+          resolve_error: term(),
+          ips: [],
+          purposes: [],
+          state: :fresh | :revalidating,
+          pin_stale: boolean(),
+          used: boolean(),
+          refresh_at: integer(),
+          expires_at: integer()
+        }
+
   @typedoc "Anything this cache can hold."
-  @type cached :: entry() | marking_entry()
+  @type cached :: entry() | marking_entry() | unresolvable_entry()
 
   # --- Client API ---
 
@@ -209,10 +236,16 @@ defmodule Loopctl.Egress.PinCache do
   `invalidate_tenant/1` landed in that window and the write is DROPPED — the built
   entry is still returned to the caller, it is simply not cached. Without this a
   revocation or an ENABLE is silently resurrected for a full TTL.
+
+  `opts[:ttl_ms]` overrides the hard TTL for this entry. Used by the NEGATIVE
+  cache (`Loopctl.Egress.Policy`), which must remember "this host did not resolve"
+  for far less time than a successful classification — long enough to collapse a
+  burst of lookups, short enough that recovery from a resolver blip is prompt.
   """
   @spec put(Ecto.UUID.t(), String.t(), key_host(), map(), keyword()) :: cached()
   def put(tenant_id, scope_key, host, attrs, opts \\ []) do
     now = now_ms()
+    ttl = Keyword.get(opts, :ttl_ms, @ttl_ms)
 
     entry =
       attrs
@@ -227,8 +260,11 @@ defmodule Loopctl.Egress.PinCache do
         # (and the deterministic refresher test) can steer the schedule; the
         # refresher itself DROPS both keys before re-putting, so a revalidated
         # entry always gets a fresh jittered point and can never loop.
-        refresh_at: Map.get(attrs, :refresh_at) || now + jittered_refresh_ms(),
-        expires_at: Map.get(attrs, :expires_at) || now + @ttl_ms
+        #
+        # `min/2` keeps a short-TTL entry from being scheduled for a refresh it
+        # would never live to see.
+        refresh_at: Map.get(attrs, :refresh_at) || now + min(jittered_refresh_ms(), ttl),
+        expires_at: Map.get(attrs, :expires_at) || now + ttl
       })
 
     key = {tenant_id, scope_key, host}
@@ -509,9 +545,12 @@ defmodule Loopctl.Egress.PinCache do
     ArgumentError -> :ok
   end
 
+  # `:unresolvable` (the NEGATIVE cache) is skipped for the same reason
+  # `:denylisted` is: there is no pin to revalidate, and its short TTL means it
+  # expires long before it could ever be due anyway.
   defp refreshable?(entry, now) do
     is_binary(entry.host) and now >= entry.refresh_at and not entry.pin_stale and
-      Map.get(entry, :base_verdict) != :denylisted
+      Map.get(entry, :base_verdict) not in [:denylisted, :unresolvable]
   end
 
   defp revalidate(entry) do

--- a/lib/loopctl/egress/policy.ex
+++ b/lib/loopctl/egress/policy.ex
@@ -450,10 +450,36 @@ defmodule Loopctl.Egress.Policy do
     end
   end
 
+  @doc """
+  How long a FAILED classification is remembered (review fix).
+
+  Only SUCCESSFUL classifications used to be cached, so every caller paid the full
+  resolve cost for an unresolvable host on every call, forever. That is the cost
+  `Loopctl.Egress.posture/2` pays — a role `:agent`, parameterless endpoint agents
+  are told to call before every harvest — over TENANT-SUPPLIED hostnames, and
+  `UrlGuard`'s resolver spends up to 6s (`:inet` then `:inet6`) per dead host.
+
+  Short on purpose: long enough to collapse a burst of lookups over the same dead
+  host, short enough that a resolver blip clears promptly. A negative entry is a
+  REFUSAL (`{:error, reason}`, fail-closed), never a permit, so caching one can
+  never widen egress — the worst it can do is refuse a recovered host for the
+  remainder of the window.
+  """
+  @spec negative_ttl_ms() :: pos_integer()
+  def negative_ttl_ms do
+    Application.get_env(:loopctl, :egress_negative_classification_ttl_ms, 30_000)
+  end
+
   defp cached_classification(scope, host, purpose) do
     scope_key = Scope.key(scope)
 
     case PinCache.fetch(scope.tenant_id, scope_key, host) do
+      # NEGATIVE cache hit. Short-circuited BEFORE `resolve_verdict/2`, which has
+      # no meaning for an entry that never resolved (its catch-all would report
+      # `:non_local` — a verdict, and on an unmarked scope a permissive one).
+      {:ok, %{base_verdict: :unresolvable} = entry} ->
+        {:error, Map.get(entry, :resolve_error, :unresolvable)}
+
       {:ok, entry} ->
         {:ok, resolve_verdict(entry, purpose)}
 
@@ -463,13 +489,31 @@ defmodule Loopctl.Egress.Policy do
         # so a revocation landing in that window is not resurrected by this put.
         generation = PinCache.generation(scope.tenant_id)
 
-        with {:ok, attrs} <- classify_uncached(scope, host) do
-          entry =
-            PinCache.put(scope.tenant_id, scope_key, host, attrs, generation: generation)
+        case classify_uncached(scope, host) do
+          {:ok, attrs} ->
+            entry =
+              PinCache.put(scope.tenant_id, scope_key, host, attrs, generation: generation)
 
-          {:ok, resolve_verdict(entry, purpose)}
+            {:ok, resolve_verdict(entry, purpose)}
+
+          {:error, reason} = error ->
+            cache_unresolvable(scope, scope_key, host, reason, generation)
+            error
         end
     end
+  end
+
+  defp cache_unresolvable(scope, scope_key, host, reason, generation) do
+    PinCache.put(
+      scope.tenant_id,
+      scope_key,
+      host,
+      %{base_verdict: :unresolvable, resolve_error: reason, ips: [], purposes: []},
+      generation: generation,
+      ttl_ms: negative_ttl_ms()
+    )
+
+    :ok
   end
 
   @doc """

--- a/lib/loopctl/net/url_guard.ex
+++ b/lib/loopctl/net/url_guard.ex
@@ -92,6 +92,33 @@ defmodule Loopctl.Net.UrlGuard do
   end
 
   @doc """
+  Validates only the SHAPE of `url` — scheme allowlist and host presence —
+  WITHOUT resolving DNS or applying the address denylist.
+
+  Exposed for callers whose ADDRESS decision belongs to `Loopctl.Egress.Policy`
+  rather than here (US-41.5): the webhook changeset validates shape at cast time,
+  and the `Loopctl.Webhooks` context then makes the ONE policy call, which does
+  the single DNS resolution and can see the OPERATOR deployment allowlist. Using
+  `validate_egress/2` there instead would resolve the host TWICE for one write
+  and re-decide the address with a copy of the rules that cannot see the
+  allowlist. The scheme list still lives here, so there is no second policy.
+  """
+  @spec validate_shape(String.t(), keyword()) :: {:ok, URI.t()} | {:error, reason()}
+  def validate_shape(url, opts \\ [])
+
+  def validate_shape(url, opts) when is_binary(url) do
+    schemes = Keyword.get(opts, :schemes, @default_schemes)
+    uri = URI.parse(url)
+
+    with :ok <- check_scheme(uri, schemes),
+         {:ok, _host} <- host(uri) do
+      {:ok, uri}
+    end
+  end
+
+  def validate_shape(_url, _opts), do: {:error, :invalid_url}
+
+  @doc """
   Validates `url` and returns the single IP to pin the connection to.
 
   Same checks as `validate_egress/2`, but on success returns

--- a/lib/loopctl/webhooks.ex
+++ b/lib/loopctl/webhooks.ex
@@ -8,6 +8,19 @@ defmodule Loopctl.Webhooks do
 
   All operations are tenant-scoped via `tenant_id` and include audit
   logging via `Ecto.Multi`.
+
+  ## Destinations are vetted at CONFIG TIME, not only at delivery time (US-41.5)
+
+  AC-41.5.3: creating or updating a subscription whose destination is not local
+  for an already-`local_only` scope is REJECTED here with a legible remediation,
+  rather than accepted and silently blocked on every later delivery. The check
+  needs tenant/DB state (the effective marking and the tenant's declarations), so
+  it lives in the context rather than the changeset — but it runs BEFORE the
+  `Ecto.Multi`, so nothing is persisted on rejection.
+
+  It consults the SAME single egress policy the delivery path does
+  (`Loopctl.Egress.webhook_destination_check/2` → `Loopctl.Egress.Policy`), with
+  purpose `:webhook`. There is deliberately no second copy of the URL rules here.
   """
 
   import Ecto.Query
@@ -15,6 +28,8 @@ defmodule Loopctl.Webhooks do
   alias Ecto.Multi
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
+  alias Loopctl.Egress
+  alias Loopctl.Egress.Scope
   alias Loopctl.Tenants
   alias Loopctl.Webhooks.Webhook
   alias Loopctl.Webhooks.WebhookEvent
@@ -56,6 +71,7 @@ defmodule Loopctl.Webhooks do
           signing_secret_encrypted: raw_secret
         }
         |> Webhook.create_changeset(attrs)
+        |> validate_destination_locality(tenant_id)
 
       multi =
         Multi.new()
@@ -182,7 +198,10 @@ defmodule Loopctl.Webhooks do
         "active" => webhook.active
       }
 
-      changeset = Webhook.update_changeset(webhook, attrs)
+      changeset =
+        webhook
+        |> Webhook.update_changeset(attrs)
+        |> validate_destination_locality(tenant_id)
 
       multi =
         Multi.new()
@@ -209,6 +228,7 @@ defmodule Loopctl.Webhooks do
       case AdminRepo.transaction(multi) do
         {:ok, %{webhook: updated}} -> {:ok, updated}
         {:error, :webhook, changeset, _} -> {:error, changeset}
+        {:error, _step, reason, _changes} -> {:error, reason}
       end
     end
   end
@@ -441,6 +461,34 @@ defmodule Loopctl.Webhooks do
   end
 
   # --- Private helpers ---
+
+  # AC-41.5.3. Runs ONLY when the destination URL is actually being set/changed
+  # AND the changeset is otherwise valid: classifying a URL that already failed
+  # `validate_egress/1` would replace a precise scheme/DNS error with a locality
+  # one, and re-classifying an UNCHANGED url on an unrelated update (e.g.
+  # `active: false`) would make a subscription that predates the marking
+  # un-editable — including the very edit that fixes it.
+  defp validate_destination_locality(%Ecto.Changeset{valid?: false} = changeset, _tenant_id),
+    do: changeset
+
+  defp validate_destination_locality(changeset, tenant_id) do
+    case Ecto.Changeset.get_change(changeset, :url) do
+      nil ->
+        changeset
+
+      url ->
+        project_id = Ecto.Changeset.get_field(changeset, :project_id)
+        scope = Scope.new(tenant_id, project_id)
+
+        case Egress.webhook_destination_check(scope, url) do
+          :ok ->
+            changeset
+
+          {:error, {_verdict, remediation}} ->
+            Ecto.Changeset.add_error(changeset, :url, remediation)
+        end
+    end
+  end
 
   defp generate_signing_secret do
     :crypto.strong_rand_bytes(32) |> Base.encode16(case: :lower)

--- a/lib/loopctl/webhooks.ex
+++ b/lib/loopctl/webhooks.ex
@@ -30,6 +30,7 @@ defmodule Loopctl.Webhooks do
   alias Loopctl.Audit
   alias Loopctl.Egress
   alias Loopctl.Egress.Scope
+  alias Loopctl.Projects.Project
   alias Loopctl.Tenants
   alias Loopctl.Webhooks.Webhook
   alias Loopctl.Webhooks.WebhookEvent
@@ -65,17 +66,15 @@ defmodule Loopctl.Webhooks do
          :ok <- check_webhook_limit(tenant_id, tenant) do
       raw_secret = generate_signing_secret()
 
-      changeset =
-        %Webhook{
-          tenant_id: tenant_id,
-          signing_secret_encrypted: raw_secret
-        }
-        |> Webhook.create_changeset(attrs)
-        |> validate_destination_locality(tenant_id)
+      base = %Webhook{tenant_id: tenant_id, signing_secret_encrypted: raw_secret}
 
       multi =
         Multi.new()
-        |> Multi.insert(:webhook, changeset)
+        |> lock_egress_config(tenant_id)
+        |> Multi.run(:changeset, fn _repo, _changes ->
+          validated_changeset(Webhook.create_changeset(base, attrs), tenant_id)
+        end)
+        |> Multi.insert(:webhook, & &1.changeset)
         |> Audit.log_in_multi(:audit, fn %{webhook: webhook} ->
           %{
             tenant_id: tenant_id,
@@ -98,7 +97,7 @@ defmodule Loopctl.Webhooks do
         {:ok, %{webhook: webhook}} ->
           {:ok, %{webhook: webhook, signing_secret: raw_secret}}
 
-        {:error, :webhook, changeset, _} ->
+        {:error, step, %Ecto.Changeset{} = changeset, _} when step in [:changeset, :webhook] ->
           {:error, changeset}
 
         {:error, _step, reason, _changes} ->
@@ -147,6 +146,45 @@ defmodule Loopctl.Webhooks do
 
     {:ok, %{data: webhooks, total: total, page: page, page_size: page_size}}
   end
+
+  @doc """
+  Every subscription `Loopctl.Egress` must classify, oldest first.
+
+  The ONE reader the egress guard uses, so webhook persistence stays behind THIS
+  context (US-41.5 review). `Loopctl.Egress` previously built its own queries
+  against `Loopctl.Webhooks.Webhook` for both the `local_only` pre-flight and the
+  posture report, which put the tenant-scoping predicate for webhooks in two
+  contexts: a later change to webhook visibility (soft delete, an archived flag,
+  a project-scoping rule) would have silently missed the guard and the report —
+  precisely the report/guard divergence the posture exists to prevent.
+
+  `project_id` selects the MARKING's coverage, not the delivery scope:
+
+    * `:all` — every subscription (a TENANT-scope marking covers all of them).
+    * a project UUID — only that project's subscriptions. A project marking
+      cannot cover a tenant-wide (project-less) subscription, whose delivery
+      scope it does not narrow (AC-41.4.2, most-restrictive-wins).
+
+  `:limit` bounds the number of rows an egress caller will classify (each
+  classification can cost a DNS resolve).
+  """
+  @spec list_for_egress(Ecto.UUID.t(), Ecto.UUID.t() | :all, keyword()) :: [Webhook.t()]
+  def list_for_egress(tenant_id, project_id \\ :all, opts \\ []) do
+    Webhook
+    |> where([w], w.tenant_id == ^tenant_id)
+    |> egress_project_filter(project_id)
+    |> order_by([w], asc: w.inserted_at)
+    |> maybe_limit(Keyword.get(opts, :limit))
+    |> AdminRepo.all()
+  end
+
+  defp egress_project_filter(query, :all), do: query
+
+  defp egress_project_filter(query, project_id),
+    do: where(query, [w], w.project_id == ^project_id)
+
+  defp maybe_limit(query, nil), do: query
+  defp maybe_limit(query, max) when is_integer(max), do: limit(query, ^max)
 
   @doc """
   Gets a webhook by ID, scoped to a tenant.
@@ -198,14 +236,13 @@ defmodule Loopctl.Webhooks do
         "active" => webhook.active
       }
 
-      changeset =
-        webhook
-        |> Webhook.update_changeset(attrs)
-        |> validate_destination_locality(tenant_id)
-
       multi =
         Multi.new()
-        |> Multi.update(:webhook, changeset)
+        |> lock_egress_config(tenant_id)
+        |> Multi.run(:changeset, fn _repo, _changes ->
+          validated_changeset(Webhook.update_changeset(webhook, attrs), tenant_id)
+        end)
+        |> Multi.update(:webhook, & &1.changeset)
         |> Audit.log_in_multi(:audit, fn %{webhook: updated} ->
           %{
             tenant_id: tenant_id,
@@ -226,9 +263,14 @@ defmodule Loopctl.Webhooks do
         end)
 
       case AdminRepo.transaction(multi) do
-        {:ok, %{webhook: updated}} -> {:ok, updated}
-        {:error, :webhook, changeset, _} -> {:error, changeset}
-        {:error, _step, reason, _changes} -> {:error, reason}
+        {:ok, %{webhook: updated}} ->
+          {:ok, updated}
+
+        {:error, step, %Ecto.Changeset{} = changeset, _} when step in [:changeset, :webhook] ->
+          {:error, changeset}
+
+        {:error, _step, reason, _changes} ->
+          {:error, reason}
       end
     end
   end
@@ -462,32 +504,125 @@ defmodule Loopctl.Webhooks do
 
   # --- Private helpers ---
 
-  # AC-41.5.3. Runs ONLY when the destination URL is actually being set/changed
-  # AND the changeset is otherwise valid: classifying a URL that already failed
-  # `validate_egress/1` would replace a precise scheme/DNS error with a locality
-  # one, and re-classifying an UNCHANGED url on an unrelated update (e.g.
-  # `active: false`) would make a subscription that predates the marking
-  # un-editable — including the very edit that fixes it.
+  # Serializes this write against a concurrent `Egress.enable_local_only/3` on the
+  # same tenant (review fix). The AC-41.5.3 config-time check reads the MARKING
+  # table, and the enable pre-flight reads the WEBHOOK table, so without a shared
+  # lock a subscription created between the pre-flight snapshot and the marking
+  # commit is neither refused here nor reported there — it is just silently
+  # blocked at delivery. Both writers take this lock FIRST and run their check
+  # inside it. See `Loopctl.Egress.lock_scope_config!/2`.
+  defp lock_egress_config(multi, tenant_id) do
+    Multi.run(multi, :egress_lock, fn repo, _changes ->
+      {:ok, Egress.lock_scope_config!(repo, tenant_id)}
+    end)
+  end
+
+  # The two DB-dependent validations, in the order their errors should surface:
+  # a `project_id` that is not this tenant's makes the egress SCOPE meaningless,
+  # so it is settled before the destination is classified under that scope.
+  #
+  # Returns an `{:ok, changeset}` / `{:error, changeset}` pair because it runs as
+  # a `Multi.run/3` step INSIDE the locked transaction (the classification would
+  # otherwise race the marking write). The DNS cost of a cache-missing
+  # classification is therefore paid while an `AdminRepo` connection is held —
+  # accepted deliberately: webhook writes are rare and capped by `max_webhooks`,
+  # and correctness of the config-time gate is the point of the story.
+  defp validated_changeset(changeset, tenant_id) do
+    validated =
+      changeset
+      |> validate_project_ownership(tenant_id)
+      |> validate_destination_locality(tenant_id)
+
+    if validated.valid?, do: {:ok, validated}, else: {:error, validated}
+  end
+
+  # `project_id` is cast from client input and its FK targets `projects.id`
+  # ALONE, so another tenant's project satisfies the database — and writes go
+  # through `AdminRepo`, which bypasses RLS. US-41.5 makes that load-bearing: the
+  # delivery scope IS `Scope.new(webhook.tenant_id, webhook.project_id)`, so a
+  # foreign `project_id` matches no marking of this tenant and side-steps a
+  # project-scoped `local_only` marking without touching the audited, `:user`-
+  # gated marking row (it also skews the pre-flight and the posture report, which
+  # scope by the same field). Validated here rather than by a composite FK so the
+  # caller gets a changeset error instead of a constraint violation, matching
+  # what `LoopctlWeb.EgressController` already does for its own `project_id`.
+  defp validate_project_ownership(%Ecto.Changeset{valid?: false} = changeset, _tenant_id),
+    do: changeset
+
+  defp validate_project_ownership(changeset, tenant_id) do
+    # `get_field/2` (not `get_change/2`): an update that changes only the URL must
+    # still be classified under a scope this tenant actually owns.
+    case Ecto.Changeset.get_field(changeset, :project_id) do
+      nil ->
+        changeset
+
+      project_id ->
+        if project_of_tenant?(tenant_id, project_id) do
+          changeset
+        else
+          Ecto.Changeset.add_error(
+            changeset,
+            :project_id,
+            "does not belong to this tenant (or does not exist)"
+          )
+        end
+    end
+  end
+
+  defp project_of_tenant?(tenant_id, project_id) do
+    Project
+    |> where([p], p.id == ^project_id and p.tenant_id == ^tenant_id)
+    |> limit(1)
+    |> AdminRepo.exists?()
+  end
+
+  # AC-41.5.3. Runs when the edit changes the EFFECTIVE EGRESS DECISION — the
+  # destination url, the scope it is delivered under (`project_id`), or a
+  # re-activation — AND the changeset is otherwise valid: classifying a URL that
+  # already failed `validate_egress/1` would replace a precise scheme/DNS error
+  # with a locality one.
+  #
+  # It deliberately does NOT run on an edit that touches neither (e.g.
+  # `active: false`, `events`), so a subscription that predates the marking stays
+  # editable — including by the very edit that fixes it.
+  #
+  # REVIEW FIX: keying only on a `:url` change left the check bypassable. The
+  # egress scope is `Scope.new(tenant_id, project_id)`, so a PATCH carrying only
+  # `project_id` re-scoped a public destination under a `local_only` project and
+  # was accepted — the "accepted, then silently blocked at delivery time" outcome
+  # AC-41.5.3 exists to prevent. A `false -> true` re-activation is checked for
+  # the same reason the pre-flight (AC-41.5.4) reports INACTIVE subscriptions:
+  # re-activating one under an unchanged marking would silently produce a blocked
+  # destination.
   defp validate_destination_locality(%Ecto.Changeset{valid?: false} = changeset, _tenant_id),
     do: changeset
 
   defp validate_destination_locality(changeset, tenant_id) do
-    case Ecto.Changeset.get_change(changeset, :url) do
-      nil ->
-        changeset
+    if egress_decision_changed?(changeset) do
+      url = Ecto.Changeset.get_field(changeset, :url)
+      project_id = Ecto.Changeset.get_field(changeset, :project_id)
+      scope = Scope.new(tenant_id, project_id)
 
-      url ->
-        project_id = Ecto.Changeset.get_field(changeset, :project_id)
-        scope = Scope.new(tenant_id, project_id)
+      case Egress.webhook_destination_check(scope, url) do
+        :ok ->
+          changeset
 
-        case Egress.webhook_destination_check(scope, url) do
-          :ok ->
-            changeset
-
-          {:error, {_verdict, remediation}} ->
-            Ecto.Changeset.add_error(changeset, :url, remediation)
-        end
+        {:error, {_verdict, remediation}} ->
+          Ecto.Changeset.add_error(changeset, :url, remediation)
+      end
+    else
+      changeset
     end
+  end
+
+  # `Map.has_key?/2` on `changes` rather than `get_change/2` for `:project_id`:
+  # UNSETTING the project (`project_id: nil`) widens a project-scoped delivery to
+  # the TENANT scope and must be classified too, and `get_change/2` returns nil
+  # for both "changed to nil" and "not changed".
+  defp egress_decision_changed?(changeset) do
+    not is_nil(Ecto.Changeset.get_change(changeset, :url)) or
+      Map.has_key?(changeset.changes, :project_id) or
+      Ecto.Changeset.get_change(changeset, :active) == true
   end
 
   defp generate_signing_secret do

--- a/lib/loopctl/webhooks/delivery_behaviour.ex
+++ b/lib/loopctl/webhooks/delivery_behaviour.ex
@@ -2,15 +2,48 @@ defmodule Loopctl.Webhooks.DeliveryBehaviour do
   @moduledoc """
   Behaviour for webhook HTTP delivery.
 
-  Implementations must accept a URL, JSON body, and headers,
-  then return success or failure with details.
+  Implementations must accept a URL, JSON body, headers and the EGRESS SCOPE the
+  delivery is made on behalf of, then return success, a delivery failure, or an
+  EGRESS REFUSAL.
+
+  ## Why the scope is a callback argument (US-41.5, AC-41.5.1)
+
+  Webhook delivery is content-carrying egress: the payload is tenant state. It
+  therefore consults the SAME single egress policy (`Loopctl.Egress.Policy`) as
+  the model-provider path, and that decision is scope-dependent
+  (most-restrictive-wins, `project OR tenant`). A behaviour without a scope
+  argument would force the implementation to re-derive the scope from the URL —
+  which is impossible — or to keep a private copy of the locality rules, which
+  AC-41.4.9 calls a review failure.
+
+  `scope: nil` marks OPERATOR-PLANE delivery (the scale-alert webhook, whose URL
+  is operator configuration and which carries no tenant content). There is no
+  tenant marking to apply, so nil-scope delivery is guarded by the SSRF denylist
+  alone — the same `Loopctl.Net.UrlGuard` denylist the policy composes, not a
+  second policy. See the triage table in `docs/egress-guard.md`.
+
+  ## `{:refused, refusal}` is NOT `{:error, reason}`
+
+  A refusal is a CONFIGURATION CONFLICT, not a delivery failure (AC-41.5.2). The
+  caller must be able to tell them apart: a failure retries and eventually
+  exhausts, whereas `:egress_blocked` is TERMINAL (no retry, no attempts burned)
+  and `:pin_stale` / `:egress_unavailable` are TRANSIENT (snooze, never
+  terminal). `Loopctl.Egress.oban_result/1` is the ONE mapping.
   """
 
+  alias Loopctl.Egress.Scope
+
   @type headers :: [{String.t(), String.t()}]
+  @type refusal :: {atom(), map()}
   @type delivery_result ::
           {:ok, %{status: integer(), body: String.t()}}
           | {:error, String.t()}
+          | {:refused, refusal()}
 
-  @callback deliver(url :: String.t(), body :: String.t(), headers :: headers()) ::
-              delivery_result()
+  @callback deliver(
+              url :: String.t(),
+              body :: String.t(),
+              headers :: headers(),
+              scope :: Scope.t() | nil
+            ) :: delivery_result()
 end

--- a/lib/loopctl/webhooks/req_delivery.ex
+++ b/lib/loopctl/webhooks/req_delivery.ex
@@ -4,23 +4,83 @@ defmodule Loopctl.Webhooks.ReqDelivery do
 
   Makes HTTP POST requests to webhook URLs with JSON payloads.
   Uses a 10-second timeout. Supports Req.Test plug for test mocking.
+
+  ## The egress decision is delegated, never re-derived (US-41.5, AC-41.5.1)
+
+  A webhook destination is a TENANT-SUPPLIED url carrying TENANT CONTENT, so it
+  consults the ONE egress policy (`Loopctl.Egress.Policy.check/4`) with purpose
+  `:webhook` and `tenant_supplied: true` — exactly as the ingestion fetch and the
+  tenant-configured chat endpoint do. That single call subsumes what this module
+  used to do with a bare `UrlGuard.pin/1`, and adds the locality decision on top:
+
+    * the SSRF denylist stays MANDATORY for every scope, marked or not
+      (`tenant_supplied: true` makes a `:denylisted` verdict the PERMANENT
+      `:egress_blocked` on the default path) — GHSA-jh42-wf7g-f5rg stays closed;
+    * on a `local_only` scope a destination that is not `:network_local`
+      (operator deployment allowlist) or `:tenant_declared` FOR THE `webhook`
+      PURPOSE is refused BEFORE the request is built;
+    * conversely, an allowlisted or purpose-declared destination now BECOMES
+      deliverable — the old unconditional `UrlGuard.pin/1` refused every
+      loopback/private destination for every tenant.
+
+  The pin is still applied (`pinned_request_opts/2` + `redirect: false`), so the
+  IP connected to is the IP that was classified: no second resolution for an
+  attacker to rebind (ie-02 / GHSA-jh42-wf7g-f5rg).
+
+  `scope: nil` is OPERATOR-PLANE delivery (scale alerts). No tenant marking
+  applies, so it keeps the SSRF denylist alone — the same `UrlGuard` primitive
+  the policy composes, not a second policy. See `docs/egress-guard.md`.
   """
 
   @behaviour Loopctl.Webhooks.DeliveryBehaviour
 
+  alias Loopctl.Egress.Policy
+  alias Loopctl.Egress.Scope
   alias Loopctl.Net.UrlGuard
 
   @impl true
-  def deliver(url, body, headers) do
-    # Validate AND pin at delivery time (not just at changeset time) to defend
-    # against DNS rebinding / TOCTOU (ie-02 / GHSA-jh42-wf7g-f5rg): pin/1 resolves
-    # the host ONCE, and pinned_request_opts/1 makes Req connect to that exact IP
-    # while keeping the original host for Host/SNI/cert — so there is no second
-    # resolution for an attacker to rebind.
+  def deliver(url, body, headers, scope)
+
+  def deliver(url, body, headers, %Scope{} = scope) do
+    # `tenant_supplied: true`: the destination is tenant-writable, so the default
+    # (non-local_only) path must NOT degrade to an unpinned, redirect-following
+    # request when classification fails — it fails CLOSED as the TRANSIENT
+    # `:egress_unavailable`, and a denylisted host is the PERMANENT
+    # `:egress_blocked`. That is the same semantic the old `UrlGuard.pin/1`
+    # refusal had, expressed through the ONE policy.
+    case Policy.check(scope, url, :webhook, tenant_supplied: true) do
+      {:ok, %{} = pinned} ->
+        do_deliver(pinned, body, headers)
+
+      # Unreachable for `tenant_supplied: true` (that path refuses instead of
+      # degrading), but the policy's contract still admits it — so handle it as a
+      # REFUSAL rather than letting a future policy change silently hand webhook
+      # delivery an unpinned, redirect-following request to a tenant-chosen host.
+      {:ok, :unpinned} ->
+        {:refused, {:egress_unavailable, unpinnable_details(scope, url)}}
+
+      {:error, tag, details} ->
+        {:refused, {tag, details}}
+    end
+  end
+
+  def deliver(url, body, headers, nil) do
     case UrlGuard.pin(url) do
       {:ok, pinned} -> do_deliver(pinned, body, headers)
       {:error, reason} -> {:error, "blocked_url: #{reason}"}
     end
+  end
+
+  defp unpinnable_details(scope, url) do
+    %{
+      host: URI.parse(url).host,
+      scope: Scope.key(scope),
+      verdict: :unclassifiable,
+      remediation:
+        "The webhook destination could not be pinned, so nothing was sent. This is " <>
+          "TRANSIENT — the delivery is retried. Verify the destination host resolves " <>
+          "from loopctl and re-check with the egress_posture tool."
+    }
   end
 
   defp do_deliver(pinned, body, headers) do

--- a/lib/loopctl/webhooks/webhook.ex
+++ b/lib/loopctl/webhooks/webhook.ex
@@ -102,21 +102,29 @@ defmodule Loopctl.Webhooks.Webhook do
     |> foreign_key_constraint(:project_id)
   end
 
-  # SSRF egress guard (ie-02 / GHSA-jh42-wf7g-f5rg). Delegates to the shared
-  # Loopctl.Net.UrlGuard, which does scheme allowlisting, real DNS resolution,
-  # and a private/loopback/link-local/metadata blocklist for BOTH IPv4 and IPv6
-  # (the old @private_ip_prefixes string blocklist missed IPv6, numeric IPv4,
-  # 0.0.0.0, and did no DNS resolution). Re-validated again at delivery time in
-  # Loopctl.Webhooks.ReqDelivery to defend against DNS rebinding.
+  # URL SHAPE validation only: scheme allowlist + host presence, via the shared
+  # `Loopctl.Net.UrlGuard`.
+  #
+  # The ADDRESS decision (DNS resolution + the private/loopback/metadata
+  # denylist) is DELIBERATELY NOT made here (US-41.5, AC-41.5.1/AC-41.5.6). A
+  # changeset cannot see the tenant, so it cannot consult the OPERATOR deployment
+  # allowlist — and deciding here kept a PRIVATE COPY of the URL rules that
+  # permanently refused every allowlisted loopback/private destination, which is
+  # exactly the destination the epic's local_only tier needs to reach. It also
+  # meant TWO DNS resolutions per write once the context started classifying.
+  #
+  # `Loopctl.Webhooks` therefore makes the ONE policy call
+  # (`Egress.webhook_destination_check/2`) right after this, and
+  # `Loopctl.Webhooks.ReqDelivery` re-applies it at delivery time. A
+  # non-allowlisted private destination is still rejected in BOTH places, so
+  # nothing is weakened (ie-02 / GHSA-jh42-wf7g-f5rg).
   defp validate_url(changeset) do
     validate_change(changeset, :url, fn :url, url ->
-      case UrlGuard.validate_egress(url) do
+      case UrlGuard.validate_shape(url) do
         {:ok, _uri} -> []
         {:error, :invalid_scheme} -> [url: "must use HTTPS or HTTP scheme"]
         {:error, :missing_host} -> [url: "must have a valid host"]
-        {:error, :invalid_url} -> [url: "must be a valid URL"]
-        {:error, :dns_resolution_failed} -> [url: "host could not be resolved"]
-        {:error, :blocked_ip} -> [url: "must not target a private or loopback address"]
+        {:error, _other} -> [url: "must be a valid URL"]
       end
     end)
   end

--- a/lib/loopctl/webhooks/webhook_event.ex
+++ b/lib/loopctl/webhooks/webhook_event.ex
@@ -12,13 +12,28 @@ defmodule Loopctl.Webhooks.WebhookEvent do
   - `delivered` -- successfully delivered (HTTP 2xx)
   - `failed` -- delivery failed, may be retried
   - `exhausted` -- all retry attempts used up
+  - `blocked` -- REFUSED by the egress guard before any request was made
+
+  ## `blocked` is deliberately NOT `failed` (US-41.5, AC-41.5.2)
+
+  A blocked delivery is a CONFIGURATION CONFLICT between the subscription's
+  destination and the scope's `local_only` marking (or the SSRF denylist) — not
+  a flaky endpoint. An operator or agent reading the delivery list needs to tell
+  them apart: `failed`/`exhausted` mean "the endpoint did not accept it, we
+  retried"; `blocked` means "loopctl refused to send it, and retrying changes
+  nothing until the configuration changes". It is TERMINAL: no attempts are
+  burned and no retry is scheduled.
+
+  `error` carries the agent-readable reason from `Loopctl.Egress.refusal_reason/1`,
+  prefixed with the BLOCK KIND (`ssrf_denied` vs `locality_denied`) so the two
+  refusal causes stay distinguishable.
   """
 
   use Loopctl.Schema
 
   @type t :: %__MODULE__{}
 
-  @statuses [:pending, :delivered, :failed, :exhausted]
+  @statuses [:pending, :delivered, :failed, :exhausted, :blocked]
 
   schema "webhook_events" do
     tenant_field()

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -64,7 +64,6 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
   alias Loopctl.Llm.ShapeError
-  alias Loopctl.Net.UrlGuard
   alias Loopctl.Oban.FairShare
   alias Loopctl.Provider
   alias Loopctl.Provider.Admission
@@ -655,46 +654,43 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   end
 
   defp resolve_content(scope, url, _content) when is_binary(url) do
-    # SSRF egress guard (worker-01 / GHSA-j7m9-ffmr-pwhm) AND the US-41.4 local_only
-    # guard, in that order — they are different controls:
+    # ONE address decision (US-41.5 review). This used to gate on `UrlGuard.pin/1`
+    # FIRST and only then consult the policy, which meant:
     #
-    #   * `UrlGuard.pin/1` is the SSRF denylist. It runs FIRST and unconditionally,
-    #     because a private-range URL must be refused for EVERY tenant, marked or not.
-    #   * `Loopctl.Provider.get/3` then applies the ONE egress policy (AC-41.4.9:
-    #     ingestion consults it too, not just the provider guard and the probe). The
-    #     purpose is `:ingest`: a host declared for `inference` does NOT authorize
-    #     loopctl to fetch tenant-supplied URLs on a local_only scope.
-    case UrlGuard.pin(url) do
-      {:ok, pinned} -> fetch_url(scope, url, pinned)
-      {:error, reason} -> blocked_url(url, reason)
-    end
+    #   * the pre-gate could not see the OPERATOR deployment allowlist, so an
+    #     allowlisted private host was a legal WEBHOOK destination but still a hard
+    #     refusal as an INGESTION source — an asymmetry inside the very path
+    #     US-41.5 unified; and
+    #   * every fetch resolved the URL twice.
+    #
+    # `Loopctl.Provider.get/3` now makes the whole decision through
+    # `Loopctl.Egress.Policy` with `tenant_supplied_url: true`, which is what turns
+    # a `:denylisted` verdict into the PERMANENT `:egress_blocked` on the default
+    # (unmarked) path — so the SSRF denylist stays mandatory for EVERY tenant,
+    # marked or not (worker-01 / GHSA-j7m9-ffmr-pwhm), and `denylist_gate/4` is the
+    # single place that call is made. The purpose is `:ingest`: a host declared for
+    # `inference` does NOT authorize loopctl to fetch tenant-supplied URLs.
+    fetch_url(scope, url)
   end
 
   defp resolve_content(_scope, nil, _), do: {:error, :no_content}
 
-  defp blocked_url(url, reason) do
-    Logger.warning(
-      "ContentIngestionWorker: refusing to fetch blocked URL " <>
-        "(url=#{url}, reason=#{reason})"
-    )
-
-    {:error, {:url_blocked, reason}}
-  end
-
-  defp fetch_url(scope, url, pinned) do
+  defp fetch_url(scope, url) do
     req_opts =
-      UrlGuard.pinned_request_opts(pinned)
-      |> Keyword.merge(
+      [
         receive_timeout: 15_000,
         retry: :transient,
         max_retries: 1,
         # Do not follow redirects — a redirect hop would re-enter an unvalidated
         # URL and bypass the egress guard (worker-01 / GHSA-j7m9-ffmr-pwhm).
+        # `Provider` sets this too for a pinned request; belt and braces.
         redirect: false
-      )
+      ]
       |> maybe_add_plug()
 
-    case Provider.get(url, req_opts, %{scope: scope, purpose: :ingest, pinned_by_caller: true}) do
+    ctx = %{scope: scope, purpose: :ingest, tenant_supplied_url: true}
+
+    case Provider.get(url, req_opts, ctx) do
       {:ok, %{status: status} = resp} when status in 200..299 ->
         handle_fetched_body(resp.body, Req.Response.get_header(resp, "content-type"))
 

--- a/lib/loopctl/workers/scale_alert_delivery_worker.ex
+++ b/lib/loopctl/workers/scale_alert_delivery_worker.ex
@@ -97,10 +97,20 @@ defmodule Loopctl.Workers.ScaleAlertDeliveryWorker do
     body = Jason.encode!(payload)
     headers = [{"content-type", "application/json"}]
 
-    case @delivery_client.deliver(url, body, headers) do
+    # `scope: nil` — OPERATOR-PLANE delivery (US-41.5). The URL is operator
+    # configuration, not tenant data, and the payload carries metric names and
+    # thresholds, not tenant content: there is no tenant `local_only` marking to
+    # apply. It stays guarded by the SSRF denylist (the same `UrlGuard` primitive
+    # the egress policy composes). Triaged in `docs/egress-guard.md`.
+    case @delivery_client.deliver(url, body, headers, nil) do
       {:ok, _resp} ->
         :ok
 
+      # There is deliberately NO `{:refused, _}` clause. Passing `scope: nil` above
+      # selects the operator-plane delivery path, which makes no locality decision
+      # and therefore cannot refuse — the compiler proves it (Elixir 1.19 flags a
+      # clause here as a typing violation), so adding one for symmetry would be
+      # dead code that misrepresents the contract.
       {:error, reason} ->
         Logger.warning(
           "ScaleAlertDeliveryWorker: delivery failed (#{inspect(reason)}), Oban will retry"

--- a/lib/loopctl/workers/webhook_cleanup_worker.ex
+++ b/lib/loopctl/workers/webhook_cleanup_worker.ex
@@ -2,10 +2,18 @@ defmodule Loopctl.Workers.WebhookCleanupWorker do
   @moduledoc """
   Oban worker that prunes old webhook_events records.
 
-  Runs daily via the Oban Cron plugin. Deletes webhook events with status
-  `delivered` or `exhausted` that are older than the configurable retention
-  period (default: 30 days). Events with status `pending` or `failed` are
-  never pruned (they are still in-flight).
+  Runs daily via the Oban Cron plugin. Deletes webhook events in a TERMINAL
+  status — `delivered`, `exhausted` or `blocked` — that are older than the
+  configurable retention period (default: 30 days). Events with status `pending`
+  or `failed` are never pruned (they are still in-flight).
+
+  `:blocked` (US-41.5) is terminal exactly like `:exhausted`, so retention
+  applies identically — and it is the status most likely to be produced in VOLUME
+  by a persistent misconfiguration: a blocked delivery deliberately does not
+  increment `consecutive_failures`, so the auto-disable valve never fires and a
+  `local_only` tenant with one incompatible subscription emits a blocked row per
+  matching state change indefinitely. Excluding it from retention (the review
+  finding this comment records) meant those rows were never reclaimed.
 
   Deletions are batched (1000 per iteration) to avoid long-running transactions.
   """
@@ -22,6 +30,11 @@ defmodule Loopctl.Workers.WebhookCleanupWorker do
 
   @default_retention_days 30
   @batch_size 1000
+
+  # Terminal statuses — the ones retention may reclaim. Keep in parity with
+  # `Loopctl.Webhooks.WebhookEvent`'s status enum: a new terminal status that is
+  # not listed here is never pruned.
+  @terminal_statuses [:delivered, :exhausted, :blocked]
 
   @impl Oban.Worker
   def perform(_job) do
@@ -65,7 +78,7 @@ defmodule Loopctl.Workers.WebhookCleanupWorker do
     ids =
       WebhookEvent
       |> where([e], e.tenant_id == ^tenant_id)
-      |> where([e], e.status in [:delivered, :exhausted])
+      |> where([e], e.status in ^@terminal_statuses)
       |> where([e], e.inserted_at < ^cutoff)
       |> select([e], e.id)
       |> limit(@batch_size)

--- a/lib/loopctl/workers/webhook_delivery_worker.ex
+++ b/lib/loopctl/workers/webhook_delivery_worker.ex
@@ -14,9 +14,27 @@ defmodule Loopctl.Workers.WebhookDeliveryWorker do
   1. Load webhook_event and associated webhook
   2. Check webhook is active (mark failed if deactivated)
   3. Build delivery payload with signing headers (US-10.4)
-  4. Make HTTP POST via delivery client
-  5. Update event status (delivered/failed/exhausted)
+  4. Make HTTP POST via delivery client, on the webhook's EGRESS SCOPE
+  5. Update event status (delivered/failed/exhausted/blocked)
   6. Update webhook consecutive_failures
+
+  ## Egress refusals are not delivery failures (US-41.5, AC-41.5.2/AC-41.5.5)
+
+  `Loopctl.Egress.oban_result/1` is the reference mapping and this worker follows
+  its SEMANTICS, not its literal return: the queue is `max_attempts: 1` with
+  app-level snooze retries, so a refusal must not burn an attempt or re-enter the
+  backoff ladder.
+
+    * `:egress_blocked` is PERMANENT — the event is marked `:blocked` with an
+      agent-readable reason, the aggregated blocked-decision counter is bumped,
+      and the job returns `:ok`. TERMINAL: no snooze, no attempt consumed, no
+      `consecutive_failures` increment (the subscriber never failed — loopctl
+      refused to call it), so a misconfigured subscription cannot build an
+      unbounded retry backlog (TC-41.5.5).
+    * `:pin_stale` / `:egress_unavailable` are TRANSIENT — the job snoozes for
+      `Egress.transient_snooze_seconds/0` WITHOUT consuming an attempt and
+      WITHOUT recording a block. A DHCP lease change or a pool blip must never
+      look like a privacy refusal.
   """
 
   use Oban.Worker, queue: :webhooks, max_attempts: 1
@@ -24,6 +42,8 @@ defmodule Loopctl.Workers.WebhookDeliveryWorker do
   require Logger
 
   alias Loopctl.AdminRepo
+  alias Loopctl.Egress
+  alias Loopctl.Egress.Scope
   alias Loopctl.Webhooks
   alias Loopctl.Webhooks.Signing
   alias Loopctl.Webhooks.Webhook
@@ -80,14 +100,60 @@ defmodule Loopctl.Workers.WebhookDeliveryWorker do
     # Build headers with HMAC-SHA256 signature
     headers = build_headers(event, webhook, json_body)
 
-    case @delivery_client.deliver(webhook.url, json_body, headers) do
+    # The delivery scope is the webhook's own (tenant, project) pair —
+    # most-restrictive-wins, and a project-less subscription follows the TENANT
+    # marking (AC-41.4.2 / AC-41.5.1).
+    scope = Scope.new(webhook.tenant_id, webhook.project_id)
+
+    case @delivery_client.deliver(webhook.url, json_body, headers, scope) do
       {:ok, _response} ->
         mark_delivered(event, webhook)
         :ok
 
+      {:refused, refusal} ->
+        handle_refusal(event, webhook, scope, refusal)
+
       {:error, error_msg} ->
         handle_failure(event, webhook, error_msg)
     end
+  end
+
+  # AC-41.5.2: a blocked delivery is NOT a silent drop and NOT an infinite retry.
+  defp handle_refusal(event, webhook, scope, refusal) do
+    case Egress.block_kind(refusal) do
+      :transient ->
+        Logger.info(
+          "WebhookDeliveryWorker: transient egress refusal for webhook #{webhook.id}, " <>
+            "snoozing without burning an attempt — #{Egress.refusal_reason(refusal)}"
+        )
+
+        {:snooze, Egress.transient_snooze_seconds()}
+
+      kind ->
+        mark_blocked(event, scope, kind, refusal)
+        :ok
+    end
+  end
+
+  defp mark_blocked(event, scope, kind, {_tag, details} = refusal) do
+    reason = "#{kind}: #{Egress.refusal_reason(refusal)}"
+
+    Logger.warning(
+      "WebhookDeliveryWorker: delivery REFUSED before any request (event_id=#{event.id}) — " <>
+        reason
+    )
+
+    # The aggregated, deduplicated AC-41.4.6 record + the unbuffered
+    # [:loopctl, :egress, :blocked] telemetry counter.
+    Egress.record_blocked(scope, details)
+
+    event
+    |> Ecto.Changeset.change(%{
+      status: :blocked,
+      last_attempt_at: DateTime.utc_now(),
+      error: reason
+    })
+    |> AdminRepo.update!()
   end
 
   defp build_delivery_payload(event) do

--- a/lib/loopctl/workers/webhook_delivery_worker.ex
+++ b/lib/loopctl/workers/webhook_delivery_worker.ex
@@ -35,6 +35,23 @@ defmodule Loopctl.Workers.WebhookDeliveryWorker do
       `Egress.transient_snooze_seconds/0` WITHOUT consuming an attempt and
       WITHOUT recording a block. A DHCP lease change or a pool blip must never
       look like a privacy refusal.
+
+  ### The transient path is BOUNDED (review fix)
+
+  "Transient" is a claim about the CAUSE, not a promise that it ends. A webhook
+  destination whose domain lapses classifies as `:egress_unavailable` on EVERY
+  attempt (fail-closed for a tenant-supplied url), so an unconditional snooze —
+  on a `max_attempts: 1` queue where each snooze also bumps `max_attempts` —
+  produced one IMMORTAL job per event: `attempts` stayed 0, the event stayed
+  `:pending`, `consecutive_failures` never rose, the subscription was never
+  auto-disabled, and every new event added another permanent job. That
+  contradicts AC-41.5.2 ("NOT an infinite retry").
+
+  So a transient refusal snoozes for free at most `@max_transient_snoozes` times
+  per job; after that it falls through to the ORDINARY failure ladder
+  (`handle_failure/3`) — burning an attempt each time, reaching `:exhausted` at
+  `@max_attempts`, incrementing `consecutive_failures` and reaching the
+  auto-disable valve, exactly as an unreachable destination did before US-41.5.
   """
 
   use Oban.Worker, queue: :webhooks, max_attempts: 1
@@ -59,6 +76,19 @@ defmodule Loopctl.Workers.WebhookDeliveryWorker do
   @backoff_schedule [60, 300, 1500, 7200, 36_000]
   @max_attempts 6
 
+  # How many times ONE job may snooze for free on a TRANSIENT egress refusal
+  # before the refusal is treated as an ordinary delivery failure. Bounds the
+  # snooze path (see the moduledoc) so an unresolvable destination cannot produce
+  # an immortal job.
+  @max_transient_snoozes 6
+
+  @doc """
+  Free (attempt-less) transient-egress snoozes allowed per job before the
+  ordinary failure ladder takes over.
+  """
+  @spec max_transient_snoozes() :: pos_integer()
+  def max_transient_snoozes, do: @max_transient_snoozes
+
   @doc """
   Returns the backoff duration in seconds for the given attempt number (1-based).
   """
@@ -76,12 +106,12 @@ defmodule Loopctl.Workers.WebhookDeliveryWorker do
   def timeout(_job), do: :timer.seconds(30)
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"webhook_event_id" => event_id, "tenant_id" => tenant_id}}) do
+  def perform(%Oban.Job{args: %{"webhook_event_id" => event_id, "tenant_id" => tenant_id}} = job) do
     with {:ok, event} <- load_event(tenant_id, event_id),
          {:ok, webhook} <- load_webhook(tenant_id, event.webhook_id) do
       # Check if webhook is active (unless test event)
       if webhook.active or event.event_type == "webhook.test" do
-        attempt_delivery(event, webhook)
+        attempt_delivery(job, event, webhook)
       else
         mark_deactivated(event)
       end
@@ -92,7 +122,7 @@ defmodule Loopctl.Workers.WebhookDeliveryWorker do
     end
   end
 
-  defp attempt_delivery(event, webhook) do
+  defp attempt_delivery(job, event, webhook) do
     # Build and size-limit the delivery payload
     payload = build_delivery_payload(event)
     json_body = Signing.prepare_payload(payload)
@@ -111,7 +141,7 @@ defmodule Loopctl.Workers.WebhookDeliveryWorker do
         :ok
 
       {:refused, refusal} ->
-        handle_refusal(event, webhook, scope, refusal)
+        handle_refusal(job, event, webhook, scope, refusal)
 
       {:error, error_msg} ->
         handle_failure(event, webhook, error_msg)
@@ -119,15 +149,10 @@ defmodule Loopctl.Workers.WebhookDeliveryWorker do
   end
 
   # AC-41.5.2: a blocked delivery is NOT a silent drop and NOT an infinite retry.
-  defp handle_refusal(event, webhook, scope, refusal) do
+  defp handle_refusal(job, event, webhook, scope, refusal) do
     case Egress.block_kind(refusal) do
       :transient ->
-        Logger.info(
-          "WebhookDeliveryWorker: transient egress refusal for webhook #{webhook.id}, " <>
-            "snoozing without burning an attempt — #{Egress.refusal_reason(refusal)}"
-        )
-
-        {:snooze, Egress.transient_snooze_seconds()}
+        handle_transient_refusal(job, event, webhook, refusal)
 
       kind ->
         mark_blocked(event, scope, kind, refusal)
@@ -135,7 +160,44 @@ defmodule Loopctl.Workers.WebhookDeliveryWorker do
     end
   end
 
-  defp mark_blocked(event, scope, kind, {_tag, details} = refusal) do
+  # BOUNDED (see the moduledoc): free snoozes first, then the ordinary failure
+  # ladder, so a permanently-unresolvable destination still exhausts and still
+  # reaches the auto-disable valve.
+  defp handle_transient_refusal(job, event, webhook, refusal) do
+    reason = Egress.refusal_reason(refusal)
+
+    if transient_snoozes(job, event) < @max_transient_snoozes do
+      Logger.info(
+        "WebhookDeliveryWorker: transient egress refusal for webhook #{webhook.id}, " <>
+          "snoozing without burning an attempt — #{reason}"
+      )
+
+      {:snooze, Egress.transient_snooze_seconds()}
+    else
+      Logger.warning(
+        "WebhookDeliveryWorker: transient egress refusal for webhook #{webhook.id} PERSISTED " <>
+          "past #{@max_transient_snoozes} free snoozes; treating it as a delivery failure — " <>
+          reason
+      )
+
+      handle_failure(event, webhook, "egress_unavailable_persisted: #{reason}")
+    end
+  end
+
+  # Free snoozes taken by THIS job so far, derived — no new column.
+  #
+  # Oban increments `attempt` on every execution and bumps `max_attempts` on a
+  # snooze, so for a job that has executed `attempt` times of which `attempts`
+  # (the EVENT's counter) burned a delivery attempt, the remainder are the free
+  # transient snoozes. Clamped at 0 so a hand-built job (`attempt: 0`) is safe.
+  defp transient_snoozes(%Oban.Job{attempt: attempt}, event) when is_integer(attempt) do
+    max(attempt - event.attempts - 1, 0)
+  end
+
+  defp transient_snoozes(_job, _event), do: 0
+
+  defp mark_blocked(event, scope, kind, refusal) do
+    details = refusal_details(scope, refusal)
     reason = "#{kind}: #{Egress.refusal_reason(refusal)}"
 
     Logger.warning(
@@ -154,6 +216,27 @@ defmodule Loopctl.Workers.WebhookDeliveryWorker do
       error: reason
     })
     |> AdminRepo.update!()
+  end
+
+  # `Egress.block_kind/1` classifies an UNRECOGNISED refusal term as terminal
+  # (`:unrecognized`), so the details map it carries may not exist. Synthesize one
+  # rather than crashing the block record — the aggregated counter still names the
+  # scope, and the event's `error` carries the raw term.
+  defp refusal_details(scope, refusal) do
+    case Egress.refusal(refusal) do
+      {_tag, details} ->
+        details
+
+      nil ->
+        %{
+          host: nil,
+          scope: Scope.key(scope),
+          verdict: :unrecognized_refusal,
+          remediation:
+            "The delivery client returned a refusal term the egress policy does not " <>
+              "recognise. Nothing was sent. This is a loopctl BUG — report it."
+        }
+    end
   end
 
   defp build_delivery_payload(event) do

--- a/lib/loopctl_web/controllers/egress_controller.ex
+++ b/lib/loopctl_web/controllers/egress_controller.ex
@@ -153,6 +153,11 @@ defmodule LoopctlWeb.EgressController do
   ARE. The deployment allowlist CONTENTS appear only at `:user`+ — at `:agent`
   the payload carries only a boolean per endpoint saying whether the verdict came
   from the allowlist.
+
+  Webhook destinations follow the same split: `host` + `verdict` +
+  `blocked_by_local_only` at `:agent`, the FULL destination URL only at `:user`+
+  (a webhook path is frequently the credential, and reading webhook URLs is
+  `role: :user` everywhere else).
   """
   def posture(conn, _params) do
     key = conn.assigns.current_api_key
@@ -168,6 +173,11 @@ defmodule LoopctlWeb.EgressController do
   `egress_blocked`, responds `409 would_block_endpoints` NAMING each offending
   endpoint. Retry with `"acknowledge": true` to proceed; the response then
   REPORTS the resulting blocked posture. Never a silent tenant-wide outage.
+
+  Webhook entries in `blocked_endpoints` carry only the destination HOST below
+  role `:user` (`Egress.redact_blocked_endpoints/2`) — this endpoint is
+  `:orchestrator`, one level under the `role: :user` gate on
+  `LoopctlWeb.WebhookController`, and a webhook path is frequently the credential.
   """
   def enable_local_only(conn, params) do
     key = conn.assigns.current_api_key
@@ -185,7 +195,7 @@ defmodule LoopctlWeb.EgressController do
         json(conn, %{
           local_only: true,
           scope: scope_label(params["project_id"]),
-          blocked_endpoints: blocked,
+          blocked_endpoints: Egress.redact_blocked_endpoints(blocked, key.role),
           acknowledged: params["acknowledge"] == true,
           note: blocked_note(blocked)
         })
@@ -204,7 +214,7 @@ defmodule LoopctlWeb.EgressController do
               "offending webhook subscription(s), or retry with acknowledge=true to " <>
               "accept the resulting blocked posture. Nothing was changed and no " <>
               "subscription was disabled.",
-          blocked_endpoints: blocked
+          blocked_endpoints: Egress.redact_blocked_endpoints(blocked, key.role)
         })
 
       {:error, reason} ->

--- a/lib/loopctl_web/controllers/egress_controller.ex
+++ b/lib/loopctl_web/controllers/egress_controller.ex
@@ -197,10 +197,13 @@ defmodule LoopctlWeb.EgressController do
           error: "would_block_endpoints",
           message:
             "Enabling local_only on this scope would immediately block " <>
-              "#{length(blocked)} currently-resolved endpoint(s). Configure a " <>
+              "#{length(blocked)} currently-resolved endpoint(s) and/or webhook " <>
+              "subscription(s) (see blocked_endpoints[].kind). Configure a " <>
               "satisfying endpoint AT TENANT level (role :user), declare a trusted " <>
-              "endpoint (role :user), or retry with acknowledge=true to accept the " <>
-              "resulting blocked posture.",
+              "endpoint for the required purpose (role :user), repoint or remove the " <>
+              "offending webhook subscription(s), or retry with acknowledge=true to " <>
+              "accept the resulting blocked posture. Nothing was changed and no " <>
+              "subscription was disabled.",
           blocked_endpoints: blocked
         })
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -4962,7 +4962,8 @@ const TOOLS = [
     name: "egress_posture",
     description:
       "VERIFY BEFORE YOU HARVEST. Reports this instance's egress posture for YOUR tenant: " +
-      "the resolved embedding and chat endpoints, a locality VERDICT for each " +
+      "the resolved embedding and chat endpoints, EVERY webhook destination " +
+      "(webhook_destinations), a locality VERDICT for each " +
       "(network-local / 'tenant-declared (unverified attestation), not network-local' / " +
       "non-local), your declared trusted endpoints with their purposes, per-scope " +
       "local_only status, and any named posture defects. Endpoints are shown; KEYS NEVER " +
@@ -4972,9 +4973,11 @@ const TOOLS = [
       "infrastructure and are NOT disclosed at agent role: you get only a boolean per " +
       "endpoint saying whether its verdict came from the allowlist (contents at user+). " +
       "SCOPE OF THE GUARANTEE: fail-closed enforcement covers every outbound HTTP call " +
-      "made by loopctl application code on the MODEL-PROVIDER path. Webhook delivery is " +
-      "not covered yet (US-41.5), and HTTP performed inside a dependency, plus this " +
-      "separate mcp-server codebase, are outside the static chokepoint check.",
+      "made by loopctl application code on every CONTENT-CARRYING path — model-provider " +
+      "calls, the ingestion fetch, and webhook delivery (US-41.5). HTTP performed inside " +
+      "a dependency, plus this separate mcp-server codebase, are outside the static " +
+      "chokepoint check; the remaining non-content outbound paths are triaged in " +
+      "docs/egress-guard.md.",
     inputSchema: { type: "object", properties: {}, required: [] },
   },
   {
@@ -4985,10 +4988,13 @@ const TOOLS = [
       "everywhere; nothing changes until a scope opts in. Scope resolution is " +
       "MOST-RESTRICTIVE-WINS (project OR tenant) and a project can NEVER relax a tenant " +
       "marking. MANDATORY PRE-FLIGHT: the call is REFUSED with 409 would_block_endpoints, " +
-      "naming every endpoint that would become egress_blocked, unless you pass " +
+      "naming every endpoint that would become egress_blocked — including every WEBHOOK " +
+      "SUBSCRIPTION whose destination would be refused (kind: 'webhook', US-41.5) — " +
+      "unless you pass " +
       "acknowledge: true — because on a tenant still using vendor default endpoints this " +
       "instantly stops embedding, extraction, classification and merge, and only a " +
-      "human user-role key can undo it. Requires an ORCHESTRATOR key: tightening is safe " +
+      "human user-role key can undo it. Subscriptions are never silently disabled: they " +
+      "are either the reason for the refusal, or reported back to you on acknowledgement. Requires an ORCHESTRATOR key: tightening is safe " +
       "to automate. CLEARING is a different tool (clear_local_only) and is user-only.",
     inputSchema: {
       type: "object",

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -4972,6 +4972,9 @@ const TOOLS = [
       "key you already have. NOTE the deployment allowlist CONTENTS are operator " +
       "infrastructure and are NOT disclosed at agent role: you get only a boolean per " +
       "endpoint saying whether its verdict came from the allowlist (contents at user+). " +
+      "Webhook destinations follow the same split: HOST plus verdict plus " +
+      "blocked_by_local_only at agent role, the FULL destination URL (endpoint) only at " +
+      "user+ — a webhook path is frequently the credential. " +
       "SCOPE OF THE GUARANTEE: fail-closed enforcement covers every outbound HTTP call " +
       "made by loopctl application code on every CONTENT-CARRYING path — model-provider " +
       "calls, the ingestion fetch, and webhook delivery (US-41.5). HTTP performed inside " +

--- a/test/loopctl/egress/chokepoint_scan_test.exs
+++ b/test/loopctl/egress/chokepoint_scan_test.exs
@@ -115,15 +115,60 @@ defmodule Loopctl.Egress.ChokepointScanTest do
       end
     end
 
-    test "the known-unguarded call sites are named explicitly, not silently missed" do
+    test "the remaining non-content call sites are named explicitly, not silently missed" do
       allowed = ChokepointScan.allowed()
 
-      # These three are the sites Admission itself misses today. Naming them here
-      # is the point: the gap is DOCUMENTED, not invisible.
-      assert Map.has_key?(allowed, "Loopctl.Webhooks.ReqDelivery")
-      assert allowed["Loopctl.Webhooks.ReqDelivery"] =~ "US-41.5"
+      # Naming them here is the point: each exemption is DOCUMENTED, not invisible.
       assert Map.has_key?(allowed, "Loopctl.Verification.GitHubActions")
       assert Map.has_key?(allowed, "Loopctl.Secrets.FlyAdapter")
+      assert Map.has_key?(allowed, "Loopctl.CLI.Client")
+    end
+
+    # US-41.5 brought webhook delivery UNDER the guard, so its allowlist entry is
+    # now the same kind of entry `Loopctl.Provider` has — "IS the wrapper" — not
+    # "a known gap". A justification that still reads as a deferral would mean the
+    # docs and the posture report are claiming coverage the code does not have.
+    test "the webhook entry is a WRAPPER exemption, not a deferred gap" do
+      justification = ChokepointScan.allowed()["Loopctl.Webhooks.ReqDelivery"]
+
+      assert justification =~ "webhook chokepoint wrapper"
+      assert justification =~ "Egress.Policy"
+      assert justification =~ ":webhook"
+      refute justification =~ "Bringing it under"
+      refute justification =~ "must NOT claim total egress control yet"
+    end
+
+    # AC-41.5.6: the doc triage list must MATCH the static check's findings
+    # EXACTLY — an allowlisted call site with no triage entry is a review failure.
+    # Asserting it mechanically is what makes the audit standing rather than a
+    # paragraph that rots at the next merge.
+    test "every allowlisted module has a triage row in docs/egress-guard.md" do
+      doc = File.read!("docs/egress-guard.md")
+
+      for {module, _justification} <- ChokepointScan.allowed() do
+        assert doc =~ module,
+               "#{module} is exempted by the static check but has NO triage entry in " <>
+                 "docs/egress-guard.md (AC-41.5.6)"
+      end
+    end
+
+    # The other direction of AC-41.5.6: the paths the triage table claims are
+    # UNDER the guard must genuinely not be exempt. If either ever acquired an
+    # allowlist entry, the table would be advertising coverage that the static
+    # check had stopped enforcing.
+    test "the paths documented as UNDER the guard are NOT allowlisted" do
+      doc = File.read!("docs/egress-guard.md")
+      allowed = ChokepointScan.allowed()
+
+      for module <- [
+            "Loopctl.Workers.ContentIngestionWorker",
+            "Loopctl.Workers.ScaleAlertDeliveryWorker"
+          ] do
+        assert doc =~ module, "#{module} is missing from the triage table (AC-41.5.6)"
+
+        refute Map.has_key?(allowed, module),
+               "#{module} is documented as being UNDER the guard but is allowlisted out of it"
+      end
     end
   end
 

--- a/test/loopctl/egress/policy_test.exs
+++ b/test/loopctl/egress/policy_test.exs
@@ -279,8 +279,11 @@ defmodule Loopctl.Egress.PolicyTest do
       # subscriber is excluded), hence the round trip through the GenServer.
       :ok = PinCache.invalidate_tenant(t.id)
 
-      assert_receive {:invalidate, tenant_id}, 1_000
-      assert tenant_id == t.id
+      # The topic is GLOBAL, so a CONCURRENT async test invalidating a different
+      # tenant can land first. Asserting on the FIRST message received made this
+      # test lose that race (two different tenant UUIDs). Drain until OUR tenant's
+      # broadcast arrives instead.
+      assert_invalidate_received(t.id)
     end
 
     test "the owner busts its node-local table when a PEER broadcasts", %{tenant: t, scope: scope} do
@@ -527,6 +530,18 @@ defmodule Loopctl.Egress.PolicyTest do
       fun.()
     after
       AllowlistSource.clear()
+    end
+  end
+
+  # `"egress:pin_cache:invalidate"` is a GLOBAL topic, so a concurrent async test
+  # invalidating a DIFFERENT tenant can be delivered first. Drain until ours
+  # arrives rather than asserting on whichever message happens to be first.
+  defp assert_invalidate_received(tenant_id) do
+    receive do
+      {:invalidate, ^tenant_id} -> :ok
+      {:invalidate, _other_tenant} -> assert_invalidate_received(tenant_id)
+    after
+      1_000 -> flunk("no {:invalidate, #{tenant_id}} broadcast received")
     end
   end
 end

--- a/test/loopctl/egress/webhook_egress_test.exs
+++ b/test/loopctl/egress/webhook_egress_test.exs
@@ -1,0 +1,508 @@
+defmodule Loopctl.Egress.WebhookEgressTest do
+  @moduledoc """
+  US-41.5 — webhook delivery under the ONE egress policy.
+
+  Covers TC-41.5.1 (local_only blocks a public destination), TC-41.5.2
+  (allowlisted / tenant-declared destinations still deliver, plus the SSRF
+  control case), TC-41.5.3 (config-time rejection), TC-41.5.4 (pre-existing
+  subscriptions surfaced on enable), TC-41.5.6 (blocked records are
+  tenant-isolated) and the AC-41.5.5 posture extension.
+
+  TC-41.5.5 (no unbounded retry backlog) needs the real Oban queue and lives in
+  `Loopctl.Egress.WebhookObanTerminalTest`.
+  """
+
+  use Loopctl.DataCase, async: true
+
+  import Mox
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Egress
+  alias Loopctl.Egress.PinCache
+  alias Loopctl.Egress.Scope
+  alias Loopctl.Test.AllowlistSource
+  alias Loopctl.Webhooks
+  alias Loopctl.Webhooks.WebhookEvent
+  alias Loopctl.Workers.WebhookDeliveryWorker
+
+  setup :verify_on_exit!
+
+  setup do
+    tenant = fixture(:tenant)
+    on_exit(fn -> PinCache.invalidate_tenant(tenant.id) end)
+    {:ok, tenant: tenant, scope: Scope.new(tenant.id)}
+  end
+
+  # --- helpers ---------------------------------------------------------------
+
+  defp mark_local_only(tenant_id, project_id \\ nil) do
+    {:ok, _} = Egress.enable_local_only(tenant_id, project_id, acknowledge: true)
+    PinCache.invalidate_tenant(tenant_id)
+    :ok
+  end
+
+  defp with_allowlist(entries, fun) do
+    AllowlistSource.put(entries)
+
+    try do
+      fun.()
+    after
+      AllowlistSource.clear()
+    end
+  end
+
+  # A stub that FAILS the test if the delivery path ever issues a request.
+  defp forbid_http! do
+    test_pid = self()
+
+    Req.Test.stub(Loopctl.Webhooks.ReqDelivery, fn conn ->
+      send(test_pid, :unexpected_http_call)
+      Req.Test.json(conn, %{"ok" => true})
+    end)
+  end
+
+  defp subscription(tenant_id, url, attrs \\ %{}) do
+    fixture(
+      :webhook,
+      Map.merge(
+        %{tenant_id: tenant_id, url: url, events: ["story.status_changed"]},
+        attrs
+      )
+    )
+  end
+
+  defp pending_event(tenant_id, webhook_id) do
+    fixture(:webhook_event, %{
+      tenant_id: tenant_id,
+      webhook_id: webhook_id,
+      event_type: "story.status_changed",
+      payload: %{"event" => "story.status_changed", "story_id" => Ecto.UUID.generate()},
+      status: :pending
+    })
+  end
+
+  defp deliver(event, tenant_id) do
+    WebhookDeliveryWorker.perform(%Oban.Job{
+      args: %{"webhook_event_id" => event.id, "tenant_id" => tenant_id}
+    })
+  end
+
+  # --- TC-41.5.1 -------------------------------------------------------------
+
+  describe "TC-41.5.1 — local_only blocks a public webhook destination" do
+    setup %{tenant: tenant} do
+      webhook = subscription(tenant.id, "https://hooks.example.com/inbound")
+      :ok = mark_local_only(tenant.id)
+      forbid_http!()
+      {:ok, webhook: webhook, event: pending_event(tenant.id, webhook.id)}
+    end
+
+    test "NO request is issued and the delivery is recorded as blocked, not failed",
+         %{tenant: tenant, event: event} do
+      assert :ok = deliver(event, tenant.id)
+      refute_received :unexpected_http_call
+
+      reloaded = AdminRepo.get!(WebhookEvent, event.id)
+
+      # Blocked is its OWN status: an operator reading failures must be able to
+      # tell a configuration conflict from a flaky subscriber.
+      assert reloaded.status == :blocked
+      refute reloaded.status in [:failed, :exhausted]
+
+      # ... and it is TERMINAL: no attempt burned, nothing to retry.
+      assert reloaded.attempts == 0
+      assert reloaded.last_attempt_at != nil
+    end
+
+    test "the recorded reason is AGENT-READABLE and names the conflict",
+         %{tenant: tenant, event: event} do
+      assert :ok = deliver(event, tenant.id)
+
+      reason = AdminRepo.get!(WebhookEvent, event.id).error
+
+      assert reason =~ "locality_denied"
+      assert reason =~ "egress_blocked"
+      assert reason =~ "tenant:#{tenant.id}"
+      assert reason =~ "hooks.example.com"
+      assert reason =~ "remediation="
+    end
+
+    test "the subscriber's consecutive_failures is NOT incremented (it never failed)",
+         %{tenant: tenant, webhook: webhook, event: event} do
+      assert :ok = deliver(event, tenant.id)
+
+      assert AdminRepo.get!(Loopctl.Webhooks.Webhook, webhook.id).consecutive_failures == 0
+    end
+
+    test "the blocked decision is surfaced through the aggregated egress record",
+         %{tenant: tenant, event: event} do
+      assert :ok = deliver(event, tenant.id)
+      :ok = Egress.flush_blocked_decisions(tenant.id)
+
+      assert [decision] = Egress.list_blocked_decisions(tenant.id)
+      assert decision.endpoint_host == "hooks.example.com"
+      assert decision.reason == "non_local"
+    end
+  end
+
+  # --- TC-41.5.2 -------------------------------------------------------------
+
+  describe "TC-41.5.2 — allowlisted / tenant-declared destinations still deliver" do
+    test "an OPERATOR-allowlisted private destination is deliverable under local_only",
+         %{tenant: tenant} do
+      webhook = subscription(tenant.id, "https://93.184.216.34/inbound")
+      event = pending_event(tenant.id, webhook.id)
+
+      # Repoint the subscription at the allowlisted loopback destination without
+      # going through the context (which would reject it BEFORE the allowlist
+      # entry exists — that is AC-41.5.3 working).
+      webhook
+      |> Ecto.Changeset.change(%{url: "http://127.0.0.1:9000/inbound"})
+      |> AdminRepo.update!()
+
+      :ok = mark_local_only(tenant.id)
+
+      Req.Test.stub(Loopctl.Webhooks.ReqDelivery, fn conn ->
+        Req.Test.json(conn, %{"ok" => true})
+      end)
+
+      with_allowlist(["127.0.0.1"], fn ->
+        assert :ok = deliver(event, tenant.id)
+      end)
+
+      assert AdminRepo.get!(WebhookEvent, event.id).status == :delivered
+    end
+
+    # The control case: the SAME private-range host with NO allowlist entry and no
+    # declaration is still refused. GHSA-jh42-wf7g-f5rg stays closed.
+    test "the same private host WITHOUT an allowlist entry is still refused",
+         %{tenant: tenant} do
+      webhook = subscription(tenant.id, "https://93.184.216.34/inbound")
+
+      webhook
+      |> Ecto.Changeset.change(%{url: "http://127.0.0.1:9000/inbound"})
+      |> AdminRepo.update!()
+
+      event = pending_event(tenant.id, webhook.id)
+      :ok = mark_local_only(tenant.id)
+      forbid_http!()
+
+      assert :ok = deliver(event, tenant.id)
+      refute_received :unexpected_http_call
+
+      reloaded = AdminRepo.get!(WebhookEvent, event.id)
+      assert reloaded.status == :blocked
+      # The SSRF cause, not the locality one — different remediation, different owner.
+      assert reloaded.error =~ "ssrf_denied"
+      assert reloaded.error =~ "OPERATOR deployment allowlist"
+    end
+
+    test "a TENANT-DECLARED host with the 'webhook' purpose is deliverable", %{tenant: tenant} do
+      stub(Loopctl.MockDnsResolver, :resolve, fn
+        "hooks.tenant-owned.example.com" -> {:ok, [{203, 0, 113, 10}]}
+        _ -> {:ok, [{93, 184, 216, 34}]}
+      end)
+
+      webhook = subscription(tenant.id, "https://hooks.tenant-owned.example.com/inbound")
+      event = pending_event(tenant.id, webhook.id)
+
+      {:ok, _} =
+        Egress.declare_trusted_endpoint(tenant.id, %{
+          "host" => "hooks.tenant-owned.example.com",
+          "purposes" => ["webhook"]
+        })
+
+      :ok = mark_local_only(tenant.id)
+
+      Req.Test.stub(Loopctl.Webhooks.ReqDelivery, fn conn ->
+        Req.Test.json(conn, %{"ok" => true})
+      end)
+
+      assert :ok = deliver(event, tenant.id)
+      assert AdminRepo.get!(WebhookEvent, event.id).status == :delivered
+    end
+
+    # Purpose scoping is a SECURITY invariant (AC-41.4.5 constraint 2): a host
+    # declared for an Ollama INFERENCE box does not authorize POSTing tenant
+    # content to it.
+    test "a host declared for INFERENCE only does NOT authorize webhook delivery",
+         %{tenant: tenant} do
+      stub(Loopctl.MockDnsResolver, :resolve, fn
+        "ollama.example.com" -> {:ok, [{203, 0, 113, 10}]}
+        _ -> {:ok, [{93, 184, 216, 34}]}
+      end)
+
+      webhook = subscription(tenant.id, "https://ollama.example.com/inbound")
+      event = pending_event(tenant.id, webhook.id)
+
+      {:ok, _} =
+        Egress.declare_trusted_endpoint(tenant.id, %{
+          "host" => "ollama.example.com",
+          "purposes" => ["inference"]
+        })
+
+      :ok = mark_local_only(tenant.id)
+      forbid_http!()
+
+      assert :ok = deliver(event, tenant.id)
+      refute_received :unexpected_http_call
+      assert AdminRepo.get!(WebhookEvent, event.id).status == :blocked
+    end
+  end
+
+  # --- TC-41.5.3 -------------------------------------------------------------
+
+  describe "TC-41.5.3 — an incompatible subscription is rejected at CREATION" do
+    setup %{tenant: tenant} do
+      :ok = mark_local_only(tenant.id)
+      :ok
+    end
+
+    test "creation is rejected with a legible remediation and NOTHING is persisted",
+         %{tenant: tenant} do
+      assert {:error, changeset} =
+               Webhooks.create_webhook(tenant.id, %{
+                 "url" => "https://hooks.example.com/inbound",
+                 "events" => ["story.status_changed"]
+               })
+
+      assert %{url: [message]} = errors_on(changeset)
+      assert message =~ "local_only"
+      assert message =~ "hooks.example.com"
+      assert message =~ "webhook"
+      assert message =~ "clear the local_only marking"
+
+      assert Webhooks.count_webhooks(tenant.id) == 0
+    end
+
+    test "an UPDATE that repoints an existing subscription at a non-local host is rejected",
+         %{tenant: tenant} do
+      webhook = subscription(tenant.id, "https://hooks.example.com/inbound")
+
+      assert {:error, changeset} =
+               Webhooks.update_webhook(tenant.id, webhook.id, %{
+                 "url" => "https://elsewhere.example.com/inbound"
+               })
+
+      assert %{url: [_message]} = errors_on(changeset)
+
+      assert AdminRepo.get!(Loopctl.Webhooks.Webhook, webhook.id).url ==
+               "https://hooks.example.com/inbound"
+    end
+
+    # A pre-existing (now incompatible) subscription must stay EDITABLE — including
+    # by the very edit that fixes it. Re-classifying an unchanged url on an
+    # unrelated field update would make it un-savable.
+    test "an unrelated update to a pre-existing incompatible subscription still works",
+         %{tenant: tenant} do
+      webhook = subscription(tenant.id, "https://hooks.example.com/inbound")
+
+      assert {:ok, updated} =
+               Webhooks.update_webhook(tenant.id, webhook.id, %{"active" => false})
+
+      refute updated.active
+    end
+
+    test "a DELIVERABLE destination is accepted under the same marking", %{tenant: tenant} do
+      with_allowlist(["127.0.0.1"], fn ->
+        assert {:ok, %{webhook: webhook}} =
+                 Webhooks.create_webhook(tenant.id, %{
+                   "url" => "http://127.0.0.1:9000/inbound",
+                   "events" => ["story.status_changed"]
+                 })
+
+        assert webhook.url == "http://127.0.0.1:9000/inbound"
+      end)
+    end
+
+    test "an unmarked tenant is unaffected — the default posture never rejects", %{} do
+      other = fixture(:tenant)
+      on_exit(fn -> PinCache.invalidate_tenant(other.id) end)
+
+      assert {:ok, _} =
+               Webhooks.create_webhook(other.id, %{
+                 "url" => "https://hooks.example.com/inbound",
+                 "events" => ["story.status_changed"]
+               })
+    end
+  end
+
+  # --- TC-41.5.4 -------------------------------------------------------------
+
+  describe "TC-41.5.4 — pre-existing subscriptions are surfaced when enabling local_only" do
+    test "the enable is REFUSED and names the offending subscription", %{tenant: tenant} do
+      webhook = subscription(tenant.id, "https://hooks.example.com/inbound")
+
+      assert {:error, {:would_block, endpoints}} = Egress.enable_local_only(tenant.id, nil)
+
+      assert entry = Enum.find(endpoints, &(&1.kind == :webhook))
+      assert entry.webhook_id == webhook.id
+      assert entry.endpoint == "https://hooks.example.com/inbound"
+      assert entry.verdict == "non_local"
+      assert entry.active
+
+      # Never a silent state change: nothing was marked, nothing was disabled.
+      refute Egress.effective_local_only?(Scope.new(tenant.id))
+      assert AdminRepo.get!(Loopctl.Webhooks.Webhook, webhook.id).active
+    end
+
+    test "acknowledge: true completes the enable and REPORTS them explicitly",
+         %{tenant: tenant} do
+      webhook = subscription(tenant.id, "https://hooks.example.com/inbound")
+
+      assert {:ok, %{blocked_endpoints: blocked, marking: marking}} =
+               Egress.enable_local_only(tenant.id, nil, acknowledge: true)
+
+      assert Enum.any?(blocked, &(&1[:webhook_id] == webhook.id))
+      assert "https://hooks.example.com/inbound" in marking.acknowledged_blocked_endpoints
+
+      # The subscription is untouched — reported, never silently disabled.
+      reloaded = AdminRepo.get!(Loopctl.Webhooks.Webhook, webhook.id)
+      assert reloaded.active
+      assert reloaded.url == "https://hooks.example.com/inbound"
+    end
+
+    test "a PROJECT marking does not report a tenant-wide (project-less) subscription",
+         %{tenant: tenant} do
+      project = fixture(:project, %{tenant_id: tenant.id})
+      _tenant_wide = subscription(tenant.id, "https://hooks.example.com/inbound")
+
+      scoped =
+        subscription(tenant.id, "https://scoped.example.com/inbound", %{project_id: project.id})
+
+      blocked = Egress.blocked_webhook_subscriptions(Scope.new(tenant.id, project.id))
+
+      assert Enum.map(blocked, & &1.webhook_id) == [scoped.id]
+    end
+  end
+
+  # --- TC-41.5.6 -------------------------------------------------------------
+
+  # AC-41.5.7. This story introduced NO new table and NO new column: a blocked
+  # delivery is a `webhook_events` row with `status: :blocked`, and the
+  # aggregated record is an `egress_blocked_decisions` row. BOTH tables already
+  # carry `tenant_id` and are created with `enable_rls/1` (ENABLE, not FORCE).
+  #
+  # What ACTUALLY isolates tenants on these paths is the mandatory
+  # `where tenant_id == ^tenant_id` on every read — both contexts go through
+  # `AdminRepo` (BYPASSRLS) by design, exactly as `Loopctl.Egress`'s moduledoc
+  # states — so that is what this test proves, plus the presence of the RLS
+  # policy as defence in depth. Labelling a BYPASSRLS-path test "RLS" would be a
+  # lie about which control is load-bearing.
+  describe "TC-41.5.6 — blocked-delivery records are tenant-isolated" do
+    setup %{tenant: tenant_a} do
+      tenant_b = fixture(:tenant)
+      on_exit(fn -> PinCache.invalidate_tenant(tenant_b.id) end)
+
+      webhook = subscription(tenant_a.id, "https://hooks.example.com/inbound")
+      event = pending_event(tenant_a.id, webhook.id)
+      :ok = mark_local_only(tenant_a.id)
+      forbid_http!()
+
+      assert :ok = deliver(event, tenant_a.id)
+      :ok = Egress.flush_blocked_decisions(tenant_a.id)
+
+      {:ok, tenant_b: tenant_b, webhook: webhook, event: event}
+    end
+
+    test "tenant B cannot read tenant A's blocked deliveries", %{
+      tenant: tenant_a,
+      tenant_b: tenant_b,
+      webhook: webhook,
+      event: event
+    } do
+      # The subscription itself is invisible, so its deliveries are unreachable.
+      assert {:error, :not_found} = Webhooks.list_deliveries(tenant_b.id, webhook.id)
+
+      # ... and it IS reachable for its owner, so this is isolation, not a 404 for
+      # everyone.
+      assert {:ok, %{data: deliveries}} = Webhooks.list_deliveries(tenant_a.id, webhook.id)
+      assert [%{id: id, status: :blocked}] = deliveries
+      assert id == event.id
+    end
+
+    test "tenant B cannot read tenant A's aggregated blocked decisions", %{
+      tenant: tenant_a,
+      tenant_b: tenant_b
+    } do
+      assert [_ | _] = Egress.list_blocked_decisions(tenant_a.id)
+      assert Egress.list_blocked_decisions(tenant_b.id) == []
+    end
+
+    test "tenant B's posture reports none of tenant A's destinations", %{
+      tenant_b: tenant_b,
+      webhook: webhook
+    } do
+      posture = Egress.posture(tenant_b.id, :agent)
+
+      assert posture.webhook_destinations == []
+      refute Enum.any?(posture.webhook_destinations, &(&1.webhook_id == webhook.id))
+    end
+
+    test "the blocked row carries tenant_id and both tables have an RLS policy", %{
+      tenant: tenant_a,
+      event: event
+    } do
+      assert AdminRepo.get!(WebhookEvent, event.id).tenant_id == tenant_a.id
+
+      for table <- ["webhook_events", "egress_blocked_decisions"] do
+        %{rows: rows} =
+          AdminRepo.query!("SELECT policyname FROM pg_policies WHERE tablename = $1", [table])
+
+        assert rows != [], "#{table} has no RLS policy (AC-41.5.7)"
+      end
+    end
+  end
+
+  # --- AC-41.5.5 -------------------------------------------------------------
+
+  describe "AC-41.5.5 — posture reports webhook destinations" do
+    test "every subscription is classified, with the allowlist disclosed as a BOOLEAN at :agent",
+         %{tenant: tenant} do
+      webhook = subscription(tenant.id, "https://hooks.example.com/inbound")
+      :ok = mark_local_only(tenant.id)
+
+      posture = Egress.posture(tenant.id, :agent)
+
+      assert [destination] = posture.webhook_destinations
+      assert destination.webhook_id == webhook.id
+      assert destination.endpoint == "https://hooks.example.com/inbound"
+      assert destination.host == "hooks.example.com"
+      assert destination.verdict == "non-local"
+      assert destination.verdict_from_deployment_allowlist == false
+      assert destination.blocked_by_local_only
+      assert destination.active
+    end
+
+    test "a tenant-declared destination is labelled as an UNVERIFIED ATTESTATION",
+         %{tenant: tenant} do
+      stub(Loopctl.MockDnsResolver, :resolve, fn
+        "hooks.tenant-owned.example.com" -> {:ok, [{203, 0, 113, 10}]}
+        _ -> {:ok, [{93, 184, 216, 34}]}
+      end)
+
+      _webhook = subscription(tenant.id, "https://hooks.tenant-owned.example.com/inbound")
+
+      {:ok, _} =
+        Egress.declare_trusted_endpoint(tenant.id, %{
+          "host" => "hooks.tenant-owned.example.com",
+          "purposes" => ["webhook"]
+        })
+
+      :ok = mark_local_only(tenant.id)
+
+      assert [destination] = Egress.posture(tenant.id, :agent).webhook_destinations
+      assert destination.verdict == Egress.tenant_declared_label()
+      assert destination.verdict =~ "unverified attestation"
+      refute destination.blocked_by_local_only
+    end
+
+    test "the guarantee wording no longer excludes webhook delivery", %{tenant: tenant} do
+      guarantee = Egress.posture(tenant.id, :agent).guarantee_scope
+
+      assert guarantee =~ "WEBHOOK DELIVERY"
+      refute guarantee =~ "NOT yet covered"
+      refute guarantee =~ "US-41.5"
+    end
+  end
+end

--- a/test/loopctl/egress/webhook_egress_test.exs
+++ b/test/loopctl/egress/webhook_egress_test.exs
@@ -87,6 +87,18 @@ defmodule Loopctl.Egress.WebhookEgressTest do
     })
   end
 
+  # Oban increments `attempt` on EVERY execution (and bumps `max_attempts` on a
+  # snooze), so `attempt` is how the worker counts the free transient snoozes a
+  # job has already taken.
+  defp deliver_at(event, tenant_id, attempt) do
+    WebhookDeliveryWorker.perform(%Oban.Job{
+      attempt: attempt,
+      args: %{"webhook_event_id" => event.id, "tenant_id" => tenant_id}
+    })
+  end
+
+  defp reload(event), do: AdminRepo.get!(WebhookEvent, event.id)
+
   # --- TC-41.5.1 -------------------------------------------------------------
 
   describe "TC-41.5.1 — local_only blocks a public webhook destination" do
@@ -466,12 +478,35 @@ defmodule Loopctl.Egress.WebhookEgressTest do
 
       assert [destination] = posture.webhook_destinations
       assert destination.webhook_id == webhook.id
-      assert destination.endpoint == "https://hooks.example.com/inbound"
       assert destination.host == "hooks.example.com"
       assert destination.verdict == "non-local"
       assert destination.verdict_from_deployment_allowlist == false
       assert destination.blocked_by_local_only
       assert destination.active
+    end
+
+    # A webhook destination's PATH is frequently the credential (Slack/Discord/
+    # Teams/Zapier capability URLs), and `LoopctlWeb.WebhookController` is
+    # `role: :user` at module level — so disclosing the full URL on the un-gated
+    # posture endpoint would be a role DOWNGRADE of existing data.
+    test "the FULL destination URL is :user+ only; :agent gets host + verdict",
+         %{tenant: tenant} do
+      _webhook = subscription(tenant.id, "https://hooks.example.com/services/T0/B0/s3cr3t")
+
+      assert [agent_view] = Egress.posture(tenant.id, :agent).webhook_destinations
+      refute Map.has_key?(agent_view, :endpoint)
+      assert agent_view.host == "hooks.example.com"
+      assert agent_view.verdict
+
+      for role <- [:user, :superadmin] do
+        assert [privileged] = Egress.posture(tenant.id, role).webhook_destinations
+        assert privileged.endpoint == "https://hooks.example.com/services/T0/B0/s3cr3t"
+      end
+
+      # An ORCHESTRATOR key is below :user in the hierarchy and gets the same
+      # redacted view an agent does.
+      assert [orchestrator_view] = Egress.posture(tenant.id, :orchestrator).webhook_destinations
+      refute Map.has_key?(orchestrator_view, :endpoint)
     end
 
     test "a tenant-declared destination is labelled as an UNVERIFIED ATTESTATION",
@@ -497,6 +532,52 @@ defmodule Loopctl.Egress.WebhookEgressTest do
       refute destination.blocked_by_local_only
     end
 
+    # The endpoint agents are told to call BEFORE EVERY HARVEST classified every
+    # webhook row serially with no deadline, so tenant-writable input (hosts, and
+    # `max_webhooks` itself) could make it take tens of seconds.
+    test "classification is BOUNDED — a slow resolver yields unclassified entries, not a hang",
+         %{tenant: tenant} do
+      stub(Loopctl.MockDnsResolver, :resolve, fn _host ->
+        Process.sleep(div(Egress.classification_budget_ms(), 2) + 100)
+        {:ok, [{93, 184, 216, 34}]}
+      end)
+
+      for i <- 1..3, do: subscription(tenant.id, "https://hooks-#{i}.example.com/inbound")
+
+      destinations = Egress.posture(tenant.id, :agent).webhook_destinations
+
+      # Every destination is still REPORTED (the report never silently drops rows)…
+      assert length(destinations) == 3
+
+      # …but the pass stops resolving once the budget is spent.
+      assert Enum.any?(destinations, &(&1.verdict == "unclassified"))
+    end
+
+    # Timed on the webhook-only pass (the `local_only` enable pre-flight), so the
+    # measurement is not diluted by the provider endpoints posture also classifies.
+    test "the webhook classification pass is bounded by the budget",
+         %{tenant: tenant, scope: scope} do
+      stub(Loopctl.MockDnsResolver, :resolve, fn _host ->
+        Process.sleep(div(Egress.classification_budget_ms(), 2) + 100)
+        {:ok, [{93, 184, 216, 34}]}
+      end)
+
+      for i <- 1..5, do: subscription(tenant.id, "https://hooks-#{i}.example.com/inbound")
+
+      {elapsed_us, blocked} =
+        :timer.tc(fn -> Egress.blocked_webhook_subscriptions(scope) end)
+
+      assert length(blocked) == 5
+
+      # Unbounded this would be 5 x ~1.1s; bounded it is the budget plus at most
+      # one in-flight classification.
+      assert elapsed_us < 2 * Egress.classification_budget_ms() * 1_000
+    end
+
+    test "an unclassified destination is NOT treated as local (fail-closed)" do
+      refute Egress.local_verdict?(:unclassified)
+    end
+
     test "the guarantee wording no longer excludes webhook delivery", %{tenant: tenant} do
       guarantee = Egress.posture(tenant.id, :agent).guarantee_scope
 
@@ -504,5 +585,302 @@ defmodule Loopctl.Egress.WebhookEgressTest do
       refute guarantee =~ "NOT yet covered"
       refute guarantee =~ "US-41.5"
     end
+  end
+
+  # --- Review fixes ----------------------------------------------------------
+
+  describe "AC-41.5.2 — the TRANSIENT refusal path is BOUNDED" do
+    setup %{tenant: tenant} do
+      # An unresolvable destination on an UNMARKED tenant: `tenant_supplied: true`
+      # fails CLOSED as the TRANSIENT `:egress_unavailable` on every attempt. This
+      # is the shape (lapsed domain, NXDOMAIN, resolve timeout) that snoozed
+      # forever: attempts stayed 0, the event stayed pending, the subscription was
+      # never auto-disabled, and every new event added another immortal job.
+      stub(Loopctl.MockDnsResolver, :resolve, fn _host -> {:error, :nxdomain} end)
+
+      webhook = subscription(tenant.id, "https://lapsed.example.com/inbound")
+      forbid_http!()
+
+      {:ok, webhook: webhook, event: pending_event(tenant.id, webhook.id)}
+    end
+
+    test "the first refusals snooze WITHOUT burning an attempt",
+         %{tenant: tenant, event: event} do
+      assert {:snooze, seconds} = deliver_at(event, tenant.id, 1)
+      assert seconds == Egress.transient_snooze_seconds()
+
+      reloaded = reload(event)
+      assert reloaded.attempts == 0
+      assert reloaded.status == :pending
+      refute_received :unexpected_http_call
+    end
+
+    test "past the free-snooze cap it falls through to the ORDINARY failure ladder",
+         %{tenant: tenant, event: event} do
+      attempt = WebhookDeliveryWorker.max_transient_snoozes() + 1
+
+      assert {:snooze, seconds} = deliver_at(event, tenant.id, attempt)
+      # The BACKOFF ladder, not the flat transient snooze.
+      assert seconds == WebhookDeliveryWorker.backoff_seconds(1)
+
+      reloaded = reload(event)
+      assert reloaded.attempts == 1
+      assert reloaded.error =~ "egress_unavailable_persisted"
+    end
+
+    test "it EXHAUSTS and reaches the auto-disable valve instead of retrying forever",
+         %{tenant: tenant, webhook: webhook, event: event} do
+      # One attempt short of the ladder's end, having already spent its free snoozes.
+      event =
+        event
+        |> Ecto.Changeset.change(%{attempts: 5})
+        |> AdminRepo.update!()
+
+      attempt = 5 + WebhookDeliveryWorker.max_transient_snoozes() + 1
+
+      assert :ok = deliver_at(event, tenant.id, attempt)
+
+      reloaded = reload(event)
+      assert reloaded.status == :exhausted
+      assert reloaded.attempts == 6
+
+      # The safety valve the unbounded snooze had disabled: consecutive_failures
+      # rises, so a permanently-unresolvable subscription is eventually disabled.
+      assert AdminRepo.get!(Webhooks.Webhook, webhook.id).consecutive_failures == 1
+    end
+
+    test "an UNRECOGNISED refusal term is TERMINAL, never an immortal snooze",
+         %{tenant: tenant, event: event} do
+      # A malformed `{:refused, term}` from a future delivery-client change, a Mox
+      # stub, or a third-party DeliveryBehaviour implementation.
+      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers, _scope ->
+        {:refused, :something_new}
+      end)
+
+      assert Egress.block_kind(:something_new) == :unrecognized
+      assert :ok = deliver(event, tenant.id)
+
+      reloaded = reload(event)
+      assert reloaded.status == :blocked
+      assert reloaded.error =~ "unrecognized"
+      refute_received :unexpected_http_call
+    end
+
+    test "block_kind/1 keeps the two transient tags transient" do
+      assert Egress.block_kind({:pin_stale, %{}}) == :transient
+      assert Egress.block_kind({:egress_unavailable, %{}}) == :transient
+      assert Egress.block_kind({:egress_blocked, %{verdict: :denylisted}}) == :ssrf_denied
+      assert Egress.block_kind({:egress_blocked, %{verdict: :non_local}}) == :locality_denied
+    end
+  end
+
+  describe "AC-41.5.3 — the config-time check follows the SCOPE, not just the URL" do
+    test "moving a subscription into a local_only PROJECT is REJECTED", %{tenant: tenant} do
+      project = fixture(:project, %{tenant_id: tenant.id})
+      webhook = subscription(tenant.id, "https://hooks.example.com/inbound")
+      :ok = mark_local_only(tenant.id, project.id)
+
+      # The URL does not change — only the scope it is delivered under. Accepting
+      # this is the "accepted, then silently blocked at delivery time" outcome
+      # AC-41.5.3 forbids.
+      assert {:error, changeset} =
+               Webhooks.update_webhook(tenant.id, webhook.id, %{"project_id" => project.id})
+
+      assert %{url: [message]} = errors_on(changeset)
+      assert message =~ "local_only"
+
+      assert AdminRepo.get!(Webhooks.Webhook, webhook.id).project_id == nil
+    end
+
+    test "moving it into an UNMARKED project is still allowed", %{tenant: tenant} do
+      project = fixture(:project, %{tenant_id: tenant.id})
+      webhook = subscription(tenant.id, "https://hooks.example.com/inbound")
+
+      assert {:ok, updated} =
+               Webhooks.update_webhook(tenant.id, webhook.id, %{"project_id" => project.id})
+
+      assert updated.project_id == project.id
+    end
+
+    test "RE-ACTIVATING a now-incompatible subscription is REJECTED", %{tenant: tenant} do
+      webhook = subscription(tenant.id, "https://hooks.example.com/inbound", %{active: false})
+      :ok = mark_local_only(tenant.id)
+
+      assert {:error, changeset} =
+               Webhooks.update_webhook(tenant.id, webhook.id, %{"active" => true})
+
+      assert %{url: [_message]} = errors_on(changeset)
+      refute AdminRepo.get!(Webhooks.Webhook, webhook.id).active
+    end
+
+    test "DEACTIVATING an incompatible subscription stays possible", %{tenant: tenant} do
+      webhook = subscription(tenant.id, "https://hooks.example.com/inbound")
+      :ok = mark_local_only(tenant.id)
+
+      assert {:ok, updated} =
+               Webhooks.update_webhook(tenant.id, webhook.id, %{"active" => false})
+
+      refute updated.active
+    end
+
+    test "a project_id belonging to ANOTHER tenant is REJECTED", %{tenant: tenant} do
+      other = fixture(:tenant)
+      foreign = fixture(:project, %{tenant_id: other.id})
+      webhook = subscription(tenant.id, "https://hooks.example.com/inbound")
+
+      # The webhooks FK targets `projects.id` alone and writes go through
+      # AdminRepo (no RLS), so nothing below this check would have stopped it —
+      # and US-41.5 makes `project_id` the selector for the DELIVERY SCOPE, so a
+      # foreign one side-steps a project-scoped local_only marking.
+      assert {:error, changeset} =
+               Webhooks.update_webhook(tenant.id, webhook.id, %{"project_id" => foreign.id})
+
+      assert %{project_id: [message]} = errors_on(changeset)
+      assert message =~ "does not belong to this tenant"
+      assert AdminRepo.get!(Webhooks.Webhook, webhook.id).project_id == nil
+    end
+
+    test "CREATING with another tenant's project_id is REJECTED", %{tenant: tenant} do
+      other = fixture(:tenant)
+      foreign = fixture(:project, %{tenant_id: other.id})
+
+      assert {:error, changeset} =
+               Webhooks.create_webhook(tenant.id, %{
+                 "url" => "https://hooks.example.com/inbound",
+                 "events" => ["story.status_changed"],
+                 "project_id" => foreign.id
+               })
+
+      assert %{project_id: [_]} = errors_on(changeset)
+      assert Webhooks.count_webhooks(tenant.id) == 0
+    end
+  end
+
+  # --- transient CLASSIFICATION failures under local_only ---------------------
+
+  describe "a transient classification failure under local_only is NOT a permanent drop" do
+    setup %{tenant: tenant} do
+      webhook = subscription(tenant.id, "https://gone.example.com/inbound")
+      :ok = mark_local_only(tenant.id)
+      # The marking enable classified the host with the permissive default stub;
+      # drop that so the delivery below re-classifies against the failing one.
+      PinCache.invalidate_tenant(tenant.id)
+      forbid_http!()
+
+      {:ok, webhook: webhook, event: pending_event(tenant.id, webhook.id)}
+    end
+
+    defp resolver_fails_with(reason) do
+      stub(Loopctl.MockDnsResolver, :resolve, fn _host -> {:error, reason} end)
+    end
+
+    test "an NXDOMAIN snoozes instead of terminally dropping the event",
+         %{tenant: tenant, event: event} do
+      resolver_fails_with(:nxdomain)
+
+      # Before the fix this was a TERMINAL `status: :blocked` labelled
+      # locality_denied — the same resolver failure that merely snoozes on an
+      # UNMARKED scope silently destroyed a one-shot notification on a marked one,
+      # and its remediation ("declare the endpoint, or clear the marking") cannot
+      # fix a DNS outage on an endpoint that is already declared.
+      assert {:snooze, seconds} = deliver_at(event, tenant.id, 1)
+      assert seconds == Egress.transient_snooze_seconds()
+
+      reloaded = reload(event)
+      assert reloaded.status == :pending
+      refute reloaded.status == :blocked
+      assert reloaded.attempts == 0
+      refute_received :unexpected_http_call
+    end
+
+    test "it is still BOUNDED — past the free snoozes it exhausts and auto-disables",
+         %{tenant: tenant, webhook: webhook, event: event} do
+      resolver_fails_with(:nxdomain)
+
+      event = event |> Ecto.Changeset.change(%{attempts: 5}) |> AdminRepo.update!()
+      attempt = 5 + WebhookDeliveryWorker.max_transient_snoozes() + 1
+
+      assert :ok = deliver_at(event, tenant.id, attempt)
+
+      reloaded = reload(event)
+      assert reloaded.status == :exhausted
+      assert AdminRepo.get!(Webhooks.Webhook, webhook.id).consecutive_failures == 1
+    end
+
+    test "block_kind/1 separates a resolver failure from a locality decision" do
+      assert Egress.block_kind({:egress_blocked, %{verdict: :unclassifiable, host: "a.example"}}) ==
+               :transient
+
+      # No host at all is a MALFORMED destination, which retrying never fixes.
+      assert Egress.block_kind({:egress_blocked, %{verdict: :unclassifiable, host: nil}}) ==
+               :locality_denied
+
+      # `oban_result/1` is deliberately coarser — its callers carry no snooze bound.
+      assert {:cancel, _} =
+               Egress.oban_result(
+                 {:egress_blocked, %{verdict: :unclassifiable, host: "a.example"}}
+               )
+    end
+
+    test "the FAILED classification is negatively cached, so the resolve is not repaid",
+         %{tenant: tenant} do
+      test_pid = self()
+
+      stub(Loopctl.MockDnsResolver, :resolve, fn _host ->
+        send(test_pid, :resolved)
+        {:error, :nxdomain}
+      end)
+
+      scope = Scope.new(tenant.id)
+
+      assert Egress.endpoint_verdict(scope, "https://gone.example.com/x", :webhook) ==
+               :unclassifiable
+
+      assert_received :resolved
+
+      # Second lookup of the SAME dead host inside the negative TTL must not
+      # re-resolve: `posture/2` is role :agent, parameterless, and classifies
+      # TENANT-SUPPLIED hostnames, so an uncached failure was a repeatable
+      # multi-second cost for any agent key.
+      assert Egress.endpoint_verdict(scope, "https://gone.example.com/x", :webhook) ==
+               :unclassifiable
+
+      refute_received :resolved
+    end
+  end
+
+  # --- AC-41.5.4: the enable pre-flight is atomic ----------------------------
+
+  describe "AC-41.5.4 — the enable decision and the marking write are one transaction" do
+    test "a refused pre-flight writes NOTHING (no marking, no audit)", %{tenant: tenant} do
+      _webhook = subscription(tenant.id, "https://hooks.example.com/inbound")
+
+      before_audits = audit_count(tenant.id)
+
+      assert {:error, {:would_block, blocked}} = Egress.enable_local_only(tenant.id, nil)
+      assert Enum.any?(blocked, &(&1.kind == :webhook))
+
+      refute Egress.effective_local_only?(Scope.new(tenant.id))
+      assert Egress.get_marking(tenant.id, nil) == nil
+      assert audit_count(tenant.id) == before_audits
+    end
+
+    test "the advisory lock key is derived from the tenant UUID, stably", %{tenant: tenant} do
+      key = Egress.tenant_lock_key(tenant.id)
+
+      assert is_integer(key)
+      # Must fit PostgreSQL's int4 — pg_advisory_xact_lock(int4, int4).
+      assert key >= -2_147_483_648 and key <= 2_147_483_647
+      # Deterministic: two nodes in a rolling deploy must agree or they do not
+      # serialize at all (which is why this is NOT :erlang.phash2/1).
+      assert Egress.tenant_lock_key(tenant.id) == key
+      assert Egress.tenant_lock_key(fixture(:tenant).id) != key
+    end
+  end
+
+  defp audit_count(tenant_id) do
+    Loopctl.Audit.AuditLog
+    |> Ecto.Query.where([a], a.tenant_id == ^tenant_id)
+    |> AdminRepo.aggregate(:count, :id)
   end
 end

--- a/test/loopctl/egress/webhook_oban_terminal_test.exs
+++ b/test/loopctl/egress/webhook_oban_terminal_test.exs
@@ -1,0 +1,110 @@
+defmodule Loopctl.Egress.WebhookObanTerminalTest do
+  @moduledoc """
+  US-41.5 (AC-41.5.2, TC-41.5.5) — a blocked webhook delivery is TERMINAL.
+
+  The `:webhooks` queue is `max_attempts: 1` with APP-LEVEL snooze retries, so a
+  refusal that took the ordinary failure path would re-enter the backoff ladder
+  and sit `scheduled` for hours, once per event, against a configuration that
+  cannot change on its own. This file proves the consequence: a batch of events
+  against a blocked subscription leaves NO retry backlog and issues NO request.
+
+  `async: false`: the drain runs jobs through the real Oban queue (inserted under
+  a process-scoped `:manual` testing mode) and the counts asserted are queue-wide.
+  """
+
+  use Loopctl.DataCase, async: false
+  use Oban.Testing, repo: Loopctl.Repo
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Egress
+  alias Loopctl.Egress.PinCache
+  alias Loopctl.Webhooks.WebhookEvent
+  alias Loopctl.Workers.WebhookDeliveryWorker
+
+  setup :verify_on_exit!
+
+  setup do
+    tenant = fixture(:tenant)
+    on_exit(fn -> PinCache.invalidate_tenant(tenant.id) end)
+
+    webhook =
+      fixture(:webhook, %{
+        tenant_id: tenant.id,
+        url: "https://hooks.example.com/inbound",
+        events: ["story.status_changed"]
+      })
+
+    {:ok, _} = Egress.enable_local_only(tenant.id, nil, acknowledge: true)
+    PinCache.invalidate_tenant(tenant.id)
+
+    test_pid = self()
+
+    Req.Test.stub(Loopctl.Webhooks.ReqDelivery, fn conn ->
+      send(test_pid, :unexpected_http_call)
+      Req.Test.json(conn, %{"ok" => true})
+    end)
+
+    {:ok, tenant: tenant, webhook: webhook}
+  end
+
+  defp job_states(queue) do
+    Loopctl.Repo.all(
+      from j in "oban_jobs",
+        where: j.queue == ^queue,
+        group_by: j.state,
+        select: {j.state, count(j.id)}
+    )
+    |> Map.new()
+  end
+
+  test "several blocked deliveries leave NO retry backlog", %{tenant: tenant, webhook: webhook} do
+    events =
+      for _i <- 1..5 do
+        fixture(:webhook_event, %{
+          tenant_id: tenant.id,
+          webhook_id: webhook.id,
+          event_type: "story.status_changed",
+          payload: %{"event" => "story.status_changed"},
+          status: :pending
+        })
+      end
+
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      for event <- events do
+        {:ok, _} =
+          %{"webhook_event_id" => event.id, "tenant_id" => tenant.id}
+          |> WebhookDeliveryWorker.new()
+          |> Oban.insert()
+      end
+
+      assert 5 == Enum.count(all_enqueued(worker: WebhookDeliveryWorker))
+
+      drained = Oban.drain_queue(queue: :webhooks)
+
+      # Blocked is TERMINAL and CLEAN: the job succeeded at doing the right thing
+      # (recording the refusal), so it neither fails nor snoozes.
+      assert Map.get(drained, :success, 0) == 5
+      assert Map.get(drained, :failure, 0) == 0
+      assert Map.get(drained, :snoozed, 0) == 0
+
+      states = job_states("webhooks")
+      assert Map.get(states, "retryable", 0) == 0
+      assert Map.get(states, "available", 0) == 0
+      assert Map.get(states, "scheduled", 0) == 0
+    end)
+
+    # No data ever left the boundary.
+    refute_received :unexpected_http_call
+
+    # Every event is blocked, and no attempt was burned on any of them.
+    blocked =
+      AdminRepo.all(
+        from e in WebhookEvent, where: e.tenant_id == ^tenant.id, select: {e.status, e.attempts}
+      )
+
+    assert length(blocked) == 5
+    assert Enum.all?(blocked, &(&1 == {:blocked, 0}))
+  end
+end

--- a/test/loopctl/egress/webhook_oban_terminal_test.exs
+++ b/test/loopctl/egress/webhook_oban_terminal_test.exs
@@ -59,6 +59,20 @@ defmodule Loopctl.Egress.WebhookObanTerminalTest do
     |> Map.new()
   end
 
+  # Drains until the queue holds no runnable job, returning the number of passes
+  # it took. Bounded so a job that never terminates FAILS the test instead of
+  # hanging the suite.
+  defp drain_until_settled(max_passes, pass \\ 0) do
+    drained = Oban.drain_queue(queue: :webhooks, with_scheduled: true)
+    executed = Map.get(drained, :snoozed, 0) + Map.get(drained, :success, 0)
+
+    cond do
+      executed == 0 -> pass
+      pass + 1 >= max_passes -> max_passes
+      true -> drain_until_settled(max_passes, pass + 1)
+    end
+  end
+
   test "several blocked deliveries leave NO retry backlog", %{tenant: tenant, webhook: webhook} do
     events =
       for _i <- 1..5 do
@@ -106,5 +120,68 @@ defmodule Loopctl.Egress.WebhookObanTerminalTest do
 
     assert length(blocked) == 5
     assert Enum.all?(blocked, &(&1 == {:blocked, 0}))
+  end
+
+  # REVIEW FIX (AC-41.5.2). The TRANSIENT branch snoozed unconditionally, and on a
+  # `max_attempts: 1` queue every snooze also bumps `max_attempts` — so a
+  # destination that can never be classified (lapsed domain, NXDOMAIN, resolve
+  # timeout) produced an IMMORTAL job per event. Draining `with_scheduled: true`
+  # is the end-to-end proof: under the old code this test would never terminate.
+  test "a permanently-unresolvable destination TERMINATES instead of snoozing forever" do
+    tenant = fixture(:tenant)
+    on_exit(fn -> PinCache.invalidate_tenant(tenant.id) end)
+
+    # No local_only marking: this is the DEFAULT posture, where a tenant-supplied
+    # url that cannot be classified fails closed as the TRANSIENT
+    # `:egress_unavailable` on every single attempt.
+    stub(Loopctl.MockDnsResolver, :resolve, fn _host -> {:error, :nxdomain} end)
+
+    webhook =
+      fixture(:webhook, %{
+        tenant_id: tenant.id,
+        url: "https://lapsed.example.invalid/inbound",
+        events: ["story.status_changed"]
+      })
+
+    event =
+      fixture(:webhook_event, %{
+        tenant_id: tenant.id,
+        webhook_id: webhook.id,
+        event_type: "story.status_changed",
+        payload: %{"event" => "story.status_changed"},
+        status: :pending
+      })
+
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      {:ok, _} =
+        %{"webhook_event_id" => event.id, "tenant_id" => tenant.id}
+        |> WebhookDeliveryWorker.new()
+        |> Oban.insert()
+
+      # Each drain pass runs the jobs that exist NOW (snoozes re-schedule into the
+      # future), so drain repeatedly. The BOUND is what is under test: the job must
+      # stop needing passes. Under the old unconditional snooze it never would —
+      # the loop would exhaust its cap with the job still scheduled.
+      passes = drain_until_settled(20)
+
+      assert passes < 20, "the job never reached a terminal state (unbounded snooze)"
+
+      states = job_states("webhooks")
+      assert Map.get(states, "scheduled", 0) == 0
+      assert Map.get(states, "available", 0) == 0
+      assert Map.get(states, "retryable", 0) == 0
+    end)
+
+    refute_received :unexpected_http_call
+
+    # The event reached the ordinary ladder's end...
+    reloaded = AdminRepo.get!(WebhookEvent, event.id)
+    assert reloaded.status == :exhausted
+    assert reloaded.attempts == 6
+    assert reloaded.error =~ "egress_unavailable_persisted"
+
+    # ...and the auto-disable safety valve — dead while the snooze was unbounded —
+    # is reachable again.
+    assert AdminRepo.get!(Loopctl.Webhooks.Webhook, webhook.id).consecutive_failures == 1
   end
 end

--- a/test/loopctl/telemetry/scale_alerts_test.exs
+++ b/test/loopctl/telemetry/scale_alerts_test.exs
@@ -57,7 +57,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
     # Default permissive stub (DataCase isn't used here — this is a plain ExUnit.Case),
     # so an unexpected deliver doesn't crash; tests that assert a POST override with
     # expect/3. Allowed in global mode for any process.
-    stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers ->
+    stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers, _scope ->
       {:ok, %{status: 200, body: "ok"}}
     end)
 
@@ -160,7 +160,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
   end
 
   defp expect_delivery(test_pid) do
-    expect(Loopctl.MockDelivery, :deliver, fn url, body, headers ->
+    expect(Loopctl.MockDelivery, :deliver, fn url, body, headers, _scope ->
       send(test_pid, {:alert_delivered, url, body, headers})
       {:ok, %{status: 200, body: "ok"}}
     end)
@@ -288,7 +288,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
          %{server: server} do
       test_pid = self()
 
-      stub(Loopctl.MockDelivery, :deliver, fn _u, _b, _h ->
+      stub(Loopctl.MockDelivery, :deliver, fn _u, _b, _h, _scope ->
         send(test_pid, :unexpected_delivery)
         {:ok, %{status: 200, body: "ok"}}
       end)
@@ -353,7 +353,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
          %{server: server} do
       test_pid = self()
 
-      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers ->
+      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers, _scope ->
         send(test_pid, :unexpected_delivery)
         {:ok, %{status: 200, body: "ok"}}
       end)
@@ -370,7 +370,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
          %{server: server} do
       test_pid = self()
 
-      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers ->
+      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers, _scope ->
         send(test_pid, :unexpected_delivery)
         {:ok, %{status: 200, body: "ok"}}
       end)
@@ -414,7 +414,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
     test "TC-34.3.4: no false fire under threshold for all three new signals", %{server: server} do
       test_pid = self()
 
-      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers ->
+      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers, _scope ->
         send(test_pid, :unexpected_delivery)
         {:ok, %{status: 200, body: "ok"}}
       end)
@@ -431,7 +431,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
     test "queue_time p95 below the sample floor is skipped (no noise alert)", %{server: server} do
       test_pid = self()
 
-      stub(Loopctl.MockDelivery, :deliver, fn _u, _b, _h ->
+      stub(Loopctl.MockDelivery, :deliver, fn _u, _b, _h, _scope ->
         send(test_pid, :unexpected_delivery)
         {:ok, %{status: 200, body: "ok"}}
       end)
@@ -521,7 +521,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
       # unexpected expect were set, but here we assert NO delivery by counting calls.
       test_pid = self()
 
-      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers ->
+      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers, _scope ->
         send(test_pid, :unexpected_delivery)
         {:ok, %{status: 200, body: "ok"}}
       end)
@@ -536,7 +536,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
     test "p95 below the sample floor is skipped (no noise alert)", %{server: server} do
       test_pid = self()
 
-      stub(Loopctl.MockDelivery, :deliver, fn _u, _b, _h ->
+      stub(Loopctl.MockDelivery, :deliver, fn _u, _b, _h, _scope ->
         send(test_pid, :unexpected_delivery)
         {:ok, %{status: 200, body: "ok"}}
       end)
@@ -556,7 +556,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
       # Override the setup stub so EVERY deliver call is observable (a 2nd fire that fell
       # through to a silent stub would otherwise hide a debounce regression). Any call
       # sends {:fired, ...}, so refute_received is airtight.
-      stub(Loopctl.MockDelivery, :deliver, fn _url, body, _headers ->
+      stub(Loopctl.MockDelivery, :deliver, fn _url, body, _headers, _scope ->
         send(test_pid, {:fired, Jason.decode!(body)["metric"]})
         {:ok, %{status: 200, body: "ok"}}
       end)
@@ -575,7 +575,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
     test "after the metric clears, a fresh breach fires again", %{server: server} do
       test_pid = self()
 
-      stub(Loopctl.MockDelivery, :deliver, fn _url, body, _headers ->
+      stub(Loopctl.MockDelivery, :deliver, fn _url, body, _headers, _scope ->
         send(test_pid, {:fired, Jason.decode!(body)["value"]})
         {:ok, %{status: 200, body: "ok"}}
       end)
@@ -600,7 +600,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
     test "counters reset each evaluate so a one-off spike doesn't persist", %{server: server} do
       test_pid = self()
 
-      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers ->
+      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers, _scope ->
         send(test_pid, :fired)
         {:ok, %{status: 200, body: "ok"}}
       end)
@@ -619,7 +619,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
     test "with a nil url, a breach logs and does NOT POST or enqueue (AC-34.5.4)" do
       test_pid = self()
 
-      stub(Loopctl.MockDelivery, :deliver, fn _u, _b, _h ->
+      stub(Loopctl.MockDelivery, :deliver, fn _u, _b, _h, _scope ->
         send(test_pid, :unexpected_delivery)
         {:ok, %{status: 200, body: "ok"}}
       end)
@@ -680,7 +680,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
          %{server: server} do
       test_pid = self()
 
-      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers ->
+      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers, _scope ->
         {:error, "connection_refused"}
       end)
 
@@ -722,7 +722,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
 
       on_exit(fn -> :telemetry.detach(handler_id) end)
 
-      expect(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers ->
+      expect(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers, _scope ->
         {:ok, %{status: 200, body: "ok"}}
       end)
 
@@ -754,7 +754,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
         end
       end
 
-      stub(Loopctl.MockDelivery, :deliver, fn _url, body, _headers ->
+      stub(Loopctl.MockDelivery, :deliver, fn _url, body, _headers, _scope ->
         send(test_pid, {:delivered, Jason.decode!(body)["metric"]})
         {:ok, %{status: 200, body: "ok"}}
       end)
@@ -789,7 +789,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
         raise DBConnection.ConnectionError, "connection not available"
       end
 
-      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers ->
+      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers, _scope ->
         send(test_pid, :unexpected_delivery)
         {:ok, %{status: 200, body: "ok"}}
       end)
@@ -803,7 +803,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
         )
 
       emit_timeout(6)
-      # The call itself must complete normally (not crash/timeout) — proving `deliver/3`
+      # The call itself must complete normally (not crash/timeout) — proving `deliver/4`
       # rescued the raise instead of letting it propagate out of `handle_call(:evaluate)`.
       assert :ok = ScaleAlerts.evaluate(name)
 
@@ -813,7 +813,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
   end
 
   describe "no secret persisted in the enqueued job (review fix)" do
-    # Uses the `insert_fn` test seam to capture the EXACT job `deliver/3` builds, before
+    # Uses the `insert_fn` test seam to capture the EXACT job `deliver/4` builds, before
     # it reaches Oban, and proves the webhook URL (potentially secret-bearing) is never
     # part of the args that would be JSON-serialized into `oban_jobs.args`.
     test "the job enqueued for delivery carries only :payload — never the webhook url" do
@@ -824,7 +824,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
         Oban.insert(job)
       end
 
-      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers ->
+      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers, _scope ->
         {:ok, %{status: 200, body: "ok"}}
       end)
 
@@ -847,12 +847,12 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
 
   describe "malformed webhook url config does not crash the GenServer (review fix)" do
     # A non-nil, non-binary `:scale_alert_webhook_url` (e.g. a charlist/atom from a
-    # config typo) must be treated as a delivery error, not raise past `deliver/3` and
+    # config typo) must be treated as a delivery error, not raise past `deliver/4` and
     # crash the un-rescued `handle_call(:evaluate)`.
     test "a non-binary configured url logs, reports :error, and keeps the GenServer alive" do
       test_pid = self()
 
-      stub(Loopctl.MockDelivery, :deliver, fn _u, _b, _h ->
+      stub(Loopctl.MockDelivery, :deliver, fn _u, _b, _h, _scope ->
         send(test_pid, :unexpected_delivery)
         {:ok, %{status: 200, body: "ok"}}
       end)
@@ -867,7 +867,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
         )
 
       emit_timeout(6)
-      # Must complete normally (not crash/timeout) — proving the catch-all `deliver/3`
+      # Must complete normally (not crash/timeout) — proving the catch-all `deliver/4`
       # clause handled the malformed config instead of raising FunctionClauseError.
       assert :ok = ScaleAlerts.evaluate(name)
 
@@ -887,7 +887,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
     test "re-fires once the re-notify interval elapses, stays silent before it, re-arms on clear" do
       test_pid = self()
 
-      stub(Loopctl.MockDelivery, :deliver, fn _url, body, _headers ->
+      stub(Loopctl.MockDelivery, :deliver, fn _url, body, _headers, _scope ->
         send(test_pid, {:fired, Jason.decode!(body)["metric"]})
         {:ok, %{status: 200, body: "ok"}}
       end)

--- a/test/loopctl/webhooks/req_delivery_test.exs
+++ b/test/loopctl/webhooks/req_delivery_test.exs
@@ -1,42 +1,81 @@
 defmodule Loopctl.Webhooks.ReqDeliveryTest do
   @moduledoc """
-  Tests the SSRF egress guard on the webhook delivery path
-  (ie-02 / GHSA-jh42-wf7g-f5rg): re-validation at delivery time and
-  `redirect: false`.
+  The egress guard on the webhook delivery path.
+
+  Two layers, both exercised here:
+
+    * the SSRF denylist (ie-02 / GHSA-jh42-wf7g-f5rg) — re-validation at delivery
+      time and `redirect: false`. Since US-41.5 it is enforced through the ONE
+      policy (`Egress.Policy.check/4`, `tenant_supplied: true`) rather than a bare
+      `UrlGuard.pin/1`, so these tests pin the SEMANTICS, not the call;
+    * the US-41.5 locality decision — refusals are `{:refused, {tag, details}}`,
+      never `{:error, _}`, so a caller can tell a configuration conflict from a
+      delivery failure.
   """
   use Loopctl.DataCase, async: true
 
   setup :verify_on_exit!
 
+  alias Loopctl.Egress
+  alias Loopctl.Egress.PinCache
+  alias Loopctl.Egress.Scope
+  alias Loopctl.Test.AllowlistSource
   alias Loopctl.Webhooks.ReqDelivery
 
-  describe "deliver/3 re-validates the URL (DNS rebinding / TOCTOU)" do
-    test "refuses a metadata IPv4 literal without making a request" do
-      assert {:error, message} =
-               ReqDelivery.deliver("http://169.254.169.254/latest/meta-data/", "{}", [])
+  setup do
+    tenant = fixture(:tenant)
+    on_exit(fn -> PinCache.invalidate_tenant(tenant.id) end)
+    {:ok, tenant: tenant, scope: Scope.new(tenant.id)}
+  end
 
-      assert message =~ "blocked_url"
+  defp with_allowlist(entries, fun) do
+    AllowlistSource.put(entries)
+
+    try do
+      fun.()
+    after
+      AllowlistSource.clear()
+    end
+  end
+
+  describe "deliver/4 re-validates the URL (DNS rebinding / TOCTOU)" do
+    test "refuses a metadata IPv4 literal without making a request", %{scope: scope} do
+      assert {:refused, {:egress_blocked, details}} =
+               ReqDelivery.deliver("http://169.254.169.254/latest/meta-data/", "{}", [], scope)
+
+      assert details.verdict == :denylisted
+      assert Egress.block_kind({:egress_blocked, details}) == :ssrf_denied
     end
 
-    test "refuses a Fly 6PN IPv6 literal" do
-      assert {:error, message} = ReqDelivery.deliver("http://[fdaa::1]/x", "{}", [])
-      assert message =~ "blocked_url"
+    test "refuses a Fly 6PN IPv6 literal", %{scope: scope} do
+      assert {:refused, {:egress_blocked, %{verdict: :denylisted}}} =
+               ReqDelivery.deliver("http://[fdaa::1]/x", "{}", [], scope)
     end
 
-    test "refuses a hostname that now resolves to a private address" do
+    test "refuses a hostname that now resolves to a private address", %{scope: scope} do
       expect(Loopctl.MockDnsResolver, :resolve, fn _host ->
         {:ok, [{10, 0, 0, 1}]}
       end)
 
-      assert {:error, message} =
-               ReqDelivery.deliver("https://rebind.example.com/hooks", "{}", [])
+      assert {:refused, {:egress_blocked, %{verdict: :denylisted}}} =
+               ReqDelivery.deliver("https://rebind.example.com/hooks", "{}", [], scope)
+    end
 
-      assert message =~ "blocked_url"
+    # A tenant-supplied destination must NEVER degrade to an unpinned,
+    # redirect-following request when classification fails — and the refusal must
+    # be the TRANSIENT one, since a resolve failure is a blip, not a config state.
+    test "an unresolvable destination fails CLOSED as TRANSIENT", %{scope: scope} do
+      stub(Loopctl.MockDnsResolver, :resolve, fn _host -> {:error, :nxdomain} end)
+
+      assert {:refused, {:egress_unavailable, _details} = refusal} =
+               ReqDelivery.deliver("https://who-knows.example.com/hooks", "{}", [], scope)
+
+      assert Egress.block_kind(refusal) == :transient
     end
   end
 
-  describe "deliver/3 does not follow redirects" do
-    test "a 302 to an internal target is NOT followed (redirect: false)" do
+  describe "deliver/4 does not follow redirects" do
+    test "a 302 to an internal target is NOT followed (redirect: false)", %{scope: scope} do
       # Public IP literal passes the guard (no DNS). The plug returns a 302 whose
       # Location points at the metadata IP. With redirect: false the 302 is
       # returned as-is (a non-2xx), so delivery fails instead of silently hopping
@@ -48,26 +87,26 @@ defmodule Loopctl.Webhooks.ReqDeliveryTest do
       end)
 
       assert {:error, message} =
-               ReqDelivery.deliver("https://93.184.216.34/hooks", "{}", [])
+               ReqDelivery.deliver("https://93.184.216.34/hooks", "{}", [], scope)
 
       assert message =~ "302"
     end
   end
 
-  describe "deliver/3 happy path" do
-    test "delivers to a public URL" do
+  describe "deliver/4 happy path" do
+    test "delivers to a public URL", %{scope: scope} do
       Req.Test.stub(Loopctl.Webhooks.ReqDelivery, fn conn ->
         Req.Test.json(conn, %{"ok" => true})
       end)
 
       assert {:ok, %{status: 200}} =
-               ReqDelivery.deliver("https://93.184.216.34/hooks", "{}", [])
+               ReqDelivery.deliver("https://93.184.216.34/hooks", "{}", [], scope)
     end
 
-    test "a legit hostname-based delivery still succeeds through the pinned path" do
+    test "a legit hostname-based delivery still succeeds through the pinned path", %{scope: scope} do
       # Resolve ONCE to a public IP; the connection is pinned to that IP while the
       # original host is preserved for Host/SNI/cert (proves pinning didn't break
-      # normal delivery — FIX C).
+      # normal delivery).
       expect(Loopctl.MockDnsResolver, :resolve, 1, fn "hooks.example.com" ->
         {:ok, [{93, 184, 216, 34}]}
       end)
@@ -77,7 +116,46 @@ defmodule Loopctl.Webhooks.ReqDeliveryTest do
       end)
 
       assert {:ok, %{status: 200}} =
-               ReqDelivery.deliver("https://hooks.example.com/hooks", "{}", [])
+               ReqDelivery.deliver("https://hooks.example.com/hooks", "{}", [], scope)
+    end
+  end
+
+  describe "operator-plane delivery (scope: nil)" do
+    # The scale-alert webhook. No tenant marking applies, but the SSRF denylist
+    # still does — the same UrlGuard primitive the policy composes.
+    test "still refuses a denylisted destination" do
+      assert {:error, message} =
+               ReqDelivery.deliver("http://169.254.169.254/alert", "{}", [], nil)
+
+      assert message =~ "blocked_url"
+    end
+
+    test "delivers to a public URL" do
+      Req.Test.stub(Loopctl.Webhooks.ReqDelivery, fn conn ->
+        Req.Test.json(conn, %{"ok" => true})
+      end)
+
+      assert {:ok, %{status: 200}} =
+               ReqDelivery.deliver("https://93.184.216.34/alert", "{}", [], nil)
+    end
+  end
+
+  describe "the operator allowlist is the ONLY carve-out for a private destination" do
+    test "an allowlisted loopback destination becomes deliverable — it was not before",
+         %{scope: scope} do
+      Req.Test.stub(Loopctl.Webhooks.ReqDelivery, fn conn ->
+        Req.Test.json(conn, %{"ok" => true})
+      end)
+
+      with_allowlist(["127.0.0.1"], fn ->
+        assert {:ok, %{status: 200}} =
+                 ReqDelivery.deliver("http://127.0.0.1:9000/hooks", "{}", [], scope)
+      end)
+    end
+
+    test "the SAME private host WITHOUT an allowlist entry is still refused", %{scope: scope} do
+      assert {:refused, {:egress_blocked, %{verdict: :denylisted}}} =
+               ReqDelivery.deliver("http://127.0.0.1:9000/hooks", "{}", [], scope)
     end
   end
 end

--- a/test/loopctl/webhooks/webhooks_test.exs
+++ b/test/loopctl/webhooks/webhooks_test.exs
@@ -112,7 +112,13 @@ defmodule Loopctl.WebhooksTest do
             "events" => ["story.status_changed"]
           })
 
-        assert "must not target a private or loopback address" in errors_on(changeset).url
+        # US-41.5: the address decision moved to the ONE policy, which can see the
+        # OPERATOR allowlist. The legacy phrase is preserved as the message PREFIX,
+        # now followed by the remediation naming WHO can carve it out.
+        assert Enum.any?(
+                 errors_on(changeset).url,
+                 &(&1 =~ "must not target a private or loopback address")
+               )
       end
     end
 
@@ -141,7 +147,10 @@ defmodule Loopctl.WebhooksTest do
           "events" => ["story.status_changed"]
         })
 
-      assert "must not target a private or loopback address" in errors_on(changeset).url
+      assert Enum.any?(
+               errors_on(changeset).url,
+               &(&1 =~ "must not target a private or loopback address")
+             )
     end
 
     test "reports an unresolvable host distinctly from a private address" do
@@ -158,7 +167,11 @@ defmodule Loopctl.WebhooksTest do
         })
 
       assert "host could not be resolved" in errors_on(changeset).url
-      refute "must not target a private or loopback address" in errors_on(changeset).url
+
+      refute Enum.any?(
+               errors_on(changeset).url,
+               &(&1 =~ "must not target a private or loopback address")
+             )
     end
 
     test "enforces max_webhooks limit" do

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -16,6 +16,7 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
   setup :verify_on_exit!
 
   alias Loopctl.Knowledge
+  alias Loopctl.Test.AllowlistSource
   alias Loopctl.Workers.ContentIngestionWorker
 
   defp setup_tenant do
@@ -269,7 +270,12 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
         flunk("SSRF guard should have blocked the request before Req.get/1")
       end)
 
-      assert {:error, {:url_blocked, :blocked_ip}} =
+      # US-41.5 review: the SSRF call is made by the ONE policy
+      # (`denylist_gate/4` on a `tenant_supplied_url`), not by a second
+      # `UrlGuard.pin/1` pre-gate — so the refusal is the PERMANENT
+      # `:egress_blocked`, which `Egress.oban_result/1` CANCELS (it was retried as
+      # a generic error before). Nothing is fetched either way.
+      assert {:cancel, reason} =
                ContentIngestionWorker.perform(%Oban.Job{
                  id: 200,
                  args: %{
@@ -279,6 +285,10 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
                    "source_type" => "web_article"
                  }
                })
+
+      assert reason =~ "egress_blocked"
+      assert reason =~ "denylisted"
+      assert reason =~ "169.254.169.254"
 
       assert %{data: []} = Knowledge.list_articles(tenant.id, source_type: "web_article")
     end
@@ -290,7 +300,7 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
         {:ok, [{10, 0, 0, 5}]}
       end)
 
-      assert {:error, {:url_blocked, :blocked_ip}} =
+      assert {:cancel, reason} =
                ContentIngestionWorker.perform(%Oban.Job{
                  id: 201,
                  args: %{
@@ -300,6 +310,58 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
                    "source_type" => "web_article"
                  }
                })
+
+      assert reason =~ "egress_blocked"
+      assert reason =~ "denylisted"
+      assert reason =~ "rebind.example.com"
+    end
+
+    # The operator deployment allowlist could not be consulted while the fetch
+    # was pre-gated by a bare `UrlGuard.pin/1`: an allowlisted private host was a
+    # legal WEBHOOK destination but still a hard refusal as an INGESTION source.
+    # Now both paths ask the same policy (US-41.5 review).
+    test "an OPERATOR-allowlisted private host is fetchable as an ingestion source" do
+      %{tenant: tenant} = setup_tenant()
+
+      stub(Loopctl.MockDnsResolver, :resolve, fn _host -> {:ok, [{10, 0, 0, 5}]} end)
+
+      Req.Test.stub(ContentIngestionWorker, fn conn ->
+        Req.Test.html(conn, "<html><body>Allowlisted ingest body</body></html>")
+      end)
+
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                     _content,
+                                                                     _opts ->
+        {:ok,
+         [
+           %{
+             title: "Allowlisted host finding",
+             body: "Important pattern from an allowlisted internal host.",
+             category: :finding,
+             tags: ["egress"]
+           }
+         ]}
+      end)
+
+      AllowlistSource.put(["10.0.0.0/8"])
+
+      try do
+        assert :ok =
+                 ContentIngestionWorker.perform(%Oban.Job{
+                   id: 202,
+                   args: %{
+                     "tenant_id" => tenant.id,
+                     "url" => "https://internal.example.com/doc",
+                     "content_hash" => "allowlisted1",
+                     "source_type" => "web_article"
+                   }
+                 })
+      after
+        AllowlistSource.clear()
+      end
+
+      %{data: articles} = Knowledge.list_articles(tenant.id, source_type: "web_article")
+      assert Enum.any?(articles, &(&1.title == "Allowlisted host finding"))
     end
   end
 

--- a/test/loopctl/workers/scale_alert_delivery_worker_test.exs
+++ b/test/loopctl/workers/scale_alert_delivery_worker_test.exs
@@ -38,7 +38,7 @@ defmodule Loopctl.Workers.ScaleAlertDeliveryWorkerTest do
 
   describe "perform/1" do
     test "args carry no url — successful delivery resolves it from config and delivers the exact JSON payload + headers" do
-      expect(Loopctl.MockDelivery, :deliver, fn url, body, headers ->
+      expect(Loopctl.MockDelivery, :deliver, fn url, body, headers, _scope ->
         assert url == @url
         assert {"content-type", "application/json"} in headers
         assert Jason.decode!(body) == @payload
@@ -49,7 +49,7 @@ defmodule Loopctl.Workers.ScaleAlertDeliveryWorkerTest do
     end
 
     test "delivery failure returns {:error, _} so Oban retries (not dropped)" do
-      expect(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers ->
+      expect(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers, _scope ->
         {:error, "connection_refused"}
       end)
 
@@ -58,7 +58,7 @@ defmodule Loopctl.Workers.ScaleAlertDeliveryWorkerTest do
     end
 
     test "a job with a persisted url arg (legacy/pre-fix job) is ignored — the config url wins" do
-      expect(Loopctl.MockDelivery, :deliver, fn url, _body, _headers ->
+      expect(Loopctl.MockDelivery, :deliver, fn url, _body, _headers, _scope ->
         assert url == @url
         {:ok, %{status: 200, body: "ok"}}
       end)
@@ -72,12 +72,12 @@ defmodule Loopctl.Workers.ScaleAlertDeliveryWorkerTest do
 
   describe "deliver_or_skip/2 (review fix — URL resolved at run time, not from args)" do
     test "a nil url (unset by delivery time) logs and completes as a no-op :ok, no delivery attempted" do
-      # No expect/3 set — verify_on_exit! would fail if `deliver/3` were called unexpectedly.
+      # No expect/3 set — verify_on_exit! would fail if `deliver/4` were called unexpectedly.
       assert :ok = ScaleAlertDeliveryWorker.deliver_or_skip(@payload, nil)
     end
 
     test "a binary url delivers exactly as perform/1 would" do
-      expect(Loopctl.MockDelivery, :deliver, fn url, body, headers ->
+      expect(Loopctl.MockDelivery, :deliver, fn url, body, headers, _scope ->
         assert url == @url
         assert {"content-type", "application/json"} in headers
         assert Jason.decode!(body) == @payload

--- a/test/loopctl/workers/webhook_cleanup_worker_test.exs
+++ b/test/loopctl/workers/webhook_cleanup_worker_test.exs
@@ -73,5 +73,44 @@ defmodule Loopctl.Workers.WebhookCleanupWorkerTest do
 
       assert length(remaining) == 1
     end
+
+    # US-41.5 review: `:blocked` is TERMINAL, and it is the status a persistent
+    # misconfiguration produces in VOLUME — a blocked delivery deliberately does
+    # not increment consecutive_failures, so the auto-disable valve never fires
+    # and rows accumulate for every matching state change. Leaving it out of the
+    # retention predicate meant those rows were never reclaimed.
+    test "prunes BLOCKED events older than the retention period" do
+      tenant = fixture(:tenant)
+      webhook = fixture(:webhook, %{tenant_id: tenant.id})
+
+      for status <- [:blocked, :exhausted] do
+        fixture(:webhook_event, %{
+          tenant_id: tenant.id,
+          webhook_id: webhook.id,
+          status: status
+        })
+        |> Ecto.Changeset.change(%{
+          inserted_at: DateTime.add(DateTime.utc_now(), -45 * 86_400, :second)
+        })
+        |> AdminRepo.update!()
+      end
+
+      recent_blocked =
+        fixture(:webhook_event, %{
+          tenant_id: tenant.id,
+          webhook_id: webhook.id,
+          status: :blocked
+        })
+
+      assert :ok = WebhookCleanupWorker.perform(%Oban.Job{})
+
+      remaining =
+        WebhookEvent
+        |> where([e], e.tenant_id == ^tenant.id)
+        |> AdminRepo.all()
+
+      assert [%{id: id}] = remaining
+      assert id == recent_blocked.id
+    end
   end
 end

--- a/test/loopctl_web/controllers/egress_controller_test.exs
+++ b/test/loopctl_web/controllers/egress_controller_test.exs
@@ -106,6 +106,48 @@ defmodule LoopctlWeb.EgressControllerTest do
       assert body["blocked_endpoints"] != []
       assert body["note"] =~ "egress_blocked"
     end
+
+    test "a webhook destination in the pre-flight list is redacted to its HOST below :user",
+         %{conn: conn, keys: keys, tenant: t} do
+      secret_path = "/services/T00000/B00000/CAPABILITY-TOKEN"
+
+      fixture(:webhook, %{
+        tenant_id: t.id,
+        url: "https://hooks.example.com#{secret_path}",
+        events: ["story.status_changed"]
+      })
+
+      body =
+        conn
+        |> auth(keys.orchestrator)
+        |> post(~p"/api/v1/egress/local-only", %{})
+        |> json_response(409)
+
+      webhooks = Enum.filter(body["blocked_endpoints"], &(&1["kind"] == "webhook"))
+      assert [entry] = webhooks
+
+      # This endpoint is :orchestrator, one level BELOW the role: :user gate on
+      # WebhookController — and a webhook path is frequently the credential.
+      assert entry["endpoint"] == "hooks.example.com"
+      refute entry["endpoint"] =~ secret_path
+      refute Jason.encode!(body) =~ "CAPABILITY-TOKEN"
+
+      # Still actionable: the orchestrator learns WHICH subscription conflicts.
+      assert is_binary(entry["webhook_id"])
+    end
+
+    test "a :user DOES receive the full destination URL", %{conn: conn, keys: keys, tenant: t} do
+      url = "https://hooks.example.com/services/T00000/B00000/CAPABILITY-TOKEN"
+      fixture(:webhook, %{tenant_id: t.id, url: url, events: ["story.status_changed"]})
+
+      body =
+        conn
+        |> auth(keys.user)
+        |> post(~p"/api/v1/egress/local-only", %{})
+        |> json_response(409)
+
+      assert Enum.any?(body["blocked_endpoints"], &(&1["endpoint"] == url))
+    end
   end
 
   describe "the deployment allowlist is not writable at ANY role (AC-41.4.5, TC-41.4.7)" do
@@ -190,15 +232,16 @@ defmodule LoopctlWeb.EgressControllerTest do
       refute body["guarantee_scope"] =~ "NOT yet covered"
     end
 
-    # AC-41.5.5: the destination and its locality classification are readable at
-    # AGENT role (the URL is not a secret — only the signing secret is), while
-    # the allowlist CONTENTS stay a boolean.
-    test "webhook destinations are classified at :agent, allowlist as a BOOLEAN",
+    # AC-41.5.5: the destination's HOST and its locality classification are
+    # readable at AGENT role. The FULL URL is NOT: a webhook path is frequently
+    # the credential, and reading webhook URLs is `role: :user` on
+    # `LoopctlWeb.WebhookController` — the posture must not be a way around it.
+    test "webhook destinations are classified at :agent, URL and allowlist withheld",
          %{conn: conn, keys: keys, tenant: tenant} do
       webhook =
         fixture(:webhook, %{
           tenant_id: tenant.id,
-          url: "https://hooks.example.com/inbound",
+          url: "https://hooks.example.com/services/T0/B0/s3cr3t",
           events: ["story.status_changed"]
         })
 
@@ -206,12 +249,29 @@ defmodule LoopctlWeb.EgressControllerTest do
 
       assert [destination] = body["webhook_destinations"]
       assert destination["webhook_id"] == webhook.id
-      assert destination["endpoint"] == "https://hooks.example.com/inbound"
       assert destination["host"] == "hooks.example.com"
       assert is_binary(destination["verdict"])
       assert is_boolean(destination["verdict_from_deployment_allowlist"])
       assert destination["blocked_by_local_only"] == true
       refute Map.has_key?(destination, "signing_secret_encrypted")
+
+      refute Map.has_key?(destination, "endpoint")
+      refute Jason.encode!(body) =~ "s3cr3t"
+    end
+
+    test "at :user — the full webhook destination URL IS present",
+         %{conn: conn, keys: keys, tenant: tenant} do
+      _webhook =
+        fixture(:webhook, %{
+          tenant_id: tenant.id,
+          url: "https://hooks.example.com/services/T0/B0/s3cr3t",
+          events: ["story.status_changed"]
+        })
+
+      body = conn |> auth(keys.user) |> get(~p"/api/v1/egress/posture") |> json_response(200)
+
+      assert [destination] = body["webhook_destinations"]
+      assert destination["endpoint"] == "https://hooks.example.com/services/T0/B0/s3cr3t"
     end
 
     test "at :user — the allowlist contents ARE present", %{conn: conn, keys: keys} do

--- a/test/loopctl_web/controllers/egress_controller_test.exs
+++ b/test/loopctl_web/controllers/egress_controller_test.exs
@@ -178,9 +178,40 @@ defmodule LoopctlWeb.EgressControllerTest do
       assert scope["local_only"] == true
       assert scope["encrypt_body"] == false
       assert body["posture_defects"] == []
-      # The guarantee wording does NOT claim total egress control before US-41.5.
-      assert body["guarantee_scope"] =~ "US-41.5"
+
+      # US-41.5: webhook delivery is now covered and reported per destination, so
+      # the guarantee no longer carves it out — but it is still narrowed to what
+      # the static chokepoint check actually proves.
+      assert Map.has_key?(body, "webhook_destinations")
+      assert is_list(body["webhook_destinations"])
+      assert body["guarantee_scope"] =~ "WEBHOOK DELIVERY"
       assert body["guarantee_scope"] =~ "loopctl application code"
+      assert body["guarantee_scope"] =~ "inside a dependency"
+      refute body["guarantee_scope"] =~ "NOT yet covered"
+    end
+
+    # AC-41.5.5: the destination and its locality classification are readable at
+    # AGENT role (the URL is not a secret — only the signing secret is), while
+    # the allowlist CONTENTS stay a boolean.
+    test "webhook destinations are classified at :agent, allowlist as a BOOLEAN",
+         %{conn: conn, keys: keys, tenant: tenant} do
+      webhook =
+        fixture(:webhook, %{
+          tenant_id: tenant.id,
+          url: "https://hooks.example.com/inbound",
+          events: ["story.status_changed"]
+        })
+
+      body = conn |> auth(keys.agent) |> get(~p"/api/v1/egress/posture") |> json_response(200)
+
+      assert [destination] = body["webhook_destinations"]
+      assert destination["webhook_id"] == webhook.id
+      assert destination["endpoint"] == "https://hooks.example.com/inbound"
+      assert destination["host"] == "hooks.example.com"
+      assert is_binary(destination["verdict"])
+      assert is_boolean(destination["verdict_from_deployment_allowlist"])
+      assert destination["blocked_by_local_only"] == true
+      refute Map.has_key?(destination, "signing_secret_encrypted")
     end
 
     test "at :user — the allowlist contents ARE present", %{conn: conn, keys: keys} do

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -210,8 +210,8 @@ defmodule Loopctl.DataCase do
     # webhook-worker tests — which Req.Test.stub(Loopctl.Webhooks.ReqDelivery) — keep
     # working unchanged. ScaleAlerts tests override this with Mox.expect/3 to assert the
     # firing POST.
-    Mox.stub(Loopctl.MockDelivery, :deliver, fn url, body, headers ->
-      ReqDelivery.deliver(url, body, headers)
+    Mox.stub(Loopctl.MockDelivery, :deliver, fn url, body, headers, scope ->
+      ReqDelivery.deliver(url, body, headers, scope)
     end)
 
     # Default Req.Test stub for CLI HTTP client


### PR DESCRIPTION
## US-41.5 — Extend the egress guard to non-provider egress (webhook delivery)

Webhook delivery was the one content-carrying outbound path the US-41.4 guard did not
cover. It now consults the SAME single egress policy module as the model-provider path
instead of its own UrlGuard.pin call, so there is exactly one URL policy in lib/.

### What changed

- **Delivery path (AC-41.5.1)** — DeliveryBehaviour.deliver/4 gained the egress Scope
  (tenant, webhook.project_id). ReqDelivery calls Egress.Policy.check/4 with purpose
  :webhook and tenant_supplied: true. The SSRF denylist stays mandatory for every scope;
  the locality decision is layered on top. An operator-allowlisted or purpose-declared
  destination is now deliverable - it was not before. scope: nil marks operator-plane
  delivery (scale alerts), SSRF-guarded only.
- **Blocked is not failed (AC-41.5.2)** — webhook_events gained a :blocked status.
  Blocked is terminal: no attempt burned, no retry, no consecutive_failures increment,
  so a misconfigured subscription cannot build a retry backlog. event.error carries the
  block kind (ssrf_denied vs locality_denied) plus the agent-readable refusal reason.
  Transient refusals (pin_stale / egress_unavailable) snooze instead.
- **Config-time rejection (AC-41.5.3)** — Webhooks.create_webhook/update_webhook reject a
  destination that is denylisted, unresolvable, or non-local on an already local_only
  scope, before the Multi, with a legible remediation. The address decision moved out of
  Webhook.validate_url into the policy: a changeset cannot see the operator allowlist,
  and keeping it there both refused every allowlisted destination and resolved DNS twice
  per write. The changeset now validates shape via UrlGuard.validate_shape/2.
- **Enable pre-flight (AC-41.5.4)** — enable_local_only pre-flight now includes
  incompatible webhook subscriptions (kind: :webhook), reusing the documented
  refuse-unless-acknowledged contract. Subscriptions are never silently disabled.
- **Posture (AC-41.5.5)** — egress_posture reports webhook_destinations with
  per-destination verdict, allowlist boolean and blocked_by_local_only. The guarantee
  wording and the MCP tool descriptions no longer carve webhook delivery out.
- **Triage (AC-41.5.6)** — re-ran the AC-41.4.4 outbound inventory. The chokepoint
  allowlist justification for ReqDelivery is rewritten as a wrapper exemption, and
  docs/egress-guard.md gained a triage table that a test asserts is in parity with the
  allowlist.
- **AC-41.5.7** — no new table or column: blocked deliveries are webhook_events rows and
  egress_blocked_decisions rows, both already tenant_id-scoped with enable_rls. The
  tenant-isolation assertion is TC-41.5.6.

### Tests

TC-41.5.1 through TC-41.5.6 plus the posture and triage-parity assertions, in
test/loopctl/egress/webhook_egress_test.exs and
test/loopctl/egress/webhook_oban_terminal_test.exs.

mix precommit green: 5603 tests, 0 failures, credo --strict clean, dialyzer clean.
