### PR TITLE
#470 [retrieval] Replace min-max weighted-sum fusion with RRF + graph-neighbor lane in search_combined

### DIFF
--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -39,11 +39,11 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:463-469`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:428-430`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:7072`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:7297`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
-   (`absolute_score/1`, `:7135-7140`) clears a scale-matched threshold AND beats the best retrieved
-   candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:7169-7178`; the pure decision is
-   `resolve_provenance/4`, `:7222-7234`) AND is authoritative (not superseded/conflicted — the caller
+   (`absolute_score/1`, `:7424-7429`) clears a scale-matched threshold AND beats the best retrieved
+   candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:7458-7466`; the pure decision is
+   `resolve_provenance/4`, `:7511-7523`) AND is authoritative (not superseded/conflicted — the caller
    passes only `list_curated_sources/2`-filtered scores). Otherwise `:retrieved`. Both branches return identical `results`/`meta`
    key sets — callers branch on `meta.provenance` alone. A sparse pool must never let a near-but-wrong
    curated doc win.

--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -39,11 +39,11 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:463-469`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:428-430`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:7351`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:7410`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
-   (`absolute_score/1`, `:7424-7429`) clears a scale-matched threshold AND beats the best retrieved
-   candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:7458-7466`; the pure decision is
-   `resolve_provenance/4`, `:7511-7523`) AND is authoritative (not superseded/conflicted — the caller
+   (`absolute_score/1`, `:7537-7542`) clears a scale-matched threshold AND beats the best retrieved
+   candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:7588-7596`; the pure decision is
+   `resolve_provenance/4`, `:7643-7653`) AND is authoritative (not superseded/conflicted — the caller
    passes only `list_curated_sources/2`-filtered scores). Otherwise `:retrieved`. Both branches return identical `results`/`meta`
    key sets — callers branch on `meta.provenance` alone. A sparse pool must never let a near-but-wrong
    curated doc win.

--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -39,7 +39,7 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:463-469`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:428-430`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:7297`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:7351`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
    (`absolute_score/1`, `:7424-7429`) clears a scale-matched threshold AND beats the best retrieved
    candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:7458-7466`; the pure decision is

--- a/.claude/skills/tenancy-rls/SKILL.md
+++ b/.claude/skills/tenancy-rls/SKILL.md
@@ -57,12 +57,12 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
    (`heavy_read.ex:642-660`) RAISES unless EVERY base-table source — `from`, every join, and every
    subquery, recursively — carries a conjunctive `x.tenant_id == ^tenant_id` bound to the passed
    `tenant_id`; `test/loopctl/heavy_read_guard_test.exs` additionally bars direct `HeavyReadRepo` calls.
-   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:440`) also requires a conjunctive
-   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:664-686`), because `subject_id`
+   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:444`) also requires a conjunctive
+   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:668-690`), because `subject_id`
    scoping is application-level only. Always go through `Loopctl.HeavyRead`, never `HeavyReadRepo`
    directly; on `AdminRepo` there is no guard at all, so the predicate is on you.
-7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:386`),
-   `one/3` (`heavy_read.ex:405`) and `all_memory/4` (`heavy_read.ex:440`) are specced to return it: the
+7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:390`),
+   `one/3` (`heavy_read.ex:409`) and `all_memory/4` (`heavy_read.ex:444`) are specced to return it: the
    per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:468-482`) sheds over the cap —
    `on_overload: :raise` (default) raises → 429, `on_overload: :tag` returns the tuple. Binding the
    result as a list crashes exactly under the load the gate exists for.

--- a/config/config.exs
+++ b/config/config.exs
@@ -735,13 +735,18 @@ config :loopctl, :knowledge_rrf_k, 60
 # score (their hybrid-resolver absolute_score stays 0.0) and never inflate
 # meta.semantic_result_count.
 config :loopctl, :knowledge_rrf_graph_lane_enabled, false
-# Weight of the graph-neighbor lane in RRF fusion when enabled. Defaults to 0.5 to
-# MATCH the keyword/semantic per-lane weights this system actually uses (search_combined
-# defaults each primary lane to 0.5, structurally summed to 1.0). A 1.0 graph weight
-# would make a zero-signal one-hop neighbor at graph-rank 1 (1.0/(k+1)) outrank every
-# single-lane rank-1 hit (0.5/(k+1)) — the graph lane carries no relevance/similarity
-# signal by design, so it must not double the primary lanes' contribution (#470 review).
-config :loopctl, :knowledge_rrf_graph_weight, 0.5
+# Weight of the graph-neighbor lane in RRF fusion when enabled. Defaults to 0.25 —
+# STRICTLY BELOW the keyword/semantic per-lane weight (0.5 each). The graph lane carries
+# NO relevance/similarity signal (a neighbor surfaces only because it is link-adjacent to
+# a seed), so it must never tie OR outrank a genuine single-lane hit. At the primary weight
+# (0.5) a graph-rank-1 neighbor scores 0.5/(k+1) — EXACTLY equal to a single-lane rank-1
+# hit — and the deterministic `{final_score, id}` desc tiebreak could then float a
+# zero-signal neighbor with a larger id ABOVE the true top hit (#470 review). At 0.25 a
+# graph-rank-1 neighbor scores 0.25/(k+1) < 0.5/(k+1), so the "never outranks a genuine
+# single-lane top hit" invariant holds by construction, in POSITION not just in score. A
+# doc that is ALSO a genuine hit still sums its primary-lane contribution, so real
+# cross-lane consensus is unaffected.
+config :loopctl, :knowledge_rrf_graph_weight, 0.25
 # Number of top merged candidates used as graph-lane seeds (bounds link fan-out).
 config :loopctl, :knowledge_rrf_graph_seed_count, 10
 # Overall cap on distinct graph-lane neighbors injected into the fusion.

--- a/config/config.exs
+++ b/config/config.exs
@@ -735,9 +735,13 @@ config :loopctl, :knowledge_rrf_k, 60
 # score (their hybrid-resolver absolute_score stays 0.0) and never inflate
 # meta.semantic_result_count.
 config :loopctl, :knowledge_rrf_graph_lane_enabled, false
-# Weight of the graph-neighbor lane in RRF fusion when enabled (default 1.0, matching
-# the canonical per-lane weight).
-config :loopctl, :knowledge_rrf_graph_weight, 1.0
+# Weight of the graph-neighbor lane in RRF fusion when enabled. Defaults to 0.5 to
+# MATCH the keyword/semantic per-lane weights this system actually uses (search_combined
+# defaults each primary lane to 0.5, structurally summed to 1.0). A 1.0 graph weight
+# would make a zero-signal one-hop neighbor at graph-rank 1 (1.0/(k+1)) outrank every
+# single-lane rank-1 hit (0.5/(k+1)) — the graph lane carries no relevance/similarity
+# signal by design, so it must not double the primary lanes' contribution (#470 review).
+config :loopctl, :knowledge_rrf_graph_weight, 0.5
 # Number of top merged candidates used as graph-lane seeds (bounds link fan-out).
 config :loopctl, :knowledge_rrf_graph_seed_count, 10
 # Overall cap on distinct graph-lane neighbors injected into the fusion.

--- a/config/config.exs
+++ b/config/config.exs
@@ -718,6 +718,31 @@ config :loopctl, :knowledge_hybrid_curated_margin, 0.1
 config :loopctl, :knowledge_hybrid_curated_threshold_keyword, 0.5
 config :loopctl, :knowledge_hybrid_curated_margin_keyword, 0.1
 
+# search_combined/3 lane fusion (#470). RRF (Reciprocal Rank Fusion) replaces the
+# legacy min-max normalized weighted-sum: `score(doc) = Σ_lane weight_lane / (k +
+# rank_lane(doc))`. RRF is rank-based, so it is immune to the incommensurable-scale
+# problem (ts_rank_cd vs cosine similarity) that made min-max brittle, and the `k`
+# smoothing constant makes cross-lane consensus outweigh one lane's single #1 vote.
+# The legacy min-max path is kept behind `:min_max` for A/B and eval comparison.
+# All are overridable per-call (opts) for tests/experiments — config-DI, never
+# Application.put_env in tests.
+config :loopctl, :knowledge_fusion_strategy, :rrf
+# RRF smoothing constant. Default 60 per the canonical RRF formula (KB f4a10824).
+config :loopctl, :knowledge_rrf_k, 60
+# Optional third graph-neighbor lane (#470): one-hop link-graph neighbors of the top
+# merged candidates fed into the fusion. OFF by default — a purely additive recall
+# lane that a caller opts into. Graph-only neighbors carry no relevance/similarity
+# score (their hybrid-resolver absolute_score stays 0.0) and never inflate
+# meta.semantic_result_count.
+config :loopctl, :knowledge_rrf_graph_lane_enabled, false
+# Weight of the graph-neighbor lane in RRF fusion when enabled (default 1.0, matching
+# the canonical per-lane weight).
+config :loopctl, :knowledge_rrf_graph_weight, 1.0
+# Number of top merged candidates used as graph-lane seeds (bounds link fan-out).
+config :loopctl, :knowledge_rrf_graph_seed_count, 10
+# Overall cap on distinct graph-lane neighbors injected into the fusion.
+config :loopctl, :knowledge_rrf_graph_max_neighbors, 20
+
 # DI: WebAuthn adapter — defaults to Wax (overridden in test env)
 config :loopctl, :webauthn_adapter, Loopctl.WebAuthn.Wax
 

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -204,7 +204,10 @@ defmodule Loopctl.HeavyRead do
   sign, so it never runs on a lagging read replica), `:export` (the US-27.16 long
   streamed-export scans), and
   `:llm_usage` (the customer-facing LLM-usage aggregate over `llm_usage_events`, a
-  bounded indexed COUNT/GROUP BY — classified LIGHT by the gate).
+  bounded indexed COUNT/GROUP BY — classified LIGHT by the gate), and `:graph_lane` (the
+  #470 opt-in graph-neighbor lane of `search_combined/3`: a bounded, index-backed
+  `ArticleLink` seed-set read plus a bounded neighbor-article fetch — classified HEAVY by
+  the gate since it fans a preload across up to `@graph_lane_link_limit` link rows).
   """
   # US-38.4: the pgvector-ANN (kNN) endpoints whose reads run an index-ordered
   # `ORDER BY (embedding cosine-distance $const) LIMIT k` scan against the HNSW index and are
@@ -302,6 +305,7 @@ defmodule Loopctl.HeavyRead do
     sth_incremental
     export
     llm_usage
+    graph_lane
   )a
 
   @doc """

--- a/lib/loopctl/heavy_read/tenant_gate.ex
+++ b/lib/loopctl/heavy_read/tenant_gate.ex
@@ -168,6 +168,7 @@ defmodule Loopctl.HeavyRead.TenantGate do
     distant_pairs
     distant_pairs_bridge
     export
+    graph_lane
   )a
 
   # --- Client API ---

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -1743,16 +1743,21 @@ defmodule Loopctl.Knowledge do
     |> AdminRepo.all()
   end
 
