### PR TITLE
Fix two flaky US-41.1 embedding tests (timezone trap + shared-HNSW-index clique)

### DIFF
--- a/test/loopctl/embeddings_review_fixes_test.exs
+++ b/test/loopctl/embeddings_review_fixes_test.exs
@@ -57,8 +57,12 @@ defmodule Loopctl.EmbeddingsReviewFixesTest do
     assert Embeddings.side_table_reads_enabled?()
   end
 
-  defp vec(dim), do: List.duplicate(1.0, div(dim, 2)) ++ List.duplicate(0.0, div(dim, 2))
-  defp far_vec(dim), do: List.duplicate(0.0, div(dim, 2)) ++ List.duplicate(1.0, div(dim, 2))
+  # Per-test-unique via `Loopctl.DataCase.test_vec/2` (dissolves the shared-HNSW-index
+  # clique; see its @doc). `vec` == `:primary` (cosine 1.0), `far_vec` == `:orthogonal`
+  # (cosine 0). NOTE: a 3072-dim vector has no supported HNSW index; test_vec still returns a
+  # valid sparse vector for the dimension-rejection tests that never index it.
+  defp vec(dim), do: test_vec(dim, :primary)
+  defp far_vec(dim), do: test_vec(dim, :orthogonal)
 
   defp content_hash(text), do: :sha256 |> :crypto.hash(text) |> Base.encode16(case: :lower)
 
@@ -615,10 +619,7 @@ defmodule Loopctl.EmbeddingsReviewFixesTest do
       assert is_binary(original_hash)
       assert Embeddings.stale_system_articles(tenant.id, 1536) == []
 
-      AdminRepo.query!(
-        "UPDATE articles SET body = $1, updated_at = NOW() + interval '1 second' WHERE id = $2",
-        ["a materially different body", Ecto.UUID.dump!(article.id)]
-      )
+      stamp_article_newer(article.id, body: "a materially different body")
 
       assert Enum.map(Embeddings.stale_system_articles(tenant.id, 1536), & &1.id) == [article.id]
 
@@ -636,12 +637,7 @@ defmodule Loopctl.EmbeddingsReviewFixesTest do
 
       assert :ok = perform_job(SystemCorpusEmbeddingWorker, %{"tenant_id" => tenant.id})
 
-      AdminRepo.query!(
-        "UPDATE articles SET updated_at = NOW() + interval '1 second' WHERE id = $1",
-        [
-          Ecto.UUID.dump!(article.id)
-        ]
-      )
+      stamp_article_newer(article.id)
 
       assert Enum.map(Embeddings.stale_system_articles(tenant.id, 1536), & &1.id) == [article.id]
 
@@ -821,6 +817,34 @@ defmodule Loopctl.EmbeddingsReviewFixesTest do
   end
 
   # A SYSTEM-scoped article: `tenant_id IS NULL`, `scope: :system`.
+  # Stamp an article's `updated_at` STRICTLY after its embedding, using an app-side
+  # UTC timestamp — the SAME basis the embedding worker writes with
+  # (`DateTime.utc_now()`). Do NOT use Postgres `NOW()` here: `articles.updated_at`
+  # is `timestamp WITHOUT time zone`, and a `timestamptz` `NOW()` coerced into it is
+  # converted to the SESSION timezone and stored naive. On a non-UTC server (e.g. a
+  # dev box in America/Denver, UTC-6) that value lands HOURS behind the UTC timestamp
+  # the worker wrote, so `ae.updated_at < a.updated_at` is false and the article
+  # never looks stale — a deterministic local failure that passes on CI only because
+  # CI runs Postgres in UTC. Binding an explicit naive-UTC value removes the
+  # ambient-timezone dependency entirely.
+  defp stamp_article_newer(article_id, opts \\ []) do
+    newer = NaiveDateTime.add(NaiveDateTime.utc_now(), 1, :second)
+
+    case Keyword.fetch(opts, :body) do
+      {:ok, body} ->
+        AdminRepo.query!(
+          "UPDATE articles SET body = $1, updated_at = $2 WHERE id = $3",
+          [body, newer, Ecto.UUID.dump!(article_id)]
+        )
+
+      :error ->
+        AdminRepo.query!(
+          "UPDATE articles SET updated_at = $1 WHERE id = $2",
+          [newer, Ecto.UUID.dump!(article_id)]
+        )
+    end
+  end
+
   defp system_article(opts \\ []) do
     status = Keyword.get(opts, :status, :published)
     now = DateTime.utc_now()

--- a/test/loopctl/embeddings_side_table_reads_test.exs
+++ b/test/loopctl/embeddings_side_table_reads_test.exs
@@ -45,38 +45,17 @@ defmodule Loopctl.EmbeddingsSideTableReadsTest do
     assert Embeddings.side_table_reads_enabled?()
   end
 
