### PR TITLE
Close cross-tenant ANN under-return with config-gated hnsw.iterative_scan (#488)

### DIFF
--- a/.claude/skills/tenancy-rls/SKILL.md
+++ b/.claude/skills/tenancy-rls/SKILL.md
@@ -54,16 +54,16 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 6. **On `AdminRepo`/`HeavyReadRepo`, RLS does NOTHING — the explicit `tenant_id` predicate is the only
    isolation there** (`knowledge.ex:9-14`, `heavy_read.ex:3-7`). This is the compensating invariant for
    the other two repos, and it is enforced structurally on the heavy path: the private `guard!/2`
-   (`heavy_read.ex:740-760`) RAISES unless EVERY base-table source — `from`, every join, and every
+   (`heavy_read.ex:803-823`) RAISES unless EVERY base-table source — `from`, every join, and every
    subquery, recursively — carries a conjunctive `x.tenant_id == ^tenant_id` bound to the passed
    `tenant_id`; `test/loopctl/heavy_read_guard_test.exs` additionally bars direct `HeavyReadRepo` calls.
-   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:518`) also requires a conjunctive
-   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:762-790`), because `subject_id`
+   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:581`) also requires a conjunctive
+   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:825-853`), because `subject_id`
    scoping is application-level only. Always go through `Loopctl.HeavyRead`, never `HeavyReadRepo`
    directly; on `AdminRepo` there is no guard at all, so the predicate is on you.
-7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:462`),
-   `one/3` (`heavy_read.ex:482`) and `all_memory/4` (`heavy_read.ex:518`) are specced to return it: the
-   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:547-561`) sheds over the cap —
+7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:525`),
+   `one/3` (`heavy_read.ex:545`) and `all_memory/4` (`heavy_read.ex:581`) are specced to return it: the
+   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:610-624`) sheds over the cap —
    `on_overload: :raise` (default) raises → 429, `on_overload: :tag` returns the tuple. Binding the
    result as a list crashes exactly under the load the gate exists for.
 8. **A consistency-coupled heavy read must be PRIMARY-PINNED.** `repo_for/1` (`heavy_read.ex:112-114`,
@@ -75,7 +75,7 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 ## The pgbouncer gotcha (US-27.13 — production outage, do not regress)
 
 `HeavyReadRepo` enforces a server-side `statement_timeout` **per-read via `SET LOCAL` inside the
-transaction** (`heavy_read.ex:462-492` — `all/3` and `one/3`, both via `with_statement_timeout/5`;
+transaction** (`heavy_read.ex:525-555` — `all/3` and `one/3`, both via `with_statement_timeout/5`;
 `heavy_read_repo.ex:19-32`) — NOT as a connection startup
 `:parameters` value. Fly MPG fronts Postgres with **pgbouncer**, which rejects a `statement_timeout`
 startup parameter with `FATAL 08P01 unsupported startup parameter`, crash-looping the whole pool so it

--- a/.claude/skills/tenancy-rls/SKILL.md
+++ b/.claude/skills/tenancy-rls/SKILL.md
@@ -54,16 +54,16 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 6. **On `AdminRepo`/`HeavyReadRepo`, RLS does NOTHING — the explicit `tenant_id` predicate is the only
    isolation there** (`knowledge.ex:9-14`, `heavy_read.ex:3-7`). This is the compensating invariant for
    the other two repos, and it is enforced structurally on the heavy path: the private `guard!/2`
-   (`heavy_read.ex:642-660`) RAISES unless EVERY base-table source — `from`, every join, and every
+   (`heavy_read.ex:740-760`) RAISES unless EVERY base-table source — `from`, every join, and every
    subquery, recursively — carries a conjunctive `x.tenant_id == ^tenant_id` bound to the passed
    `tenant_id`; `test/loopctl/heavy_read_guard_test.exs` additionally bars direct `HeavyReadRepo` calls.
-   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:444`) also requires a conjunctive
-   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:668-690`), because `subject_id`
+   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:518`) also requires a conjunctive
+   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:762-790`), because `subject_id`
    scoping is application-level only. Always go through `Loopctl.HeavyRead`, never `HeavyReadRepo`
    directly; on `AdminRepo` there is no guard at all, so the predicate is on you.
