### PR TITLE
fix(mix): run hex.audit before compile in precommit alias (unbreaks local mix precommit)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -170,12 +170,17 @@ defmodule Loopctl.MixProject do
       "assets.setup": ["tailwind.install --if-missing", "esbuild.install --if-missing"],
       "assets.deploy": ["tailwind loopctl --minify", "esbuild loopctl --minify", "phx.digest"],
       precommit: [
+        # hex.audit MUST run BEFORE `compile`: `compile` purges the archive code
+        # path, after which a chained `hex.audit` (a Hex archive task) fails with
+        # "task could not be found" — which silently broke every local `mix precommit`
+        # (CI was unaffected: it runs `mix hex.audit` as its own step). Running it
+        # first also fails fast on a retired/advised dependency.
+        "hex.audit",
         "compile --warnings-as-errors",
         "deps.unlock --check-unused",
         "format --check-formatted",
         "credo --strict",
         "loopctl.check_skill_citations",
-        "hex.audit",
         "dialyzer",
         "test"
       ]


### PR DESCRIPTION
## What

Move `hex.audit` to the front of the `precommit` alias, before `compile --warnings-as-errors`.

## Why

`hex.audit` (added to the alias in #486) ran **after** `compile`. `mix compile` purges the archive
code path, so the chained `hex.audit` — a Hex archive task — resolved as:

```
** (Mix) The task "hex.audit" could not be found
❌ Pre-commit checks FAILED!
```

This silently broke **every local `mix precommit` run** (i.e. every local commit via the pre-commit
hook). It was invisible in CI because CI invokes `mix hex.audit` as its **own standalone step**, never
through the alias — so the alias regression never surfaced there.

Reproduce on `master`:

```
mix do compile + hex.audit   # => "The task hex.audit could not be found"
mix hex.audit                # => runs fine standalone
```

## Fix

Run `hex.audit` first. It only reads `mix.lock` (no compilation needed), so ordering it before
`compile` both fixes the archive-path resolution and fails fast on a retired/advised dependency
before the slow `compile`/`dialyzer`/`test` steps.

No application behavior change.

## Verification

`mix precommit` now runs to completion locally: hex.audit → compile → format → credo →
check_skill_citations → dialyzer → test (5966 tests, 0 failures).
