### PR TITLE
Add opt-in file-backed Secrets adapter for non-Fly deployments

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -528,3 +528,10 @@ if config_env() == :prod do
   #
   # Check `Plug.SSL` for all available options in `force_ssl`.
 end
+
+# Tenant secrets: opt-in file-backed adapter for non-Fly deployments
+# (FlyAdapter hard-fails signup off-platform: {:audit_key_storage_failed, :fly_not_configured}).
+# Default behavior (Fly) is unchanged unless SECRETS_ADAPTER=local_file is set.
+if System.get_env("SECRETS_ADAPTER") == "local_file" do
+  config :loopctl, :secrets_adapter, Loopctl.Secrets.LocalFileAdapter
+end

--- a/lib/loopctl/secrets/local_file_adapter.ex
+++ b/lib/loopctl/secrets/local_file_adapter.ex
@@ -1,0 +1,64 @@
+defmodule Loopctl.Secrets.LocalFileAdapter do
+  @moduledoc """
+  selfhost fix: file-backed secrets adapter for non-Fly deployments.
+
+  The only production adapter is Fly.io (`FlyAdapter`), which hard-fails off
+  Fly (`:fly_not_configured`) and takes tenant signup down with it. This
+  adapter keeps the same contract with a JSON file (values base64-encoded)
+  at `SECRETS_FILE` (default `/data/secrets.json`), chmod 0600, atomic
+  tmp+rename writes. Select via `SECRETS_ADAPTER=local_file` (runtime.exs).
+
+  Threat model note: suitable for single-machine self-hosting where the host
+  disk is trusted (FileVault + encrypted off-site backups). Not for shared
+  infrastructure — that's what the Fly adapter is for.
+  """
+
+  @behaviour Loopctl.Secrets.Behaviour
+
+  defp path, do: System.get_env("SECRETS_FILE") || "/data/secrets.json"
+
+  defp read_all do
+    with {:ok, bin} <- File.read(path()),
+         {:ok, %{} = map} <- Jason.decode(bin) do
+      map
+    else
+      _ -> %{}
+    end
+  end
+
+  defp write_all(map) do
+    p = path()
+    File.mkdir_p!(Path.dirname(p))
+    tmp = p <> ".tmp"
+    File.write!(tmp, Jason.encode!(map))
+    File.chmod!(tmp, 0o600)
+    File.rename!(tmp, p)
+    :ok
+  rescue
+    e -> {:error, {:local_secrets_write_failed, Exception.message(e)}}
+  end
+
+  @impl true
+  def get(name) when is_binary(name) do
+    case Map.fetch(read_all(), name) do
+      {:ok, encoded} ->
+        case Base.decode64(encoded) do
+          {:ok, value} -> {:ok, value}
+          :error -> {:error, :corrupt_secret}
+        end
+
+      :error ->
+        {:error, :not_found}
+    end
+  end
+
+  @impl true
+  def set(name, value) when is_binary(name) and is_binary(value) do
+    read_all() |> Map.put(name, Base.encode64(value)) |> write_all()
+  end
+
+  @impl true
+  def delete(name) when is_binary(name) do
+    read_all() |> Map.delete(name) |> write_all()
+  end
+end


### PR DESCRIPTION
Refs #496.

Tenant signup hard-depends on Fly secrets storage: off-platform, `FlyAdapter` fails signup with `{:audit_key_storage_failed, :fly_not_configured}` — a fresh non-Fly install cannot create its first tenant.

**Change:** an opt-in `Loopctl.Secrets.LocalFileAdapter` (same behaviour contract as `FlyAdapter`; atomic write via temp+rename; file mode 0600; path from `SECRETS_FILE`). It is selected in `runtime.exs` **only** when `SECRETS_ADAPTER=local_file` is set — default (Fly) behaviour is unchanged, so this is purely additive for cloud deployments.

I'm aware this one touches product direction (self-hosting) more than the other two PRs, so treat it as a proposal — happy to rework the shape (adapter name, env contract, or moving it under the epic-39 private-tier umbrella) to fit your vision.

**Testing:** this adapter has been running in my self-hosted deployment since 2026-07-22 (signup, key issuance, daily use). Compile-checked against current `master` with the Dockerfile's build image.