+  # The relevance term of the context blend MUST be the ABSOLUTE per-row score
+  # (`absolute_score/1` — raw cosine similarity, or a bounded transform of raw
+  # ts_rank_cd), NEVER the fused `:final_score`. Post-#470 the default fusion is RRF,
+  # whose `:final_score` is `Σ weight/(k+rank)` — a top value of ~0.008-0.016, ~30-60x
+  # smaller than the old min-max 0..1 scale. Blending that against the 0..1 recency_score
+  # in `build_context_results/6` (`0.7*relevance + 0.3*recency`) would let recency
+  # dominate ordering ~25x, so an irrelevant-but-fresh article would beat a
+  # highly-relevant-but-old one and `/knowledge/context` would order essentially by
+  # recency. Reading the absolute score keeps relevance on the same 0..1 scale the
+  # recency blend was calibrated for (same root fix as the hybrid resolver's
+  # `absolute_score/1`, US-31.2 — #470 review).
   defp find_relevance_score(results, article_id) do
     case Enum.find(results, fn r -> r[:id] == article_id end) do
-      nil ->
-        0.0
-
-      r ->
-        Map.get(r, :final_score) ||
-          Map.get(r, :relevance_score) ||
-          Map.get(r, :similarity_score) ||
-          0.0
+      nil -> 0.0
+      r -> absolute_score(r)
     end
   end
 
@@ -6904,9 +6909,10 @@ defmodule Loopctl.Knowledge do
 
   # --- Reciprocal Rank Fusion (#470) ------------------------------------------
   #
-  # `score(doc) = Σ_lane weight_lane / (k + rank_lane(doc))`, ranks 1-based, per-lane
-  # weight 0.5 (keyword/semantic/graph all match, so no lane structurally out-votes
-  # another), default k=60 (KB f4a10824). Rank-based fusion sidesteps the
+  # `score(doc) = Σ_lane weight_lane / (k + rank_lane(doc))`, ranks 1-based, keyword/
+  # semantic per-lane weight 0.5 and the opt-in graph lane STRICTLY BELOW them (0.25) so a
+  # zero-signal one-hop neighbor can never tie/outrank a genuine single-lane hit (#470
+  # review), default k=60 (KB f4a10824). Rank-based fusion sidesteps the
   # incommensurable-scale problem (ts_rank_cd vs cosine similarity) that made the old
   # min-max weighted-sum brittle: a doc with cross-lane CONSENSUS can outrank one that
   # is #1 in a single lane. Each lane's list is ALREADY sorted by its own relevance
@@ -7023,10 +7029,10 @@ defmodule Loopctl.Knowledge do
   # --- Graph-neighbor lane (#470) ---------------------------------------------
   #
   # OFF by default. When enabled, takes the top merged candidates as SEEDS, pulls their
-  # one-hop link-graph neighbors (tenant-scoped, visibility-filtered — a tenant B
-  # neighbor can never surface for tenant A), ranks them by cross-seed CONSENSUS
-  # (how many distinct seeds link to them, best seed position as tiebreak), and returns
-  # published article maps in that rank order for the fusion. The neighbor maps carry
+  # one-hop link-graph neighbors (heavy-pool-routed, tenant-scoped, visibility-filtered — a
+  # tenant B neighbor can never surface for tenant A), ranks them by cross-seed CONSENSUS
+  # (how many DISTINCT seeds link to them, best seed position as tiebreak), and returns
+  # requested-status article maps in that rank order for the fusion. The neighbor maps carry
   # NO `:relevance_score`/`:similarity_score`, so their hybrid-resolver `absolute_score`
   # is 0.0 — a graph-only hit can never falsely win the curated-vs-retrieved decision.
   defp put_graph_lane(opts, tenant_id, kw, semantic) do
@@ -7046,6 +7052,11 @@ defmodule Loopctl.Knowledge do
 
   defp build_graph_lane(tenant_id, kw, semantic, opts) do
     vis = Keyword.get(opts, :visibility_agent_id)
+    # Graph-lane neighbors honor the SAME status filter the primary lanes use (search_keyword/
+    # search_semantic both default `:published` and honor the caller opt). Hardcoding
+    # `:published` here would make a `graph_lane: true` + non-published-status search return an
+    # inconsistent lane vs. its primary lanes (#470 review).
+    status = Keyword.get(opts, :status, :published)
 
     # Seeds: the top merged candidates by their existing lane order (keyword first,
     # then semantic), deduped, capped. Seeds themselves are excluded from the neighbor
@@ -7062,8 +7073,10 @@ defmodule Loopctl.Knowledge do
     # ONE tenant-scoped round-trip for the WHOLE seed set (was one AdminRepo query
     # PER seed — an N+1 that fanned up to `rrf_graph_seed_count` sequential reads
     # onto the deliberately small BYPASSRLS AdminRepo pool). Per-seed provenance is
-    # recovered in memory from the source/target ids each link row already carries,
-    # so the consensus tally is byte-for-byte the same (#470 review).
+    # recovered in memory from the source/target ids each link row already carries.
+    # `%{neighbor_id => MapSet<seed_index>}`: a SET of DISTINCT seed indices, NOT a link-row
+    # count, so a neighbor linked from ONE seed via several rows counts that seed once (#470
+    # review — see `tally_graph_neighbor/3`).
     neighbor_stats =
       tenant_id
       |> list_links_for_seed_set(seed_ids, vis)
@@ -7077,31 +7090,69 @@ defmodule Loopctl.Knowledge do
 
     ranked_ids =
       neighbor_stats
-      # Rank: most distinct seeds (consensus) first, then best seed position, then id
-      # for a deterministic total order.
-      |> Enum.sort_by(fn {nid, {count, best_idx}} -> {-count, best_idx, nid} end)
+      # Rank: most DISTINCT seeds (consensus) first, then best (lowest) seed position, then
+      # id for a deterministic total order.
+      |> Enum.sort_by(fn {nid, seed_idxs} ->
+        {-MapSet.size(seed_idxs), Enum.min(seed_idxs), nid}
+      end)
       |> Enum.map(&elem(&1, 0))
       |> Enum.take(rrf_graph_max_neighbors())
 
-    fetch_graph_lane_articles(tenant_id, ranked_ids)
+    fetch_graph_lane_articles(tenant_id, ranked_ids, status)
   end
 
-  # One tenant-scoped, visibility-filtered read of every link touching ANY seed in
-  # the set — the single query that replaces the per-seed N+1.
+  # Cap on link rows read per seed-set graph-lane query — bounds fan-out on a densely-linked
+  # hub, matching the per-article `list_links_for_article/3` limit (#470 review). Without it,
+  # up to `rrf_graph_seed_count` hub seeds could pull thousands of ArticleLink rows in one read.
+  @graph_lane_link_limit 200
+
+  # One tenant-scoped, visibility-filtered read of every link touching ANY seed in the set —
+  # the single query that replaces the per-seed N+1.
   defp list_links_for_seed_set(_tenant_id, [], _vis), do: []
 
   defp list_links_for_seed_set(tenant_id, seed_ids, vis) do
-    from(l in ArticleLink,
-      where: l.tenant_id == ^tenant_id,
-      where: l.source_article_id in ^seed_ids or l.target_article_id in ^seed_ids,
-      preload: [:source_article, :target_article],
-      order_by: [desc: l.inserted_at]
-    )
-    |> AdminRepo.all()
-    # Visibility (#163): drop links whose far-side article the caller can't see, so a
-    # neighbor can't leak another agent's private memory id/title — same filter the
-    # per-article `list_links_for_article/3` applies.
-    |> filter_links_by_visibility(vis)
+    # Preload only the far-side fields the #163 visibility filter needs (id/tenant_id/status/
+    # metadata) — NOT the full Article body. A dense hub would otherwise materialize hundreds
+    # of full bodies just to drop them after the visibility check.
+    summary =
+      from(a in Article, select: struct(a, [:id, :tenant_id, :status, :metadata]))
+
+    query =
+      from(l in ArticleLink,
+        where: l.tenant_id == ^tenant_id,
+        where: l.source_article_id in ^seed_ids or l.target_article_id in ^seed_ids,
+        preload: [source_article: ^summary, target_article: ^summary],
+        order_by: [desc: l.inserted_at],
+        limit: @graph_lane_link_limit
+      )
+
+    # Route through Loopctl.HeavyRead (US-27.11): the dedicated heavy-read pool with a per-read
+    # SET LOCAL statement_timeout, isolated from the deliberately tiny ~3-connection BYPASSRLS
+    # AdminRepo pool. search_combined is the DEFAULT mode, so once an operator enables the graph
+    # lane EVERY combined search runs this — it must not starve light admin ops (the same reason
+    # the distant-pairs self-join was routed here). `on_overload: :tag` degrades an over-cap
+    # tenant's lane to empty (it is a purely additive recall lane) instead of raising a 429. The
+    # (unscoped) preload of far-side articles stays safe because every id comes from a
+    # tenant-scoped link row, and article links never cross tenants.
+    case heavy_read_graph_lane(tenant_id, query) do
+      {:error, :heavy_read_overloaded} ->
+        []
+
+      links ->
+        # Visibility (#163): drop links whose far-side article the caller can't see, so a
+        # neighbor can't leak another agent's private memory id/title — same filter the
+        # per-article `list_links_for_article/3` applies. The neighbor STATUS filter is applied
+        # downstream in `fetch_graph_lane_articles/3` (a link to a non-matching-status neighbor
+        # yields no lane row), so no lane result can carry a wrong-status article.
+        filter_links_by_visibility(links, vis)
+    end
+  end
+
+  # HeavyRead read for the opt-in graph lane: heavy-pool-routed, statement-timed, and shed to
+  # `{:error, :heavy_read_overloaded}` (never a 429) when the tenant is over its in-flight cap.
+  defp heavy_read_graph_lane(tenant_id, query) do
+    opts = Keyword.put(HeavyRead.opts(:graph_lane), :on_overload, :tag)
+    HeavyRead.all(tenant_id, query, opts)
   end
 
   # A link contributes AT MOST one `{seed_id, neighbor_id}` edge: the neighbor is the
@@ -7122,22 +7173,23 @@ defmodule Loopctl.Knowledge do
     end
   end
 
-  # Fold one `seed → neighbor` edge into the running `%{neighbor_id => {seed_count,
-  # best_seed_idx}}` tally, so a neighbor linked from MORE distinct top seeds
-  # accumulates cross-seed consensus (the graph lane's rank signal), with best seed
-  # position as tiebreak.
+  # Fold one `seed → neighbor` edge into the running `%{neighbor_id => MapSet<seed_index>}`
+  # tally. The value is a SET of DISTINCT seed indices, so a neighbor linked from the SAME
+  # seed via several ArticleLink rows — multiple relationship_types, or a bidirectional pair
+  # whose source/target swap both map to the same {seed,neighbor} — counts that seed ONCE.
+  # Consensus is then `MapSet.size` (distinct seeds), matching the documented distinct-seed
+  # signal; counting link ROWS let a single densely-linked seed masquerade as multi-seed
+  # consensus (#470 review).
   defp tally_graph_neighbor(acc, neighbor_id, seed_idx) do