-  # Deterministic, well-separated vectors: `:close` and `:query` are identical
-  # (cosine distance 0); `:far` is a STRICTLY WORSE but still genuinely NEAR
-  # neighbour (cosine similarity ~0.71 — it shares a quarter of the query's
-  # non-zero dimensions).
-  #
-  # `:far` was ORTHOGONAL (similarity 0.0, the worst rank expressible) and that made
-  # the ranking test flake ~8/10. Two independent mechanisms punish a worst-case
-  # vector, and neither is a defect:
-  #
-  #   1. HNSW is an APPROXIMATE index. Its graph traversal is not obliged to reach
-  #      the most distant point in the set, and the graph's shape depends on
-  #      insertion order, so "does the single worst match come back" is a coin flip
-  #      by construction — not something an ANN read path ever promises.
-  #   2. AC-41.1.7 makes the semantic read path materialize the SYSTEM corpus on
-  #      demand, and the Epic 26 bootstrap migrations seed a system-scoped article
-  #      set into EVERY database, CI included (20260411231009_seed_epic_26_phase_0_
-  #      articles and siblings). Under `testing: :inline` that runs SYNCHRONOUSLY
-  #      inside the search, so those rows join the pool — and every one of them
-  #      (positive similarity) outranks an orthogonal vector.
-  #
-  # Ranking is what AC-41.1.5 is about, so `:far` is now near enough that HNSW
-  # reliably finds it and it reliably sorts BELOW `:close`. Keep it a real
-  # neighbour; do not restore the orthogonal form.
-  defp vec(dim, :close), do: half_ones(dim)
-  defp vec(dim, :query), do: half_ones(dim)
-
-  defp vec(dim, :far) do
-    quarter = div(dim, 4)
-    List.duplicate(1.0, quarter) ++ List.duplicate(0.0, dim - quarter)
-  end
-
-  defp half_ones(dim), do: List.duplicate(1.0, div(dim, 2)) ++ List.duplicate(0.0, div(dim, 2))
+  # Per-test-unique vectors via `Loopctl.DataCase.test_vec/2` (see its @doc). `:close`
+  # and `:query` are identical (cosine 1.0); `:far` is a strictly-worse but genuinely
+  # NEAR neighbour (`:near`, cosine ~0.71). Keying every test's vectors into a disjoint
+  # window is what dissolves the shared-HNSW-index clique that made this ranking test
+  # flake on CI — a fixed `half_ones` vector shared across ~50 uses in this file (plus
+  # siblings) formed an all-ties clique the approximate ANN walk could not navigate, so
+  # `:far` was intermittently evicted before the tenant filter ran. Do NOT reintroduce a
+  # fixed/global vector here.
+  defp vec(dim, :close), do: test_vec(dim, :primary)
+  defp vec(dim, :query), do: test_vec(dim, :primary)
+  defp vec(dim, :far), do: test_vec(dim, :near)
 
   defp embedded_article(tenant_id, attrs, kind, dim) do
     article = fixture(:article, Map.merge(%{tenant_id: tenant_id, status: :published}, attrs))

--- a/test/loopctl/knowledge/hybrid_e2e_test.exs
+++ b/test/loopctl/knowledge/hybrid_e2e_test.exs
@@ -42,14 +42,14 @@ defmodule Loopctl.Knowledge.HybridE2ETest do
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
 
-  # A "direction" + a midpoint, mirroring the pattern in knowledge_hybrid_test.exs
-  # / knowledge_semantic_search_test.exs: cosine similarity of identical
-  # directions is 1.0, and the midpoint sits at ~0.7033 to it — deterministic
-  # enough to sit safely below the 0.75 default threshold without
-  # floating-point flakiness, while still representing a genuinely near
-  # (not orthogonal) chunk.
-  @direction_a List.duplicate(1.0, 768) ++ List.duplicate(0.0, 768)
-  @direction_medium List.duplicate(0.5, 768) ++ List.duplicate(0.5, 768)
+  # A "direction" + a midpoint, mirroring knowledge_hybrid_test.exs /
+  # knowledge_semantic_search_test.exs: cosine of identical directions is 1.0, and the
+  # midpoint sits at ~0.71 — safely below the 0.75 default threshold while still a genuinely
+  # near (not orthogonal) chunk. Sourced per-test from `Loopctl.DataCase.test_vec/2`
+  # (functions, not compile-time attributes) so each test's vectors occupy a DISJOINT window
+  # of the shared HNSW index — dissolving the all-ties clique that flakes recall.
+  defp direction_a, do: test_vec(1536, :primary)
+  defp direction_medium, do: test_vec(1536, :near)
 
   defp auth_conn(conn, raw_key) do
     put_req_header(conn, "authorization", "Bearer #{raw_key}")
@@ -102,10 +102,10 @@ defmodule Loopctl.Knowledge.HybridE2ETest do
           title: "Refund Policy Guide",
           body: "Our refund policy allows returns within 30 days for a full refund."
         })
-        |> then(&set_embedding(tenant.id, &1, @direction_a))
+        |> then(&set_embedding(tenant.id, &1, direction_a()))
 
       # A fuzzy, non-curated chunk that sits NEAR the query in embedding space
-      # (@direction_medium, ~0.7033 cosine to the query — the same near-miss
+      # (direction_medium(), ~0.7033 cosine to the query — the same near-miss
       # vector used by the below-threshold test further down) rather than
       # orthogonal to it. This is what docs/knowledge-hybrid-retrieval.md:20-26
       # actually describes as the harvested failure: a chunk close enough that
@@ -121,10 +121,10 @@ defmodule Loopctl.Knowledge.HybridE2ETest do
           body: "How long orders take to ship across different carriers.",
           status: :published
         })
-        |> then(&set_embedding(tenant.id, &1, @direction_medium))
+        |> then(&set_embedding(tenant.id, &1, direction_medium()))
 
       query = "refund policy"
-      stub_embeddings_by_query(%{query => @direction_a})
+      stub_embeddings_by_query(%{query => direction_a()})
 
       # (a) WITH the curated article present: it wins :curated, is hoisted to
       # the front, and the unrelated chunk is NOT what the caller is handed as
@@ -181,10 +181,10 @@ defmodule Loopctl.Knowledge.HybridE2ETest do
       near_but_wrong =
         tenant.id
         |> curated_article(%{title: "Shipping Refund Process"})
-        |> then(&set_embedding(tenant.id, &1, @direction_medium))
+        |> then(&set_embedding(tenant.id, &1, direction_medium()))
 
       query = "what is the refund policy?"
-      stub_embeddings_by_query(%{query => @direction_a})
+      stub_embeddings_by_query(%{query => direction_a()})
 
       assert {:ok, %{results: results, meta: meta}} =
                Knowledge.hybrid_search(tenant.id, query, keyword_weight: 0, semantic_weight: 1)
