### PR TITLE
Add put_root_layout to the browser pipeline

### DIFF
--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -4,6 +4,8 @@ defmodule LoopctlWeb.Router do
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
+    plug :fetch_live_flash
+    plug :put_root_layout, html: {LoopctlWeb.Layouts, :root}
     plug :protect_from_forgery
 
     plug :put_secure_browser_headers, %{


### PR DESCRIPTION
Fixes #494.

On a fresh install, `/signup` renders without the root layout — no CSS bundle, no flash support, and the page is effectively non-functional. The `:browser` pipeline was missing `put_root_layout` (and `fetch_live_flash`).

**Change:** add the two standard plugs to the `:browser` pipeline. After this, `/signup` renders styled and functional.

**Testing:** running in my self-hosted deployment since 2026-07-22 (Docker, fresh install; signup page renders correctly). Compile-checked against current `master` with the Dockerfile's build image.

(One of the fixes I've been carrying locally since setting up self-hosting — sending it upstream per your suggestion. Two more follow-up PRs reference #494/#496.)
