### PR TITLE
Replace three global-state test hooks with dependency injection

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -114,6 +114,11 @@ config :loopctl,
   #   mid-bomb. Defaults 50 MB / 200 MB; tunable for very large knowledge bases.
   export_chunk_size: 200,
   export_max_links_per_article: 100,
+  # US-27.16: the streaming-export producer's per-body observation seam. Production
+  # observes nothing (the producer must NOT retain bodies — that is the property the
+  # bounded-memory gate protects); config/test.exs swaps in a Mox mock so the scale gate
+  # can inject a RETAINING probe and prove that metric is load-bearing.
+  streaming_export_body_probe: Loopctl.Knowledge.StreamingExport.NoopBodyProbe,
   export_max_concurrent_global: 2,
   export_max_concurrent_per_tenant: 1,
   export_max_stream_duration_ms: 600_000,

--- a/config/test.exs
+++ b/config/test.exs
@@ -339,6 +339,11 @@ config :loopctl, :oban_orphan_count_checker, Loopctl.MockObanOrphanCountChecker
 config :loopctl, :ingestion_backlog_counter, Loopctl.MockBacklogCounter
 
 # DI: Use mock rate limiter in tests
+# US-27.16: the streaming-export body probe (see Loopctl.Knowledge.StreamingExport.BodyProbe).
+# DataCase's default stub is a no-op, matching production, so every existing export test is
+# unchanged; only the bounded-memory scale gate injects a retaining probe.
+config :loopctl, :streaming_export_body_probe, Loopctl.MockStreamingExportBodyProbe
+
 config :loopctl, :rate_limiter, Loopctl.MockRateLimiter
 
 # Trusted-proxy range for the shared Loopctl.RemoteIp resolver in tests. Headers

--- a/lib/loopctl/cli/config.ex
+++ b/lib/loopctl/cli/config.ex
@@ -31,16 +31,27 @@ defmodule Loopctl.CLI.Config do
     Path.join([home_dir(), @config_dir, @config_file])
   end
 
+  @typedoc """
+  Reads a single OS environment variable by name, returning its value or `nil`.
+  Defaults to `System.get_env/1`; injected in tests so env overrides can be exercised
+  WITHOUT `System.put_env`, which mutates BEAM-global OS env shared by every process
+  (a flake in an `async: true` suite — two tests overriding `LOOPCTL_SERVER` race).
+  """
+  @type env_getter :: (String.t() -> String.t() | nil)
+
   @doc """
   Reads the full configuration, merging file and environment overrides.
   Environment variables take precedence over file values.
+
+  `env_getter` is the OS-env reader (default `System.get_env/1`); pass a map-backed getter
+  in tests to inject overrides without touching BEAM-global env.
   """