@@ -206,8 +206,8 @@ defmodule Loopctl.Knowledge.HybridE2ETest do
       Knowledge.reset_circuit_breaker(curated_tenant.id)
 
       curated = curated_article(curated_tenant.id, %{title: "Deploy Guide Curated"})
-      set_embedding(curated_tenant.id, curated, @direction_a)
-      stub_embeddings_by_query(%{"deploy guide" => @direction_a})
+      set_embedding(curated_tenant.id, curated, direction_a())
+      stub_embeddings_by_query(%{"deploy guide" => direction_a()})
 
       assert {:ok, %{meta: curated_meta}} =
                Knowledge.hybrid_search(curated_tenant.id, "deploy guide",
@@ -253,7 +253,7 @@ defmodule Loopctl.Knowledge.HybridE2ETest do
           title: "Tenant A Refund Policy",
           body: "Tenant A's confidential refund policy details."
         })
-        |> then(&set_embedding(tenant_a.id, &1, @direction_a))
+        |> then(&set_embedding(tenant_a.id, &1, direction_a()))
 
       # tenant_b is seeded with its OWN decoy on the SAME axis, so this proves
       # tenant A's curated article does not intermingle into a populated tenant
@@ -268,10 +268,10 @@ defmodule Loopctl.Knowledge.HybridE2ETest do
           title: "Tenant B Refund Policy",
           body: "Tenant B's own refund policy on the same axis as tenant A's."
         })
-        |> then(&set_embedding(tenant_b.id, &1, @direction_a))
+        |> then(&set_embedding(tenant_b.id, &1, direction_a()))
 
       query = "refund policy"
-      stub_embeddings_by_query(%{query => @direction_a})
+      stub_embeddings_by_query(%{query => direction_a()})
 
       assert {:ok, %{results: results_b, meta: meta_b}} =
                Knowledge.hybrid_search(tenant_b.id, query, keyword_weight: 0, semantic_weight: 1)
@@ -330,7 +330,7 @@ defmodule Loopctl.Knowledge.HybridE2ETest do
           title: "Tenant A HTTP Refund Policy",
           body: "Tenant A's confidential refund policy details over HTTP."
         })
-        |> then(&set_embedding(tenant_a.id, &1, @direction_a))
+        |> then(&set_embedding(tenant_a.id, &1, direction_a()))
 
       tenant_b = fixture(:tenant)
       Knowledge.reset_circuit_breaker(tenant_b.id)
@@ -342,10 +342,10 @@ defmodule Loopctl.Knowledge.HybridE2ETest do
           title: "Tenant B HTTP Refund Policy",
           body: "Tenant B's own refund policy over HTTP."
         })
-        |> then(&set_embedding(tenant_b.id, &1, @direction_a))
+        |> then(&set_embedding(tenant_b.id, &1, direction_a()))
 
       query = "refund policy"
-      stub_embeddings_by_query(%{query => @direction_a})
+      stub_embeddings_by_query(%{query => direction_a()})
 
       conn =
         conn
@@ -424,7 +424,7 @@ defmodule Loopctl.Knowledge.HybridE2ETest do
       conflicted =
         tenant.id
         |> curated_article(%{title: "Conflicted Curated Answer"})
-        |> then(&set_embedding(tenant.id, &1, @direction_a))
+        |> then(&set_embedding(tenant.id, &1, direction_a()))
 
       rival =
         fixture(:article, %{tenant_id: tenant.id, status: :published, title: "Rival Answer"})
@@ -438,7 +438,7 @@ defmodule Loopctl.Knowledge.HybridE2ETest do
       })
 
       query = "conflicted curated answer topic"
-      stub_embeddings_by_query(%{query => @direction_a})
+      stub_embeddings_by_query(%{query => direction_a()})
 
       assert {:ok, %{results: results, meta: meta}} =
                Knowledge.hybrid_search(tenant.id, query, keyword_weight: 0, semantic_weight: 1)

--- a/test/loopctl/knowledge/vector_search_test.exs
+++ b/test/loopctl/knowledge/vector_search_test.exs
@@ -16,19 +16,26 @@ defmodule Loopctl.Knowledge.VectorSearchTest do
   # --- embedding helpers (directional; cosine measures direction, not magnitude) ---
   #
   # `base`/`near` point the same way (cosine ≈ 1.0). `near_k` adds a small amount of
-  # the orthogonal half so cosine decreases monotonically with k — giving a stable
-  # similarity ranking. `orthogonal` shares no direction with `base` (cosine ≈ 0).
+  # the orthogonal direction so cosine decreases monotonically with k (1/sqrt(1+0.0025k²))
+  # — giving a stable similarity ranking. `orthogonal` shares no direction with `base`
+  # (cosine ≈ 0).
+  #
+  # All three are sourced from `Loopctl.DataCase.test_vec/2` so this file's vectors land in
+  # THIS test's disjoint window of the shared, cross-tenant pgvector HNSW index — dissolving
+  # the all-ties `half_ones` clique that flakes recall (see test_vec/2's @doc). The graded
+  # `near_embedding/1` is composed elementwise from the (disjoint) `:primary` and `:orthogonal`
+  # windows, so the exact cosine ordering is preserved with NO fixed coordinates.
 
-  @dims 768
+  defp base_embedding, do: test_vec(1536, :primary)
 
-  defp base_embedding, do: List.duplicate(1.0, @dims) ++ List.duplicate(0.0, @dims)
-
-  # Larger k => more orthogonal mass => lower cosine similarity to base.
+  # Larger k => more orthogonal-window mass => lower cosine similarity to base.
   defp near_embedding(k) when k >= 0 do
-    List.duplicate(1.0, @dims) ++ List.duplicate(k * 0.05, @dims)
+    primary = test_vec(1536, :primary)
+    orthogonal = test_vec(1536, :orthogonal)
+    Enum.zip_with(primary, orthogonal, fn p, o -> p + k * 0.05 * o end)
   end
 