-7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:390`),
-   `one/3` (`heavy_read.ex:409`) and `all_memory/4` (`heavy_read.ex:444`) are specced to return it: the
-   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:468-482`) sheds over the cap —
+7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:462`),
+   `one/3` (`heavy_read.ex:482`) and `all_memory/4` (`heavy_read.ex:518`) are specced to return it: the
+   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:547-561`) sheds over the cap —
    `on_overload: :raise` (default) raises → 429, `on_overload: :tag` returns the tuple. Binding the
    result as a list crashes exactly under the load the gate exists for.
 8. **A consistency-coupled heavy read must be PRIMARY-PINNED.** `repo_for/1` (`heavy_read.ex:112-114`,
@@ -75,7 +75,7 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 ## The pgbouncer gotcha (US-27.13 — production outage, do not regress)
 
 `HeavyReadRepo` enforces a server-side `statement_timeout` **per-read via `SET LOCAL` inside the
-transaction** (`heavy_read.ex:386-415` — `all/3` and `one/3`, both via `with_statement_timeout/4`;
+transaction** (`heavy_read.ex:462-492` — `all/3` and `one/3`, both via `with_statement_timeout/5`;
 `heavy_read_repo.ex:19-32`) — NOT as a connection startup
 `:parameters` value. Fly MPG fronts Postgres with **pgbouncer**, which rejects a `statement_timeout`
 startup parameter with `FATAL 08P01 unsupported startup parameter`, crash-looping the whole pool so it

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -412,12 +412,75 @@ defmodule Loopctl.HeavyRead do
 
   # The per-read `hnsw.iterative_scan` mode to APPLY via `SET LOCAL`, or `nil` when OFF
   # (the default) — so the common path issues NO iterative-scan GUC round-trip and pgvector
-  # versions without the GUC are never touched.
+  # versions without the GUC are never touched. When an operator HAS enabled it, the
+  # capability probe (`iterative_scan_supported?/0`) is the second gate: on a pgvector < 0.8
+  # backend (no such GUC) it returns `nil` too, so enabling the config there is a NO-OP
+  # rather than a fleet-wide ANN outage. The `"off"` clause short-circuits BEFORE the probe,
+  # so the default path never pays for it.
   @spec iterative_scan_override() :: String.t() | nil
   defp iterative_scan_override do
     case hnsw_iterative_scan() do
       "off" -> nil
-      mode -> mode
+      mode -> if iterative_scan_supported?(), do: mode, else: nil
+    end
+  end
+
+  @iterative_scan_min_version {0, 8, 0}
+
+  @doc """
+  Whether the connected pgvector supports `hnsw.iterative_scan` (pgvector >= 0.8.0).
+
+  Probed ONCE from `pg_extension` and cached in `:persistent_term`. The probe runs only when
+  an operator has actually enabled iterative scan (`iterative_scan_override/0` short-circuits
+  at OFF), so it costs one extra round-trip on the first enabled use and nothing after.
+  FAILS CLOSED: any error / missing row / unparseable version → `false`, so no
+  `hnsw.iterative_scan` GUC is emitted against a backend that would reject it and abort the
+  heavy-read transaction. This is what makes the "safe on pgvector < 0.8" guarantee hold even
+  if the config is enabled on such a backend.
+  """
+  @spec iterative_scan_supported?() :: boolean()
+  def iterative_scan_supported? do
+    case :persistent_term.get({__MODULE__, :iterative_scan_supported}, :unknown) do
+      :unknown ->
+        supported = probe_iterative_scan_support()
+        :persistent_term.put({__MODULE__, :iterative_scan_supported}, supported)
+        supported
+
+      cached ->
+        cached
+    end
+  end
+
+  defp probe_iterative_scan_support do
+    case Loopctl.Repo.query("SELECT extversion FROM pg_extension WHERE extname = 'vector'", []) do
+      {:ok, %{rows: [[version]]}} when is_binary(version) ->
+        version_at_least?(version, @iterative_scan_min_version)
+
+      _ ->
+        false
+    end
+  rescue
+    _ -> false
+  end
+
+  @doc """
+  Compare a `"MAJOR.MINOR[.PATCH]"` pgvector extversion against a `{maj, min, patch}` floor.
+  Malformed / non-numeric versions FAIL CLOSED (`false`), never raise.
+  """
+  @spec version_at_least?(String.t(), {non_neg_integer(), non_neg_integer(), non_neg_integer()}) ::
+          boolean()
+  def version_at_least?(version, {_, _, _} = floor) when is_binary(version) do
+    case parse_version(version) do
+      {_, _, _} = parsed -> parsed >= floor
+      :error -> false
+    end
+  end
+
+  defp parse_version(version) do
+    case version |> String.split(".") |> Enum.take(3) |> Enum.map(&Integer.parse/1) do
+      [{maj, _}, {min, _}, {patch, _}] -> {maj, min, patch}
+      [{maj, _}, {min, _}] -> {maj, min, 0}
+      _ -> :error
     end
   end
 

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -243,6 +243,7 @@ defmodule Loopctl.HeavyRead do
     base
     |> Keyword.put(:statement_timeout, statement_timeout_for(endpoint))
     |> maybe_put_ef_search(endpoint)
+    |> maybe_put_iterative_scan(endpoint)
   end
 
   # US-38.4: attach the per-QUERY `hnsw.ef_search` recall breadth ONLY to the
@@ -266,6 +267,26 @@ defmodule Loopctl.HeavyRead do
       case ef_search_override() do
         nil -> opts
         ef -> Keyword.put(opts, :hnsw_ef_search, ef)
+      end
+    else
+      opts
+    end
+  end
+
+  # #488: attach the per-QUERY `hnsw.iterative_scan` mode to the pgvector-ANN endpoints
+  # ONLY, and ONLY when an operator has turned it ON (SystemConfig `"hnsw_iterative_scan"`
+  # != "off"). It rides the SAME `SET LOCAL statement_timeout` transaction as ef_search,
+  # so it adds no new pool-starvation risk. It exists because the ANN filters `tenant_id`
+  # as a POST-index residual on a cross-tenant partial HNSW index: without iterative scan,
+  # a tenant whose near rows fall outside the global top-`ef_search` is silently
+  # under-returned. Default OFF so this is a NO-OP (and pgvector < 0.8, which lacks the GUC,
+  # never sees the `SET LOCAL`) until an operator enables it after verifying the deployed
+  # pgvector is >= 0.8 — a single `SystemConfig` UPDATE, no redeploy.
+  defp maybe_put_iterative_scan(opts, endpoint) do
+    if endpoint in @ann_endpoints do
+      case iterative_scan_override() do
+        nil -> opts
+        mode -> Keyword.put(opts, :hnsw_iterative_scan, mode)
       end
     else
       opts
@@ -339,7 +360,7 @@ defmodule Loopctl.HeavyRead do
   `SET LOCAL` is actually issued is decided by `maybe_put_ef_search/2`: at the default NO
   `SET LOCAL` fires (so a role-level `ALTER ROLE <role> SET hnsw.ef_search` is honored,
   never shadowed); a NON-default value is applied per-read via `SET LOCAL` inside the
-  heavy-read transaction (`run_timed_transaction/4`), taking precedence over any role/session
+  heavy-read transaction (`run_timed_transaction/5`), taking precedence over any role/session
   default for that ANN read.
   """
   @spec hnsw_ef_search() :: pos_integer()
@@ -347,6 +368,57 @@ defmodule Loopctl.HeavyRead do
     Loopctl.SystemConfig.get_int("hnsw_ef_search", @default_hnsw_ef_search)
     |> max(1)
     |> min(1000)
+  end
+
+  # `SystemConfig` is integer-only (get_int/put), so the mode is an INT CODE — this keeps
+  # the same single-UPDATE operator lever ef_search uses. The mode string is looked up from
+  # a fixed table, so the value interpolated into `SET LOCAL hnsw.iterative_scan = <mode>`
+  # is ALWAYS one of the three literals below, never operator/attacker text.
+  @default_hnsw_iterative_scan 0
+  @hnsw_iterative_scan_modes %{1 => "relaxed_order", 2 => "strict_order"}
+  @default_hnsw_max_scan_tuples 20_000
+
+  @doc """
+  The configured `hnsw.iterative_scan` mode for ANN reads (#488): `"off"`, `"relaxed_order"`,
+  or `"strict_order"`.
+
+  Read from the live-tunable `SystemConfig` key `"hnsw_iterative_scan"` as an INT CODE
+  (0 = off (default/missing/unknown), 1 = relaxed_order, 2 = strict_order), so an operator
+  enables iterative scan fleet-wide with a single `UPDATE` — no redeploy — AFTER confirming
+  the deployed pgvector is >= 0.8.
+  """
+  @spec hnsw_iterative_scan() :: String.t()
+  def hnsw_iterative_scan do
+    Map.get(
+      @hnsw_iterative_scan_modes,
+      Loopctl.SystemConfig.get_int("hnsw_iterative_scan", @default_hnsw_iterative_scan),
+      "off"
+    )
+  end
+
+  @doc """
+  The `hnsw.max_scan_tuples` ceiling applied alongside `hnsw.iterative_scan` (#488) —
+  bounds how far iterative scan may walk before giving up, so a pathological query cannot
+  scan the whole relation. Live-tunable via `SystemConfig` `"hnsw_max_scan_tuples"`
+  (pgvector's default #{@default_hnsw_max_scan_tuples}), clamped to a sane `[1, 1_000_000]`
+  so a bad value can never make the `SET LOCAL` raise and roll back the read.
+  """
+  @spec hnsw_max_scan_tuples() :: pos_integer()
+  def hnsw_max_scan_tuples do
+    Loopctl.SystemConfig.get_int("hnsw_max_scan_tuples", @default_hnsw_max_scan_tuples)
+    |> max(1)
+    |> min(1_000_000)
+  end
+
+  # The per-read `hnsw.iterative_scan` mode to APPLY via `SET LOCAL`, or `nil` when OFF
+  # (the default) — so the common path issues NO iterative-scan GUC round-trip and pgvector
+  # versions without the GUC are never touched.
+  @spec iterative_scan_override() :: String.t() | nil
+  defp iterative_scan_override do
+    case hnsw_iterative_scan() do
+      "off" -> nil
+      mode -> mode
+    end
   end
 
   # The per-endpoint override if a positive int, else the pool-wide default. Always a
@@ -394,12 +466,13 @@ defmodule Loopctl.HeavyRead do
     # default", muddying the always-timed contract.
     {st, opts} = Keyword.pop(opts, :statement_timeout, default_statement_timeout())
     {ef, opts} = Keyword.pop(opts, :hnsw_ef_search, nil)
+    {iter, opts} = Keyword.pop(opts, :hnsw_iterative_scan, nil)
     {on_overload, opts} = Keyword.pop(opts, :on_overload, :raise)
     query = guard!(tenant_id, queryable)
     read_repo = repo_for(endpoint(opts))
 
     gated(tenant_id, opts, on_overload, fn ->
-      with_statement_timeout(read_repo, st, ef, fn -> read_repo.all(query, opts) end)
+      with_statement_timeout(read_repo, st, ef, iter, fn -> read_repo.all(query, opts) end)
     end)
   end
 
@@ -409,12 +482,13 @@ defmodule Loopctl.HeavyRead do
   def one(tenant_id, queryable, opts \\ []) do
     {st, opts} = Keyword.pop(opts, :statement_timeout, default_statement_timeout())
     {ef, opts} = Keyword.pop(opts, :hnsw_ef_search, nil)
+    {iter, opts} = Keyword.pop(opts, :hnsw_iterative_scan, nil)
     {on_overload, opts} = Keyword.pop(opts, :on_overload, :raise)
     query = guard!(tenant_id, queryable)
     read_repo = repo_for(endpoint(opts))
 
     gated(tenant_id, opts, on_overload, fn ->
-      with_statement_timeout(read_repo, st, ef, fn -> read_repo.one(query, opts) end)
+      with_statement_timeout(read_repo, st, ef, iter, fn -> read_repo.one(query, opts) end)
     end)
   end
 
@@ -444,12 +518,13 @@ defmodule Loopctl.HeavyRead do
   def all_memory(tenant_id, subject_id, queryable, opts \\ []) do
     {st, opts} = Keyword.pop(opts, :statement_timeout, default_statement_timeout())
     {ef, opts} = Keyword.pop(opts, :hnsw_ef_search, nil)
+    {iter, opts} = Keyword.pop(opts, :hnsw_iterative_scan, nil)
     {on_overload, opts} = Keyword.pop(opts, :on_overload, :raise)
     query = guard_memory!(tenant_id, subject_id, queryable)
     read_repo = repo_for(endpoint(opts))
 
     gated(tenant_id, opts, on_overload, fn ->
-      with_statement_timeout(read_repo, st, ef, fn -> read_repo.all(query, opts) end)
+      with_statement_timeout(read_repo, st, ef, iter, fn -> read_repo.all(query, opts) end)
     end)
   end
 
@@ -505,8 +580,8 @@ defmodule Loopctl.HeavyRead do
   # positive default, and a non-positive/`nil` value (an explicit mis-call) raises rather than
   # silently running un-timed (US-27.13: every heavy read MUST carry a server-side timeout
   # since the pgbouncer-rejected startup `:parameters` lever is gone).
-  defp with_statement_timeout(read_repo, ms, ef, fun) when is_integer(ms) and ms > 0 do
-    case run_timed_transaction(read_repo, ms, ef, fun) do
+  defp with_statement_timeout(read_repo, ms, ef, iter, fun) when is_integer(ms) and ms > 0 do
+    case run_timed_transaction(read_repo, ms, ef, iter, fun) do
       {:ok, result} ->
         result
 
@@ -519,7 +594,7 @@ defmodule Loopctl.HeavyRead do
     end
   end
 
-  defp with_statement_timeout(_read_repo, ms, _ef, _fun) do
+  defp with_statement_timeout(_read_repo, ms, _ef, _iter, _fun) do
     raise ArgumentError,
           ":statement_timeout (got #{inspect(ms)}) must be a positive integer (ms)"
   end
@@ -529,10 +604,11 @@ defmodule Loopctl.HeavyRead do
   # `SET LOCAL hnsw.ef_search` in the SAME transaction, then runs `fun`. Mirrors the
   # public `transaction/2` SET LOCAL, but pinned to the caller-resolved read repo so a
   # primary-pinned read (US-38.1) both times AND executes on the primary.
-  defp run_timed_transaction(read_repo, ms, ef, fun) do
+  defp run_timed_transaction(read_repo, ms, ef, iter, fun) do
     read_repo.transaction(fn ->
       read_repo.query!("SET LOCAL statement_timeout = #{ms}")
       maybe_set_ef_search(read_repo, ef)
+      maybe_set_iterative_scan(read_repo, iter)
       fun.()
     end)
   end
@@ -549,6 +625,24 @@ defmodule Loopctl.HeavyRead do
 
   defp maybe_set_ef_search(read_repo, ef) when is_integer(ef) and ef > 0 do
     read_repo.query!("SET LOCAL hnsw.ef_search = #{ef}")
+  end
+
+  # `SET LOCAL hnsw.iterative_scan = <mode>` + a bounded `hnsw.max_scan_tuples` for an ANN
+  # read (#488): when enabled, HNSW keeps scanning past the initial `ef_search` batch until
+  # the LIMIT is filled with rows that pass the residual `tenant_id` filter — closing the
+  # cross-tenant post-ANN-filter under-return. Fired ONLY when an operator has turned it on;
+  # `mode` is a validated literal from the fixed `@hnsw_iterative_scan_modes` table (never
+  # operator text), so the interpolation is injection-safe. `max_scan_tuples` is an
+  # integer clamped by `hnsw_max_scan_tuples/0`. Transaction-scoped (resets at COMMIT); `nil`
+  # (the default OFF) sets nothing, so a pgvector < 0.8 backend without the GUC is never
+  # touched. Both GUCs are pgvector custom GUCs settable before the vector module loads in
+  # the backend, applied when the ANN operator in `fun` runs — the same order ef_search uses.
+  defp maybe_set_iterative_scan(_read_repo, nil), do: :ok
+
+  defp maybe_set_iterative_scan(read_repo, mode)
+       when mode in ["relaxed_order", "strict_order"] do
+    read_repo.query!("SET LOCAL hnsw.iterative_scan = #{mode}")
+    read_repo.query!("SET LOCAL hnsw.max_scan_tuples = #{hnsw_max_scan_tuples()}")
   end
 
   @doc """

--- a/lib/loopctl/knowledge/vector_search.ex
+++ b/lib/loopctl/knowledge/vector_search.ex
@@ -79,7 +79,7 @@ defmodule Loopctl.Knowledge.VectorSearch do
   objection that setting it per-request via `SET LOCAL` "needs a transaction and so
   re-introduces the #172 pool-starvation anti-pattern" is now **stale**: since US-27.13
   every heavy read ALREADY runs inside a short `SET LOCAL statement_timeout` transaction
-  (`Loopctl.HeavyRead.run_timed_transaction/4`), so a `SET LOCAL hnsw.ef_search = N`
+  (`Loopctl.HeavyRead.run_timed_transaction/5`), so a `SET LOCAL hnsw.ef_search = N`
   piggybacks on that EXISTING bounded, self-draining transaction with **no new
   starvation risk**. `Loopctl.HeavyRead.opts/1` therefore attaches `:hnsw_ef_search`
   (config `SystemConfig "hnsw_ef_search"`, default 40 = pgvector's default) to every

--- a/test/loopctl/heavy_read_hnsw_ef_search_test.exs
+++ b/test/loopctl/heavy_read_hnsw_ef_search_test.exs
@@ -239,6 +239,28 @@ defmodule Loopctl.HeavyReadHnswEfSearchTest do
       refute Enum.any?(sqls, &(&1 =~ ~r/iterative_scan|max_scan_tuples/)),
              "expected a non-ANN read to NOT touch iterative-scan GUCs, got: #{inspect(sqls)}"
     end
+
+    test "version_at_least?/2 parses pgvector versions and FAILS CLOSED on malformed input" do
+      assert HeavyRead.version_at_least?("0.8.0", {0, 8, 0})
+      assert HeavyRead.version_at_least?("0.8.5", {0, 8, 0})
+      assert HeavyRead.version_at_least?("0.9.0", {0, 8, 0})
+      assert HeavyRead.version_at_least?("1.0.0", {0, 8, 0})
+      assert HeavyRead.version_at_least?("0.8", {0, 8, 0}), "missing patch defaults to 0"
+
+      refute HeavyRead.version_at_least?("0.7.4", {0, 8, 0})
+      refute HeavyRead.version_at_least?("0.7", {0, 8, 0})
+      refute HeavyRead.version_at_least?("garbage", {0, 8, 0}), "unparseable fails closed"
+      refute HeavyRead.version_at_least?("", {0, 8, 0})
+      refute HeavyRead.version_at_least?("0.x.0", {0, 8, 0})
+    end
+
+    test "iterative_scan_supported?/0 detects the test DB's pgvector (>= 0.8) — the enable gate" do
+      # On a < 0.8 backend this returns false, so enabling the config there is a NO-OP; the
+      # deterministic decision logic is covered by version_at_least?/2 above. Here we assert
+      # the live probe succeeds against the actual test DB so the emission tests' precondition
+      # (that iterative scan CAN be enabled) is real, not assumed.
+      assert HeavyRead.iterative_scan_supported?()
+    end
   end
 
   defp prime_iterative_scan(code) do

--- a/test/loopctl/heavy_read_hnsw_ef_search_test.exs
+++ b/test/loopctl/heavy_read_hnsw_ef_search_test.exs
@@ -145,6 +145,114 @@ defmodule Loopctl.HeavyReadHnswEfSearchTest do
     end
   end
 
+  describe "per-query hnsw.iterative_scan (#488)" do
+    test "hnsw_iterative_scan/0 maps SystemConfig int codes to modes (0/unknown => off)" do
+      assert HeavyRead.hnsw_iterative_scan() == "off", "default/missing => off"
+
+      prime_iterative_scan(1)
+      assert HeavyRead.hnsw_iterative_scan() == "relaxed_order"
+
+      prime_iterative_scan(2)
+      assert HeavyRead.hnsw_iterative_scan() == "strict_order"
+
+      prime_iterative_scan(99)
+      assert HeavyRead.hnsw_iterative_scan() == "off", "an unknown code falls back to off"
+    end
+
+    test "hnsw_max_scan_tuples/0 reads the pgvector default and clamps out-of-range" do
+      assert HeavyRead.hnsw_max_scan_tuples() == 20_000, "default"
+
+      prime_max_scan_tuples(5_000_000)
+      assert HeavyRead.hnsw_max_scan_tuples() == 1_000_000, "above-range clamps to max"
+
+      prime_max_scan_tuples(0)
+      assert HeavyRead.hnsw_max_scan_tuples() == 1, "zero clamps to min"
+    end
+
+    test "opts/1 attaches :hnsw_iterative_scan for ANN endpoints ONLY when enabled" do
+      # OFF (default): no key on any endpoint, so pgvector < 0.8 (no such GUC) is never touched.
+      for endpoint <- HeavyRead.ann_endpoints() do
+        refute Keyword.has_key?(HeavyRead.opts(endpoint), :hnsw_iterative_scan),
+               "expected #{endpoint} opts to carry NO :hnsw_iterative_scan at OFF"
+      end
+
+      prime_iterative_scan(1)
+
+      for endpoint <- HeavyRead.ann_endpoints() do
+        assert Keyword.get(HeavyRead.opts(endpoint), :hnsw_iterative_scan) == "relaxed_order",
+               "expected enabled ANN #{endpoint} opts to carry :hnsw_iterative_scan"
+      end
+
+      for endpoint <- HeavyRead.known_endpoints() -- HeavyRead.ann_endpoints() do
+        refute Keyword.has_key?(HeavyRead.opts(endpoint), :hnsw_iterative_scan),
+               "expected non-ANN #{endpoint} opts to NOT carry :hnsw_iterative_scan"
+      end
+    end
+
+    test "an enabled ANN heavy read issues SET LOCAL hnsw.iterative_scan + hnsw.max_scan_tuples" do
+      prime_iterative_scan(1)
+      prime_max_scan_tuples(50_000)
+      tenant = fixture(:tenant)
+      q = from(a in Article, where: a.tenant_id == ^tenant.id, select: %{id: a.id})
+
+      sqls =
+        Loopctl.PlanAssertions.capture_repo_queries(fn ->
+          HeavyRead.all(tenant.id, q, HeavyRead.opts(:vector_search))
+        end)
+        |> Enum.map(fn {sql, _params} -> sql end)
+
+      assert Enum.any?(sqls, &(&1 =~ ~r/SET LOCAL hnsw\.iterative_scan = relaxed_order/)),
+             "expected SET LOCAL hnsw.iterative_scan = relaxed_order, got: #{inspect(sqls)}"
+
+      assert Enum.any?(sqls, &(&1 =~ ~r/SET LOCAL hnsw\.max_scan_tuples = 50000/)),
+             "expected SET LOCAL hnsw.max_scan_tuples = 50000, got: #{inspect(sqls)}"
+    end
+
+    test "an ANN heavy read at OFF (default) issues NO SET LOCAL hnsw.iterative_scan" do
+      # The default must touch NOTHING iterative-scan — this is what keeps the feature
+      # inert (and safe on a pgvector < 0.8 backend without the GUC) until an operator opts in.
+      assert HeavyRead.hnsw_iterative_scan() == "off", "precondition: default OFF"
+      tenant = fixture(:tenant)
+      q = from(a in Article, where: a.tenant_id == ^tenant.id, select: %{id: a.id})
+
+      sqls =
+        Loopctl.PlanAssertions.capture_repo_queries(fn ->
+          HeavyRead.all(tenant.id, q, HeavyRead.opts(:vector_search))
+        end)
+        |> Enum.map(fn {sql, _params} -> sql end)
+
+      refute Enum.any?(sqls, &(&1 =~ ~r/iterative_scan|max_scan_tuples/)),
+             "expected an ANN read at OFF to touch NO iterative-scan GUC, got: #{inspect(sqls)}"
+    end
+
+    test "a non-ANN heavy read does NOT issue SET LOCAL hnsw.iterative_scan even when enabled" do
+      prime_iterative_scan(1)
+      tenant = fixture(:tenant)
+      q = from(a in Article, where: a.tenant_id == ^tenant.id, select: %{id: a.id})
+
+      sqls =
+        Loopctl.PlanAssertions.capture_repo_queries(fn ->
+          HeavyRead.all(tenant.id, q, HeavyRead.opts(:change_feed))
+        end)
+        |> Enum.map(fn {sql, _params} -> sql end)
+
+      refute Enum.any?(sqls, &(&1 =~ ~r/iterative_scan|max_scan_tuples/)),
+             "expected a non-ANN read to NOT touch iterative-scan GUCs, got: #{inspect(sqls)}"
+    end
+  end
+
+  defp prime_iterative_scan(code) do
+    pt_key = {Loopctl.SystemConfig, "hnsw_iterative_scan"}
+    :persistent_term.put(pt_key, code)
+    on_exit(fn -> :persistent_term.erase(pt_key) end)
+  end
+
+  defp prime_max_scan_tuples(value) do
+    pt_key = {Loopctl.SystemConfig, "hnsw_max_scan_tuples"}
+    :persistent_term.put(pt_key, value)
+    on_exit(fn -> :persistent_term.erase(pt_key) end)
+  end
+
   # US-38.4: prime the live-tunable `SystemConfig "hnsw_ef_search"` cache directly (the
   # documented persistent_term key format) rather than `SystemConfig.put/2`, to avoid a
   # leaked DB row, and erase on exit. This module is `async: false` precisely BECAUSE this


### PR DESCRIPTION
Closes #488.

## What

The side-table (and legacy / memory) semantic ANN filters `tenant_id` as a **post-index residual** on a cross-tenant partial HNSW index, so HNSW returns the ~`ef_search` globally-nearest rows and then drops non-matching tenants. At scale a tenant whose near rows fall outside that global top-`ef_search` is **silently under-returned**. This enables pgvector's iterative scan to close that gap, gated behind a config lever that is off by default.

## How

- `hnsw.iterative_scan` + a bounded `hnsw.max_scan_tuples` are applied per-read via the **same `SET LOCAL` transaction** that already carries `statement_timeout` and `hnsw.ef_search` (pgbouncer-safe, US-27.13). When on, HNSW keeps scanning past the first batch until the `LIMIT` is filled with rows that pass the residual filter.
- Live-tunable via `SystemConfig` (integer-only, so the mode is an int code: 0=off, 1=relaxed_order, 2=strict_order; the mode string is looked up from a fixed table, never interpolated from operator text). `max_scan_tuples` clamped to `[1, 1_000_000]`.
- Attached in `opts/1` for `@ann_endpoints` only (covers semantic / vector_search / **memory_recall** / suggested_links / novelty), threaded through `all`/`one`/`all_memory` → `run_timed_transaction`.

## Safety (default-off + fail-closed)

1. **Default OFF** → no iterative-scan GUC is ever emitted, so the path is inert and a pgvector `< 0.8` backend (which lacks the GUC) is never touched.
2. **Fail-closed capability guard** → even when an operator enables it, `iterative_scan_supported?/0` probes `pg_extension` once (cached; only ever runs when enabled) and returns `false` on any error / missing row / version `< 0.8` / unparseable version. So enabling the config on a `< 0.8` backend is a **no-op, not a fleet-wide ANN outage** — the "safe on < 0.8" guarantee holds unconditionally, not just at the default.

Tenant isolation is unchanged: `guard!/2` and the conjunctive `tenant_id` residual predicate are untouched; iterative scan only changes how many index tuples are walked *before* that filter, so it can only raise the caller's own tenant rows returned, never admit another tenant's.

## Operator enablement (post-merge)

`SystemConfig` `hnsw_iterative_scan` = 1 (relaxed_order), after confirming the deployed Fly Postgres pgvector is `>= 0.8`. `max_scan_tuples` defaults to pgvector's 20000; raise with an eye on ANN-endpoint latency / shed rates (per-read wall-clock stays bounded by the existing `statement_timeout`).

## Review

Adversarial security review: **SOUND** — no HIGH/MEDIUM/CRITICAL. Injection-safe (mode is a fixed literal, `max_scan_tuples` always an int), default-off inert, clamp-resilient, threading consistent, tenant isolation unchanged. Two confirmed findings fixed in-branch: the fail-closed version guard (was flagged as an operator footgun) and a stale `run_timed_transaction/4→/5` moduledoc arity. The `max_scan_tuples` cost was assessed and is operator-gated + `statement_timeout`-bounded (not attacker-reachable).

## Test

- Emission + gating asserted deterministically: `SET LOCAL hnsw.iterative_scan` + `hnsw.max_scan_tuples` fired only for ANN endpoints, only when enabled AND supported; nothing at the default. `version_at_least?/2` unit-tested incl. fail-closed on malformed input.
- The recall improvement itself is a pgvector-semantics guarantee, best validated by a prod-scale corpus test (a scale-tagged follow-up).
- Full suite green; compile `--warnings-as-errors`, format, credo `--strict`, dialyzer, skill-citations all clean.