-    Map.update(acc, neighbor_id, {1, seed_idx}, fn {count, best} ->
-      {count + 1, min(best, seed_idx)}
-    end)
+    Map.update(acc, neighbor_id, MapSet.new([seed_idx]), &MapSet.put(&1, seed_idx))
   end
 
-  defp fetch_graph_lane_articles(_tenant_id, []), do: []
+  defp fetch_graph_lane_articles(_tenant_id, [], _status), do: []
 
-  defp fetch_graph_lane_articles(tenant_id, ranked_ids) do
-    rows =
+  defp fetch_graph_lane_articles(tenant_id, ranked_ids, status) do
+    query =
       from(a in Article,
-        where: a.tenant_id == ^tenant_id and a.id in ^ranked_ids and a.status == :published,
+        where: a.tenant_id == ^tenant_id and a.id in ^ranked_ids and a.status == ^status,
         select: %{
           id: a.id,
           tenant_id: a.tenant_id,
@@ -7150,11 +7202,18 @@ defmodule Loopctl.Knowledge do
           updated_at: a.updated_at
         }
       )
-      |> AdminRepo.all()
+
+    # Also heavy-pool-routed (US-27.11) — a bounded (`<= rrf_graph_max_neighbors`) id-set read,
+    # kept off the tiny AdminRepo pool for the same reason as the link read above.
+    rows =
+      case heavy_read_graph_lane(tenant_id, query) do
+        {:error, :heavy_read_overloaded} -> []
+        list -> list
+      end
       |> Map.new(&{&1.id, &1})
 