-  defp orthogonal_embedding, do: List.duplicate(0.0, @dims) ++ List.duplicate(1.0, @dims)
+  defp orthogonal_embedding, do: test_vec(1536, :orthogonal)
 
   # Creates a PUBLISHED article with a known embedding, bypassing the Oban cascade.
   defp article_with_embedding(tenant_id, embedding, attrs \\ %{}) do

--- a/test/loopctl/knowledge_combined_priors_test.exs
+++ b/test/loopctl/knowledge_combined_priors_test.exs
@@ -13,8 +13,9 @@ defmodule Loopctl.KnowledgeCombinedPriorsTest do
   @now ~U[2026-07-21 00:00:00Z]
 
   # Two 1536-dim vectors: :query and :close point the same direction (cosine similarity 1),
-  # so both near-duplicate articles are exact ties in the semantic lane too.
-  defp query_vector, do: List.duplicate(1.0, 768) ++ List.duplicate(0.0, 768)
+  # so both near-duplicate articles are exact ties in the semantic lane too. Per-test-unique
+  # via `Loopctl.DataCase.test_vec/2` (dissolves the shared-HNSW-index clique; see its @doc).
+  defp query_vector, do: test_vec(1536, :primary)
 
   defp create_article(tenant_id, attrs) do
     article =
@@ -73,8 +74,12 @@ defmodule Loopctl.KnowledgeCombinedPriorsTest do
   end
 
   defp expect_query_embedding do
+    # Capture in THIS process: the embedding is generated in a spawned worker that lacks this
+    # process's :test_vec_axis, so a lazy `query_vector()` there would miss the articles' window.
+    qv = query_vector()
+
     Mox.expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
-      {:ok, query_vector()}
+      {:ok, qv}
     end)
   end
 

--- a/test/loopctl/knowledge_hybrid_test.exs
+++ b/test/loopctl/knowledge_hybrid_test.exs
@@ -15,14 +15,15 @@ defmodule Loopctl.KnowledgeHybridTest do
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.ArticleAccessEvent
 
-  # Two orthogonal "directions" + a midpoint, mirroring the pattern in
-  # knowledge_semantic_search_test.exs: cosine similarity of identical directions is
-  # 1.0, orthogonal directions is 0.0, and the midpoint sits at ~0.7033 to either —
-  # deterministic enough to sit safely below the 0.75 default threshold without
-  # floating-point flakiness.
-  @direction_a List.duplicate(1.0, 768) ++ List.duplicate(0.0, 768)
-  @direction_b List.duplicate(0.0, 768) ++ List.duplicate(1.0, 768)
-  @direction_medium List.duplicate(0.5, 768) ++ List.duplicate(0.5, 768)
+  # Two orthogonal "directions" + a midpoint, mirroring knowledge_semantic_search_test.exs:
+  # cosine of identical directions is 1.0, orthogonal directions 0.0, and the midpoint sits
+  # at ~0.71 to `:primary` — safely below the 0.75 default threshold. Sourced per-test from
+  # `Loopctl.DataCase.test_vec/2` (compile-time module attributes can't be per-test, so these
+  # are functions), placing each test's vectors in a DISJOINT window of the shared HNSW index
+  # to dissolve the all-ties clique that flakes recall (see test_vec/2's @doc).
+  defp direction_a, do: test_vec(1536, :primary)
+  defp direction_b, do: test_vec(1536, :orthogonal)
+  defp direction_medium, do: test_vec(1536, :near)
 
   # Creates a published tenant article and marks it curated via the governed path
   # (mirrors test/loopctl/knowledge_curated_test.exs).
@@ -60,12 +61,12 @@ defmodule Loopctl.KnowledgeHybridTest do
       answering =
         tenant.id
         |> curated_article(%{title: "Refund Policy Answer"})
-        |> then(&set_embedding(tenant.id, &1, @direction_a))
+        |> then(&set_embedding(tenant.id, &1, direction_a()))
 
       _near_but_wrong =
         tenant.id
         |> curated_article(%{title: "Shipping Refund Process"})
-        |> then(&set_embedding(tenant.id, &1, @direction_medium))
+        |> then(&set_embedding(tenant.id, &1, direction_medium()))
 
       # A non-curated distractor exactly aligned with `other_query`'s embedding —
       # the genuine best-retrieved competitor `other_query` must fall back to,
@@ -76,12 +77,12 @@ defmodule Loopctl.KnowledgeHybridTest do
           title: "Unrelated Distractor",
           status: :published
         })
-        |> then(&set_embedding(tenant.id, &1, @direction_b))
+        |> then(&set_embedding(tenant.id, &1, direction_b()))
 
       answering_query = "what is the refund policy?"
       other_query = "a query only loosely related to shipping refunds"
 
-      stub_embeddings_by_query(%{answering_query => @direction_a, other_query => @direction_b})
+      stub_embeddings_by_query(%{answering_query => direction_a(), other_query => direction_b()})
 
       assert {:ok, %{results: results1, meta: meta1}} =
                Knowledge.hybrid_search(tenant.id, answering_query,
@@ -116,10 +117,10 @@ defmodule Loopctl.KnowledgeHybridTest do
       weak_curated =
         tenant.id
         |> curated_article(%{title: "Shipping Refund Process"})
-        |> then(&set_embedding(tenant.id, &1, @direction_medium))
+        |> then(&set_embedding(tenant.id, &1, direction_medium()))
 
       query = "what is the refund policy?"
-      stub_embeddings_by_query(%{query => @direction_a})
+      stub_embeddings_by_query(%{query => direction_a()})
 
       assert {:ok, %{results: results, meta: meta}} =
                Knowledge.hybrid_search(tenant.id, query, keyword_weight: 0, semantic_weight: 1)
@@ -169,7 +170,7 @@ defmodule Loopctl.KnowledgeHybridTest do
             "Invoice generation troubleshooting steps for common invoice generation issues. " <>
               "Invoice generation troubleshooting requires careful invoice generation review."
         })