-  @spec read() :: map()
-  def read do
+  @spec read(env_getter()) :: map()
+  def read(env_getter \\ &System.get_env/1) do
     file_config = read_file()
 
     Enum.reduce(@env_overrides, file_config, fn {key, env_var}, acc ->
-      case System.get_env(env_var) do
+      case env_getter.(env_var) do
         nil -> acc
         "" -> acc
         value -> Map.put(acc, key, value)
@@ -51,13 +62,17 @@ defmodule Loopctl.CLI.Config do
   @doc """
   Gets a specific configuration value by key.
   Returns `nil` if the key is not set.
+
+  `env_getter` is threaded to `read/1` (default `System.get_env/1`).
   """
-  @spec get(String.t()) :: String.t() | nil
-  def get(key) when key in @valid_keys do
-    Map.get(read(), key)
+  @spec get(String.t(), env_getter()) :: String.t() | nil
+  def get(key, env_getter \\ &System.get_env/1)
+
+  def get(key, env_getter) when key in @valid_keys do
+    Map.get(read(env_getter), key)
   end
 
-  def get(_key), do: nil
+  def get(_key, _env_getter), do: nil
 
   @doc """
   Sets a configuration value in the config file.

--- a/lib/loopctl/knowledge/streaming_export.ex
+++ b/lib/loopctl/knowledge/streaming_export.ex
@@ -333,18 +333,17 @@ defmodule Loopctl.Knowledge.StreamingExport do
 
   defp emit_article_page(writer, tenant_id, format, _project_id, page) do
     links_by_article = load_bounded_links(tenant_id, page)
+    body_probe = body_probe()
 
     Enum.reduce_while(page, {:ok, writer}, fn row, {:ok, writer} ->
       article = to_article(row)
       {links, truncated?} = Map.get(links_by_article, row.id, {[], false})
 
-      # MUTATION-CHECK seam (#1, test-only, default OFF): when the
-      # `:export_force_materialize_for_test` flag is set, retain every article body in
-      # the producer process so the bounded-memory test can confirm its metric is
-      # LOAD-BEARING (i.e. that a materializing producer makes the ratio FAIL). The
-      # config is never set outside the mutation-check test, so prod/normal exports
-      # never retain.
-      maybe_materialize_for_test(row.body)
+      # Injected observation seam (`Loopctl.Knowledge.StreamingExport.BodyProbe`). The
+      # production impl is a no-op; the bounded-memory scale gate injects a RETAINING probe
+      # to prove that metric is load-bearing. Resolved once per page (see `body_probe/0`),
+      # so this is a plain fun call per row — no config lookup, no behaviour dispatch.
+      body_probe.(row.body)
 
       ctx = %{
         links: links,
@@ -363,21 +362,16 @@ defmodule Loopctl.Knowledge.StreamingExport do
     e -> {:error, e, writer}
   end
 
-  # MUTATION-CHECK seam (#1): default no-op. Only when the test flag is set does this
-  # accumulate bodies in the process dictionary (the producer process), turning the
-  # streaming producer into a materializing one — so the scale test can prove the
-  # bounded-memory metric actually catches it (ratio FAILS under the mutation).
-  @materialize_key {__MODULE__, :materialized_bodies}
-
-  defp maybe_materialize_for_test(body) do
-    if Application.get_env(:loopctl, :export_force_materialize_for_test, false) do
-      acc = Process.get(@materialize_key, [])
-      # Copy the binary so it's RETAINED by this process (a sub-binary of the row
-      # would be reclaimed with the row); :binary.copy forces a fresh refc binary.
-      Process.put(@materialize_key, [:binary.copy(body || <<>>) | acc])
-    end
-
-    :ok
+  # Config-based DI (`CLAUDE.md`: behaviours + `Application.get_env`, never opts, never
+  # `put_env` from a test). Production resolves to `NoopBodyProbe`; `config/test.exs`
+  # points at a Mox mock whose DEFAULT stub is equally a no-op, so only the one scale test
+  # that injects a retaining probe sees any retention.
+  defp body_probe do
+    Application.get_env(
+      :loopctl,
+      :streaming_export_body_probe,
+      Loopctl.Knowledge.StreamingExport.NoopBodyProbe
+    ).probe()
   end
 
   # --- bounded per-page link preload (AC-27.16.3/.5, #7 truncation marker) ---

--- a/lib/loopctl/knowledge/streaming_export/body_probe.ex
+++ b/lib/loopctl/knowledge/streaming_export/body_probe.ex
@@ -1,0 +1,44 @@
+defmodule Loopctl.Knowledge.StreamingExport.BodyProbe do
+  @moduledoc """
+  Injected seam letting a test observe each article body the streaming-export producer
+  emits, WITHOUT the producer knowing a test exists (US-27.16, AC-27.16.1).
+
+  This exists for one reason: the bounded-memory scale gate claims the producer's peak
+  RETAINED bytes stay ~flat in N. A metric like that is worthless unless it is proven
+  LOAD-BEARING — i.e. that a MATERIALIZING producer (one retaining every body) actually
+  makes the ratio FAIL. Proving that requires turning the streaming producer into a
+  materializing one on demand, which needs a seam in the production path.
+
+  ## Why a closure, not a per-body callback
+
+  `probe/0` is resolved ONCE per export and returns a plain anonymous function that the
+  producer then calls per row. The per-row work is therefore an ordinary fun call, not a
+  behaviour dispatch — an 80k-article export would otherwise pay 80k Mox dispatches in
+  the test env, which is both slow and a strange amount of machinery on a hot loop.
+
+  ## Why this replaced a config flag
+
+  The previous shape read `Application.get_env(:loopctl, :export_force_materialize_for_test)`
+  ONCE PER ARTICLE inside the emit loop, and the scale test flipped it with
+  `Application.put_env/3`. That was wrong three ways: it put test-only branching in a
+  production hot path, it did a global ETS config lookup per row, and it mutated VM-wide
+  state from a test (which `CLAUDE.md` forbids outright — every dependency is swapped via
+  config-based DI, never `put_env`). Mutating global config is also not safely reversible
+  under failure: an exception between `put_env` and its cleanup leaves a materializing
+  producer configured for every later export in the VM.
+
+  Now the production impl (`Loopctl.Knowledge.StreamingExport.NoopBodyProbe`) is a no-op
+  and the RETAINING behaviour lives entirely in the test's own stub closure. Mox stubs run
+  in the CALLING process, so a test stub that retains binaries retains them in the producer
+  process — exactly where the memory metric measures — with no production code aware of it.
+  """
+
+  @doc """
+  Returns the per-body probe function to use for one export.
+
+  Called once per export; the returned fun is invoked with each article body (which may be
+  `nil`) as the producer emits it. Implementations must return quickly and must not raise —
+  it runs inside the producer's emit loop.
+  """
+  @callback probe() :: (binary() | nil -> :ok)
+end

--- a/lib/loopctl/knowledge/streaming_export/noop_body_probe.ex
+++ b/lib/loopctl/knowledge/streaming_export/noop_body_probe.ex
@@ -1,0 +1,20 @@
+defmodule Loopctl.Knowledge.StreamingExport.NoopBodyProbe do
+  @moduledoc """
+  Production `Loopctl.Knowledge.StreamingExport.BodyProbe`: observes nothing.
+
+  The streaming producer must NOT retain article bodies — that is the entire property the
+  bounded-memory gate protects — so the production probe is a no-op returning a shared,
+  module-level fun (no per-export closure allocation).
+  """
+
+  @behaviour Loopctl.Knowledge.StreamingExport.BodyProbe
+
+  @noop &__MODULE__.ignore/1
+
+  @impl true
+  def probe, do: @noop
+
+  @doc false
+  @spec ignore(binary() | nil) :: :ok
+  def ignore(_body), do: :ok
+end

--- a/lib/loopctl/memory_usage.ex
+++ b/lib/loopctl/memory_usage.ex
@@ -18,7 +18,7 @@ defmodule Loopctl.MemoryUsage do
   Wired via config:
   `Application.compile_env(:loopctl, :memory_module, Loopctl.MemoryUsage.Default)`.
   The bounded-memory scale test injects a materializing producer (via the
-  `:export_force_materialize_for_test` flag) to PROVE the metric is load-bearing
+  `Loopctl.Knowledge.StreamingExport.BodyProbe` DI seam) to PROVE the metric is load-bearing
   (the ratio FAILS under the mutation) — mutation testing for AC-27.16.1.
   """
 

--- a/lib/loopctl/workers/memory_graduation_sweep_worker.ex
+++ b/lib/loopctl/workers/memory_graduation_sweep_worker.ex
@@ -102,9 +102,9 @@ defmodule Loopctl.Workers.MemoryGraduationSweepWorker do
   @actor_opts [actor_type: "system", actor_label: "memory_graduation_sweep"]
 
   @impl Oban.Worker
-  def perform(%Oban.Job{}) do
-    cap = Memory.graduation_max_per_run()
-    candidates = candidate_memories()
+  def perform(%Oban.Job{args: args}) do
+    cap = resolve_cap(args)
+    candidates = candidate_memories(cap)
 
     {processed, tally} =
       Enum.reduce_while(candidates, {0, %{}}, fn memory, {processed, tally} ->
@@ -199,9 +199,20 @@ defmodule Loopctl.Workers.MemoryGraduationSweepWorker do
   #      spread fairly: a tenant with few hot memories is fully served early instead of
   #      waiting behind a hotter tenant's long tail. With one active tenant the interleave
   #      is a no-op, so budget is still fully utilized.
-  defp candidate_memories do
+  # The per-run execution budget. Defaults to the configured `graduation_max_per_run/0`,
+  # but an explicit `"max_per_run"` in the Oban job args overrides it for THIS invocation.
+  # Job args are per-job and travel with the job row, so a caller (or a test) can bound a
+  # single tick WITHOUT mutating VM-global config — the async-safe alternative to
+  # `Application.put_env`, which would leak the cap into every other test/job in the VM.
+  defp resolve_cap(args) do
+    case args do
+      %{"max_per_run" => n} when is_integer(n) and n > 0 -> n
+      _ -> Memory.graduation_max_per_run()
+    end
+  end
+
+  defp candidate_memories(cap) do
     threshold = Memory.graduation_recall_threshold()
-    cap = Memory.graduation_max_per_run()
 
     # Round-robin serves >=1 memory per tenant and perform/1 processes at most `cap`
     # memories, so at most `cap` tenants can contribute in one tick — never fetch more.

--- a/test/loopctl/cli/config_test.exs
+++ b/test/loopctl/cli/config_test.exs
@@ -67,50 +67,37 @@ defmodule Loopctl.CLI.ConfigTest do
     end
   end
 
+  # A map-backed env getter injected into Config.read/1. This exercises the OS-env override
+  # path WITHOUT System.put_env, which mutates BEAM-global env shared across every process —
+  # a real flake in this `async: true` suite (two of these tests both override LOOPCTL_SERVER
+  # and would race each other and any other async test reading it).
+  defp env_getter(overrides), do: fn var -> Map.get(overrides, var) end
+
   describe "environment variable overrides" do
     test "LOOPCTL_SERVER overrides file config" do
-      System.put_env("LOOPCTL_SERVER", "https://test.loopctl.io")
-
-      try do
-        config = Config.read()
-        assert config["server"] == "https://test.loopctl.io"
-      after
-        System.delete_env("LOOPCTL_SERVER")
-      end
+      config = Config.read(env_getter(%{"LOOPCTL_SERVER" => "https://test.loopctl.io"}))
+      assert config["server"] == "https://test.loopctl.io"
     end
 
     test "LOOPCTL_API_KEY overrides file config" do
-      System.put_env("LOOPCTL_API_KEY", "lc_test123")
-
-      try do
-        config = Config.read()
-        assert config["api_key"] == "lc_test123"
-      after
-        System.delete_env("LOOPCTL_API_KEY")
-      end
+      config = Config.read(env_getter(%{"LOOPCTL_API_KEY" => "lc_test123"}))
+      assert config["api_key"] == "lc_test123"
     end
 
     test "LOOPCTL_FORMAT overrides file config" do
-      System.put_env("LOOPCTL_FORMAT", "human")
-
-      try do
-        config = Config.read()
-        assert config["format"] == "human"
-      after
-        System.delete_env("LOOPCTL_FORMAT")
-      end
+      config = Config.read(env_getter(%{"LOOPCTL_FORMAT" => "human"}))
+      assert config["format"] == "human"
     end
 
     test "empty env var does not override" do
-      System.put_env("LOOPCTL_SERVER", "")
+      # Empty string must NOT override — the key stays whatever the file has.
+      config = Config.read(env_getter(%{"LOOPCTL_SERVER" => ""}))
+      refute config["server"] == ""
+    end
 
-      try do
-        config = Config.read()
-        # Empty string should not override -- the key should be whatever the file has
-        refute config["server"] == ""
-      after
-        System.delete_env("LOOPCTL_SERVER")
-      end
+    test "an unset env var (getter returns nil) does not override" do
+      config = Config.read(env_getter(%{}))
+      refute Map.has_key?(config, "server") and config["server"] == nil
     end
   end
 end

--- a/test/loopctl/knowledge/streaming_export_scale_test.exs
+++ b/test/loopctl/knowledge/streaming_export_scale_test.exs
@@ -44,6 +44,39 @@ defmodule Loopctl.Knowledge.StreamingExportScaleTest do
   # requires `:manual` mode). Kept as a thin seam so the call sites read clearly.
   defp unboxed(fun), do: fun.()
 
+  # Mox wiring is PER-TEST, not `setup_all`, and that placement is load-bearing.
+  #
+  # The export is served by a REAL HTTP server whose handler processes are outside any
+  # per-test Mox context, so the stubs must be GLOBAL for those handlers to resolve them
+  # (`set_mox_global/0` is valid here — `async: false`). But in global mode Mox lets ONLY
+  # the OWNER process register stubs. Owning global mode from `setup_all` therefore makes
+  # the whole module read-only for stubs: the MUTATION CHECK below, which must inject a
+  # retaining body probe from the TEST BODY, raises
+  # `ArgumentError: cannot add expectations/stubs ... Mox is in global mode`.
+  #
+  # Running this per test makes EACH test process the owner for its own duration, so both
+  # `setup` and the test body can register stubs. Mox releases global mode when the owner
+  # exits, so the next test re-acquires it cleanly. Same pattern as
+  # `vector_endpoint_e2e_latency_scale_test.exs`.
+  setup do
+    Mox.set_mox_global()
+
+    # `config/test.exs` points EVERY injected collaborator at a Mox mock for the whole
+    # test env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed
+    # them. The Bandit handler processes run the FULL authenticated pipeline, so an
+    # export request reaches far more collaborators than the clock alone (the rate
+    # limiter among them) — hand-picking mocks one at a time is how this file kept
+    # breaking. `stub_all_defaults/0` is the single source of truth and a superset,
+    # so a mock added to DataCase is covered here automatically. It also installs the
+    # PRODUCTION (no-op) default for the streaming-export body probe, which the mutation
+    # check overrides.
+    Loopctl.DataCase.stub_all_defaults()
+
+    Mox.stub(Loopctl.MockClock, :utc_now, &DateTime.utc_now/0)
+
+    :ok
+  end
+
   setup_all do
     # The export is served by a REAL HTTP server whose request handlers run in
     # separate processes that check out their OWN repo connections. Sandbox `:manual`
@@ -54,29 +87,6 @@ defmodule Loopctl.Knowledge.StreamingExportScaleTest do
     Sandbox.mode(Loopctl.AdminRepo, :auto)
     Sandbox.mode(Loopctl.HeavyReadRepo, :auto)
     on_exit(fn -> Sandbox.mode(Loopctl.AdminRepo, :manual) end)
-
-    # The real HTTP server runs the request pipeline in handler processes that are
-    # OUTSIDE the per-test Mox context (which DataCase/ConnCase set up). The rate
-    # limiter plug calls the injected clock mock, so it must be GLOBALLY stubbed for
-    # those handler processes to resolve it. `set_mox_global` is appropriate here —
-    # this module is `async: false`.
-    Mox.set_mox_global()
-
-    # `config/test.exs` points EVERY injected collaborator at a Mox mock for the whole
-    # test env, and this module does not `use Loopctl.DataCase`, so nothing has stubbed
-    # them. The Bandit handler processes run the FULL authenticated pipeline, so an
-    # export request reaches far more collaborators than the clock alone (the rate
-    # limiter among them) — hand-picking mocks one at a time is how this file kept
-    # breaking. `stub_all_defaults/0` is the single source of truth and a superset,
-    # so a mock added to DataCase is covered here automatically.
-    #
-    # It MUST be here in `setup_all`, NOT a per-test `setup`: `set_mox_global/0` above
-    # makes THIS process the global owner, and in global mode Mox lets ONLY the owner
-    # register stubs — a `Mox.stub` from the per-test setup (a different process) raises
-    # ArgumentError and fails every test in the module before its body runs.
-    Loopctl.DataCase.stub_all_defaults()
-
-    Mox.stub(Loopctl.MockClock, :utc_now, &DateTime.utc_now/0)
 
     # The big tenant: ~80k committed articles (prod floor). A separate SMALL tenant
     # gives the 500-article memory baseline for the ratio assertion.
@@ -160,15 +170,31 @@ defmodule Loopctl.Knowledge.StreamingExportScaleTest do
       normal_big = measure_export(ctx.port, ctx.user_key, "/api/v1/knowledge/okf/export")
       normal_ratio = normal_big.peak_retained / small_floor
 
-      # Force the producer to retain every body (the materializing mutation).
-      Application.put_env(:loopctl, :export_force_materialize_for_test, true)
+      # Force the producer to retain every body (the materializing mutation) by INJECTING a
+      # retaining probe, not by mutating global config. `Mox.stub/3` runs the closure in the
+      # CALLING process — here the Bandit handler running the export — so the copied binaries
+      # are retained in the producer process, which is exactly where the telemetry measures
+      # peak retained bytes.
+      #
+      # `:binary.copy/1` is required: `row.body` is a sub-binary of the DB result, which
+      # would be reclaimed along with the row. Copying forces a fresh refc binary that the
+      # producer genuinely holds — without it the "mutation" would retain nothing and the
+      # check would pass vacuously.
+      Mox.stub(Loopctl.MockStreamingExportBodyProbe, :probe, fn ->
+        key = {__MODULE__, :materialized_bodies}
 
-      mutated_big =
-        try do
-          measure_export(ctx.port, ctx.user_key, "/api/v1/knowledge/okf/export")
-        after
-          Application.delete_env(:loopctl, :export_force_materialize_for_test)
+        fn body ->
+          Process.put(key, [:binary.copy(body || <<>>) | Process.get(key, [])])
+          :ok
         end
+      end)
+
+      # No cleanup needed, and that is the point of the DI seam: the stub is scoped to THIS
+      # test's Mox global-mode ownership, which is re-established per test in `setup`, so
+      # the retaining probe cannot outlive this test even if the measurement below raises.
+      # The old `Application.put_env` + `delete_env` pair had exactly that failure mode — a
+      # raise in between left a materializing producer configured for the rest of the VM.
+      mutated_big = measure_export(ctx.port, ctx.user_key, "/api/v1/knowledge/okf/export")
 
       mutated_ratio = mutated_big.peak_retained / small_floor
 

--- a/test/loopctl/workers/memory_graduation_sweep_worker_test.exs
+++ b/test/loopctl/workers/memory_graduation_sweep_worker_test.exs
@@ -198,11 +198,9 @@ defmodule Loopctl.Workers.MemoryGraduationSweepWorkerTest do
       _a = hot_memory(tenant.id, recall_count: 9, text: "hot A")
       _b = hot_memory(tenant.id, recall_count: 8, text: "hot B")
 
-      prev = Application.get_env(:loopctl, :memory_graduation_max_per_run)
-      Application.put_env(:loopctl, :memory_graduation_max_per_run, 1)
-      on_exit(fn -> restore(:memory_graduation_max_per_run, prev) end)
-
-      assert :ok = perform_job(MemoryGraduationSweepWorker, %{})
+      # Cap this ONE tick to 1 via job args — async-safe (per-job, no VM-global mutation),
+      # unlike the old `Application.put_env` which leaked into every concurrent test.
+      assert :ok = perform_job(MemoryGraduationSweepWorker, %{"max_per_run" => 1})
 
       # Exactly one graduated this run (the cap); the other remains for the next tick.
       assert length(articles_for(tenant.id)) == 1
@@ -227,18 +225,12 @@ defmodule Loopctl.Workers.MemoryGraduationSweepWorkerTest do
       _h2 = hot_memory(hot.id, recall_count: 8, text: "hot tenant fact B")
       cool = hot_memory(other.id, recall_count: 5, text: "other tenant fact")
 
-      prev = Application.get_env(:loopctl, :memory_graduation_max_per_run)
-      Application.put_env(:loopctl, :memory_graduation_max_per_run, 2)
-      on_exit(fn -> restore(:memory_graduation_max_per_run, prev) end)
-
-      assert :ok = perform_job(MemoryGraduationSweepWorker, %{})
+      # Cap this ONE tick to 2 via job args (per-job, async-safe — no global mutation).
+      assert :ok = perform_job(MemoryGraduationSweepWorker, %{"max_per_run" => 2})
 
       # The cooler tenant is graduated within the shared budget — not starved.
       refute is_nil(reload(cool).graduated_at)
       assert [_one] = articles_for(other.id)
     end
   end
-
-  defp restore(key, nil), do: Application.delete_env(:loopctl, key)
-  defp restore(key, val), do: Application.put_env(:loopctl, key, val)
 end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -20,6 +20,7 @@ defmodule Loopctl.DataCase do
   alias Loopctl.Custody.Coverage
   alias Loopctl.Egress.Scope, as: EgressScope
   alias Loopctl.Embeddings.SystemConfigReadPath
+  alias Loopctl.Knowledge.StreamingExport.NoopBodyProbe
   alias Loopctl.Oban.FairShare
   alias Loopctl.Telemetry.ScaleAlerts
   alias Loopctl.Telemetry.ScaleMetrics
@@ -99,6 +100,13 @@ defmodule Loopctl.DataCase do
     end)
 
     stub_embedding_read_path()
+
+    # US-27.16: default to PRODUCTION behaviour — the streaming-export producer observes
+    # (and therefore retains) nothing. Only the bounded-memory scale gate overrides this,
+    # with a retaining closure, to prove its metric catches a materializing producer.
+    Mox.stub(Loopctl.MockStreamingExportBodyProbe, :probe, fn ->
+      &NoopBodyProbe.ignore/1
+    end)
 
     Mox.stub(Loopctl.MockHealthChecker, :check, fn ->
       {:ok,

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -105,3 +105,17 @@ Mox.defmock(Loopctl.MockCustodyCoverage, for: Loopctl.Custody.CoverageBehaviour)
 # production behaviour unchanged); the US-41.1 read-path tests override it with
 # `Mox.stub/3`, which is scoped to the calling process.
 Mox.defmock(Loopctl.MockEmbeddingReadPath, for: Loopctl.Embeddings.ReadPathBehaviour)
+
+# US-27.16: DI seam for the streaming-export producer's per-body observation point. The
+# bounded-memory scale gate must prove its metric is LOAD-BEARING by turning the streaming
+# producer into a MATERIALIZING one, which needs a seam in the production emit path.
+# Before this mock that seam was an `Application.get_env` flag read ONCE PER ARTICLE, and
+# the scale test flipped it with `Application.put_env/3` — test-only branching on a
+# production hot path plus VM-wide mutation from a test (which `CLAUDE.md` forbids). The
+# DataCase default stub is a no-op (production behaviour, so every pre-existing export
+# test is unchanged); the mutation-check test overrides it with a RETAINING closure. Mox
+# stubs run in the CALLING process, so the retention lands in the producer process — where
+# the memory metric actually measures — with no production code aware of it.
+Mox.defmock(Loopctl.MockStreamingExportBodyProbe,
+  for: Loopctl.Knowledge.StreamingExport.BodyProbe
+)


### PR DESCRIPTION
## Why

Three test hooks drove test-only behaviour by **mutating VM-global state** — the anti-pattern `CLAUDE.md` forbids (config-based DI only). Each is also a genuine flake source, not just a style issue: global state is shared by every process, so a concurrent test reading the same key sees the mutation. Two of the three are in **`async: true`** files.

## What changed

**1. `streaming_export` mutation seam.** The producer read `Application.get_env(:export_force_materialize_for_test)` **once per article** — 80k reads per export — on the production hot path, and the bounded-memory scale test flipped it with `Application.put_env`. That put test-only branching in production, did a global config lookup per row, and mutated VM-wide state from a test.

Replaced with an injected `BodyProbe` behaviour: production `NoopBodyProbe` observes nothing and is resolved **once per page** into a plain closure (no per-row behaviour dispatch — an 80k-row export would otherwise pay 80k Mox dispatches). The scale test injects a *retaining* closure via `Mox.stub`, which runs in the calling process, so the retention lands in the producer process exactly where the memory metric measures.

The mutation check still separates the honest and materializing producers by **251×** (ratio 0.365 vs 91.6) — the metric stays load-bearing.

**2. `memory_graduation_sweep_worker` per-run budget.** An `async: true` test set the cap with `Application.put_env`, so a concurrently running test reading `graduation_max_per_run` could see the wrong value. The worker now reads the cap from its **Oban job args** (per-job, process-local) with the config value as fallback. Production schedules via cron with empty args, so its behaviour is unchanged.

**3. `CLI.Config` OS-env overrides.** `read/0` read `LOOPCTL_*` via `System.get_env`, and the `async: true` test set them with `System.put_env` — two tests even overrode `LOOPCTL_SERVER` and could race each other. `read/1`/`get/2` now take an `env_getter` defaulting to `&System.get_env/1`; tests pass a map-backed getter.

## Note on the Mox global-mode move

Moving `streaming_export_scale_test`'s `set_mox_global` + `stub_all_defaults` from `setup_all` to per-test `setup` was required, not cosmetic: global mode lets **only the owning process** register stubs, so a `setup_all` owner blocks the test body from injecting the probe (`ArgumentError`). Per-test ownership also means the retaining probe cannot outlive its test even on a raise — strictly safer than the old `put_env`/`delete_env` pair, where a raise in between left the flag set for the rest of the VM.

## Scope

Production code changes are behaviour-preserving: the new `BodyProbe` prod impl is a no-op, the worker's cron path passes no args, and `CLI.Config`'s default getter is `System.get_env`.

## Verification

`mix precommit` — **6189 tests, 0 failures**. The `streaming_export` scale gate was run against a fresh 80k corpus and the mutation check confirmed load-bearing (5 tests, 0 failures).