-    # Preserve the consensus rank order; silently drop any neighbor that isn't a
-    # published article (unpublished/visibility-filtered rows never join the lane).
+    # Preserve the consensus rank order; silently drop any neighbor that isn't in the
+    # requested status (other-status / visibility-filtered rows never join the lane).
     Enum.flat_map(ranked_ids, fn id ->
       case Map.fetch(rows, id) do
         {:ok, row} -> [row]
@@ -7481,6 +7540,23 @@ defmodule Loopctl.Knowledge do
     do: normalize_keyword_score(score)
 
   defp absolute_score(_result), do: 0.0
+
+  @doc """
+  The ABSOLUTE (pool-independent) relevance score for a `search_combined/3` /
+  `search_semantic/3` / `search_keyword/3` result map — the raw cosine `:similarity_score`
+  (already 0..1) when present, else a bounded `raw/(raw+1)` transform of the raw keyword
+  `:relevance_score`, else `0.0`.
+
+  Public seam for CROSS-SOURCE ranking (e.g. `Loopctl.Memory.recall_context/2`), which must
+  compare a knowledge result against memory's absolute cosine similarity on the SAME 0..1
+  scale. It must NOT use the fused `:final_score`: post-#470 that is an RRF `Σ weight/(k+rank)`
+  value (top ~0.008-0.016), which — compared against a memory row's 0..1 cosine — would
+  systematically sink every knowledge row below every memory row (#470 review). This is the
+  same absolute signal `absolute_score/1` gives the hybrid resolver (US-31.2).
+  """
+  @spec absolute_result_score(map()) :: float()
+  def absolute_result_score(result) when is_map(result), do: absolute_score(result)
+  def absolute_result_score(_), do: 0.0
 
   # `ts_rank_cd` is RAW/UNBOUNDED (a short, heavily-title-weighted match can exceed
   # `1.0` — confirmed empirically up to ~2.0 for a title-exact match) — unlike cosine

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -6620,7 +6620,14 @@ defmodule Loopctl.Knowledge do
             # alertable signal and the meta carries `semantic_result_count`.
             maybe_emit_semantic_empty(tenant_id, length(semantic.results), query_string)
 
-            {:ok, merged} = merge_results(kw, semantic, keyword_weight, semantic_weight, opts)
+            # Optional third graph-neighbor lane (#470), OFF by default. Computed here
+            # because it needs `tenant_id` (a DB read of the link graph); threaded into
+            # `merge_results/5` via opts so that function stays a pure fusion function
+            # (no DB) — its arity and public contract are unchanged.
+            merge_opts = put_graph_lane(opts, tenant_id, kw, semantic)
+
+            {:ok, merged} =
+              merge_results(kw, semantic, keyword_weight, semantic_weight, merge_opts)
 
             maybe_record_search_access(
               tenant_id,
@@ -6816,45 +6823,35 @@ defmodule Loopctl.Knowledge do
     :ok
   end
 
+  # Fuse the per-lane result lists into one ranked, deduplicated candidate set (#470).
+  #
+  # Default strategy is Reciprocal Rank Fusion (RRF); the legacy min-max weighted-sum
+  # is retained behind `:min_max` for A/B and the eval harness. Both strategies produce
+  # the IDENTICAL result/meta shape and BOTH preserve every candidate's raw, ABSOLUTE
+  # `:relevance_score` / `:similarity_score` (the hybrid resolver US-31.2 reads those
+  # raw fields via `absolute_score/1`, never the fused `:final_score`).
+  #
+  # `merge_results/5` is a PURE fusion function — the optional graph-neighbor lane
+  # (which needs a DB read) is computed by the caller and threaded in via
+  # `opts[:_graph_lane_results]`, so this arity and contract stay stable.
   defp merge_results(keyword_result, semantic_result, kw_weight, sem_weight, opts) do
-    kw_normalized = normalize_scores(keyword_result.results, :relevance_score)
-    sem_normalized = normalize_scores(semantic_result.results, :similarity_score)
+    graph_results = Keyword.get(opts, :_graph_lane_results, [])
 
-    # Build merged map by article ID
-    kw_map =
-      Map.new(kw_normalized, fn r ->
-        {r.id, Map.put(r, :final_score, kw_weight * r.normalized_score)}
-      end)
-
-    sem_map =
-      Map.new(sem_normalized, fn r ->
-        {r.id, Map.put(r, :final_score, sem_weight * r.normalized_score)}
-      end)
-
-    # For a candidate found in BOTH pools, `Map.merge(kw, sem)` keeps EACH side's
-    # exclusive raw fields (kw's raw `:relevance_score`/`:snippet`, sem's raw
-    # `:similarity_score`) instead of silently dropping one — the hybrid resolver
-    # (US-31.2) needs both raw, ABSOLUTE (non-pool-relative) scores to survive on the
-    # merged result map so it never has to fall back to the pool-normalized
-    # `:final_score` for its curated-confidence decision (see `absolute_score/1`).
-    # `:final_score` itself is explicitly overridden to the correct weighted SUM
-    # (Map.merge alone would have just taken sem's half).
-    merged =
-      Map.merge(kw_map, sem_map, fn _id, kw, sem ->
-        kw
-        |> Map.merge(sem)
-        |> Map.put(:final_score, kw.final_score + sem.final_score)
-      end)
-
-    # Sort by `final_score` desc with the article `id` as a DETERMINISTIC secondary key.
-    # `Map.values/1` order is hash-driven, and `final_score` ties are not incidental — the
-    # Reciprocal Rank Fusion scoring (#470) produces `1/(k+rank)` values that tie by
-    # construction. Without a tiebreak, which of two tied candidates survives the top-k limit
-    # (and thus recall@k / nDCG@k / MRR) would flip run-to-run. The id makes it total + stable.
     sorted =
-      merged
-      |> Map.values()
-      |> Enum.sort_by(&{&1.final_score, &1.id}, :desc)
+      case fusion_strategy(opts) do
+        :min_max ->
+          fuse_min_max(keyword_result.results, semantic_result.results, kw_weight, sem_weight)
+
+        _rrf ->
+          fuse_rrf(
+            keyword_result.results,
+            semantic_result.results,
+            graph_results,
+            kw_weight,
+            sem_weight,
+            opts
+          )
+      end
 
     paginated = paginate_results(sorted, opts)
 
@@ -6862,6 +6859,10 @@ defmodule Loopctl.Knowledge do
      %{
        results: paginated.results,
        meta: %{
+         # `total_count` = size of the full fused/deduplicated candidate set
+         # pre-pagination. When the (opt-in) graph lane is enabled it also counts the
+         # one-hop neighbors it contributed; with the lane OFF (the default) this is
+         # exactly the keyword ∪ semantic union, byte-for-byte as before.
          total_count: length(sorted),
          limit: paginated.limit,
          offset: paginated.offset,
@@ -6878,10 +6879,234 @@ defmodule Loopctl.Knowledge do
          # Observability for #297: how many rows the semantic half contributed. A
          # `0` here with `fallback: false` is the "embed worked but recall is broken"
          # signal (distinct from an embed-failure keyword_only fallback), so operators
-         # and clients can tell the two silent-degradation causes apart.
+         # and clients can tell the two silent-degradation causes apart. The graph
+         # lane NEVER inflates this — it stays the semantic lane's own row count.
          semantic_result_count: length(semantic_result.results)
        }
      }}
+  end
+
+  # --- Reciprocal Rank Fusion (#470) ------------------------------------------
+  #
+  # `score(doc) = Σ_lane weight_lane / (k + rank_lane(doc))`, ranks 1-based, default
+  # weight 1.0, default k=60 (KB f4a10824). Rank-based fusion sidesteps the
+  # incommensurable-scale problem (ts_rank_cd vs cosine similarity) that made the old
+  # min-max weighted-sum brittle: a doc with cross-lane CONSENSUS can outrank one that
+  # is #1 in a single lane. Each lane's list is ALREADY sorted by its own relevance
+  # (keyword desc ts_rank_cd, semantic desc cosine similarity, graph desc consensus),
+  # so its position IS its rank. Duplicate docs across lanes merge to one, summing
+  # their contributions and keeping the UNION of raw fields.
+  defp fuse_rrf(kw_results, sem_results, graph_results, kw_weight, sem_weight, opts) do
+    k = rrf_k(opts)
+    graph_weight = rrf_graph_weight(opts)
+
+    lanes = [
+      {kw_results, kw_weight},
+      {sem_results, sem_weight},
+      {graph_results, graph_weight}
+    ]
+
+    lanes
+    |> Enum.reduce(%{}, fn {results, weight}, acc ->
+      accumulate_rrf_lane(acc, results, weight, k)
+    end)
+    |> Map.values()
+    # Deterministic total order: `final_score` desc with `id` as the secondary key.
+    # RRF's `1/(k+rank)` values tie by construction, and `Map.values/1` order is
+    # hash-driven, so without the id tiebreak which tied candidate survives the top-k
+    # limit (and thus recall@k / nDCG@k / MRR) would flip run-to-run.
+    |> Enum.sort_by(&{&1.final_score, &1.id}, :desc)
+  end
+
+  defp accumulate_rrf_lane(acc, results, weight, k) do
+    results
+    |> Enum.with_index(1)
+    |> Enum.reduce(acc, fn {result, rank}, inner ->
+      contribution = weight / (k + rank)
+
+      Map.update(
+        inner,
+        result.id,
+        Map.put(result, :final_score, contribution),
+        fn existing ->
+          # Union the raw fields (a doc seen in multiple lanes keeps kw's raw
+          # `:relevance_score`/`:snippet` AND sem's raw `:similarity_score` — the
+          # hybrid resolver needs both), and ADD this lane's contribution. `result`
+          # carries no `:final_score`, so merging it in never clobbers the running sum.
+          existing
+          |> Map.merge(result)
+          |> Map.put(:final_score, existing.final_score + contribution)
+        end
+      )
+    end)
+  end
+
+  # --- Legacy min-max weighted-sum fusion (#470 A/B) --------------------------
+  #
+  # Retained behind `config :loopctl, :knowledge_fusion_strategy, :min_max` (or the
+  # per-call `fusion_strategy: :min_max` opt) so the eval harness can compare the two
+  # and an operator can roll back. Min-max normalizes each lane's raw scores into
+  # `0..1` (dominated by pool outliers/composition — the reason RRF replaced it) and
+  # weight-sums them. Graph lane is not fused here (min-max is the legacy 2-lane path).
+  defp fuse_min_max(kw_results, sem_results, kw_weight, sem_weight) do
+    kw_map =
+      kw_results
+      |> normalize_scores(:relevance_score)
+      |> Map.new(fn r -> {r.id, Map.put(r, :final_score, kw_weight * r.normalized_score)} end)
+
+    sem_map =
+      sem_results
+      |> normalize_scores(:similarity_score)
+      |> Map.new(fn r -> {r.id, Map.put(r, :final_score, sem_weight * r.normalized_score)} end)
+
+    kw_map
+    |> Map.merge(sem_map, fn _id, kw, sem ->
+      kw
+      |> Map.merge(sem)
+      |> Map.put(:final_score, kw.final_score + sem.final_score)
+    end)
+    |> Map.values()
+    |> Enum.sort_by(&{&1.final_score, &1.id}, :desc)
+  end
+
+  defp fusion_strategy(opts) do
+    Keyword.get(
+      opts,
+      :fusion_strategy,
+      Application.get_env(:loopctl, :knowledge_fusion_strategy, :rrf)
+    )
+  end
+
+  defp rrf_k(opts) do
+    Keyword.get(opts, :rrf_k, Application.get_env(:loopctl, :knowledge_rrf_k, 60))
+  end
+
+  defp rrf_graph_weight(opts) do
+    Keyword.get(
+      opts,
+      :graph_weight,
+      Application.get_env(:loopctl, :knowledge_rrf_graph_weight, 1.0)
+    )
+  end
+
+  defp graph_lane_enabled?(opts) do
+    Keyword.get(
+      opts,
+      :graph_lane,
+      Application.get_env(:loopctl, :knowledge_rrf_graph_lane_enabled, false)
+    )
+  end
+
+  defp rrf_graph_seed_count,
+    do: Application.get_env(:loopctl, :knowledge_rrf_graph_seed_count, 10)
+
+  defp rrf_graph_max_neighbors,
+    do: Application.get_env(:loopctl, :knowledge_rrf_graph_max_neighbors, 20)
+
+  # --- Graph-neighbor lane (#470) ---------------------------------------------
+  #
+  # OFF by default. When enabled, takes the top merged candidates as SEEDS, pulls their
+  # one-hop link-graph neighbors (tenant-scoped, visibility-filtered — a tenant B
+  # neighbor can never surface for tenant A), ranks them by cross-seed CONSENSUS
+  # (how many distinct seeds link to them, best seed position as tiebreak), and returns
+  # published article maps in that rank order for the fusion. The neighbor maps carry
+  # NO `:relevance_score`/`:similarity_score`, so their hybrid-resolver `absolute_score`
+  # is 0.0 — a graph-only hit can never falsely win the curated-vs-retrieved decision.
+  defp put_graph_lane(opts, tenant_id, kw, semantic) do
+    if graph_lane_enabled?(opts) do
+      case build_graph_lane(tenant_id, kw, semantic, opts) do
+        [] -> opts
+        neighbors -> Keyword.put(opts, :_graph_lane_results, neighbors)
+      end
+    else
+      opts
+    end
+  end
+
+  defp build_graph_lane(tenant_id, kw, semantic, opts) do
+    vis = Keyword.get(opts, :visibility_agent_id)
+
+    # Seeds: the top merged candidates by their existing lane order (keyword first,
+    # then semantic), deduped, capped. Seeds themselves are excluded from the neighbor
+    # set (a lane already ranks them; the graph lane exists to surface their neighbors).
+    seed_ids =
+      (kw.results ++ semantic.results)
+      |> Enum.map(& &1.id)
+      |> Enum.uniq()
+      |> Enum.take(rrf_graph_seed_count())
+
+    seed_set = MapSet.new(seed_ids)
+
+    neighbor_stats =
+      seed_ids
+      |> Enum.with_index()
+      |> Enum.reduce(%{}, fn {seed_id, seed_idx}, acc ->
+        tenant_id
+        |> list_links_for_article(seed_id, visibility_agent_id: vis)
+        |> Enum.flat_map(&graph_neighbor_ids(&1, seed_id))
+        |> Enum.reject(&MapSet.member?(seed_set, &1))
+        |> tally_graph_neighbors(acc, seed_idx)
+      end)
+
+    ranked_ids =
+      neighbor_stats
+      # Rank: most distinct seeds (consensus) first, then best seed position, then id
+      # for a deterministic total order.
+      |> Enum.sort_by(fn {nid, {count, best_idx}} -> {-count, best_idx, nid} end)
+      |> Enum.map(&elem(&1, 0))
+      |> Enum.take(rrf_graph_max_neighbors())
+
+    fetch_graph_lane_articles(tenant_id, ranked_ids)
+  end
+
+  # Fold this seed's neighbor ids into the running `%{neighbor_id => {seed_count,
+  # best_seed_idx}}` tally, so a neighbor linked to MULTIPLE top seeds accumulates
+  # cross-seed consensus (the graph lane's rank signal).
+  defp tally_graph_neighbors(neighbor_ids, acc, seed_idx) do
+    Enum.reduce(neighbor_ids, acc, fn nid, inner ->
+      Map.update(inner, nid, {1, seed_idx}, fn {count, best} ->
+        {count + 1, min(best, seed_idx)}
+      end)
+    end)
+  end
+
+  defp graph_neighbor_ids(%ArticleLink{source_article_id: src, target_article_id: tgt}, seed_id) do
+    cond do
+      src == seed_id and tgt != seed_id -> [tgt]
+      tgt == seed_id and src != seed_id -> [src]
+      true -> []
+    end
+  end
+
+  defp fetch_graph_lane_articles(_tenant_id, []), do: []
+
+  defp fetch_graph_lane_articles(tenant_id, ranked_ids) do
+    rows =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id and a.id in ^ranked_ids and a.status == :published,
+        select: %{
+          id: a.id,
+          tenant_id: a.tenant_id,
+          project_id: a.project_id,
+          title: a.title,
+          category: a.category,
+          status: a.status,
+          tags: a.tags,
+          inserted_at: a.inserted_at,
+          updated_at: a.updated_at
+        }
+      )
+      |> AdminRepo.all()
+      |> Map.new(&{&1.id, &1})
+
+    # Preserve the consensus rank order; silently drop any neighbor that isn't a
+    # published article (unpublished/visibility-filtered rows never join the lane).
+    Enum.flat_map(ranked_ids, fn id ->
+      case Map.fetch(rows, id) do
+        {:ok, row} -> [row]
+        :error -> []
+      end
+    end)
   end
 
   defp normalize_scores([], _score_key), do: []

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -6395,7 +6395,13 @@ defmodule Loopctl.Knowledge do
       )
 
     from(c in subquery(inner_pool),
-      order_by: [desc: c.similarity_score],
+      # Deterministic total order: cosine similarity desc, then `id` asc as a
+      # secondary key. Ties are real (two identical embeddings share similarity
+      # 1.0), and Postgres leaves tied-row order unspecified, so without the id
+      # tiebreak the RRF ranks that fusion derives from this list — and thus
+      # which candidate wins the top slot by a sub-1e-5 RRF margin — would flip
+      # run-to-run (#470 review).
+      order_by: [desc: c.similarity_score, asc: c.id],
       select: %{
         id: c.id,
         tenant_id: c.tenant_id,
@@ -6867,10 +6873,20 @@ defmodule Loopctl.Knowledge do
          limit: paginated.limit,
          offset: paginated.offset,
          search_mode: "combined",
-         # Size of the deduplicated UNION of a keyword and a semantic sub-search
-         # (each capped at 100, so up to ~200 with no overlap), NOT a corpus total
-         # or full match count. Use list mode or knowledge_stats to size the corpus.
-         total_count_scope: "merged_candidates",
+         # Names what `total_count` counts so a client can size/interpret the pool.
+         # Default `merged_candidates`: the deduplicated UNION of a keyword and a
+         # semantic sub-search (each capped at 100, so up to ~200 with no overlap),
+         # NOT a corpus total or full match count. When the opt-in graph lane
+         # actually contributes one-hop neighbors, the count folds them in, so the
+         # scope becomes `merged_candidates_with_graph` — the documented
+         # `merged_candidates` invariant (keyword ∪ semantic only) still holds for
+         # its literal value (#470 review). Use list mode or knowledge_stats to size
+         # the corpus.
+         total_count_scope:
+           if(graph_results == [],
+             do: "merged_candidates",
+             else: "merged_candidates_with_graph"
+           ),
          # Carry the semantic sub-search's relevance-pool truncation forward (US-27.7a)
          # — combined is the DEFAULT mode, so silently dropping the flag would hide
          # truncation on the most-used path. `maybe_put` keeps the key absent unless the
@@ -6888,8 +6904,9 @@ defmodule Loopctl.Knowledge do
 
   # --- Reciprocal Rank Fusion (#470) ------------------------------------------
   #
-  # `score(doc) = Σ_lane weight_lane / (k + rank_lane(doc))`, ranks 1-based, default
-  # weight 1.0, default k=60 (KB f4a10824). Rank-based fusion sidesteps the
+  # `score(doc) = Σ_lane weight_lane / (k + rank_lane(doc))`, ranks 1-based, per-lane
+  # weight 0.5 (keyword/semantic/graph all match, so no lane structurally out-votes
+  # another), default k=60 (KB f4a10824). Rank-based fusion sidesteps the
   # incommensurable-scale problem (ts_rank_cd vs cosine similarity) that made the old
   # min-max weighted-sum brittle: a doc with cross-lane CONSENSUS can outrank one that
   # is #1 in a single lane. Each lane's list is ALREADY sorted by its own relevance
@@ -6985,7 +7002,7 @@ defmodule Loopctl.Knowledge do
     Keyword.get(
       opts,
       :graph_weight,
-      Application.get_env(:loopctl, :knowledge_rrf_graph_weight, 1.0)
+      Application.get_env(:loopctl, :knowledge_rrf_graph_weight, 0.5)
     )
   end
 
@@ -7013,7 +7030,11 @@ defmodule Loopctl.Knowledge do
   # NO `:relevance_score`/`:similarity_score`, so their hybrid-resolver `absolute_score`
   # is 0.0 — a graph-only hit can never falsely win the curated-vs-retrieved decision.
   defp put_graph_lane(opts, tenant_id, kw, semantic) do
-    if graph_lane_enabled?(opts) do
+    # Only the RRF fuser consumes `:_graph_lane_results` — `fuse_min_max/4` ignores
+    # graph neighbors entirely. Gate the (DB-backed) lane build on the strategy being
+    # RRF so a `graph_lane: true` + `fusion_strategy: :min_max` caller doesn't pay the
+    # ~11 round-trip graph read only to have the result silently discarded (#470 review).
+    if graph_lane_enabled?(opts) and fusion_strategy(opts) != :min_max do
       case build_graph_lane(tenant_id, kw, semantic, opts) do
         [] -> opts
         neighbors -> Keyword.put(opts, :_graph_lane_results, neighbors)
@@ -7036,16 +7057,22 @@ defmodule Loopctl.Knowledge do
       |> Enum.take(rrf_graph_seed_count())
 
     seed_set = MapSet.new(seed_ids)
+    seed_index = seed_ids |> Enum.with_index() |> Map.new()
 
+    # ONE tenant-scoped round-trip for the WHOLE seed set (was one AdminRepo query
+    # PER seed — an N+1 that fanned up to `rrf_graph_seed_count` sequential reads
+    # onto the deliberately small BYPASSRLS AdminRepo pool). Per-seed provenance is
+    # recovered in memory from the source/target ids each link row already carries,
+    # so the consensus tally is byte-for-byte the same (#470 review).
     neighbor_stats =
-      seed_ids
-      |> Enum.with_index()
-      |> Enum.reduce(%{}, fn {seed_id, seed_idx}, acc ->
-        tenant_id
-        |> list_links_for_article(seed_id, visibility_agent_id: vis)
-        |> Enum.flat_map(&graph_neighbor_ids(&1, seed_id))
-        |> Enum.reject(&MapSet.member?(seed_set, &1))
-        |> tally_graph_neighbors(acc, seed_idx)
+      tenant_id
+      |> list_links_for_seed_set(seed_ids, vis)
+      |> Enum.reduce(%{}, fn link, acc ->
+        link
+        |> seed_neighbor_pairs(seed_set)
+        |> Enum.reduce(acc, fn {seed_id, neighbor_id}, inner ->
+          tally_graph_neighbor(inner, neighbor_id, Map.fetch!(seed_index, seed_id))
+        end)
       end)
 
     ranked_ids =
@@ -7059,23 +7086,50 @@ defmodule Loopctl.Knowledge do
     fetch_graph_lane_articles(tenant_id, ranked_ids)
   end
 
-  # Fold this seed's neighbor ids into the running `%{neighbor_id => {seed_count,
-  # best_seed_idx}}` tally, so a neighbor linked to MULTIPLE top seeds accumulates
-  # cross-seed consensus (the graph lane's rank signal).
-  defp tally_graph_neighbors(neighbor_ids, acc, seed_idx) do
-    Enum.reduce(neighbor_ids, acc, fn nid, inner ->
-      Map.update(inner, nid, {1, seed_idx}, fn {count, best} ->
-        {count + 1, min(best, seed_idx)}
-      end)
-    end)
+  # One tenant-scoped, visibility-filtered read of every link touching ANY seed in
+  # the set — the single query that replaces the per-seed N+1.
+  defp list_links_for_seed_set(_tenant_id, [], _vis), do: []
+
+  defp list_links_for_seed_set(tenant_id, seed_ids, vis) do
+    from(l in ArticleLink,
+      where: l.tenant_id == ^tenant_id,
+      where: l.source_article_id in ^seed_ids or l.target_article_id in ^seed_ids,
+      preload: [:source_article, :target_article],
+      order_by: [desc: l.inserted_at]
+    )
+    |> AdminRepo.all()
+    # Visibility (#163): drop links whose far-side article the caller can't see, so a
+    # neighbor can't leak another agent's private memory id/title — same filter the
+    # per-article `list_links_for_article/3` applies.
+    |> filter_links_by_visibility(vis)
   end
 
-  defp graph_neighbor_ids(%ArticleLink{source_article_id: src, target_article_id: tgt}, seed_id) do
+  # A link contributes AT MOST one `{seed_id, neighbor_id}` edge: the neighbor is the
+  # endpoint that is NOT itself a seed. A link between two seeds (or a self-link)
+  # contributes none — a seed is already ranked by a primary lane. This mirrors the
+  # old per-seed `graph_neighbor_ids/2` + seed-set reject, one link at a time.
+  defp seed_neighbor_pairs(
+         %ArticleLink{source_article_id: src, target_article_id: tgt},
+         seed_set
+       ) do
+    src_seed = MapSet.member?(seed_set, src)
+    tgt_seed = MapSet.member?(seed_set, tgt)
+
     cond do
-      src == seed_id and tgt != seed_id -> [tgt]
-      tgt == seed_id and src != seed_id -> [src]
+      src_seed and not tgt_seed -> [{src, tgt}]
+      tgt_seed and not src_seed -> [{tgt, src}]
       true -> []
     end
+  end
+
+  # Fold one `seed → neighbor` edge into the running `%{neighbor_id => {seed_count,
+  # best_seed_idx}}` tally, so a neighbor linked from MORE distinct top seeds
+  # accumulates cross-seed consensus (the graph lane's rank signal), with best seed
+  # position as tiebreak.
+  defp tally_graph_neighbor(acc, neighbor_id, seed_idx) do
+    Map.update(acc, neighbor_id, {1, seed_idx}, fn {count, best} ->
+      {count + 1, min(best, seed_idx)}
+    end)
   end
 
   defp fetch_graph_lane_articles(_tenant_id, []), do: []

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -1038,27 +1038,28 @@ defmodule Loopctl.Memory do
 
   ## Scores are heuristically comparable, NOT calibrated
 
-  The merged list is sorted by a single `score` DESC across BOTH sources, but the two
-  scores come from different scales:
+  The merged list is sorted by a single `score` DESC across BOTH sources, and BOTH sides
+  are put on the SAME absolute 0..1 scale so neither systematically outranks the other:
 
     * memory `score` = `max(0, 1 - cosine_distance)` — an absolute per-row similarity
       in `[0, 1]` (or `nil` on the ILIKE text-match fallback path, treated as `0.0`
       for ranking only).
-    * knowledge `score` = the combined search's `final_score` — a weighted
-      keyword+semantic score, MIN-MAX normalized WITHIN the returned pool (so it is
-      pool-relative, not an absolute similarity).
+    * knowledge `score` = `Knowledge.absolute_result_score/1` — the ABSOLUTE per-row
+      relevance: the raw cosine `:similarity_score` (`1 - cosine_distance`, the SAME
+      derivation as the memory side) when the row matched semantically, else a bounded
+      `raw/(raw+1)` transform of the raw keyword `:relevance_score`. It is NOT the fused
+      `:final_score`: post-#470 combined search fuses lanes with RRF, whose `:final_score`
+      is a pool-relative `Σ weight/(k+rank)` value (top ~0.008-0.016) that — compared
+      against memory's 0..1 cosine — would sink every knowledge row below every memory
+      row (#470 review). Reading the absolute score removes that inversion.
 
-  KNOWN BIAS: because the knowledge `final_score` is min-max normalized within the
-  returned pool, the top knowledge row is ~1.0 regardless of its ABSOLUTE relevance,
-  so knowledge items systematically outrank memory items in the default `results`
-  ordering even when the memory matches are strong. This is a documented heuristic,
-  NOT a calibrated cross-source ranking — do NOT read the merged `results` order as
-  "knowledge was more relevant than memory". `meta.results_ranking` carries the stable
-  tag `"heuristic_cross_source"` so consumers can detect this programmatically.
-
-  Treat the cross-source ordering as a useful heuristic, not a calibrated ranking.
-  Callers that need a calibrated re-rank get BOTH the merged view AND the untouched
-  per-source envelopes (`:memory`, `:knowledge`), each carrying its own native scores.
+  STILL A HEURISTIC, not a fully calibrated ranking: the two absolute scores share a
+  scale and derivation for semantic matches, but a keyword-only knowledge row's
+  `raw/(raw+1)` transform is only magnitude-comparable to cosine, not identically
+  calibrated. So `meta.results_ranking` keeps the stable tag `"heuristic_cross_source"`
+  — do NOT over-read a one-position gap. Callers that need a calibrated re-rank get BOTH
+  the merged view AND the untouched per-source envelopes (`:memory`, `:knowledge`), each
+  carrying its own native scores.
 
   ## Degradation, never a 500 (and never a whole-endpoint 429)
 
@@ -1088,13 +1089,14 @@ defmodule Loopctl.Memory do
   intentionally NOT done, because two simultaneous slots would double a single request's
   peak pressure under the very cap that shields other tenants.
 
-  ## Known bias on the degraded path
+  ## The degraded path stays on the same bounded scale
 
-  On a degraded knowledge side (keyword-only fallback) memory rows carry absolute cosine
-  scores while knowledge rows carry raw (un-normalized) keyword `relevance_score`, which
-  can exceed memory's cosine max of 1.0 and outrank memory in the merged `data`. A caller
-  needing memory-first ordering under degradation should read the per-source `:memory`
-  envelope (it preserves the honest native scores/nils), disclosed via `meta.degraded?`.
+  On a degraded knowledge side (keyword-only fallback) knowledge rows carry only a raw
+  keyword `relevance_score`; `Knowledge.absolute_result_score/1` applies the same bounded
+  `raw/(raw+1)` transform there, so the merged score stays in 0..1 and can no longer
+  exceed memory's cosine max of 1.0 or spuriously outrank memory (pre-#470 the raw
+  un-normalized ts_rank_cd could). A caller needing the honest native scores/nils still
+  reads the per-source `:memory` envelope, disclosed via `meta.degraded?`.
 
   ## Options
 
@@ -1327,17 +1329,16 @@ defmodule Loopctl.Memory do
     end
   end
 
-  # Knowledge combined ranking score. Normal combined results carry `:final_score`
-  # (pool-normalized weighted keyword+semantic, in [0, 1]); when combined DEGRADES to a
-  # keyword-only fallback the results carry `:relevance_score` (and no `:final_score`),
-  # so mirror `KnowledgeSearchJSON.extract_score/2`'s chain
-  # (`final_score || relevance_score || similarity_score`) via bracket access rather
-  # than scoring every degraded-path item 0.0 and sinking all knowledge below memory.
-  # Defaults to 0.0 for a malformed/scoreless result map (defensive).
-  defp knowledge_score(result) when is_map(result) do
-    score = result[:final_score] || result[:relevance_score] || result[:similarity_score]
-    if is_number(score), do: score, else: 0.0
-  end
+  # Knowledge ranking score for the CROSS-SOURCE merge — the ABSOLUTE per-row relevance
+  # (`Knowledge.absolute_result_score/1`: raw cosine `:similarity_score`, else a bounded
+  # `raw/(raw+1)` transform of the raw keyword `:relevance_score`), NOT the fused
+  # `:final_score`. The merged list is sorted DESC by this single score across BOTH
+  # sources, and memory rows carry an absolute cosine `max(0, 1 - cosine_distance)` in
+  # [0, 1]; comparing them requires the knowledge side to be on that SAME absolute 0..1
+  # scale. Post-#470 the combined `:final_score` is an RRF `Σ weight/(k+rank)` value (top
+  # ~0.008-0.016) — reading it here would systematically sink every knowledge row below
+  # every memory row (#470 review). Defaults to 0.0 for a scoreless result map.
+  defp knowledge_score(result) when is_map(result), do: Knowledge.absolute_result_score(result)
 
   defp knowledge_score(_), do: 0.0
 

--- a/lib/loopctl_web/controllers/knowledge_hybrid_search_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_hybrid_search_json.ex
@@ -43,6 +43,11 @@ defmodule LoopctlWeb.KnowledgeHybridSearchJSON do
   # Hybrid runs the combined pool, so results carry :final_score; a keyword-only
   # fallback carries :relevance_score instead — fall back rather than report a
   # misleading 0.0.
+  #
+  # Post-#470 :final_score is a Reciprocal Rank Fusion weight (`Σ weight/(k+rank)`, top
+  # ~0.008-0.016), NOT a 0..1 similarity — this per-result `score` reflects RANK only.
+  # The ABSOLUTE 0..1 confidence a caller should threshold on is `meta.confidence` (the
+  # provenance decision's `absolute_score/1`), not this field.
   defp extract_score(result) do
     result[:final_score] || result[:relevance_score] || result[:similarity_score] || 0.0
   end

--- a/lib/loopctl_web/controllers/knowledge_search_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_json.ex
@@ -125,6 +125,14 @@ defmodule LoopctlWeb.KnowledgeSearchJSON do
     # Normal combined results carry :final_score; when combined degrades to a
     # keyword-only fallback the results carry :relevance_score instead, so fall
     # back to it (then similarity) rather than reporting a misleading 0.0.
+    #
+    # SCORE MAGNITUDE (post-#470): combined :final_score is now a Reciprocal Rank Fusion
+    # value — `Σ weight/(k+rank)`, so the top hit is ~0.008-0.016 (with k=60), NOT a
+    # normalized 0..1 similarity. Result ORDER is unchanged (still a pure sort by this
+    # score, higher = more relevant), so ranking/sort-by-score clients are unaffected; but
+    # any client that THRESHOLDS on or displays the absolute magnitude must treat `score`
+    # as an un-normalized relative rank weight, not a 0..1 confidence. Use
+    # knowledge_hybrid_search's `meta.confidence` (absolute) when a 0..1 signal is needed.
     result[:final_score] || result[:relevance_score] || result[:similarity_score] || 0.0
   end
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -3780,6 +3780,10 @@ const TOOLS = [
       "a keyword and a semantic sub-search, each capped at 100, so up to ~200), or filtered_set " +
       "(list mode: the full set). Do NOT use a relevance-mode total_count to size the wiki — use " +
       "list mode or knowledge_stats. " +
+      "SCORE: in combined mode each result's `score` is a Reciprocal Rank Fusion weight " +
+      "(~0.008-0.016 at the top), NOT a normalized 0..1 confidence — use it only to compare " +
+      "RANK/order within one response; for an absolute 0..1 confidence use knowledge_hybrid_search " +
+      "(meta.confidence). " +
       "Pass story_id when working on a loopctl story so reads attribute correctly. " +
       "When you knowledge_get a result and it carries `potential_conflicts`, resolve it if it's " +
       "material to your task (see knowledge_get / the conflict-resolution wiki playbook). " +

--- a/test/loopctl/heavy_read/tenant_gate_test.exs
+++ b/test/loopctl/heavy_read/tenant_gate_test.exs
@@ -81,7 +81,8 @@ defmodule Loopctl.HeavyRead.TenantGateTest do
             :novelty,
             :suggested_links,
             :distant_pairs,
-            :distant_pairs_bridge
+            :distant_pairs_bridge,
+            :graph_lane
           ] do
         assert TenantGate.weight_for(endpoint) == heavy
       end
@@ -289,6 +290,7 @@ defmodule Loopctl.HeavyRead.TenantGateTest do
       distant_pairs: :heavy,
       distant_pairs_bridge: :heavy,
       export: :heavy,
+      graph_lane: :heavy,
       enumeration: :light,
       change_feed: :light,
       ingestion_jobs: :light,

--- a/test/loopctl/knowledge_semantic_search_test.exs
+++ b/test/loopctl/knowledge_semantic_search_test.exs
@@ -1537,12 +1537,18 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
           :far
         )
 
-      # Semantic-only: close embedding, no keyword match on "consensus".
+      # Semantic-only: a MEDIUM (not :close) embedding, no keyword match on "consensus".
+      # Deliberately less similar than `consensus` so `consensus` is unambiguously
+      # semantic rank 1. With two identical :close vectors the semantic tie was broken
+      # only by the now-deterministic id secondary sort, and in the branch where
+      # `consensus` fell to semantic rank 2 the keyword spike edged it out by a ~4e-6
+      # RRF margin — a real, seed-dependent flake. Widening the semantic gap makes the
+      # cross-lane advantage unconditional (#470 review).
       _sem_spike =
         create_article_with_embedding(
           tenant.id,
           %{title: "Fault Tolerance", body: "Supervisor trees prevent cascading failures."},
-          :close
+          :medium
         )
 
       Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
@@ -1704,6 +1710,140 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
       ids = Enum.map(results, & &1.id)
       assert neighbor_a.id in ids
       refute neighbor_b.id in ids
+    end
+
+    test "a zero-signal graph neighbor never OUTRANKS a genuine single-lane top hit" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+      %{seed: seed, neighbor: neighbor} = seed_and_neighbor(tenant.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      {:ok, %{results: results}} =
+        Knowledge.search_combined(tenant.id, "graphlane", graph_lane: true)
+
+      seed_result = Enum.find(results, &(&1.id == seed.id))
+      neighbor_result = Enum.find(results, &(&1.id == neighbor.id))
+
+      # The seed is keyword rank 1 (0.5/(k+1)); the graph-only neighbor is graph rank 1.
+      # With the graph lane weighted 0.5 to MATCH the primary lanes, the neighbor scores
+      # 0.5/(k+1) too — it TIES the top single-lane hit and never exceeds it. Under the
+      # buggy 1.0 graph weight the neighbor scored 1.0/(k+1) = DOUBLE and outranked every
+      # single-lane #1 (#470 review).
+      assert_in_delta neighbor_result.final_score, 0.5 / 61, 1.0e-9
+      assert neighbor_result.final_score <= seed_result.final_score
+    end
+
+    test "a neighbor linked from TWO seeds outranks one linked from a single seed" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      # Two seeds that both match the keyword query.
+      seed1 =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Multiseed One",
+          body: "The multiseed token appears here first.",
+          status: :published
+        })
+
+      seed2 =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Multiseed Two",
+          body: "The multiseed token appears here again.",
+          status: :published
+        })
+
+      # Shared neighbor: linked from BOTH seeds (cross-seed consensus = 2).
+      shared =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Shared Neighbor",
+          body: "Unrelated wording, no shared query token.",
+          status: :published
+        })
+
+      # Lonely neighbor: linked from ONE seed only (consensus = 1).
+      lonely =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Lonely Neighbor",
+          body: "Also unrelated wording, no shared query token.",
+          status: :published
+        })
+
+      for {src, tgt} <- [{seed1, shared}, {seed2, shared}, {seed1, lonely}] do
+        fixture(:article_link, %{
+          tenant_id: tenant.id,
+          source_article_id: src.id,
+          target_article_id: tgt.id,
+          relationship_type: :relates_to
+        })
+      end
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      {:ok, %{results: results}} =
+        Knowledge.search_combined(tenant.id, "multiseed", graph_lane: true)
+
+      shared_result = Enum.find(results, &(&1.id == shared.id))
+      lonely_result = Enum.find(results, &(&1.id == lonely.id))
+
+      # Both surface via the graph lane, but the two-seed consensus neighbor ranks
+      # ahead of the one-seed neighbor (graph rank 1 vs 2) — the core `tally` signal
+      # that was previously untested (#470 review).
+      assert shared_result
+      assert lonely_result
+      assert shared_result.final_score > lonely_result.final_score
+
+      shared_pos = Enum.find_index(results, &(&1.id == shared.id))
+      lonely_pos = Enum.find_index(results, &(&1.id == lonely.id))
+      assert shared_pos < lonely_pos
+    end
+
+    test "total_count_scope is labelled 'merged_candidates_with_graph' when the lane contributes" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+      seed_and_neighbor(tenant.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      {:ok, %{meta: meta}} =
+        Knowledge.search_combined(tenant.id, "graphlane", graph_lane: true)
+
+      # When one-hop neighbors are folded into total_count, the scope label changes so a
+      # client isn't misled that the documented `merged_candidates` (keyword ∪ semantic)
+      # invariant still describes the count (#470 review).
+      assert meta.total_count_scope == "merged_candidates_with_graph"
+    end
+
+    test "graph_lane: true + fusion_strategy: :min_max injects no neighbors (lane skipped, no wasted read)" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+      %{neighbor: neighbor} = seed_and_neighbor(tenant.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      {:ok, %{results: results, meta: meta}} =
+        Knowledge.search_combined(tenant.id, "graphlane",
+          graph_lane: true,
+          fusion_strategy: :min_max
+        )
+
+      # min_max fusion ignores graph results entirely, so the lane is not built at all
+      # (no wasted DB read) and no neighbor leaks into the min_max output. The scope
+      # label stays the plain merged label since nothing was folded in (#470 review).
+      refute Enum.any?(results, &(&1.id == neighbor.id))
+      assert meta.total_count_scope == "merged_candidates"
     end
   end
 end

--- a/test/loopctl/knowledge_semantic_search_test.exs
+++ b/test/loopctl/knowledge_semantic_search_test.exs
@@ -1459,4 +1459,251 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
       assert meta.pool_capped == true
     end
   end
+
+  # --- #470: Reciprocal Rank Fusion (RRF) scoring ------------------------------
+
+  describe "search_combined/3 - RRF fusion (#470)" do
+    test "a keyword-only candidate scores exactly keyword_weight / (k + rank)" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      # No embedding → excluded from the semantic lane, so this is a PURE keyword-lane
+      # rank-1 candidate. Unique token keeps it the only keyword match.
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Zzquux Reference",
+        body: "The zzquux token appears only here.",
+        status: :published
+      })
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      {:ok, %{results: [result]}} =
+        Knowledge.search_combined(tenant.id, "zzquux",
+          keyword_weight: 0.5,
+          semantic_weight: 0.5
+        )
+
+      # RRF: weight / (k + rank), default k = 60, rank 1 → 0.5 / 61.
+      assert_in_delta result.final_score, 0.5 / 61, 1.0e-9
+    end
+
+    test "the smoothing constant k is configurable per call" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Zzquux Reference",
+        body: "The zzquux token appears only here.",
+        status: :published
+      })
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      {:ok, %{results: [result]}} =
+        Knowledge.search_combined(tenant.id, "zzquux",
+          keyword_weight: 0.5,
+          semantic_weight: 0.5,
+          rrf_k: 10
+        )
+
+      # weight / (k + rank) with k = 10, rank 1 → 0.5 / 11.
+      assert_in_delta result.final_score, 0.5 / 11, 1.0e-9
+    end
+
+    test "a cross-lane consensus doc outranks a doc that is #1 in a single lane" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      # Appears in BOTH lanes (keyword match on "consensus" + close embedding), but is
+      # unlikely to be strictly #1 in either.
+      consensus =
+        create_article_with_embedding(
+          tenant.id,
+          %{title: "Consensus Overview", body: "A consensus across retrieval lanes."},
+          :close
+        )
+
+      # Strong keyword-only spike: matches "consensus" but far embedding.
+      _kw_spike =
+        create_article_with_embedding(
+          tenant.id,
+          %{title: "Consensus Consensus Consensus", body: "consensus consensus consensus"},
+          :far
+        )
+
+      # Semantic-only: close embedding, no keyword match on "consensus".
+      _sem_spike =
+        create_article_with_embedding(
+          tenant.id,
+          %{title: "Fault Tolerance", body: "Supervisor trees prevent cascading failures."},
+          :close
+        )
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      {:ok, %{results: results}} =
+        Knowledge.search_combined(tenant.id, "consensus",
+          keyword_weight: 0.5,
+          semantic_weight: 0.5
+        )
+
+      # The consensus doc, present in both lanes, wins the top slot over either
+      # single-lane spike — the smoothing constant makes agreement beat one strong vote.
+      assert hd(results).id == consensus.id
+    end
+
+    test "the min-max path is available behind the :min_max A/B flag" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      create_article_with_embedding(
+        tenant.id,
+        %{title: "Alpha Guide", body: "alpha content for fusion ab test"},
+        :close
+      )
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      {:ok, %{results: results, meta: meta}} =
+        Knowledge.search_combined(tenant.id, "alpha", fusion_strategy: :min_max)
+
+      # Same public shape; min-max produces normalized 0..1 weighted-sum scores (a lone
+      # both-lane hit normalizes to 1.0 per lane → 0.5 + 0.5 = 1.0), unlike RRF's
+      # ~1/(k+rank) magnitudes.
+      assert meta.search_mode == "combined"
+      assert Enum.all?(results, &Map.has_key?(&1, :final_score))
+      assert Enum.all?(results, &(&1.final_score <= 1.0))
+    end
+
+    test "meta shape is preserved (MCP contract)" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      create_article_with_embedding(
+        tenant.id,
+        %{title: "Shape Guide", body: "shape preservation content"},
+        :close
+      )
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      {:ok, %{meta: meta}} = Knowledge.search_combined(tenant.id, "shape")
+
+      assert meta.search_mode == "combined"
+      assert meta.total_count_scope == "merged_candidates"
+      assert is_integer(meta.total_count)
+      assert meta.limit == 10
+      assert meta.offset == 0
+      assert meta.pool_capped == false
+      assert is_integer(meta.semantic_result_count)
+    end
+  end
+
+  # --- #470: optional graph-neighbor lane -------------------------------------
+
+  describe "search_combined/3 - graph-neighbor lane (#470)" do
+    # A seed that matches the query so it enters the merged pool, plus a linked
+    # neighbor that matches NEITHER lane (no keyword hit, no embedding) so it can only
+    # surface through the graph lane.
+    defp seed_and_neighbor(tenant_id) do
+      seed =
+        fixture(:article, %{
+          tenant_id: tenant_id,
+          title: "Graphlane Seed",
+          body: "The graphlane token appears here.",
+          status: :published
+        })
+
+      neighbor =
+        fixture(:article, %{
+          tenant_id: tenant_id,
+          title: "Orphan Neighbor",
+          body: "Completely unrelated wording with no shared token.",
+          status: :published
+        })
+
+      fixture(:article_link, %{
+        tenant_id: tenant_id,
+        source_article_id: seed.id,
+        target_article_id: neighbor.id,
+        relationship_type: :relates_to
+      })
+
+      %{seed: seed, neighbor: neighbor}
+    end
+
+    test "is OFF by default — no neighbors injected" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+      %{neighbor: neighbor} = seed_and_neighbor(tenant.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      {:ok, %{results: results}} = Knowledge.search_combined(tenant.id, "graphlane")
+
+      refute Enum.any?(results, &(&1.id == neighbor.id))
+    end
+
+    test "when ON, one-hop neighbors join the fusion" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+      %{seed: seed, neighbor: neighbor} = seed_and_neighbor(tenant.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      {:ok, %{results: results, meta: meta}} =
+        Knowledge.search_combined(tenant.id, "graphlane", graph_lane: true)
+
+      ids = Enum.map(results, & &1.id)
+      assert seed.id in ids
+      assert neighbor.id in ids
+
+      neighbor_result = Enum.find(results, &(&1.id == neighbor.id))
+
+      # A graph-only hit carries neither raw score → its hybrid-resolver absolute_score
+      # is 0.0, and it must NOT inflate the semantic lane's row count.
+      refute Map.has_key?(neighbor_result, :relevance_score)
+      refute Map.has_key?(neighbor_result, :similarity_score)
+      assert Map.has_key?(neighbor_result, :final_score)
+      # The seed matched keyword only; nothing was embedded for the query direction, so
+      # the semantic lane contributed zero rows — the graph neighbor did not change that.
+      assert meta.semantic_result_count == 0
+    end
+
+    test "graph lane is tenant-scoped — tenant B neighbors never surface for tenant A" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant_a.id)
+
+      %{neighbor: neighbor_a} = seed_and_neighbor(tenant_a.id)
+      %{neighbor: neighbor_b} = seed_and_neighbor(tenant_b.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      {:ok, %{results: results}} =
+        Knowledge.search_combined(tenant_a.id, "graphlane", graph_lane: true)
+
+      ids = Enum.map(results, & &1.id)
+      assert neighbor_a.id in ids
+      refute neighbor_b.id in ids
+    end
+  end
 end

--- a/test/loopctl/knowledge_semantic_search_test.exs
+++ b/test/loopctl/knowledge_semantic_search_test.exs
@@ -1712,7 +1712,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
       refute neighbor_b.id in ids
     end
 
-    test "a zero-signal graph neighbor never OUTRANKS a genuine single-lane top hit" do
+    test "a zero-signal graph neighbor never outranks a genuine single-lane top hit — score AND position" do
       %{tenant: tenant} = setup_tenant()
       Knowledge.reset_circuit_breaker(tenant.id)
       %{seed: seed, neighbor: neighbor} = seed_and_neighbor(tenant.id)
@@ -1728,12 +1728,20 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
       neighbor_result = Enum.find(results, &(&1.id == neighbor.id))
 
       # The seed is keyword rank 1 (0.5/(k+1)); the graph-only neighbor is graph rank 1.
-      # With the graph lane weighted 0.5 to MATCH the primary lanes, the neighbor scores
-      # 0.5/(k+1) too — it TIES the top single-lane hit and never exceeds it. Under the
-      # buggy 1.0 graph weight the neighbor scored 1.0/(k+1) = DOUBLE and outranked every
-      # single-lane #1 (#470 review).
-      assert_in_delta neighbor_result.final_score, 0.5 / 61, 1.0e-9
-      assert neighbor_result.final_score <= seed_result.final_score
+      # The graph lane is weighted 0.25 — STRICTLY BELOW the 0.5 primary per-lane weight — so
+      # the neighbor scores 0.25/(k+1), strictly LESS than the seed's 0.5/(k+1). It can
+      # therefore neither tie NOR (via the deterministic {final_score, id} desc tiebreak,
+      # which a larger neighbor id would otherwise win) float ABOVE the genuine top hit in
+      # POSITION. At the old 0.5 tie-weight a larger-id neighbor could sort above the seed
+      # (#470 review).
+      assert_in_delta neighbor_result.final_score, 0.25 / 61, 1.0e-9
+      assert neighbor_result.final_score < seed_result.final_score
+
+      seed_pos = Enum.find_index(results, &(&1.id == seed.id))
+      neighbor_pos = Enum.find_index(results, &(&1.id == neighbor.id))
+
+      assert seed_pos < neighbor_pos,
+             "a zero-signal graph neighbor must never sort above a genuine single-lane top hit"
     end
 
     test "a neighbor linked from TWO seeds outranks one linked from a single seed" do
@@ -1824,6 +1832,184 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
       assert meta.total_count_scope == "merged_candidates_with_graph"
     end
 
+    test "consensus counts DISTINCT seeds, not link rows — one seed via many links != multi-seed" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      seed1 =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Distinctseed One",
+          body: "The distinctseed token appears here first.",
+          status: :published
+        })
+
+      seed2 =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Distinctseed Two",
+          body: "The distinctseed token appears here again.",
+          status: :published
+        })
+
+      # single_seed_multi_link: linked from ONE seed (seed1) via TWO distinct link ROWS
+      # (different relationship_types). Row-counting would score its consensus as 2.
+      single_seed_multi_link =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Single Seed Multi Link",
+          body: "Unrelated wording, no shared query token.",
+          status: :published
+        })
+
+      # two_distinct_seeds: linked from seed1 AND seed2 via one row each — genuine
+      # cross-seed consensus of 2.
+      two_distinct_seeds =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Two Distinct Seeds",
+          body: "Also unrelated wording, no shared query token.",
+          status: :published
+        })
+
+      for {src, tgt, rel} <- [
+            {seed1, single_seed_multi_link, :relates_to},
+            {seed1, single_seed_multi_link, :derived_from},
+            {seed1, two_distinct_seeds, :relates_to},
+            {seed2, two_distinct_seeds, :relates_to}
+          ] do
+        fixture(:article_link, %{
+          tenant_id: tenant.id,
+          source_article_id: src.id,
+          target_article_id: tgt.id,
+          relationship_type: rel
+        })
+      end
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      {:ok, %{results: results}} =
+        Knowledge.search_combined(tenant.id, "distinctseed", graph_lane: true)
+
+      multi_link = Enum.find(results, &(&1.id == single_seed_multi_link.id))
+      distinct = Enum.find(results, &(&1.id == two_distinct_seeds.id))
+
+      assert multi_link
+      assert distinct
+
+      # Two link rows from ONE seed must NOT tie a genuine two-DISTINCT-seed neighbor. The
+      # distinct-seed neighbor (consensus 2 → graph rank 1) strictly outranks the
+      # multi-link single-seed neighbor (consensus 1 → graph rank 2). Row-counting (the bug)
+      # gave both consensus 2 and let the single-seed neighbor tie/outrank (#470 review).
+      assert distinct.final_score > multi_link.final_score
+
+      distinct_pos = Enum.find_index(results, &(&1.id == two_distinct_seeds.id))
+      multi_link_pos = Enum.find_index(results, &(&1.id == single_seed_multi_link.id))
+      assert distinct_pos < multi_link_pos
+    end
+
+    test "graph lane honors the caller status opt (not hardcoded :published)" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      # A DRAFT seed that matches the keyword lane under a :draft-status search, plus a DRAFT
+      # neighbor reachable only via the graph lane. Under the old hardcoded `status ==
+      # :published` the draft neighbor was silently dropped even though the primary lanes
+      # returned draft rows — an inconsistent lane (#470 review).
+      seed =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Draftlane Seed",
+          body: "The draftlane token appears here.",
+          status: :draft
+        })
+
+      neighbor =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Draft Neighbor",
+          body: "Unrelated wording, no shared query token.",
+          status: :draft
+        })
+
+      fixture(:article_link, %{
+        tenant_id: tenant.id,
+        source_article_id: seed.id,
+        target_article_id: neighbor.id,
+        relationship_type: :relates_to
+      })
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      {:ok, %{results: results}} =
+        Knowledge.search_combined(tenant.id, "draftlane", graph_lane: true, status: :draft)
+
+      ids = Enum.map(results, & &1.id)
+      assert seed.id in ids
+
+      assert neighbor.id in ids,
+             "a draft graph neighbor must surface under a :draft-status search"
+    end
+
+    test "graph lane never leaks another agent's private memory to an agent caller (#163)" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      seed =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Visibilitylane Seed",
+          body: "The visibilitylane token appears here.",
+          status: :published,
+          metadata: %{"visibility" => "shared"}
+        })
+
+      # A neighbor that is ANOTHER agent's PRIVATE memory — a one-hop link from a shared
+      # seed must not surface it (or leak its id/title) to a different agent caller.
+      private_neighbor =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Other Agent Private Memory",
+          body: "Unrelated wording, no shared query token.",
+          status: :published,
+          metadata: %{"visibility" => "private", "agent_id" => "agent-owner"}
+        })
+
+      fixture(:article_link, %{
+        tenant_id: tenant.id,
+        source_article_id: seed.id,
+        target_article_id: private_neighbor.id,
+        relationship_type: :relates_to
+      })
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      # A DIFFERENT agent must NOT see the private neighbor.
+      {:ok, %{results: stranger_results}} =
+        Knowledge.search_combined(tenant.id, "visibilitylane",
+          graph_lane: true,
+          visibility_agent_id: "agent-stranger"
+        )
+
+      refute Enum.any?(stranger_results, &(&1.id == private_neighbor.id)),
+             "the graph lane must not leak another agent's private memory"
+
+      # The OWNER agent still reaches its own private memory via the same lane.
+      {:ok, %{results: owner_results}} =
+        Knowledge.search_combined(tenant.id, "visibilitylane",
+          graph_lane: true,
+          visibility_agent_id: "agent-owner"
+        )
+
+      assert Enum.any?(owner_results, &(&1.id == private_neighbor.id))
+    end
+
     test "graph_lane: true + fusion_strategy: :min_max injects no neighbors (lane skipped, no wasted read)" do
       %{tenant: tenant} = setup_tenant()
       Knowledge.reset_circuit_breaker(tenant.id)