-        |> then(&set_embedding(tenant.id, &1, @direction_b))
+        |> then(&set_embedding(tenant.id, &1, direction_b()))
       end
 
       # The curated doc shares NO keyword terms with the query at all (so it never
@@ -182,9 +183,9 @@ defmodule Loopctl.KnowledgeHybridTest do
           title: "Refund Policy Definitive Answer",
           body: "Our refund policy is fully documented here with complete refund guidance."
         })
-        |> then(&set_embedding(tenant.id, &1, @direction_a))
+        |> then(&set_embedding(tenant.id, &1, direction_a()))
 
-      stub_embeddings_by_query(%{query => @direction_a})
+      stub_embeddings_by_query(%{query => direction_a()})
 
       # Default page (limit 10, offset 0): the curated doc ranks 13th by the
       # keyword-heavy combined `:final_score` — but the resolver still finds and
@@ -230,9 +231,9 @@ defmodule Loopctl.KnowledgeHybridTest do
       Knowledge.reset_circuit_breaker(curated_tenant.id)
 
       curated = curated_article(curated_tenant.id, %{title: "Deploy Guide Curated"})
-      set_embedding(curated_tenant.id, curated, @direction_a)
+      set_embedding(curated_tenant.id, curated, direction_a())
 
-      stub_embeddings_by_query(%{"deploy guide" => @direction_a})
+      stub_embeddings_by_query(%{"deploy guide" => direction_a()})
 
       assert {:ok, %{results: [curated_result | _], meta: curated_meta}} =
                Knowledge.hybrid_search(curated_tenant.id, "deploy guide",
@@ -493,9 +494,9 @@ defmodule Loopctl.KnowledgeHybridTest do
       Knowledge.reset_circuit_breaker(tenant.id)
 
       curated = curated_article(tenant.id, %{title: "Deploy Guide Curated"})
-      set_embedding(tenant.id, curated, @direction_a)
+      set_embedding(tenant.id, curated, direction_a())
 
-      stub_embeddings_by_query(%{"deploy guide" => @direction_a})
+      stub_embeddings_by_query(%{"deploy guide" => direction_a()})
 
       assert {:ok, %{meta: %{provenance: :curated}}} =
                Knowledge.hybrid_search(tenant.id, "deploy guide",
@@ -630,8 +631,8 @@ defmodule Loopctl.KnowledgeHybridTest do
       attach_hybrid_provenance_handler(tenant.id)
 
       curated = curated_article(tenant.id, %{title: "Telemetry Deploy Guide"})
-      set_embedding(tenant.id, curated, @direction_a)
-      stub_embeddings_by_query(%{"telemetry deploy guide" => @direction_a})
+      set_embedding(tenant.id, curated, direction_a())
+      stub_embeddings_by_query(%{"telemetry deploy guide" => direction_a()})
 
       assert {:ok, %{meta: %{provenance: :curated}}} =
                Knowledge.hybrid_search(tenant.id, "telemetry deploy guide",

--- a/test/loopctl/knowledge_project_scope_test.exs
+++ b/test/loopctl/knowledge_project_scope_test.exs
@@ -16,8 +16,9 @@ defmodule Loopctl.KnowledgeProjectScopeTest do
   alias Loopctl.Knowledge
 
   # Same-direction vectors → cosine distance 0 (all match semantically), so the project
-  # filter is the only thing separating the result sets.
-  defp query_vector, do: List.duplicate(1.0, 768) ++ List.duplicate(0.0, 768)
+  # filter is the only thing separating the result sets. Per-test-unique via
+  # `Loopctl.DataCase.test_vec/2` (dissolves the shared-HNSW-index clique; see its @doc).
+  defp query_vector, do: test_vec(1536, :primary)
 
   defp article(tenant_id, project_id, title) do
     article =
@@ -34,8 +35,13 @@ defmodule Loopctl.KnowledgeProjectScopeTest do
   end
 
   defp stub_query_embedding do
+    # Capture in THIS (setup/test) process: the stub is invoked from a spawned embedding
+    # worker that carries the Mox allowance but NOT this process's :test_vec_axis, so a lazy
+    # `query_vector()` there would land in axis-0's window and miss the articles.
+    qv = query_vector()
+
     Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
-      {:ok, query_vector()}
+      {:ok, qv}
     end)
   end
 

--- a/test/loopctl/knowledge_semantic_search_test.exs
+++ b/test/loopctl/knowledge_semantic_search_test.exs
@@ -13,31 +13,20 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
   # Vectors pointing in the same direction have cosine distance 0 (similarity 1).
   # Orthogonal vectors have cosine distance 1 (similarity 0).
 
-  # A helper that creates a 1536-dim vector with a known pattern.
-  # `direction` controls which "axis group" the vector points toward.
-  defp make_embedding(:close) do
-    # Close to query: mostly 1s in the first half, 0s elsewhere
-    List.duplicate(1.0, 768) ++ List.duplicate(0.0, 768)
-  end
+  # Per-test-unique vectors via `Loopctl.DataCase.test_vec/2` (see its @doc): each test's
+  # vectors land in a DISJOINT window of the shared, cross-tenant pgvector HNSW index, so the
+  # `half_ones`/orthogonal/constant vectors these tests share no longer form the all-ties
+  # clique that flakes recall. Within a test the geometry is preserved: `:close`==`:query`
+  # (cosine 1.0), `:far`⊥query (cosine 0), `:medium` ~0.71.
+  defp make_embedding(:close), do: test_vec(1536, :primary)
+  defp make_embedding(:far), do: test_vec(1536, :orthogonal)
+  defp make_embedding(:query), do: test_vec(1536, :primary)
+  defp make_embedding(:medium), do: test_vec(1536, :near)
 
-  defp make_embedding(:far) do
-    # Far from query: mostly 0s in the first half, 1s elsewhere
-    List.duplicate(0.0, 768) ++ List.duplicate(1.0, 768)
-  end
-
-  defp make_embedding(:query) do
-    # Query vector: same direction as :close
-    List.duplicate(1.0, 768) ++ List.duplicate(0.0, 768)
-  end
-
-  defp make_embedding(:medium) do
-    # In between — equal parts of both
-    List.duplicate(0.5, 768) ++ List.duplicate(0.5, 768)
-  end
-
-  defp make_embedding(:uniform) do
-    List.duplicate(0.1, 1536)
-  end
+  # The identical-score test seeds many rows with THIS one vector and queries it; keeping them
+  # all identical (now per-test-unique) preserves the equal-scores semantics while de-cliquing
+  # the old degenerate constant (`List.duplicate(0.1, 1536)` — the KB-0bdadd52 anti-pattern).
+  defp make_embedding(:uniform), do: test_vec(1536, :primary)
 
   defp setup_tenant do
     tenant = fixture(:tenant)
@@ -1558,8 +1547,12 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
           :medium
         )
 
+      # Pin the query vector to THIS process's axis (the semantic lane's embedding is
+      # generated in a spawned worker without this process's :test_vec_axis).
+      query_embedding = make_embedding(:query)
+
       Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
-        {:ok, make_embedding(:query)}
+        {:ok, query_embedding}
       end)
 
       {:ok, %{results: results}} =
