### PR TITLE
Fix the nightly scale gate: restore test-env log messages, stub the injected collaborators, de-flake the scale assertions

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -260,8 +260,18 @@ config :loopctl, Loopctl.Telemetry.IngestionWriteStats, async: false
 # message string in tests), but declare `metadata: :all` so Credo's
 # MissedMetadataKeyInLoggerConfig check knows arbitrary structured keys
 # (sqlstate, mapped_code, … — US-27.3) are permitted in this env.
+#
+# The message placeholder MUST be `:msg`, not `:message`. This is Erlang's
+# `:logger_formatter`, where `:msg` is the one atom treated specially (replaced by the
+# formatted message) and EVERY other atom is looked up as a METADATA key. `:message` is
+# the Elixir `Logger.Formatter` spelling; here it silently resolved to a nonexistent
+# metadata key, so every log line in the whole test env rendered as a bare
+# "warning: " / "error: " with the text dropped. That blanked the diagnostics for the
+# entire suite — most damagingly the nightly scale gate, whose failures are only
+# reachable through CI logs (a fail-closed streaming-export abort logs the mapped_code
+# and SQLSTATE that say WHY, and all of it was being thrown away).
 config :logger, :default_handler,
-  formatter: {:logger_formatter, %{template: [:level, ": ", :message, "\n"]}}
+  formatter: {:logger_formatter, %{template: [:level, ": ", :msg, "\n"]}}
 
 config :logger, :default_formatter,
   metadata: [

--- a/test/loopctl/config_embedding_read_path_test.exs
+++ b/test/loopctl/config_embedding_read_path_test.exs
@@ -146,29 +146,115 @@ defmodule Loopctl.ConfigEmbeddingReadPathTest do
     end
   end
 
-  describe "bare-ExUnit scale modules stub the injected read path" do
-    test "every *_scale_test.exs without DataCase/ConnCase calls stub_embedding_read_path/0" do
-      missing =
-        "test/**/*_scale_test.exs"
-        |> Path.wildcard()
-        |> Enum.reject(fn file ->
-          source = File.read!(file)
+  # These guards classify a module by what it DOES, so every pattern must match a real
+  # directive/call — never a bare substring. `source =~ "use Loopctl.DataCase"` is a trap:
+  # the standard explanatory comment in these very files reads "this module does not `use
+  # Loopctl.DataCase`", so a substring test EXCLUDED every file it was meant to police and
+  # the guard silently passed on an empty set. Anchor to line-start code instead.
+  @uses_case_template ~r/^\s*use\s+Loopctl\.(DataCase|ConnCase)\b/m
+  @calls_stub_all_defaults ~r/^\s*(Loopctl\.DataCase\.)?stub_all_defaults\(\)/m
+  @calls_set_mox_global ~r/^\s*(Mox\.)?set_mox_global\(\)/m
 
-          source =~ "use Loopctl.DataCase" or source =~ "use Loopctl.ConnCase" or
-            source =~ "stub_embedding_read_path"
-        end)
+  defp bare_exunit_scale_modules do
+    "test/**/*_scale_test.exs"
+    |> Path.wildcard()
+    |> Enum.reject(&(File.read!(&1) =~ @uses_case_template))
+  end
+
+  describe "bare-ExUnit scale modules stub the injected collaborators" do
+    test "the module classifier matches directives, not prose (the guard itself)" do
+      assert "  use Loopctl.DataCase, async: true" =~ @uses_case_template
+      assert "  use Loopctl.ConnCase" =~ @uses_case_template
+
+      refute "  # this module does not `use Loopctl.DataCase`, so nothing stubbed it" =~
+               @uses_case_template,
+             "a COMMENT mentioning the template must not be read as using it — that is the " <>
+               "exact substring bug that made this guard vacuous"
+
+      assert "    Loopctl.DataCase.stub_all_defaults()" =~ @calls_stub_all_defaults
+      assert "    stub_all_defaults()" =~ @calls_stub_all_defaults
+
+      refute "  # `stub_all_defaults/0` is the single source of truth" =~
+               @calls_stub_all_defaults,
+             "a COMMENT naming the helper must not count as calling it"
+
+      assert "    Mox.set_mox_global()" =~ @calls_set_mox_global
+
+      refute "  # `set_mox_global` makes the stub visible from any process" =~
+               @calls_set_mox_global,
+             "a COMMENT naming set_mox_global must not count as calling it"
+
+      refute bare_exunit_scale_modules() == [],
+             "the glob/classifier matched NO modules — the guards below would be vacuous"
+    end
+
+    test "every *_scale_test.exs without DataCase/ConnCase calls stub_all_defaults/0" do
+      missing =
+        bare_exunit_scale_modules()
+        |> Enum.reject(&(File.read!(&1) =~ @calls_stub_all_defaults))
 
       assert missing == [],
              """
              These scale modules are on bare `ExUnit.Case`, so `stub_all_defaults/0` never
-             runs for them, and `config/test.exs` points `:embedding_read_path` at
-             `Loopctl.MockEmbeddingReadPath` for the whole test env. Any read reaching
-             `Loopctl.Embeddings.side_table_reads_enabled?/0` therefore raises
-             `Mox.UnexpectedCallError` — and `:scale` tests are excluded from
-             `mix precommit`, so it fails ONLY in the nightly job.
+             runs for them, and `config/test.exs` points EVERY injected collaborator at a
+             Mox mock for the whole test env. Any call reaching an unstubbed mock raises
+             `Mox.UnexpectedCallError` — and `:scale`/`:scale_nightly` tests are excluded
+             from `mix precommit`, so it fails ONLY in the nightly job.
 
-             Add `Loopctl.DataCase.stub_embedding_read_path()` to each module's `setup`:
+             This guard deliberately requires the FULL `stub_all_defaults/0`, not a
+             narrower per-mock stub. Hand-picking one mock at a time is what kept the
+             nightly red: a read-path-only stub still left `MockEmbeddingConcurrency`
+             unstubbed, and the next unstubbed mock would repeat it. `stub_all_defaults/0`
+             is the single source of truth, so a mock added to DataCase is covered here
+             automatically.
+
+             Add `Loopctl.DataCase.stub_all_defaults()` to each module:
              #{Enum.join(missing, "\n")}
+             """
+    end
+
+    test "modules in Mox GLOBAL mode register the stubs in the global-owner process" do
+      offenders =
+        Enum.filter(bare_exunit_scale_modules(), fn file ->
+          source = File.read!(file)
+
+          case Regex.scan(@calls_set_mox_global, source, return: :index) do
+            [] ->
+              false
+
+            matches ->
+              # In global mode Mox lets ONLY the process that called `set_mox_global/0`
+              # register stubs. So at least one `stub_all_defaults()` must appear AFTER
+              # the last `set_mox_global()` — i.e. in that same (owner) block. A call that
+              # only appears BEFORE it is running in some other process (typically a
+              # per-test `setup` while the owner is `setup_all`) and raises ArgumentError,
+              # failing every test in the module before its body runs.
+              [{last_global, _} | _] = List.last(matches)
+
+              stub_positions =
+                @calls_stub_all_defaults
+                |> Regex.scan(source, return: :index)
+                |> Enum.map(fn [{pos, _} | _] -> pos end)
+
+              not Enum.any?(stub_positions, &(&1 > last_global))
+          end
+        end)
+
+      assert offenders == [],
+             """
+             These scale modules call `Mox.set_mox_global/0` but never call
+             `Loopctl.DataCase.stub_all_defaults()` after it, so the stubs are registered
+             from a NON-owner process. Mox raises
+
+                 cannot add expectations/stubs to <Mock> in the current process ...
+                 because Mox is in global mode
+
+             which fails every test in the module before its body runs — and only in the
+             nightly job, since these are `:scale_nightly`-tagged.
+
+             Move the `stub_all_defaults()` call into the same block as `set_mox_global()`
+             (immediately after it), not a per-test `setup`:
+             #{Enum.join(offenders, "\n")}
              """
     end
   end

--- a/test/loopctl/knowledge/by_source_change_feed_plan_scale_test.exs
+++ b/test/loopctl/knowledge/by_source_change_feed_plan_scale_test.exs
@@ -48,11 +48,17 @@ defmodule Loopctl.Knowledge.BySourceChangeFeedPlanScaleTest do
   defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
 
   setup do
-    # `config/test.exs` points `:embedding_read_path` at a Mox mock for the whole test
-    # env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed it.
-    # Without this, any read reaching `Embeddings.side_table_reads_enabled?/0` raises
-    # `Mox.UnexpectedCallError` in the nightly scale job.
-    Loopctl.DataCase.stub_embedding_read_path()
+    # `config/test.exs` points EVERY injected collaborator at a Mox mock for the whole
+    # test env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed
+    # them. Any call reaching an unstubbed mock raises `Mox.UnexpectedCallError` in the
+    # nightly scale job. Install the SAME permissive default set DataCase gives every
+    # other test, rather than hand-picking one mock at a time: the narrow
+    # `stub_embedding_read_path/0` left `MockEmbeddingConcurrency` unstubbed, which is
+    # exactly how the nightly broke. `stub_all_defaults/0` is a superset of it and the
+    # single source of truth, so a mock added to DataCase is covered here automatically.
+    # The stub bodies are closures — an unused stub never executes, so this is inert for
+    # collaborators a given scale file never touches.
+    Loopctl.DataCase.stub_all_defaults()
 
     tenant =
       unboxed(fn ->

--- a/test/loopctl/knowledge/cosine_lint_vs_scale_gate_scale_test.exs
+++ b/test/loopctl/knowledge/cosine_lint_vs_scale_gate_scale_test.exs
@@ -45,11 +45,17 @@ defmodule Loopctl.Knowledge.CosineLintVsScaleGateScaleTest do
   defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
 
   setup do
-    # `config/test.exs` points `:embedding_read_path` at a Mox mock for the whole test
-    # env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed it.
-    # Without this, any read reaching `Embeddings.side_table_reads_enabled?/0` raises
-    # `Mox.UnexpectedCallError` in the nightly scale job.
-    Loopctl.DataCase.stub_embedding_read_path()
+    # `config/test.exs` points EVERY injected collaborator at a Mox mock for the whole
+    # test env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed
+    # them. Any call reaching an unstubbed mock raises `Mox.UnexpectedCallError` in the
+    # nightly scale job. Install the SAME permissive default set DataCase gives every
+    # other test, rather than hand-picking one mock at a time: the narrow
+    # `stub_embedding_read_path/0` left `MockEmbeddingConcurrency` unstubbed, which is
+    # exactly how the nightly broke. `stub_all_defaults/0` is a superset of it and the
+    # single source of truth, so a mock added to DataCase is covered here automatically.
+    # The stub bodies are closures — an unused stub never executes, so this is inert for
+    # collaborators a given scale file never touches.
+    Loopctl.DataCase.stub_all_defaults()
 
     tenant =
       unboxed(fn ->

--- a/test/loopctl/knowledge/distant_pairs_novelty_scale_test.exs
+++ b/test/loopctl/knowledge/distant_pairs_novelty_scale_test.exs
@@ -63,16 +63,58 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyScaleTest do
   # the `tags &&` residual is genuinely selective at 80k.
   @prior_tag "scale-tag-3"
 
+  # Steady-state latency samples taken (after one untimed warm-up) for the bridge-path
+  # latency gate. Odd, so the median is an actual observed sample rather than an
+  # interpolation, and small enough that three extra 80k queries stay negligible against
+  # the seed cost. A median (not a min or a mean) so one scheduler/autovacuum hiccup on a
+  # shared runner cannot swing the verdict either way.
+  @latency_samples 3
+
+  # Wall-clock REGRESSION ceiling, calibrated to the SLOWEST environment this gate runs on
+  # (the GitHub Actions runner, ~2.1x slower than a dev box: steady-state there is ~3.5s
+  # against 1.67s locally). Set to ~2x that worst healthy observation, so a bridge-dispatch
+  # revert — which doubles the candidate cap from 500 to 1000 — still trips it, while normal
+  # runner-speed variance never does. It is NOT the Theme-2 <2s product SLO; see the note in
+  # the test body for why that cannot be asserted on shared CI hardware, and what protects
+  # the property instead.
+  @latency_ceiling_ms 7_000
+
   defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
+
+  # Median of an odd-length sample list.
+  defp median(samples) do
+    sorted = Enum.sort(samples)
+    Enum.at(sorted, div(length(sorted), 2))
+  end
 
   # `async: false` + a stub the off-process `Task.async_stream` novelty workers must see:
   # `set_mox_global` makes the embedding stub visible from any process (not just the test
   # pid's `$callers` chain). No `expect`/`verify_on_exit!` — we only `stub`.
   setup_all do
     Mox.set_mox_global()
+
+    # `config/test.exs` points EVERY injected collaborator at a Mox mock for the whole
+    # test env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed
+    # them. Any call reaching an unstubbed mock raises `Mox.UnexpectedCallError` in the
+    # nightly scale job. Install the SAME permissive default set DataCase gives every
+    # other test, rather than hand-picking one mock at a time: a narrow
+    # read-path-only stub left `MockEmbeddingConcurrency` unstubbed, which is exactly how
+    # the nightly broke. `stub_all_defaults/0` is the single source of truth, so a mock
+    # added to DataCase is covered here automatically. The stub bodies are closures — an
+    # unused stub never executes, so this is inert for collaborators this file never
+    # touches.
+    #
+    # It MUST be here in `setup_all`, NOT in a per-test `setup`: `set_mox_global/0` above
+    # makes THIS process the global owner, and in global mode Mox lets ONLY the owner
+    # register stubs — a `Mox.stub` from the per-test setup (a different process) raises
+    # ArgumentError and fails every test in the module before its body runs.
+    Loopctl.DataCase.stub_all_defaults()
+
     # The deterministic idea embedding the novelty test scores against (a real seeded
     # vector). Stubbed in THIS (the global-owner) process — global mode only lets the
     # owner set stubs, and the off-process Task.async_stream workers read it globally.
+    # Registered AFTER `stub_all_defaults/0` so it overrides that module's generic
+    # embedding-client default rather than being overwritten by it.
     Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
       {:ok, ScaleSeed.embedding_for(0)}
     end)
@@ -81,12 +123,6 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyScaleTest do
   end
 
   setup do
-    # `config/test.exs` points `:embedding_read_path` at a Mox mock for the whole test
-    # env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed it.
-    # Without this, any read reaching `Embeddings.side_table_reads_enabled?/0` raises
-    # `Mox.UnexpectedCallError` in the nightly scale job.
-    Loopctl.DataCase.stub_embedding_read_path()
-
     tenant =
       unboxed(fn ->
         slug = "dp-novelty-scale-#{:erlang.phash2(Ecto.UUID.generate())}"
@@ -174,20 +210,63 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyScaleTest do
   # (NOT the general cap — the bridge dispatch actually took effect) and (b) meets the Theme-2
   # <2s wall-clock target. A revert of the bridge-branch dispatch (falling back to the 1000 cap)
   # would blow both the cap assertion and the wall-clock budget.
-  test "distant_pairs(bridge_path: true) is bounded by the bridge cap AND under <2s at 80k",
+  test "distant_pairs(bridge_path: true) is bounded by the bridge cap AND within the latency ceiling at 80k",
        %{tenant: tenant} do
     unboxed(fn ->
-      # Wall-clock: the actual Theme-2 <2s claim at prod scale (not just the 1.5k local bench).
-      {elapsed_us, result} =
+      # Wall-clock REGRESSION gate — deliberately NOT a restatement of the Theme-2 <2s
+      # product SLO. Measured numbers (80k corpus, PROD 500 bridge cap):
+      #
+      #   dev box (beelink):  cold 1793.8ms  median 1672.6ms  [1689.2, 1672.6, 1664.0]
+      #   GH Actions runner:  cold 3834.8ms  (nightly 2026-07-23)
+      #
+      # The runner is ~2.1x slower end-to-end on this file (680s vs 324s), and
+      # 1793.8 x 2.1 = 3767ms reproduces the observed 3834.8ms. So the gap is HARDWARE,
+      # not a cold cache: cold and steady-state differ by only ~7%, which means a
+      # 2000ms budget is unreachable on the runner warm OR cold. Asserting a
+      # production latency SLO on a shared 2-core CI runner is a category error — it
+      # can only produce a permanent false RED (this assertion is one of the reasons
+      # the nightly has never been green).
+      #
+      # What actually protects the property is the STRUCTURAL block below: exactly ONE
+      # band pass, no Seq Scan, and `assert_article_scans_capped_by_limit` against the
+      # BRIDGE cap. A revert of the bridge-branch dispatch (falling back to the 1000
+      # cap) trips those on ANY hardware, deterministically. The wall-clock here is a
+      # coarse smoke bound calibrated to the SLOWEST environment it runs on, and the
+      # real numbers are always printed so drift stays visible in the nightly log.
+      #
+      # NOTE: the <2s Theme-2 target is met on developer hardware (1.67s) but NOT on the
+      # runner (~3.5s steady-state). Closing that is a product decision — a lower
+      # `max_bridge_pair_candidates` trades result quality for latency — and is
+      # deliberately NOT made here by quietly changing a production knob.
+      {cold_us, cold_result} =
         :timer.tc(fn -> Knowledge.distant_pairs(tenant.id, bridge_path: true) end)
 
-      assert {:ok, %{pairs: _, has_more: _}} = result
+      assert {:ok, %{pairs: _, has_more: _}} = cold_result
 
-      elapsed_ms = elapsed_us / 1_000
+      samples =
+        for _ <- 1..@latency_samples do
+          {us, {:ok, _}} =
+            :timer.tc(fn -> Knowledge.distant_pairs(tenant.id, bridge_path: true) end)
 
-      assert elapsed_ms < 2_000,
-             "bridge_path distant_pairs took #{Float.round(elapsed_ms, 1)}ms at 80k — over the " <>
-               "Epic 27 Theme 2 <2s target. Lower max_bridge_pair_candidates."
+          us / 1_000
+        end
+
+      cold_ms = cold_us / 1_000
+      elapsed_ms = median(samples)
+
+      IO.puts(
+        "[scale-latency distant_pairs bridge_path] cold=#{Float.round(cold_ms, 1)}ms " <>
+          "median=#{Float.round(elapsed_ms, 1)}ms " <>
+          "samples=#{inspect(Enum.map(samples, &Float.round(&1, 1)))}"
+      )
+
+      assert elapsed_ms < @latency_ceiling_ms,
+             "bridge_path distant_pairs steady-state median was " <>
+               "#{Float.round(elapsed_ms, 1)}ms at 80k (cold #{Float.round(cold_ms, 1)}ms), over " <>
+               "the #{@latency_ceiling_ms}ms regression ceiling. That ceiling is ~2x the " <>
+               "slowest healthy observation, so this is a REAL blow-up, not runner noise — " <>
+               "check the structural assertions below first (a bridge-dispatch revert falls " <>
+               "back to the 1000 candidate cap), then max_bridge_pair_candidates."
 
       # Structural: exactly ONE band pass, no Seq Scan, and capped by the BRIDGE cap (500 under
       # the SCALE gate) — proving the bridge dispatch selected the smaller sample.

--- a/test/loopctl/knowledge/embedding_dimension_plan_scale_test.exs
+++ b/test/loopctl/knowledge/embedding_dimension_plan_scale_test.exs
@@ -84,13 +84,17 @@ defmodule Loopctl.Knowledge.EmbeddingDimensionPlanScaleTest do
   defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
 
   setup do
-    # `config/test.exs` points `:embedding_read_path` at a Mox mock for the whole test
-    # env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed it.
-    # Any read reaching `Embeddings.side_table_reads_enabled?/0` would otherwise raise
-    # `Mox.UnexpectedCallError` in the nightly scale job. Per-test (not `setup_all`):
-    # a Mox stub is registered against the CALLING process, and `setup_all` runs in a
-    # different one.
-    Loopctl.DataCase.stub_embedding_read_path()
+    # `config/test.exs` points EVERY injected collaborator at a Mox mock for the whole
+    # test env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed
+    # them. Any call reaching an unstubbed mock raises `Mox.UnexpectedCallError` in the
+    # nightly scale job. Install the SAME permissive default set DataCase gives every
+    # other test, rather than hand-picking one mock at a time: the narrow
+    # `stub_embedding_read_path/0` left `MockEmbeddingConcurrency` unstubbed, which is
+    # exactly how the nightly broke. `stub_all_defaults/0` is a superset of it and the
+    # single source of truth, so a mock added to DataCase is covered here automatically.
+    # Per-test (not `setup_all`): a Mox stub is registered against the CALLING process,
+    # and `setup_all` runs in a different one.
+    Loopctl.DataCase.stub_all_defaults()
     :ok
   end
 

--- a/test/loopctl/knowledge/keyset_plan_scale_test.exs
+++ b/test/loopctl/knowledge/keyset_plan_scale_test.exs
@@ -66,11 +66,17 @@ defmodule Loopctl.Knowledge.KeysetPlanScaleTest do
   defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
 
   setup do
-    # `config/test.exs` points `:embedding_read_path` at a Mox mock for the whole test
-    # env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed it.
-    # Without this, any read reaching `Embeddings.side_table_reads_enabled?/0` raises
-    # `Mox.UnexpectedCallError` in the nightly scale job.
-    Loopctl.DataCase.stub_embedding_read_path()
+    # `config/test.exs` points EVERY injected collaborator at a Mox mock for the whole
+    # test env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed
+    # them. Any call reaching an unstubbed mock raises `Mox.UnexpectedCallError` in the
+    # nightly scale job. Install the SAME permissive default set DataCase gives every
+    # other test, rather than hand-picking one mock at a time: the narrow
+    # `stub_embedding_read_path/0` left `MockEmbeddingConcurrency` unstubbed, which is
+    # exactly how the nightly broke. `stub_all_defaults/0` is a superset of it and the
+    # single source of truth, so a mock added to DataCase is covered here automatically.
+    # The stub bodies are closures — an unused stub never executes, so this is inert for
+    # collaborators a given scale file never touches.
+    Loopctl.DataCase.stub_all_defaults()
 
     tenant =
       unboxed(fn ->

--- a/test/loopctl/knowledge/plan_assertions_scale_test.exs
+++ b/test/loopctl/knowledge/plan_assertions_scale_test.exs
@@ -29,11 +29,17 @@ defmodule Loopctl.Knowledge.PlanAssertionsScaleTest do
   defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
 
   setup do
-    # `config/test.exs` points `:embedding_read_path` at a Mox mock for the whole test
-    # env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed it.
-    # Without this, any read reaching `Embeddings.side_table_reads_enabled?/0` raises
-    # `Mox.UnexpectedCallError` in the nightly scale job.
-    Loopctl.DataCase.stub_embedding_read_path()
+    # `config/test.exs` points EVERY injected collaborator at a Mox mock for the whole
+    # test env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed
+    # them. Any call reaching an unstubbed mock raises `Mox.UnexpectedCallError` in the
+    # nightly scale job. Install the SAME permissive default set DataCase gives every
+    # other test, rather than hand-picking one mock at a time: the narrow
+    # `stub_embedding_read_path/0` left `MockEmbeddingConcurrency` unstubbed, which is
+    # exactly how the nightly broke. `stub_all_defaults/0` is a superset of it and the
+    # single source of truth, so a mock added to DataCase is covered here automatically.
+    # The stub bodies are closures — an unused stub never executes, so this is inert for
+    # collaborators a given scale file never touches.
+    Loopctl.DataCase.stub_all_defaults()
 
     tenant =
       unboxed(fn ->

--- a/test/loopctl/knowledge/remediation_matrix_scale_test.exs
+++ b/test/loopctl/knowledge/remediation_matrix_scale_test.exs
@@ -48,11 +48,17 @@ defmodule Loopctl.Knowledge.RemediationMatrixScaleTest do
   defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
 
   setup do
-    # `config/test.exs` points `:embedding_read_path` at a Mox mock for the whole test
-    # env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed it.
-    # Without this, any read reaching `Embeddings.side_table_reads_enabled?/0` raises
-    # `Mox.UnexpectedCallError` in the nightly scale job.
-    Loopctl.DataCase.stub_embedding_read_path()
+    # `config/test.exs` points EVERY injected collaborator at a Mox mock for the whole
+    # test env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed
+    # them. Any call reaching an unstubbed mock raises `Mox.UnexpectedCallError` in the
+    # nightly scale job. Install the SAME permissive default set DataCase gives every
+    # other test, rather than hand-picking one mock at a time: the narrow
+    # `stub_embedding_read_path/0` left `MockEmbeddingConcurrency` unstubbed, which is
+    # exactly how the nightly broke. `stub_all_defaults/0` is a superset of it and the
+    # single source of truth, so a mock added to DataCase is covered here automatically.
+    # The stub bodies are closures — an unused stub never executes, so this is inert for
+    # collaborators a given scale file never touches.
+    Loopctl.DataCase.stub_all_defaults()
 
     tenant =
       unboxed(fn ->

--- a/test/loopctl/knowledge/scale_calibration_mismatch_scale_test.exs
+++ b/test/loopctl/knowledge/scale_calibration_mismatch_scale_test.exs
@@ -41,11 +41,17 @@ defmodule Loopctl.Knowledge.ScaleCalibrationMismatchScaleTest do
   defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
 
   setup do
-    # `config/test.exs` points `:embedding_read_path` at a Mox mock for the whole test
-    # env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed it.
-    # Without this, any read reaching `Embeddings.side_table_reads_enabled?/0` raises
-    # `Mox.UnexpectedCallError` in the nightly scale job.
-    Loopctl.DataCase.stub_embedding_read_path()
+    # `config/test.exs` points EVERY injected collaborator at a Mox mock for the whole
+    # test env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed
+    # them. Any call reaching an unstubbed mock raises `Mox.UnexpectedCallError` in the
+    # nightly scale job. Install the SAME permissive default set DataCase gives every
+    # other test, rather than hand-picking one mock at a time: the narrow
+    # `stub_embedding_read_path/0` left `MockEmbeddingConcurrency` unstubbed, which is
+    # exactly how the nightly broke. `stub_all_defaults/0` is a superset of it and the
+    # single source of truth, so a mock added to DataCase is covered here automatically.
+    # The stub bodies are closures — an unused stub never executes, so this is inert for
+    # collaborators a given scale file never touches.
+    Loopctl.DataCase.stub_all_defaults()
 
     tenant =
       unboxed(fn ->

--- a/test/loopctl/knowledge/streaming_export_scale_test.exs
+++ b/test/loopctl/knowledge/streaming_export_scale_test.exs
@@ -44,16 +44,6 @@ defmodule Loopctl.Knowledge.StreamingExportScaleTest do
   # requires `:manual` mode). Kept as a thin seam so the call sites read clearly.
   defp unboxed(fun), do: fun.()
 
-  setup do
-    # `config/test.exs` points `:embedding_read_path` at a Mox mock for the whole test
-    # env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed it.
-    # Without this, any read reaching `Embeddings.side_table_reads_enabled?/0` raises
-    # `Mox.UnexpectedCallError` in the nightly scale job.
-    Loopctl.DataCase.stub_embedding_read_path()
-
-    :ok
-  end
-
   setup_all do
     # The export is served by a REAL HTTP server whose request handlers run in
     # separate processes that check out their OWN repo connections. Sandbox `:manual`
@@ -71,6 +61,21 @@ defmodule Loopctl.Knowledge.StreamingExportScaleTest do
     # those handler processes to resolve it. `set_mox_global` is appropriate here —
     # this module is `async: false`.
     Mox.set_mox_global()
+
+    # `config/test.exs` points EVERY injected collaborator at a Mox mock for the whole
+    # test env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed
+    # them. The Bandit handler processes run the FULL authenticated pipeline, so an
+    # export request reaches far more collaborators than the clock alone (the rate
+    # limiter among them) — hand-picking mocks one at a time is how this file kept
+    # breaking. `stub_all_defaults/0` is the single source of truth and a superset,
+    # so a mock added to DataCase is covered here automatically.
+    #
+    # It MUST be here in `setup_all`, NOT a per-test `setup`: `set_mox_global/0` above
+    # makes THIS process the global owner, and in global mode Mox lets ONLY the owner
+    # register stubs — a `Mox.stub` from the per-test setup (a different process) raises
+    # ArgumentError and fails every test in the module before its body runs.
+    Loopctl.DataCase.stub_all_defaults()
+
     Mox.stub(Loopctl.MockClock, :utc_now, &DateTime.utc_now/0)
 
     # The big tenant: ~80k committed articles (prod floor). A separate SMALL tenant

--- a/test/loopctl/knowledge/topk_endpoints_scale_test.exs
+++ b/test/loopctl/knowledge/topk_endpoints_scale_test.exs
@@ -41,11 +41,17 @@ defmodule Loopctl.Knowledge.TopkEndpointsScaleTest do
   defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
 
   setup do
-    # `config/test.exs` points `:embedding_read_path` at a Mox mock for the whole test
-    # env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed it.
-    # Without this, any read reaching `Embeddings.side_table_reads_enabled?/0` raises
-    # `Mox.UnexpectedCallError` in the nightly scale job.
-    Loopctl.DataCase.stub_embedding_read_path()
+    # `config/test.exs` points EVERY injected collaborator at a Mox mock for the whole
+    # test env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed
+    # them. Any call reaching an unstubbed mock raises `Mox.UnexpectedCallError` in the
+    # nightly scale job. Install the SAME permissive default set DataCase gives every
+    # other test, rather than hand-picking one mock at a time: the narrow
+    # `stub_embedding_read_path/0` left `MockEmbeddingConcurrency` unstubbed, which is
+    # exactly how the nightly broke. `stub_all_defaults/0` is a superset of it and the
+    # single source of truth, so a mock added to DataCase is covered here automatically.
+    # The stub bodies are closures — an unused stub never executes, so this is inert for
+    # collaborators a given scale file never touches.
+    Loopctl.DataCase.stub_all_defaults()
 
     tenant =
       unboxed(fn ->

--- a/test/loopctl/knowledge/vector_endpoint_e2e_latency_scale_test.exs
+++ b/test/loopctl/knowledge/vector_endpoint_e2e_latency_scale_test.exs
@@ -68,11 +68,17 @@ defmodule Loopctl.Knowledge.VectorEndpointE2eLatencyScaleTest do
   defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
 
   setup do
-    # `config/test.exs` points `:embedding_read_path` at a Mox mock for the whole test
-    # env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed it.
-    # Without this, any read reaching `Embeddings.side_table_reads_enabled?/0` raises
-    # `Mox.UnexpectedCallError` in the nightly scale job.
-    Loopctl.DataCase.stub_embedding_read_path()
+    # `config/test.exs` points EVERY injected collaborator at a Mox mock for the whole
+    # test env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed
+    # them. Any call reaching an unstubbed mock raises `Mox.UnexpectedCallError` in the
+    # nightly scale job. Install the SAME permissive default set DataCase gives every
+    # other test, rather than hand-picking one mock at a time: the narrow
+    # `stub_embedding_read_path/0` left `MockEmbeddingConcurrency` unstubbed, which is
+    # exactly how the nightly broke. `stub_all_defaults/0` is a superset of it and the
+    # single source of truth, so a mock added to DataCase is covered here automatically.
+    # The stub bodies are closures — an unused stub never executes, so this is inert for
+    # collaborators a given scale file never touches.
+    Loopctl.DataCase.stub_all_defaults()
 
     # 1. Seed the corpus + tenant + an agent API key — all COMMITTED (unboxed) so the real
     #    conn (which reads on AdminRepo) finds them.

--- a/test/loopctl/knowledge/vector_search_scale_test.exs
+++ b/test/loopctl/knowledge/vector_search_scale_test.exs
@@ -35,11 +35,17 @@ defmodule Loopctl.Knowledge.VectorSearchScaleTest do
   defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
 
   setup do
-    # `config/test.exs` points `:embedding_read_path` at a Mox mock for the whole test
-    # env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed it.
-    # Without this, any read reaching `Embeddings.side_table_reads_enabled?/0` raises
-    # `Mox.UnexpectedCallError` in the nightly scale job.
-    Loopctl.DataCase.stub_embedding_read_path()
+    # `config/test.exs` points EVERY injected collaborator at a Mox mock for the whole
+    # test env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed
+    # them. Any call reaching an unstubbed mock raises `Mox.UnexpectedCallError` in the
+    # nightly scale job. Install the SAME permissive default set DataCase gives every
+    # other test, rather than hand-picking one mock at a time: the narrow
+    # `stub_embedding_read_path/0` left `MockEmbeddingConcurrency` unstubbed, which is
+    # exactly how the nightly broke. `stub_all_defaults/0` is a superset of it and the
+    # single source of truth, so a mock added to DataCase is covered here automatically.
+    # The stub bodies are closures — an unused stub never executes, so this is inert for
+    # collaborators a given scale file never touches.
+    Loopctl.DataCase.stub_all_defaults()
 
     tenant =
       unboxed(fn ->

--- a/test/loopctl/knowledge/vector_search_under_fill_scale_test.exs
+++ b/test/loopctl/knowledge/vector_search_under_fill_scale_test.exs
@@ -43,11 +43,17 @@ defmodule Loopctl.Knowledge.VectorSearchUnderFillScaleTest do
   defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
 
   setup do
-    # `config/test.exs` points `:embedding_read_path` at a Mox mock for the whole test
-    # env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed it.
-    # Without this, any read reaching `Embeddings.side_table_reads_enabled?/0` raises
-    # `Mox.UnexpectedCallError` in the nightly scale job.
-    Loopctl.DataCase.stub_embedding_read_path()
+    # `config/test.exs` points EVERY injected collaborator at a Mox mock for the whole
+    # test env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed
+    # them. Any call reaching an unstubbed mock raises `Mox.UnexpectedCallError` in the
+    # nightly scale job. Install the SAME permissive default set DataCase gives every
+    # other test, rather than hand-picking one mock at a time: the narrow
+    # `stub_embedding_read_path/0` left `MockEmbeddingConcurrency` unstubbed, which is
+    # exactly how the nightly broke. `stub_all_defaults/0` is a superset of it and the
+    # single source of truth, so a mock added to DataCase is covered here automatically.
+    # The stub bodies are closures — an unused stub never executes, so this is inert for
+    # collaborators a given scale file never touches.
+    Loopctl.DataCase.stub_all_defaults()
 
     tenant =
       unboxed(fn ->
@@ -73,6 +79,13 @@ defmodule Loopctl.Knowledge.VectorSearchUnderFillScaleTest do
     on_exit(fn ->
       try do
         unboxed(fn ->
+          # Links MUST go first: `article_links` FKs articles with `on_delete: :restrict`,
+          # so deleting articles while their links exist raises
+          # `article_links_source_article_id_fkey` — which the `rescue` below then swallows,
+          # silently leaving the whole ~80k corpus committed. CI hides that (each matrix job
+          # gets a fresh Postgres), but locally it poisons the test partition for every
+          # later run.
+          AdminRepo.delete_all(from(l in ArticleLink, where: l.tenant_id == ^tenant.id))
           AdminRepo.delete_all(from(a in Article, where: a.tenant_id == ^tenant.id))
           AdminRepo.delete_all(from(t in Tenant, where: t.id == ^tenant.id))
         end)
@@ -137,7 +150,25 @@ defmodule Loopctl.Knowledge.VectorSearchUnderFillScaleTest do
           }
         end)
 
-      {_n, _} = AdminRepo.insert_all(ArticleLink, link_rows)
+      # `on_conflict: :nothing` is REQUIRED, not defensive. `ScaleSeed` already links every
+      # article to its `link_density` index-adjacent neighbours, and the seeded embeddings
+      # are a sine wave whose index-adjacency IS vector-adjacency — so the target's seeded
+      # links are GUARANTEED to be inside the `pool`-nearest set we are linking here. A
+      # plain insert_all therefore always trips
+      # `article_links_tenant_src_tgt_rel_index`. Skipping the already-present rows
+      # preserves the intent exactly: what matters is that the target ends up linked to
+      # ALL of its `pool` nearest neighbours (so the anti-join exhausts the pool), not
+      # which of those links this insert happened to author.
+      {_n, _} =
+        AdminRepo.insert_all(ArticleLink, link_rows,
+          on_conflict: :nothing,
+          conflict_target: [
+            :tenant_id,
+            :source_article_id,
+            :target_article_id,
+            :relationship_type
+          ]
+        )
 
       test_pid = self()
       handler_id = "under-fill-scale-#{System.unique_integer([:positive])}"

--- a/test/loopctl/memory/scale_recall_test.exs
+++ b/test/loopctl/memory/scale_recall_test.exs
@@ -108,15 +108,32 @@ defmodule Loopctl.Memory.ScaleRecallTest do
     # async: false) makes the stub reachable from that spawned process.
     Mox.set_mox_global()
 
+    # `config/test.exs` points EVERY injected collaborator at a Mox mock for the whole
+    # test env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed
+    # them. `Memory.recall/2` alone reaches `Embeddings.side_table_reads_enabled?/0`, but
+    # hand-picking one mock at a time is what kept the nightly red — the next unstubbed
+    # mock just repeats it. `stub_all_defaults/0` is the single source of truth, so a mock
+    # added to DataCase is covered here automatically. Registered in THIS process, which is
+    # the `set_mox_global/0` owner above (global mode lets only the owner register stubs).
+    Loopctl.DataCase.stub_all_defaults()
+
+    # The module-specific embedding stub MUST come after `stub_all_defaults/0`, which
+    # installs a generic per-tenant `generate_embedding` default — the LAST `stub` for a
+    # given mock/arity wins. This gate is ANN-sensitive: it asserts where subject A's rows
+    # land in an HNSW pool relative to seeded decoys, so it needs the exact ScaleSeed query
+    # vector, not a generic one.
+    #
+    # BOTH arities are pinned. `/3` carries the explicit `:model` override (US-41.1
+    # AC-41.1.10) and `stub_all_defaults/0` defaults it to the generic vector too, so
+    # leaving it unpinned would silently hand a wrong query vector to any caller that takes
+    # the model-override path.
     Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
       {:ok, ScaleSeed.query_embedding()}
     end)
 
-    # `config/test.exs` points `:embedding_read_path` at a Mox mock for the whole test
-    # env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed it.
-    # `Memory.recall/2` reaches `Embeddings.side_table_reads_enabled?/0`, which would
-    # otherwise raise `Mox.UnexpectedCallError` in the nightly scale job.
-    Loopctl.DataCase.stub_embedding_read_path()
+    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text, _opts ->
+      {:ok, ScaleSeed.query_embedding()}
+    end)
 
     {tenant, seed} =
       unboxed(fn ->


### PR DESCRIPTION
## Why

The scheduled nightly CI run has failed **every one of its last 30 runs** — it has never been green in retained history. 3 of the 14 matrix jobs were red; the other 11 were green throughout.

| Nightly job | Before | After (local, fresh 80k corpus) |
|---|---|---|
| `vector_search_under_fill` | 1 failure | **2 tests, 0 failures** |
| `distant_pairs_novelty` | 2 failures | **3 tests, 0 failures** |
| `streaming_export` | 4 failures | **5 tests, 0 failures** |

## Root causes

**1. Every log message in the test env was silently dropped.** The default handler used Erlang's `:logger_formatter` with template `[:level, ": ", :message]`. That formatter treats only `:msg` as the message — every other atom is a *metadata key lookup*. `:message` resolved to a nonexistent key, so the entire suite rendered bare `warning: ` / `error: ` lines with the text discarded.

This is why the nightly stayed undiagnosable for 30 runs: a fail-closed streaming-export abort logs the `mapped_code` and SQLSTATE that say *why*, and all of it went nowhere. Confirmed by probe, and the nightly log now carries real diagnostics (`slow_query duration_ms=7833 repo=Loopctl.AdminRepo source=articles`).

**2. Bare-ExUnit scale modules stubbed injected collaborators one mock at a time**, so the next unstubbed mock kept re-breaking the nightly. All 13 now install the same permissive default set `DataCase` gives every other test. For modules in Mox **global mode** the call must live in `setup_all` — global mode lets only the owner process register stubs, so a per-test `setup` raises `ArgumentError` before any test body runs.

**3. The guard meant to prevent (2) was vacuous.** It excluded any file containing the substring `use Loopctl.DataCase` — which appears in those files' own comment saying they do *not* use it. It was policing an empty set. Both guards now match anchored directives rather than prose, a new guard enforces the global-owner placement rule, and a third test asserts the classifier rejects prose and that the module set is never empty again. Each was verified to fail against a real mutation and pass once reverted.

**4. `vector_search_under_fill` could never pass.** `ScaleSeed` links every article to its index-adjacent neighbours, and the seeded embeddings are a sine wave where index-adjacency *is* vector-adjacency — so the target's seeded links are always inside the pool the test re-links it to. Deterministic, not flaky. Its cleanup was also wrong: it deleted articles before their links, hit the `on_delete: :restrict` FK, and a blanket `rescue` swallowed it, leaking the whole 80k corpus every run (a local run left **160,023** rows behind; now 23).

**5. The `distant_pairs` wall-clock assertion was hardware-bound, not regression-bound.**

```
dev box:  cold 1793.8ms  median 1672.6ms  [1689.2, 1672.6, 1664.0]
CI runner: cold 3834.8ms
```

The runner is ~2.1× slower on this file (680s vs 324s), and `1793.8 × 2.1 ≈ 3767ms` reproduces the observed 3834.8ms. Cold and steady-state differ by only ~7%, so a 2000ms budget is unreachable there **warm or cold**. It now takes a median of samples after a warm-up against a ceiling calibrated to the slowest environment it runs on, and prints the real numbers every run.

## What this does NOT do

It deliberately does not restate the Theme-2 **<2s** product target as a CI assertion. That target is met on developer hardware (1.67s) but **not** on the runner (~3.5s steady-state). Closing that gap means lowering `max_bridge_pair_candidates`, trading result quality for latency — a product decision, not one to make by quietly changing a production knob. Flagging it rather than burying it.

The hardware-independent structural assertions (single band pass, no Seq Scan, capped by the *bridge* cap) are untouched and remain what actually catches a bridge-dispatch revert on any hardware.

## Scope

No production code changed — all test and test-config.

## Verification

Local, against freshly seeded 80k corpora on a dedicated partition:

- `vector_search_under_fill` 2/0, `distant_pairs_novelty` 3/0, `streaming_export` 5/0
- `embedding_dimension_plan` 20/0 and `scale_recall` 1/0 (the two changed `:scale`-job modules)
- `mix precommit` — **6188 tests, 0 failures**

## Known, pre-existing, out of scope

`Loopctl.Memory.ScaleRecallTest` TC-28.5.3 is flaky (observed fail, fail, pass). It fails identically on **unmodified HEAD** — verified with a control run — so this PR neither causes nor fixes it. It lives in the `:scale` job, which was green in last night's CI. It reproduces locally, which makes it a concrete lead for the intermittent ANN under-return that has hit master.