@@ -1844,6 +2030,77 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
       # label stays the plain merged label since nothing was folded in (#470 review).
       refute Enum.any?(results, &(&1.id == neighbor.id))
       assert meta.total_count_scope == "merged_candidates"
+    end
+  end
+
+  # --- #470: get_context relevance must read the ABSOLUTE score, not RRF final_score -----
+
+  describe "get_context/3 relevance uses the absolute per-row score (#470)" do
+    test "relevance_score is on the 0..1 absolute scale, not the ~0.008 RRF final_score" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      create_article_with_embedding(
+        tenant.id,
+        %{title: "Absolute Relevance", body: "content about absolute relevance scoring"},
+        :close
+      )
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      {:ok, %{results: [first | _]}} = Knowledge.get_context(tenant.id, "absolute relevance")
+
+      # The article is a strong semantic match (query == :close), so its ABSOLUTE relevance
+      # (cosine similarity_score) is ~1.0. Post-#470 the fused RRF final_score for a rank-1
+      # hit is only ~0.5/61 ≈ 0.008; if get_context read THAT, relevance would collapse ~60x.
+      assert first.relevance_score > 0.5
+    end
+
+    test "a highly-relevant OLD article outranks an irrelevant FRESH one (recency can't dominate)" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      # Strong semantic match, but stale (90 days old → recency ≈ exp(-3) ≈ 0.05).
+      relevant_old =
+        create_article_with_embedding(
+          tenant.id,
+          %{title: "Relevant Old", body: "content about ranking relevance and recency"},
+          :close
+        )
+
+      # Poor semantic match (orthogonal embedding → similarity ≈ 0), but brand new (recency 1.0).
+      _fresh_irrelevant =
+        create_article_with_embedding(
+          tenant.id,
+          %{title: "Fresh Irrelevant", body: "content about ranking relevance and recency"},
+          :far
+        )
+
+      import Ecto.Query
+
+      ninety_days_ago = DateTime.add(DateTime.utc_now(), -90 * 86_400, :second)
+
+      Loopctl.AdminRepo.update_all(
+        from(a in Knowledge.Article, where: a.id == ^relevant_old.id),
+        set: [updated_at: ninety_days_ago]
+      )
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      {:ok, %{results: results}} =
+        Knowledge.get_context(tenant.id, "ranking relevance recency", recency_weight: 0.3)
+
+      # With the fix (0.7*abs_relevance + 0.3*recency): relevant_old ≈ 0.7*1.0 + 0.3*0.05 =
+      # 0.715 beats fresh_irrelevant ≈ 0.7*0.0 + 0.3*1.0 = 0.3. With the bug (relevance =
+      # ~0.008 RRF final_score) the fresh article's recency (0.3) swamped relevance and won.
+      relevant_pos = Enum.find_index(results, &(&1.id == relevant_old.id))
+
+      assert relevant_pos == 0,
+             "a highly-relevant old article must outrank an irrelevant fresh one"
     end
   end
 end