@@ -2065,8 +2058,14 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
         :close
       )
 
+      # Bind the query vector in THIS process: the embedding stub is invoked from a
+      # spawned worker (Mox $callers allowance, but NOT this process's :test_vec_axis),
+      # so `make_embedding(:query)` computed lazily there would use axis 0 and miss the
+      # article's per-test window. Capturing it here pins it to the same axis.
+      query_embedding = make_embedding(:query)
+
       Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
-        {:ok, make_embedding(:query)}
+        {:ok, query_embedding}
       end)
 
       {:ok, %{results: [first | _]}} = Knowledge.get_context(tenant.id, "absolute relevance")
@@ -2106,8 +2105,12 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
         set: [updated_at: ninety_days_ago]
       )
 
+      # See the note above: pin the query vector to THIS process's axis so the
+      # spawned embedding worker returns a vector in the articles' window.
+      query_embedding = make_embedding(:query)
+
       Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
-        {:ok, make_embedding(:query)}
+        {:ok, query_embedding}
       end)
 
       {:ok, %{results: results}} =

--- a/test/loopctl/workers/article_linking_worker_test.exs
+++ b/test/loopctl/workers/article_linking_worker_test.exs
@@ -912,16 +912,19 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
   describe "real vector search (integration)" do
     @describetag :integration
 
-    defp similar_embedding, do: List.duplicate(1.0, 768) ++ List.duplicate(0.0, 768)
+    # Per-test-unique via `Loopctl.DataCase.test_vec/2` (dissolves the shared-HNSW-index
+    # clique; see its @doc). `similar` == the source direction (cosine 1.0); `near_similar`
+    # adds a tiny orthogonal-window perturbation (cosine ~0.9999, well above the 0.6 link
+    # threshold); `dissimilar` is orthogonal (cosine 0).
+    defp similar_embedding, do: test_vec(1536, :primary)
 
     defp near_similar_embedding do
-      List.duplicate(1.0, 768)
-      |> List.update_at(0, fn _ -> 0.99 end)
-      |> List.update_at(1, fn _ -> 1.01 end)
-      |> Kernel.++(List.duplicate(0.01, 768))
+      primary = test_vec(1536, :primary)
+      orthogonal = test_vec(1536, :orthogonal)
+      Enum.zip_with(primary, orthogonal, fn p, o -> p + 0.01 * o end)
     end
 
-    defp dissimilar_embedding, do: List.duplicate(0.0, 768) ++ List.duplicate(1.0, 768)
+    defp dissimilar_embedding, do: test_vec(1536, :orthogonal)
 
     defp publish_with_embedding(tenant_id, embedding) do
       fixture(:article, %{

--- a/test/loopctl/workers/knowledge_lint_worker_test.exs
+++ b/test/loopctl/workers/knowledge_lint_worker_test.exs
@@ -35,15 +35,15 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
     |> AdminRepo.update!()
   end
 
-  # Two near-identical directional vectors -> cosine similarity ~1.0, above the
-  # 0.6 linking threshold. (Cosine measures direction, not magnitude.)
-  defp similar_embedding, do: List.duplicate(1.0, 768) ++ List.duplicate(0.0, 768)
+  # Two near-identical directional vectors -> cosine similarity ~1.0, above the 0.6 linking
+  # threshold. Per-test-unique via `Loopctl.DataCase.test_vec/2` (dissolves the shared-HNSW-index
+  # clique; see its @doc): `near_similar` adds a tiny orthogonal-window perturbation (~0.9999).
+  defp similar_embedding, do: test_vec(1536, :primary)
 
   defp near_similar_embedding do
-    List.duplicate(1.0, 768)
-    |> List.update_at(0, fn _ -> 0.99 end)
-    |> List.update_at(1, fn _ -> 1.01 end)
-    |> Kernel.++(List.duplicate(0.01, 768))
+    primary = test_vec(1536, :primary)
+    orthogonal = test_vec(1536, :orthogonal)
+    Enum.zip_with(primary, orthogonal, fn p, o -> p + 0.01 * o end)
   end
 
   # A published orphan with NO embedding — the case a plain re-link no-ops on.

--- a/test/loopctl_web/controllers/knowledge_hybrid_search_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_hybrid_search_controller_test.exs
@@ -17,10 +17,12 @@ defmodule LoopctlWeb.KnowledgeHybridSearchControllerTest do
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.ArticleAccessEvent
 
-  # Two orthogonal directions; identical directions cosine to 1.0 (clears the 0.75
-  # curated threshold), orthogonal to 0.0.
-  @direction_a List.duplicate(1.0, 768) ++ List.duplicate(0.0, 768)
-  @direction_b List.duplicate(0.0, 768) ++ List.duplicate(1.0, 768)
+  # Two orthogonal directions; identical directions cosine to 1.0 (clears the 0.75 curated
+  # threshold), orthogonal to 0.0. Sourced per-test from `Loopctl.DataCase.test_vec/2`
+  # (functions, not compile-time attributes) so each test's vectors occupy a DISJOINT window
+  # of the shared HNSW index — dissolving the all-ties clique that flakes recall.
+  defp direction_a, do: test_vec(1536, :primary)
+  defp direction_b, do: test_vec(1536, :orthogonal)
 
   defp auth_conn(conn, raw_key) do
     put_req_header(conn, "authorization", "Bearer #{raw_key}")
@@ -61,7 +63,7 @@ defmodule LoopctlWeb.KnowledgeHybridSearchControllerTest do
           title: "Refund Policy",
           body: "Our refund policy allows returns within 30 days for a full refund."
         })
