### PR TITLE
Exclude the superadmin role from the HTTP API-key create path

### DIFF
--- a/lib/loopctl/auth.ex
+++ b/lib/loopctl/auth.ex
@@ -42,9 +42,18 @@ defmodule Loopctl.Auth do
 
   - `attrs` — must include `:name` and `:role`. For non-superadmin keys,
     `:tenant_id` must be set in the attrs (it is applied programmatically).
+
+  ## Options
+
+  - `:changeset` — which validation to apply (#462). `:full` (default) uses
+    `ApiKey.create_changeset/2` and accepts the full role set including
+    `:superadmin` — this is the privileged bootstrap/fixture/dispatch path.
+    `:http` uses `ApiKey.http_create_changeset/2`, which structurally rejects
+    `:superadmin`. The public HTTP controller passes `changeset: :http`.
   """
-  @spec generate_api_key(map()) :: {:ok, {String.t(), ApiKey.t()}} | {:error, Ecto.Changeset.t()}
-  def generate_api_key(attrs) do
+  @spec generate_api_key(map(), keyword()) ::
+          {:ok, {String.t(), ApiKey.t()}} | {:error, Ecto.Changeset.t()}
+  def generate_api_key(attrs, opts \\ []) do
     raw_key = generate_raw_key()
     key_hash = hash_key(raw_key)
     key_prefix = String.slice(raw_key, 0, 8)
@@ -56,7 +65,7 @@ defmodule Loopctl.Auth do
 
     changeset =
       base
-      |> ApiKey.create_changeset(attrs)
+      |> build_create_changeset(attrs, Keyword.get(opts, :changeset, :full))
       |> Ecto.Changeset.put_change(:key_hash, key_hash)
       |> Ecto.Changeset.put_change(:key_prefix, key_prefix)
 
@@ -72,6 +81,12 @@ defmodule Loopctl.Auth do
         {:error, changeset}
     end
   end
+
+  defp build_create_changeset(base, attrs, :http),
+    do: ApiKey.http_create_changeset(base, attrs)
+
+  defp build_create_changeset(base, attrs, _full),
+    do: ApiKey.create_changeset(base, attrs)
 
   @doc """
   Verifies a raw API key by hashing it and looking up the hash.

--- a/lib/loopctl/auth/api_key.ex
+++ b/lib/loopctl/auth/api_key.ex
@@ -20,6 +20,13 @@ defmodule Loopctl.Auth.ApiKey do
 
   @roles [:superadmin, :user, :orchestrator, :agent]
 
+  # Roles that may be minted through the public HTTP API-key create path.
+  # `:superadmin` is deliberately excluded: superadmin keys can only be
+  # provisioned out-of-band via the privileged `create_changeset/2` path
+  # (bootstrap/fixtures/dispatch). See #462 — defense-in-depth so a future
+  # internal caller that reaches the HTTP path can't mint a superadmin key.
+  @http_roles [:user, :orchestrator, :agent]
+
   schema "api_keys" do
     tenant_field()
     field :name, :string
@@ -36,17 +43,49 @@ defmodule Loopctl.Auth.ApiKey do
   end
 
   @doc """
-  Changeset for creating a new API key.
+  Changeset for creating a new API key (privileged / full-role path).
+
+  Accepts the FULL role set including `:superadmin`. This is the bootstrap /
+  fixture / dispatch provisioning path — the only path that may mint a
+  superadmin key. HTTP callers must use `http_create_changeset/2` instead,
+  which structurally excludes `:superadmin` (#462).
 
   The `key_hash` and `key_prefix` are set programmatically, not via cast.
   The `tenant_id` is also set programmatically.
   """
   @spec create_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
   def create_changeset(api_key \\ %__MODULE__{}, attrs) do
+    base_create_changeset(api_key, attrs, @roles)
+  end
+
+  @doc """
+  Changeset for creating a new API key via the public HTTP API path.
+
+  Identical to `create_changeset/2` except the allowed roles are restricted
+  to `#{inspect(@http_roles)}` — `:superadmin` is structurally rejected with a
+  clear error (#462). This is a defense-in-depth backstop: the HTTP controller
+  already returns 403 for `role: "superadmin"`, and this changeset ensures any
+  caller that opts into the HTTP path cannot mint a superadmin key even if the
+  controller guard is bypassed.
+  """
+  @spec http_create_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+  def http_create_changeset(api_key \\ %__MODULE__{}, attrs) do
+    base_create_changeset(api_key, attrs, @http_roles,
+      role_message: "superadmin keys cannot be created via the API"
+    )
+  end
+
+  defp base_create_changeset(api_key, attrs, allowed_roles, opts \\ []) do
+    inclusion_opts =
+      case Keyword.get(opts, :role_message) do
+        nil -> []
+        message -> [message: message]
+      end
+
     api_key
     |> cast(attrs, [:name, :role, :expires_at, :agent_id])
     |> validate_required([:name, :role])
-    |> validate_inclusion(:role, @roles)
+    |> validate_inclusion(:role, allowed_roles, inclusion_opts)
     |> validate_tenant_for_role()
     |> unique_constraint([:tenant_id, :agent_id],
       name: :api_keys_one_role_per_agent_idx,
@@ -81,6 +120,13 @@ defmodule Loopctl.Auth.ApiKey do
   """
   @spec roles() :: [atom()]
   def roles, do: @roles
+
+  @doc """
+  Returns the list of roles that may be created via the public HTTP API path
+  (the full role set minus `:superadmin`). See `http_create_changeset/2`.
+  """
+  @spec http_roles() :: [atom()]
+  def http_roles, do: @http_roles
 
   defp validate_tenant_for_role(changeset) do
     validate_change(changeset, :role, fn :role, role ->

--- a/lib/loopctl/auth/api_key.ex
+++ b/lib/loopctl/auth/api_key.ex
@@ -21,11 +21,15 @@ defmodule Loopctl.Auth.ApiKey do
   @roles [:superadmin, :user, :orchestrator, :agent]
 
   # Roles that may be minted through the public HTTP API-key create path.
-  # `:superadmin` is deliberately excluded: superadmin keys can only be
-  # provisioned out-of-band via the privileged `create_changeset/2` path
-  # (bootstrap/fixtures/dispatch). See #462 — defense-in-depth so a future
-  # internal caller that reaches the HTTP path can't mint a superadmin key.
-  @http_roles [:user, :orchestrator, :agent]
+  # Derived as the full role set MINUS `:superadmin` so this stays a single
+  # source of truth: adding a new non-superadmin role to `@roles` above makes
+  # it HTTP-creatable automatically, and the security-critical `:superadmin`
+  # exclusion is named explicitly here so it can never drift open. See #462 —
+  # defense-in-depth so a future internal caller that reaches the HTTP path
+  # can't mint a superadmin key. `LoopctlWeb.ApiKeyController.safe_to_role/1`
+  # references `http_roles/0` so the controller's string allowlist tracks this
+  # set too.
+  @http_roles @roles -- [:superadmin]
 
   schema "api_keys" do
     tenant_field()
@@ -82,21 +86,31 @@ defmodule Loopctl.Auth.ApiKey do
   end
 
   defp base_create_changeset(api_key, attrs, allowed_roles, opts \\ []) do
-    inclusion_opts =
-      case Keyword.get(opts, :role_message) do
-        nil -> []
-        message -> [message: message]
-      end
-
     api_key
     |> cast(attrs, [:name, :role, :expires_at, :agent_id])
     |> validate_required([:name, :role])
-    |> validate_inclusion(:role, allowed_roles, inclusion_opts)
+    |> validate_role_allowed(allowed_roles, Keyword.get(opts, :role_message))
     |> validate_tenant_for_role()
     |> unique_constraint([:tenant_id, :agent_id],
       name: :api_keys_one_role_per_agent_idx,
       message: "agent already has an active key with this role"
     )
+  end
+
+  # Restrict `:role` to `allowed_roles`. When a caller supplies a
+  # `role_message` (the HTTP path naming `:superadmin`), that message is used
+  # ONLY for the exact `:superadmin` value it describes — every OTHER
+  # disallowed role gets the generic "is invalid" so the error is never
+  # misattributed to superadmin. Mirrors `validate_inclusion/3` semantics
+  # (skips nil/absent changes so `validate_required` handles blanks).
+  defp validate_role_allowed(changeset, allowed_roles, role_message) do
+    validate_change(changeset, :role, fn :role, role ->
+      cond do
+        role in allowed_roles -> []
+        role == :superadmin and is_binary(role_message) -> [role: role_message]
+        true -> [role: "is invalid"]
+      end
+    end)
   end
 
   @doc """

--- a/lib/loopctl/auth/api_key.ex
+++ b/lib/loopctl/auth/api_key.ex
@@ -63,10 +63,16 @@ defmodule Loopctl.Auth.ApiKey do
 
   Identical to `create_changeset/2` except the allowed roles are restricted
   to `#{inspect(@http_roles)}` — `:superadmin` is structurally rejected with a
-  clear error (#462). This is a defense-in-depth backstop: the HTTP controller
-  already returns 403 for `role: "superadmin"`, and this changeset ensures any
-  caller that opts into the HTTP path cannot mint a superadmin key even if the
-  controller guard is bypassed.
+  clear error (#462).
+
+  This is a defense-in-depth backstop for DIRECT context callers that reach the
+  HTTP path with a raw `:superadmin` role. Note that the
+  `LoopctlWeb.ApiKeyController` create path does NOT exercise this specific
+  rejection: it returns 403 for `role: "superadmin"` first, and even if that
+  guard were bypassed its `safe_to_role/1` maps `"superadmin"` to `nil`, so the
+  changeset would fail via `validate_required` ("can't be blank") rather than
+  this role-inclusion message. The superadmin-specific message therefore only
+  fires for a caller passing the `:superadmin` atom directly to this changeset.
   """
   @spec http_create_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
   def http_create_changeset(api_key \\ %__MODULE__{}, attrs) do

--- a/lib/loopctl_web/controllers/api_key_controller.ex
+++ b/lib/loopctl_web/controllers/api_key_controller.ex
@@ -184,9 +184,17 @@ defmodule LoopctlWeb.ApiKeyController do
       agent_id: params["agent_id"]
     }
 
-    # Structural backstop (#462): even though `validate_not_superadmin/1` already
-    # returned 403 for role "superadmin" before we reach here, use the HTTP-scoped
-    # changeset so the context layer also refuses to mint a superadmin key.
+    # Structural backstop (#462). On THIS controller path superadmin is blocked
+    # twice before the changeset's role-inclusion gate ever sees it: first
+    # `validate_not_superadmin/1` returns 403 for role "superadmin", then
+    # `safe_to_role/1` above maps "superadmin" (and any unknown string) to nil.
+    # So `role` is already nil here — if the 403 guard were bypassed the :http
+    # changeset would reject via `validate_required` ("can't be blank"), NOT via
+    # its "superadmin keys cannot be created via the API" message. The @http_roles
+    # superadmin exclusion is the backstop for DIRECT context callers that pass a
+    # raw `:superadmin` atom (bypassing `safe_to_role/1`); we still route through
+    # the HTTP-scoped changeset here so the context layer refuses a superadmin key
+    # on every path regardless of how `role` was derived.
     Auth.generate_api_key(attrs, changeset: :http)
   end
 

--- a/lib/loopctl_web/controllers/api_key_controller.ex
+++ b/lib/loopctl_web/controllers/api_key_controller.ex
@@ -10,6 +10,7 @@ defmodule LoopctlWeb.ApiKeyController do
 
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Auth
+  alias Loopctl.Auth.ApiKey
   alias Loopctl.Tenants
 
   action_fallback LoopctlWeb.FallbackController
@@ -272,16 +273,18 @@ defmodule LoopctlWeb.ApiKeyController do
     }
   end
 
-  defp safe_to_role(nil), do: nil
-
+  # Coerce the client-supplied role string to a known HTTP-creatable role atom,
+  # or nil for anything else. The allowlist is derived from `ApiKey.http_roles/0`
+  # (the single source of truth: full role set minus :superadmin) by matching on
+  # the atom's string form — we NEVER `String.to_atom/1` untrusted input. Unknown
+  # strings and non-string JSON values (numbers, booleans, arrays) both map to
+  # nil, so they fail cleanly via `validate_required` (422 "can't be blank")
+  # rather than raising a FunctionClauseError -> 500.
   defp safe_to_role(role) when is_binary(role) do
-    case role do
-      "user" -> :user
-      "orchestrator" -> :orchestrator
-      "agent" -> :agent
-      _ -> nil
-    end
+    Enum.find(ApiKey.http_roles(), fn allowed -> Atom.to_string(allowed) == role end)
   end
+
+  defp safe_to_role(_role), do: nil
 
   defp parse_datetime(nil), do: nil
 

--- a/lib/loopctl_web/controllers/api_key_controller.ex
+++ b/lib/loopctl_web/controllers/api_key_controller.ex
@@ -184,7 +184,10 @@ defmodule LoopctlWeb.ApiKeyController do
       agent_id: params["agent_id"]
     }
 
-    Auth.generate_api_key(attrs)
+    # Structural backstop (#462): even though `validate_not_superadmin/1` already
+    # returned 403 for role "superadmin" before we reach here, use the HTTP-scoped
+    # changeset so the context layer also refuses to mint a superadmin key.
+    Auth.generate_api_key(attrs, changeset: :http)
   end
 
   defp do_rotate_key(tenant, old_key, grace_hours) do

--- a/test/loopctl/auth/api_key_test.exs
+++ b/test/loopctl/auth/api_key_test.exs
@@ -1,0 +1,131 @@
+defmodule Loopctl.Auth.ApiKeyTest do
+  @moduledoc """
+  Tests for the API-key changesets — specifically the HTTP-scoped changeset
+  that structurally excludes `:superadmin` from the public create path (#462).
+
+  Layering under test:
+
+  - `create_changeset/2` (full role set) — the privileged bootstrap/fixture/
+    dispatch path that MAY still mint a `:superadmin` key.
+  - `http_create_changeset/2` (allowlist minus superadmin) — the public HTTP
+    path backstop that refuses to mint a `:superadmin` key.
+  """
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Auth
+  alias Loopctl.Auth.ApiKey
+
+  describe "http_roles/0" do
+    test "excludes :superadmin from the HTTP-creatable role set" do
+      refute :superadmin in ApiKey.http_roles()
+      assert Enum.sort(ApiKey.http_roles()) == Enum.sort([:user, :orchestrator, :agent])
+      # And the full set still carries superadmin for the privileged path.
+      assert :superadmin in ApiKey.roles()
+    end
+  end
+
+  describe "http_create_changeset/2" do
+    test "rejects role :superadmin with a clear error" do
+      changeset =
+        ApiKey.http_create_changeset(%ApiKey{}, %{name: "hacker", role: :superadmin})
+
+      refute changeset.valid?
+
+      assert "superadmin keys cannot be created via the API" in errors_on(changeset).role
+    end
+
+    for role <- [:user, :orchestrator, :agent] do
+      test "accepts role #{inspect(role)} (tenant-scoped)" do
+        tenant = fixture(:tenant)
+
+        changeset =
+          %ApiKey{tenant_id: tenant.id}
+          |> ApiKey.http_create_changeset(%{name: "k", role: unquote(role)})
+
+        assert changeset.valid?
+        assert Ecto.Changeset.get_field(changeset, :role) == unquote(role)
+      end
+    end
+
+    test "still enforces tenant_id for non-superadmin roles" do
+      changeset = ApiKey.http_create_changeset(%ApiKey{}, %{name: "k", role: :user})
+
+      refute changeset.valid?
+      assert errors_on(changeset).tenant_id != []
+    end
+  end
+
+  describe "create_changeset/2 (privileged full-role path)" do
+    test "still accepts role :superadmin (with nil tenant_id)" do
+      changeset = ApiKey.create_changeset(%ApiKey{}, %{name: "root", role: :superadmin})
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :role) == :superadmin
+    end
+  end
+
+  describe "Auth.generate_api_key/2 with changeset: :http" do
+    test "rejects role :superadmin with a clear error" do
+      assert {:error, changeset} =
+               Auth.generate_api_key(%{name: "hacker", role: :superadmin}, changeset: :http)
+
+      assert "superadmin keys cannot be created via the API" in errors_on(changeset).role
+    end
+
+    for role <- [:user, :orchestrator, :agent] do
+      test "creates a #{inspect(role)} key" do
+        tenant = fixture(:tenant)
+
+        assert {:ok, {raw_key, %ApiKey{} = api_key}} =
+                 Auth.generate_api_key(
+                   %{tenant_id: tenant.id, name: "k", role: unquote(role)},
+                   changeset: :http
+                 )
+
+        assert String.starts_with?(raw_key, "lc_")
+        assert api_key.role == unquote(role)
+        assert api_key.tenant_id == tenant.id
+      end
+    end
+  end
+
+  describe "Auth.generate_api_key/1 (default full changeset) — regression" do
+    test "privileged superadmin provisioning path is unaffected" do
+      assert {:ok, {_raw, %ApiKey{} = api_key}} =
+               Auth.generate_api_key(%{name: "root", role: :superadmin})
+
+      assert api_key.role == :superadmin
+      assert api_key.tenant_id == nil
+    end
+  end
+
+  describe "tenant isolation" do
+    test "HTTP-created keys are scoped to their own tenant" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      assert {:ok, {_raw_a, key_a}} =
+               Auth.generate_api_key(
+                 %{tenant_id: tenant_a.id, name: "key-a", role: :agent},
+                 changeset: :http
+               )
+
+      assert {:ok, {_raw_b, key_b}} =
+               Auth.generate_api_key(
+                 %{tenant_id: tenant_b.id, name: "key-b", role: :agent},
+                 changeset: :http
+               )
+
+      assert key_a.tenant_id == tenant_a.id
+      assert key_b.tenant_id == tenant_b.id
+
+      assert {:ok, keys_a} = Auth.list_api_keys(tenant_a.id)
+      assert Enum.map(keys_a, & &1.name) == ["key-a"]
+
+      assert {:ok, keys_b} = Auth.list_api_keys(tenant_b.id)
+      assert Enum.map(keys_b, & &1.name) == ["key-b"]
+    end
+  end
+end

--- a/test/loopctl/auth/api_key_test.exs
+++ b/test/loopctl/auth/api_key_test.exs
@@ -49,6 +49,18 @@ defmodule Loopctl.Auth.ApiKeyTest do
       end
     end
 
+    test "a non-superadmin invalid role gets a generic error, not the superadmin message" do
+      tenant = fixture(:tenant)
+
+      changeset =
+        %ApiKey{tenant_id: tenant.id}
+        |> ApiKey.http_create_changeset(%{name: "k", role: :wizard})
+
+      refute changeset.valid?
+      assert "is invalid" in errors_on(changeset).role
+      refute "superadmin keys cannot be created via the API" in errors_on(changeset).role
+    end
+
     test "still enforces tenant_id for non-superadmin roles" do
       changeset = ApiKey.http_create_changeset(%ApiKey{}, %{name: "k", role: :user})
 

--- a/test/loopctl_web/controllers/api_key_controller_test.exs
+++ b/test/loopctl_web/controllers/api_key_controller_test.exs
@@ -35,6 +35,21 @@ defmodule LoopctlWeb.ApiKeyControllerTest do
       assert json_response(conn, 403)
     end
 
+    test "creates lower-role keys (agent/orchestrator/user) via the HTTP path", %{conn: _conn} do
+      for role <- ["agent", "orchestrator", "user"] do
+        tenant = fixture(:tenant)
+        {raw_key, _admin} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+        conn =
+          build_conn()
+          |> auth_conn(raw_key)
+          |> post(~p"/api/v1/api_keys", %{"name" => "k-#{role}", "role" => role})
+
+        body = json_response(conn, 201)
+        assert body["api_key"]["role"] == role
+      end
+    end
+
     test "respects max_api_keys limit", %{conn: conn} do
       tenant = fixture(:tenant, %{settings: %{"max_api_keys" => 2}})
       {raw_key, _admin} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})

--- a/test/loopctl_web/controllers/api_key_controller_test.exs
+++ b/test/loopctl_web/controllers/api_key_controller_test.exs
@@ -50,6 +50,34 @@ defmodule LoopctlWeb.ApiKeyControllerTest do
       end
     end
 
+    test "returns 422 (not 500) for a non-string role value", %{conn: _conn} do
+      # A non-string JSON role (number, boolean, array) must fail cleanly via
+      # validate_required rather than raising a FunctionClauseError -> 500.
+      for bad_role <- [123, true, ["agent"]] do
+        tenant = fixture(:tenant)
+        {raw_key, _admin} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+        conn =
+          build_conn()
+          |> auth_conn(raw_key)
+          |> post(~p"/api/v1/api_keys", %{"name" => "bad", "role" => bad_role})
+
+        assert json_response(conn, 422)
+      end
+    end
+
+    test "returns 422 for an unknown role string", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _admin} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/api_keys", %{"name" => "bad", "role" => "wizard"})
+
+      assert json_response(conn, 422)
+    end
+
     test "respects max_api_keys limit", %{conn: conn} do
       tenant = fixture(:tenant, %{settings: %{"max_api_keys" => 2}})
       {raw_key, _admin} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})


### PR DESCRIPTION
## What

Defense-in-depth hardening for #462 (LOW severity, preventative — no known exploit). The API-key changeset previously validated `:role` against the full role set including `:superadmin`. The HTTP controller already returns 403 for `role: "superadmin"`, but the changeset itself now structurally rejects superadmin so any caller reaching the HTTP path cannot mint a superadmin key even if the controller guard is bypassed.

## How

Dual-changeset design (per the issue):

- `Loopctl.Auth.ApiKey.http_create_changeset/2` — positive allowlist `@http_roles = [:user, :orchestrator, :agent]`; shares all other validation (tenant-for-role, unique constraint) with `create_changeset/2` via a private `base_create_changeset/4`. Added `ApiKey.http_roles/0` mirroring `roles/0`.
- `Loopctl.Auth.generate_api_key/2` — gains a `:changeset` opt. `:full` (default) preserves the privileged bootstrap/fixture/dispatch path that may still mint superadmin; `:http` selects the restricted changeset.
- `LoopctlWeb.ApiKeyController.do_create_key/2` passes `changeset: :http`. The existing `validate_not_superadmin/1` 403 guard is kept — belt and suspenders.

The privileged provisioning path (`generate_api_key/1` with `role: :superadmin`, used by fixtures, the auth bootstrap test, and `Dispatches.mint_and_link_key`) is unchanged and still works.

## Tests

- New `test/loopctl/auth/api_key_test.exs`: `http_create_changeset/2` rejects `:superadmin` with a clear message and accepts each lower role; `generate_api_key/2, changeset: :http` rejection + creation; regression that the default `/1` superadmin path still returns `{:ok, ...}` with nil tenant_id; tenant isolation.
- `api_key_controller_test.exs`: existing 403 superadmin test stays green; added a positive test that agent/orchestrator/user create returns 201.
- `mix precommit` green (format, credo --strict, dialyzer, 5615 tests 0 failures).

Closes #462