--- a/test/loopctl/memory_recall_context_test.exs
+++ b/test/loopctl/memory_recall_context_test.exs
@@ -174,4 +174,39 @@ defmodule Loopctl.MemoryRecallContextTest do
       assert result.meta.total_count == 3
     end
   end
+
+  # --- #470: cross-source ranking must use the ABSOLUTE knowledge score, not RRF final_score
+  describe "recall_context/2 - cross-source ranking uses the absolute knowledge score (#470)" do
+    test "a knowledge merged score is the absolute per-row relevance, not the tiny RRF final_score",
+         ctx do
+      # A query embedding equal to the article embedding (0.1 vector) makes the knowledge
+      # article a near-perfect semantic match (cosine similarity ≈ 1.0).
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:ok, List.duplicate(0.1, 1536)}
+      end)
+
+      art = article(ctx.tenant.id, ctx.project.id, "reshipment strong match")
+      _mem = mem(ctx.scope, ctx.project.id, "reshipment memory note")
+
+      result = Memory.recall_context(ctx.scope, query: "reshipment", limit: 20)
+
+      know_item =
+        Enum.find(result.results, &(&1.source == :knowledge and &1.article.id == art.id))
+
+      assert know_item
+
+      # The merged cross-source score is the ABSOLUTE relevance (cosine similarity ≈ 1.0 here)
+      # — the SAME 0..1 scale as memory's cosine — NOT the fused RRF final_score
+      # (`Σ weight/(k+rank)`, top ~0.008-0.016). Reading final_score here would sink every
+      # knowledge row below every memory row (#470 review).
+      assert know_item.score == Knowledge.absolute_result_score(know_item.article)
+      assert know_item.score > 0.5
+      assert know_item.score > (know_item.article[:final_score] || 0.0)
+
+      # The merged list is still sorted by that single score DESC across both sources.
+      scores = Enum.map(result.results, & &1.score)
+      assert scores == Enum.sort(scores, :desc)
+      assert result.meta.results_ranking == "heuristic_cross_source"
+    end
+  end
 end