-        |> then(&set_embedding(tenant.id, &1, @direction_a))
+        |> then(&set_embedding(tenant.id, &1, direction_a()))
 
       # A fuzzy, non-curated chunk on a different axis (does not clear the bar).
       _fuzzy =
@@ -71,10 +73,10 @@ defmodule LoopctlWeb.KnowledgeHybridSearchControllerTest do
           body: "How long orders take to ship.",
           status: :published
         })
-        |> then(&set_embedding(tenant.id, &1, @direction_b))
+        |> then(&set_embedding(tenant.id, &1, direction_b()))
 
       query = "refund policy"
-      stub_embeddings_by_query(%{query => @direction_a})
+      stub_embeddings_by_query(%{query => direction_a()})
 
       conn =
         conn
@@ -110,10 +112,10 @@ defmodule LoopctlWeb.KnowledgeHybridSearchControllerTest do
           body: "Some general onboarding notes for the team.",
           status: :published
         })
-        |> then(&set_embedding(tenant.id, &1, @direction_a))
+        |> then(&set_embedding(tenant.id, &1, direction_a()))
 
       query = "onboarding notes"
-      stub_embeddings_by_query(%{query => @direction_a})
+      stub_embeddings_by_query(%{query => direction_a()})
 
       conn =
         conn
@@ -189,7 +191,7 @@ defmodule LoopctlWeb.KnowledgeHybridSearchControllerTest do
           title: "Tenant A Refund Policy",
           body: "Tenant A's confidential refund policy details."
         })
-        |> then(&set_embedding(tenant_a.id, &1, @direction_a))
+        |> then(&set_embedding(tenant_a.id, &1, direction_a()))
 
       # A key for a DIFFERENT tenant, seeded with its OWN decoy content so the
       # search pool is NON-EMPTY. This proves tenant A's curated article does not
@@ -205,10 +207,10 @@ defmodule LoopctlWeb.KnowledgeHybridSearchControllerTest do
           title: "Tenant B Refund Policy",
           body: "Tenant B's own refund policy on the same axis as tenant A's."
         })
-        |> then(&set_embedding(tenant_b.id, &1, @direction_a))
+        |> then(&set_embedding(tenant_b.id, &1, direction_a()))
 
       query = "refund policy"
-      stub_embeddings_by_query(%{query => @direction_a})
+      stub_embeddings_by_query(%{query => direction_a()})
 
       conn =
         conn

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -29,6 +29,8 @@ defmodule LoopctlWeb.ConnCase do
       import Phoenix.ConnTest
       import LoopctlWeb.ConnCase
       import Loopctl.Fixtures
+      # Per-test-unique embedding vectors for pgvector recall tests (shared with DataCase).
+      import Loopctl.DataCase, only: [test_vec: 1, test_vec: 2]
       import Mox
     end
   end
@@ -37,6 +39,9 @@ defmodule LoopctlWeb.ConnCase do
     Loopctl.DataCase.setup_sandbox(tags)
     Mox.set_mox_from_context(tags)
     Loopctl.DataCase.stub_all_defaults()
+    # Per-test embedding axis (see Loopctl.DataCase.test_vec/2): unique per test so
+    # pgvector recall vectors land in a disjoint window of the shared HNSW index.
+    Process.put(:test_vec_axis, System.unique_integer([:positive]))
     # Include the witness STH header on all test connections so the
     # ValidateWitnessHeader plug doesn't block authenticated requests.
     conn =

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -41,6 +41,10 @@ defmodule Loopctl.DataCase do
     Loopctl.DataCase.setup_sandbox(tags)
     Mox.set_mox_from_context(tags)
     stub_all_defaults()
+    # Per-test embedding axis: every test gets a UNIQUE integer, so `test_vec/2` places
+    # this test's vectors in a disjoint window of the shared pgvector HNSW index. Setup
+    # runs in the test process, so `Process.get(:test_vec_axis)` at insert time sees it.
+    Process.put(:test_vec_axis, System.unique_integer([:positive]))
     :ok
   end
 
@@ -360,6 +364,59 @@ defmodule Loopctl.DataCase do
       end)
     end)
   end
