### PR TITLE
Silence the test suite: fix the 5 compile warnings and capture log output

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -17,7 +17,18 @@ import Config
 test_concurrency = min(System.schedulers_online(), 8)
 test_pool_size = test_concurrency * 2
 
-config :ex_unit, max_cases: test_concurrency
+# `capture_log: true` — the suite deliberately exercises a LOT of warn/error paths
+# (fail-closed guards, shed/overload branches, degraded-dependency fallbacks), and every
+# one of those logs printed straight into the test stream. With the `[:level, ": ",
+# :message]` default-handler template configured below and metadata-only structured logs,
+# they rendered as hundreds of bare `warning:` / `error:` tokens interleaved with the
+# progress dots — noise that buries a REAL warning and makes a green run look broken.
+#
+# Capturing attaches each test's log output TO THAT TEST instead: a FAILING test still
+# prints its logs, where they are actually diagnostic; a passing one stays quiet. Tests
+# asserting on log content via `ExUnit.CaptureLog.capture_log/1` are unaffected — that
+# captures at the test level and composes with this.
+config :ex_unit, max_cases: test_concurrency, capture_log: true
 
 # Configure your database
 #

--- a/test/loopctl/auth/api_key_invariants_test.exs
+++ b/test/loopctl/auth/api_key_invariants_test.exs
@@ -17,7 +17,7 @@ defmodule Loopctl.Auth.ApiKeyInvariantsTest do
 
   describe "nil identity self-check" do
     test "validate_not_self_report blocks nil agent_id" do
-      %{tenant: tenant, story: story, agent: agent} = setup_implementing_story()
+      %{tenant: tenant, story: story, agent: _agent} = setup_implementing_story()
 
       result = Progress.report_story(tenant.id, story.id, agent_id: nil)
       assert result == {:error, :self_report_blocked}

--- a/test/loopctl/import_export_ac_normalization_test.exs
+++ b/test/loopctl/import_export_ac_normalization_test.exs
@@ -10,7 +10,7 @@ defmodule Loopctl.ImportExportAcNormalizationTest do
 
   alias Loopctl.ImportExport
 
-  defp base_payload(story_attrs \\ %{}) do
+  defp base_payload(story_attrs) do
     story =
       Map.merge(
         %{

--- a/test/loopctl/knowledge/system_articles_test.exs
+++ b/test/loopctl/knowledge/system_articles_test.exs
@@ -13,7 +13,7 @@ defmodule Loopctl.Knowledge.SystemArticlesTest do
 
   setup :verify_on_exit!
 
-  defp create_system_article(attrs \\ %{}) do
+  defp create_system_article(attrs) do
     base = %{
       title: "System Article #{System.unique_integer([:positive])}",
       body: "System article body content for testing.",

--- a/test/loopctl_web/controllers/knowledge_analytics_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_analytics_controller_test.exs
@@ -108,7 +108,7 @@ defmodule LoopctlWeb.KnowledgeAnalyticsControllerTest do
       assert row["access_count"] == 1
     end
 
-    test "offset pages the ranking to completeness (no imposed top-N cap)", %{conn: conn} do
+    test "offset pages the ranking to completeness (no imposed top-N cap)", %{conn: _conn} do
       tenant = fixture(:tenant)
       {orch_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
       {_raw, agent} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
@@ -227,7 +227,7 @@ defmodule LoopctlWeb.KnowledgeAnalyticsControllerTest do
       assert body["meta"]["days_unused"] == 7
     end
 
-    test "offset pages the full unused set to completeness (no imposed cap)", %{conn: conn} do
+    test "offset pages the full unused set to completeness (no imposed cap)", %{conn: _conn} do
       tenant = fixture(:tenant)
       {orch_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 


### PR DESCRIPTION
`mix test` printed hundreds of bare `warning:` / `error:` tokens interleaved with the
progress dots, so a green run looked broken and a **real** warning had nowhere to stand
out. Two separate causes.

## Compile warnings (5 → 0)

- `knowledge_analytics_controller_test` — two tests destructured `%{conn: conn}` without
  using it.
- `api_key_invariants_test` — `agent` bound and unused.
- `import_export_ac_normalization_test` / `system_articles_test` — private helpers declared
  a default argument that no call site omits, so the default is dead. Dropped the default
  rather than renaming the function, since the arity-0 form is unreachable.

## Log noise (778 tokens → 0)

The suite deliberately exercises a lot of warn/error paths — fail-closed guards, shed and
overload branches, degraded-dependency fallbacks — and every one of those logs printed
straight into the test stream. With the `[:level, ": ", :message]` default-handler template
and metadata-only structured logs, they rendered as bare level prefixes with no message.

`config :ex_unit, capture_log: true` attaches each test's log output **to that test**: a
FAILING test still prints its logs, where they are diagnostic; a passing one stays quiet.
Set in `config/test.exs` next to `max_cases` rather than as an `ExUnit.start/1` argument,
so the whole ExUnit configuration lives in one place. Tests asserting on log content via
`ExUnit.CaptureLog.capture_log/1` are unaffected — that captures at the test level and
composes with this.

A useful side effect: when the ANN flake next fires in CI, the failing test will now carry
its own log output instead of it being lost in the stream.

## Verification

`mix precommit` green — **6186 tests, 0 failures** — and a full run now emits zero
`warning:` and zero `error:` tokens.
