### PR TITLE
Make WebAuthn relying-party configurable via environment

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -528,3 +528,14 @@ if config_env() == :prod do
   #
   # Check `Plug.SSL` for all available options in `force_ssl`.
 end
+
+# WebAuthn relying-party is configurable via env for non-loopctl.com deployments
+# (config.exs hardcodes loopctl.com, which breaks the enrollment ceremony on
+# localhost/self-hosted origins). Without the env var, behaviour is unchanged.
+if webauthn_rp_id = System.get_env("WEBAUTHN_RP_ID") do
+  config :loopctl, :webauthn,
+    rp_id: webauthn_rp_id,
+    rp_name: "loopctl",
+    origin: System.get_env("WEBAUTHN_ORIGIN") || "http://#{webauthn_rp_id}:4030",
+    user_verification: "preferred"
+end


### PR DESCRIPTION
Refs #494 (the WebAuthn hardcode noted in the issue comments).

`config.exs` hardcodes the WebAuthn relying-party (`rp_id`/`origin`) to `loopctl.com`, so the enrollment ceremony fails on any other origin — localhost or a self-hosted domain.

**Change:** allow overriding via `WEBAUTHN_RP_ID` / `WEBAUTHN_ORIGIN` env vars in `runtime.exs`. Without the env vars, behaviour is exactly as before (the block is skipped entirely), so cloud deployments are unaffected.

**Testing:** running in my self-hosted deployment since 2026-07-22 (`WEBAUTHN_RP_ID=localhost`, enrollment ceremony works). Compile-checked against current `master` with the Dockerfile's build image.