+
+  # The per-test embedding window width. Each test claims a disjoint pair of windows
+  # (`:primary` at `base_p`, `:orthogonal` at `base_s = base_p + @test_vec_window`),
+  # so two tests are exactly ORTHOGONAL and never share coordinates.
+  @test_vec_window 8
+
+  @doc """
+  Per-test-unique embedding vector for pgvector recall tests.
+
+  The shared, cross-tenant pgvector HNSW index (`article_embeddings` / `memory_embeddings`)
+  is a single physical structure. When many tests seed the SAME fixed vector (e.g. a
+  `half_ones` `[1×768, 0×768]`), those identical rows — live in-transaction plus
+  rolled-back-but-unvacuumed dead tuples across a full suite — form an all-ties CLIQUE the
+  approximate ANN graph walk cannot navigate, so a genuinely-near neighbour is intermittently
+  evicted before the tenant filter runs. That is the shared-index recall flake (issue #421 /
+  the AC-41.1.5 side-table ranking flake).
+
+  Keying each test's vectors on its unique `:test_vec_axis` (set in setup) into DISJOINT sparse
+  windows makes different tests exactly ORTHOGONAL — no cross-test clique AND no crowding (a
+  dense per-test rotation was tried and FAILS: rotated dense vectors sit nearer the query than a
+  0.71 neighbour and fill the `ef_search` budget). Within a single test the geometry is
+  preserved: `:primary`/`:query`/`:close` are identical (cosine 1.0), `:near` overlaps half the
+  primary window (cosine ~0.71), and `:orthogonal` shares no dimension with `:primary` (cosine 0).
+
+  Kinds (aliases group by MEANING so call sites read naturally):
+
+    * `:primary` | `:query` | `:close` | `:self` | `:similar` | `:base` — the primary window
+    * `:near` — half the primary window (a strictly-worse but genuinely-near neighbour, ~0.71)
+    * `:orthogonal` | `:secondary` | `:dissimilar` | `:complement` — the disjoint window (⊥ primary)
+  """
+  @spec test_vec(pos_integer(), atom()) :: [float()]
+  def test_vec(dim, kind \\ :primary) do
+    axis = Process.get(:test_vec_axis, 0)
+    slots = max(div(dim, @test_vec_window * 2), 1)
+    base_p = rem(axis, slots) * @test_vec_window * 2
+    base_s = base_p + @test_vec_window
+
+    case kind do
+      k when k in [:primary, :query, :close, :self, :similar, :base] ->
+        test_vec_ones(dim, base_p, @test_vec_window)
+
+      :near ->
+        test_vec_ones(dim, base_p, div(@test_vec_window, 2))
+
+      k when k in [:orthogonal, :secondary, :dissimilar, :complement] ->
+        test_vec_ones(dim, base_s, @test_vec_window)
+    end
+  end
+
+  defp test_vec_ones(dim, base, ones),
+    do:
+      List.duplicate(0.0, base) ++
+        List.duplicate(1.0, ones) ++ List.duplicate(0.0, dim - base - ones)
 
   # A DETERMINISTIC per-TENANT embedding for the default MockEmbeddingClient stubs
   # (stub_all_defaults/0). Returns a 1536-dim vector that is a PURE FUNCTION of the


### PR DESCRIPTION
## What

Fixes the two flaky US-41.1 embedding tests that were riding on lucky CI re-runs (they flaked master's own CI). Both are environment-sensitive; root-caused and fixed at the source. **Test-only — no production code changes.**

## Root causes

### 1. `stale_system_articles` (deterministic fail on a non-UTC dev box, pass on CI)

The tests stamped `articles.updated_at` with Postgres `NOW() + interval '1 second'`. `updated_at` is `timestamp WITHOUT time zone`, so a `timestamptz` `NOW()` coerced into it is stored in the **session timezone**. On a UTC−6 box that lands ~6 hours *behind* the UTC timestamp the embedding worker writes via `DateTime.utc_now()`, so `ae.updated_at < a.updated_at` is false and the article never looks stale. CI runs Postgres in UTC, hiding it.

**Fix:** stamp via an app-side naive-UTC value (`stamp_article_newer/2`), the same basis production uses. Production was never affected.

### 2. `search_semantic` side-table ranking (intermittent on CI, 20/20 local)

pgvector's HNSW index is one **shared, cross-tenant** physical structure. Many tests seeded the same fixed `half_ones` vector; those identical rows — live in-transaction plus rolled-back-but-unvacuumed dead tuples across a full suite — form an all-ties **clique** the approximate ANN walk cannot navigate, so a genuinely-near neighbor is intermittently evicted before the tenant filter runs. Local passes because the planner picks the exact btree plan for a 2-row tenant; CI's PG16 under suite bloat flips to the HNSW plan where the clique bites. (Verified: raising `ef_search` cannot navigate an all-ties clique — a ~700 clique evicts everything even at ef=800; a deterministic tiebreak cannot fix a *recall* miss.)

**Fix:** a per-test embedding axis (`Loopctl.DataCase.test_vec/2` + `:test_vec_axis` in DataCase/ConnCase setup) places each test's vectors in **disjoint sparse windows** — different tests are exactly orthogonal, so no clique forms and no test's rows crowd another's neighbor out of the ef_search budget. Converted the ~11 files that seeded fixed vectors (module-attribute vectors → per-test functions; the graded `vector_search_test` near vectors are composed from the disjoint primary/orthogonal windows, preserving the exact cosine curve `1/sqrt(1+0.0025k²)`). One gotcha handled: a query embedding generated inside a spawned worker doesn't inherit the test's axis, so those query vectors are bound in-process.

## Test

- Full suite green across **6 runs** (seeds 1/7/99999/31337/55555/default), 5966 tests each — the flake is gone under maximum clique pressure.
- The previously-deterministic `stale_system_articles` tests now pass on a UTC−6 box.
- compile `--warnings-as-errors`, format, credo `--strict`, dialyzer: clean.

## Follow-up (separate, being addressed next)

The investigation surfaced a real production concern: the side-table search filters `tenant_id` *after* the ANN over the cross-tenant partial HNSW index, with `hnsw.iterative_scan` unset — at scale a multi-row tenant whose neighbors are outnumbered within the ef_search budget could get silently under-returned results. Being planned as its own change.