### PR DESCRIPTION
## What

Replaces `Loopctl.Knowledge.merge_results/5`'s min-max normalized weighted-sum fusion with Reciprocal Rank Fusion (RRF), and adds an optional third graph-neighbor lane. Issue #470, epic #468 (Cerebras/Nick-Saraev RAG playbook).

`score(doc) = sum over lanes of weight_lane / (k + rank_lane(doc))`, default k=60, per-lane weights configurable. RRF is rank-based, so it sidesteps the incommensurable-scale problem (ts_rank_cd vs cosine similarity) that made min-max brittle, and its smoothing constant makes cross-lane consensus outweigh one lane's single #1 vote.

## Acceptance criteria

- [x] `merge_results/5` fuses via RRF (k=60, per-lane weights configurable); min-max kept behind the `:min_max` fusion-strategy flag for A/B.
- [x] Optional graph-neighbor lane, OFF by default, toggleable (config `:knowledge_rrf_graph_lane_enabled` + per-call `graph_lane:` opt), feeding one-hop link-graph neighbors into the fusion.
- [x] `search_combined/3` public result/meta shape preserved (`total_count`, `total_count_scope`, `search_mode`, `semantic_result_count`, `pool_capped`, pagination).
- [x] Degraded keyword-only fallback (`combined_keyword_fallback/5`, #297) intact, still records `fallback_reason`.
- [x] Eval harness shows recall@k / MRR / nDCG >= baseline on the golden set.

## Risk honored (issue Risks section)

`hybrid_search/3`'s curated-vs-retrieved resolver reads raw absolute `:relevance_score` / `:similarity_score` via `absolute_score/1`. RRF changes `:final_score` semantics only; every merged candidate still carries its raw score fields, so the resolver is unaffected. All 31 hybrid resolver tests pass unchanged. Graph-only neighbors carry no raw score, so their `absolute_score` is 0.0 and they can never falsely win the curated decision, nor inflate `meta.semantic_result_count`.

## Eval delta (#469 gate)

`mix loopctl.retrieval.eval --mode both` -- no regression, holds exactly at the committed baseline on every metric (delta +0.000), so no re-baseline needed:

| metric | embeddings | keyword_only |
|--------|-----------|--------------|
| recall@5  | 0.720 (base 0.720) | 0.120 (base 0.120) |
| recall@10 | 0.800 (base 0.800) | 0.120 (base 0.120) |
| ndcg@5    | 0.709 (base 0.709) | 0.141 (base 0.141) |
| ndcg@10   | 0.740 (base 0.740) | 0.141 (base 0.141) |
| mrr       | 0.736 (base 0.736) | 0.160 (base 0.160) |

## Tests

New coverage in `test/loopctl/knowledge_semantic_search_test.exs`: RRF exact `weight/(k+rank)` math, configurable `k`, cross-lane consensus beating a single-lane spike, the `:min_max` A/B flag, meta-shape preservation, graph lane OFF-by-default / ON-injects-one-hop / graph-only-hit-keeps-0-score-and-doesnt-inflate-semantic-count, and graph-lane tenant isolation. `mix precommit` green (format, credo --strict, dialyzer, 5812 tests).

Closes #470
