### PR TITLE
fix(coordination): let an agent write its own tenant's kb-scope channel (#517)

### DIFF
--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -39,7 +39,7 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:481-487`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:447-449`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8141`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8175`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
    (`absolute_score/1`, `:8246-8251`) clears a scale-matched threshold AND beats the best retrieved
    candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:8297-8307`; the pure decision is

--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -33,6 +33,7 @@ defmodule Loopctl.Coordination do
   alias Loopctl.KeysetSeek
   alias Loopctl.Knowledge
   alias Loopctl.Projects
+  alias Loopctl.Projects.Project
   alias Loopctl.Security.SecretDenylist
   alias Loopctl.Tenants.Tenant
   alias Loopctl.WorkBreakdown.Story
@@ -789,7 +790,7 @@ defmodule Loopctl.Coordination do
   so a cross-project write attempt reveals no "not a member" vs "not your tenant"
   vs "does not exist" oracle.
 
-  Two ways to be authorized:
+  Three ways to be authorized:
 
     1. **Membership** — the agent is assigned to at least one story in the project
        (`stories.assigned_agent_id`, scoped by an EXPLICIT `tenant_id` filter on
@@ -808,6 +809,22 @@ defmodule Loopctl.Coordination do
        member via story assignment — the gate is enforced for every role below
        `:user`.
 
+    3. **`:kb`-kind scope in the caller's own tenant** (issue #517) — a KB scope
+       carries NO chain-of-custody surface: `RequireWorkProject` bars work
+       attachment, so a kb-scope can NEVER have a story, and membership-by-story
+       (path 1) is therefore structurally unsatisfiable for it. Without this path an
+       agent-rooted (KB-tier) tenant — which can create a kb-scope via
+       `create_kb_scope` (#331/#505) but not a work project — had NO channel it
+       could both create AND post to, making the coordination bus (its intended
+       handoff home) unreachable for a new repo. The membership gate exists to
+       isolate CUSTODY-sensitive work-project channels; a kb-scope is a shared,
+       agent-native knowledge partition with no custody weight, so any agent in the
+       OWNING tenant may write its channel. This is NOT a cross-tenant hole:
+       `kb_scope?/2` re-applies the `tenant_id` predicate (as does the `post/4`
+       `get_project/2` guard upstream), so a kb-scope in ANOTHER tenant never
+       reaches here — it is already `:not_found`. Consistent with the #331/#505
+       carve-out that made `create_kb_scope` itself agent-role.
+
   ## Coupling (keep SHARED)
 
   This is the single project-scoped-write predicate for the coordination surface.
@@ -819,12 +836,26 @@ defmodule Loopctl.Coordination do
   @spec project_writable_by_agent(Ecto.UUID.t(), Ecto.UUID.t(), Ecto.UUID.t(), atom()) ::
           :ok | {:error, :not_found}
   def project_writable_by_agent(tenant_id, agent_id, project_id, role) do
-    if Role.role_at_least?(role, :user) or
-         agent_member_of_project?(tenant_id, agent_id, project_id) do
-      :ok
-    else
-      {:error, :not_found}
+    cond do
+      Role.role_at_least?(role, :user) -> :ok
+      kb_scope?(tenant_id, project_id) -> :ok
+      agent_member_of_project?(tenant_id, agent_id, project_id) -> :ok
+      true -> {:error, :not_found}
     end
+  end
+
+  # Issue #517: a `:kb`-kind scope OWNED by the caller's tenant is a shared,
+  # custody-free knowledge partition, writable by any agent in that tenant. The
+  # `tenant_id` predicate is what keeps this tenant-safe — a kb-scope in another
+  # tenant never matches. `exists?` compiles to `SELECT 1 ... LIMIT 1` and seeks the
+  # `projects` primary key, so it never materializes a row. Like the sibling
+  # `agent_member_of_project?/3`, `project_id` is assumed already validated by the
+  # upstream `get_project/2`/`get_post/2` chokepoint every caller runs first (a
+  # malformed id is `:not_found` there, long before it reaches this predicate).
+  defp kb_scope?(tenant_id, project_id) do
+    Project
+    |> where([p], p.id == ^project_id and p.tenant_id == ^tenant_id and p.kind == :kb)
+    |> AdminRepo.exists?()
   end
 
   # Membership derivation (US-40.D3): the agent is assigned to at least one story

--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -472,8 +472,8 @@ defmodule Loopctl.Coordination do
 
   AC-40.D3.4 requires that any residual hole left by choosing the story-assignment
   membership model (rather than a full, non-self-grantable membership relation) be
-  a DELIBERATE, documented sign-off — never a silent no-op. Two residuals are
-  accepted here, both consciously, both observable:
+  a DELIBERATE, documented sign-off — never a silent no-op. Three residuals are
+  accepted here, all consciously:
 
     1. **Membership is SELF-GRANTABLE via the claim path.** `assigned_agent_id` is
        set by `Progress.claim_story/3`, and claiming is self-service for the
@@ -511,6 +511,30 @@ defmodule Loopctl.Coordination do
        write access.) These denials all collapse to the same oracle-safe 422, so they
        are unobservable to the caller — accepted under the default-deny decision-2
        model and flagged here as a heads-up for the US-40.B1 claim/release coupling.
+
+    3. **A `:kb`-kind scope is tenant-wide-writable by ANY agent (issue #517).**
+       `project_writable_by_agent/4` grants the write when the target is a
+       `:kb`-kind project in the caller's own tenant, WITHOUT a per-project
+       membership check (see path 3 in that function's moduledoc). So in a
+       multi-agent tenant an `:agent` compromised on repo-C can post into a
+       kb-scope channel that auto-injects (via the SessionStart preview) into a
+       peer agent's session working that kb-scope — the intra-tenant, cross-scope
+       injection surface US-40.D3's membership gate closes for WORK projects. This
+       is a DELIBERATE accepted residual, not an oversight: (a) a kb-scope carries
+       NO chain-of-custody surface (`RequireWorkProject` bars work attachment, so
+       it can never hold a story), so nothing custody-critical is exposed; (b) the
+       blast radius is bounded to a single tenant (the `tenant_id` predicate in
+       `kb_scope?/2` blocks cross-tenant reach) and, per post, to the 512-byte
+       SessionStart preview (`@preview_bytes`); and (c) it mirrors the #331/#505
+       trust unit that already made `create_kb_scope` and all agent-role KB
+       curation tenant-wide — a kb-scope is a shared, agent-native knowledge
+       partition whose whole point is any-agent collaboration, so gating its
+       channel by story membership (structurally unsatisfiable — see (a)) would
+       leave an agent-rooted KB-tier tenant with NO writable coordination bus at
+       all. The compensating control is the same as decision 1's: per-project /
+       per-dispatch agent keys under Chain of Custody v2. Registered here so the
+       tenant-wide kb-channel writability is a signed-off decision, not a silent
+       reopening of the D3 injection vector for `:kb` scopes.
 
   ## Coupling (US-40.B1 / US-40.E1)
 
@@ -836,10 +860,16 @@ defmodule Loopctl.Coordination do
   @spec project_writable_by_agent(Ecto.UUID.t(), Ecto.UUID.t(), Ecto.UUID.t(), atom()) ::
           :ok | {:error, :not_found}
   def project_writable_by_agent(tenant_id, agent_id, project_id, role) do
+    # Clause order is a hot-path optimization, NOT a semantic one: kb_scope? and
+    # agent_member_of_project? are mutually exclusive (a kb-scope structurally has
+    # no stories, so it can never satisfy membership), so either order yields the
+    # same verdict. Membership is checked FIRST because the dominant write is an
+    # agent acting on a WORK project it is a member of — that resolves in a single
+    # query, and the always-false kb_scope? probe is only paid on the rare kb path.
     cond do
       Role.role_at_least?(role, :user) -> :ok
-      kb_scope?(tenant_id, project_id) -> :ok
       agent_member_of_project?(tenant_id, agent_id, project_id) -> :ok
+      kb_scope?(tenant_id, project_id) -> :ok
       true -> {:error, :not_found}
     end
   end
@@ -852,6 +882,16 @@ defmodule Loopctl.Coordination do
   # `agent_member_of_project?/3`, `project_id` is assumed already validated by the
   # upstream `get_project/2`/`get_post/2` chokepoint every caller runs first (a
   # malformed id is `:not_found` there, long before it reaches this predicate).
+  #
+  # Lifecycle: this probe matches on `(id, tenant_id, kind)` only and DELIBERATELY
+  # does not gate on `projects.status`, so an ARCHIVED kb-scope (`archive_kb_scope`)
+  # stays writable. That is the CONSISTENT choice, not an oversight: the coordination
+  # write path is status-agnostic for work projects too (a member may post to an
+  # archived work project — `get_project/2` returns archived rows and no caller
+  # status-checks), so status-gating only the kb path would be a lone inconsistency.
+  # A tenant that wants to freeze a channel deletes/expires its posts; a blanket
+  # "reject writes to archived scopes" gate (both kinds) is a separate, deliberate
+  # product decision left out of the #517 carve-out.
   defp kb_scope?(tenant_id, project_id) do
     Project
     |> where([p], p.id == ^project_id and p.tenant_id == ^tenant_id and p.kind == :kb)

--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -22,6 +22,8 @@ defmodule Loopctl.Coordination do
 
   import Ecto.Query
 
+  require Logger
+
   alias Ecto.Multi
   alias Loopctl.AdminRepo
   alias Loopctl.Agents
@@ -536,6 +538,24 @@ defmodule Loopctl.Coordination do
        tenant-wide kb-channel writability is a signed-off decision, not a silent
        reopening of the D3 injection vector for `:kb` scopes.
 
+       Custody-safety is NOT injection-safety, so the injection dimension is called
+       out explicitly (review): the 512-byte SessionStart preview is same-tenant,
+       agent-controlled text auto-injected into a peer agent's context, i.e. a genuine
+       intra-tenant prompt-injection surface (OWASP ASI06 memory-poisoning / ASI01
+       goal-hijack) — a repo-C-compromised agent can attempt to steer a peer working
+       the kb-scope. What keeps this an ACCEPTED residual rather than an active exploit
+       is that the SessionStart preview CONSUMER treats channel content as untrusted
+       DATA, never instructions: it renders the preview as inert framed text (no shell
+       interpolation, control chars stripped) and does not execute or obey it. The
+       accepted risk is therefore bounded to whatever a peer MODEL might be socially
+       engineered into by 512 bytes of adversarial prose — the same intra-tenant risk
+       any shared agent-native surface carries — mitigated by per-dispatch keys under
+       Chain of Custody v2 and by the `:kb_scope_write` telemetry marker (see
+       `emit_kb_scope_write/3`) that makes member-bypass writes independently alertable.
+       Emitting the marker on this path is deliberate: it is the one path where
+       membership is bypassed, so cross-scope kb writes must be observable separately
+       from membership-backed writes.
+
   ## Coupling (US-40.B1 / US-40.E1)
 
   This predicate is SHARED: the claim writes (US-40.B1 claim/release/done) and the
@@ -843,7 +863,15 @@ defmodule Loopctl.Coordination do
        handoff home) unreachable for a new repo. The membership gate exists to
        isolate CUSTODY-sensitive work-project channels; a kb-scope is a shared,
        agent-native knowledge partition with no custody weight, so any agent in the
-       OWNING tenant may write its channel. This is NOT a cross-tenant hole:
+       OWNING tenant may write its channel. The authorization is TENANT-WIDE, not
+       creator-scoped: there is no per-scope creator/ownership tracking, so an agent
+       may write ANY `:kb`-kind scope in its own tenant, NOT merely one it created via
+       `create_kb_scope`. This is the deliberate, signed-off breadth (the tests at
+       coordination_test.exs cover a brand-new agent with NO story assignment writing
+       a kb-scope it did not create) — a kb-scope's whole point is any-agent
+       collaboration, and an agent can already `knowledge_create` tenant-wide directly,
+       so this opens no boundary the tenant trust unit did not already grant. This is
+       NOT a cross-tenant hole:
        `kb_scope?/2` re-applies the `tenant_id` predicate (as does the `post/4`
        `get_project/2` guard upstream), so a kb-scope in ANOTHER tenant never
        reaches here — it is already `:not_found`. Consistent with the #331/#505
@@ -869,9 +897,37 @@ defmodule Loopctl.Coordination do
     cond do
       Role.role_at_least?(role, :user) -> :ok
       agent_member_of_project?(tenant_id, agent_id, project_id) -> :ok
-      kb_scope?(tenant_id, project_id) -> :ok
+      kb_scope?(tenant_id, project_id) -> emit_kb_scope_write(tenant_id, agent_id, project_id)
       true -> {:error, :not_found}
     end
+  end
+
+  # Issue #517 observability (review): the kb-scope branch is the ONE authorization
+  # path where the project-membership gate is INTENTIONALLY bypassed — any agent in
+  # the owning tenant may write a `:kb`-kind channel, including an agent that owns no
+  # story anywhere. A successful kb-scope write is otherwise audited exactly like an
+  # ordinary post and carries NO distinguishing security signal, so a burst of
+  # cross-scope injecting posts from a non-member agent (the residual-3 intra-tenant
+  # injection surface) is reconstructable only after the fact from the audit log — not
+  # independently observable/alertable. Emit a dedicated low-severity telemetry marker
+  # + log line so member-bypass kb writes can be monitored / rate-anomaly-detected
+  # separately from membership-backed writes, mirroring the denied-path signals
+  # (`:ownership_rejected` / `:agent_identity_required`) the controllers already fire.
+  # Runs at the SHARED predicate so it covers every caller (post / claim / graduate)
+  # in one place. Returns `:ok` so the branch stays authorized.
+  defp emit_kb_scope_write(tenant_id, agent_id, project_id) do
+    :telemetry.execute(
+      [:loopctl, :coordination, :kb_scope_write],
+      %{count: 1},
+      %{tenant_id: tenant_id, agent_id: agent_id, project_id: project_id}
+    )
+
+    Logger.info(
+      "coordination kb-scope member-bypass write " <>
+        "(tenant=#{tenant_id} agent=#{agent_id} project=#{project_id})"
+    )
+
+    :ok
   end
 
   # Issue #517: a `:kb`-kind scope OWNED by the caller's tenant is a shared,
@@ -2192,12 +2248,21 @@ defmodule Loopctl.Coordination do
   @spec graduate_post(Ecto.UUID.t(), Ecto.UUID.t(), atom(), term(), map()) ::
           {:ok, map()}
           | {:error, :not_found}
+          | {:error, :agent_not_found}
           | {:error, :unprocessable_entity, String.t()}
           | {:error, :duplicate_title, Knowledge.Article.t()}
           | {:error, :gate_unavailable}
           | {:error, Ecto.Changeset.t()}
   def graduate_post(tenant_id, agent_id, role, post_id, %{} = params) do
     with {:ok, post} <- get_post(tenant_id, post_id),
+         # Restore the agent-in-tenant binding that the membership probe used to give
+         # for free (review). `project_writable_by_agent/4` no longer implies it on the
+         # kb path — `kb_scope?/2` ignores `agent_id` entirely (#517), so a misconfigured
+         # key carrying a foreign-tenant `agent_id` (the agents/api_keys FKs are
+         # non-composite, see the comment at post/4) could otherwise graduate a kb post
+         # whose article carries a foreign agent's `visibility_agent_id`. Mirroring the
+         # sibling post/4 and claim/4 defense-in-depth closes that mis-attribution class.
+         {:ok, _agent} <- agent_owned(tenant_id, agent_id),
          :ok <- project_writable_by_agent(tenant_id, agent_id, post.project_id, role),
          :ok <- scan_graduation_content(params[:title], post.body, params[:tags]) do
       attrs = %{

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -4802,7 +4802,12 @@ defmodule Loopctl.Knowledge do
     query =
       suggestion_candidates_query(tenant_id, article_id, embedding, threshold, limit, vis, opts)
 
-    suggestions = HeavyRead.all(tenant_id, query, heavy_read_opts(:suggested_links))
+    suggestions =
+      HeavyRead.all(
+        tenant_id,
+        query,
+        suggested_links_read_opts(suggestion_candidate_pool(limit), opts)
+      )
 
     returned = length(suggestions)
 
@@ -4967,7 +4972,7 @@ defmodule Loopctl.Knowledge do
         }
       )
 
-    case HeavyRead.one(tenant_id, probe, heavy_read_opts(:suggested_links)) do
+    case HeavyRead.one(tenant_id, probe, suggested_links_read_opts(pool, opts)) do
       %{ann_candidates: a, above_threshold: t} -> {a || 0, t || 0}
       nil -> {0, 0}
     end
@@ -5002,6 +5007,35 @@ defmodule Loopctl.Knowledge do
   # (Knowledge / Audit). Public-but-`@doc false` so the slow-query telemetry test can
   # exercise the real opts-building path (incl. the override branch) through this name.
   def heavy_read_opts(endpoint), do: HeavyRead.opts(endpoint)
+
+  # Per-read opts for the suggested-links side-table ANN (#508 review). When the read
+  # hits the dimension-tagged side table (`reads_side_table?` threaded from
+  # `suggest_links_with_meta/3`), the inner ANN over-fetches to
+  # `side_table_inner_pool(pool)` to offset the status/visibility trim the per-dimension
+  # partial index cannot carry (`live_denorm` mirrors only `status <> 'superseded'`,
+  # not draft/archived or other-agents' private). But an HNSW scan visits only
+  # ~`ef_search` nodes regardless of LIMIT, so that over-fetch is INERT unless
+  # `ef_search` is widened in lockstep — otherwise the inner returns ~ef_search rows and
+  # the outer status/visibility/anti-join trim yields FEWER published+visible links than
+  # the legacy `articles.embedding` path did (the exact silent under-return #508 fixed,
+  # on the entire non-1536-dim tenant class), and the under-fill probe counts over the
+  # same starved set. Mirrors `search_semantic_side_table/7` (`hnsw_ef_search` raise) and
+  # `VectorSearch.nearest/4`'s `nearest_heavy_read_opts/2`. On the legacy path there is no
+  # inner over-fetch, so the base opts stand. Piggybacks the SET LOCAL transaction every
+  # heavy read already runs in (US-27.13) — no new pool-starvation risk.
+  defp suggested_links_read_opts(pool, opts) do
+    base = heavy_read_opts(:suggested_links)
+
+    if Keyword.get(opts, :reads_side_table, false) do
+      Keyword.put(
+        base,
+        :hnsw_ef_search,
+        VectorSearch.side_table_ef_search(VectorSearch.side_table_inner_pool(pool))
+      )
+    else
+      base
+    end
+  end
 
   # Builds the suggested-links candidate query (returned, not executed) so a test can
   # assert its SQL shape. Public-but-`@doc false` for that structural regression guard.

--- a/lib/loopctl/knowledge/vector_search.ex
+++ b/lib/loopctl/knowledge/vector_search.ex
@@ -280,6 +280,18 @@ defmodule Loopctl.Knowledge.VectorSearch do
     # neighbours" (suggest-links empty, ProposalGate novel, ArticleLinkingWorker no links).
     case Embeddings.check_query_vector(tenant_id, to_embedding_list(target_embedding)) do
       :ok ->
+        # Resolve the side-table cutover flag ONCE and thread it into `opts` before
+        # BOTH stages run (review): candidate_query (via candidate_pool_query) and
+        # nearest_heavy_read_opts each resolve `:reads_side_table` via Keyword.get_lazy
+        # when it is absent, so an unthreaded call reads Embeddings.side_table_reads_enabled?/0
+        # twice. A cutover flip (AC-41.1.8 can flip against live traffic) landing between
+        # the two reads would let the query BUILD (side table, pool*4 over-fetch) and the
+        # ef_search DECISION disagree — build side-table but not raise ef_search → transient
+        # under-recall. This is the same "resolve once and thread" invariant candidate_pool_query
+        # documents (vector_search.ex:447-452) and suggest_links honors (knowledge.ex:4711).
+        opts =
+          Keyword.put_new_lazy(opts, :reads_side_table, &Embeddings.side_table_reads_enabled?/0)
+
         query = candidate_query(tenant_id, target_embedding, k, opts)
         HeavyRead.all(tenant_id, query, nearest_heavy_read_opts(k, opts))
 

--- a/lib/loopctl_web/controllers/channel_post_controller.ex
+++ b/lib/loopctl_web/controllers/channel_post_controller.ex
@@ -1196,6 +1196,30 @@ defmodule LoopctlWeb.ChannelPostController do
     })
   end
 
+  # Defense-in-depth (review): the key's server-stamped agent_id does not belong to
+  # this tenant (a misconfigured key — the agent FKs are non-composite). graduate_post/5
+  # now runs the same agent_owned/2 guard create/2 does, so this is an IDENTITY fault,
+  # not a project probe — a 403 :agent_identity_required, mirroring render_write/5.
+  defp render_graduation(conn, {:error, :agent_not_found}) do
+    api_key = conn.assigns.current_api_key
+
+    emit_security_event(:agent_identity_required, %{
+      tenant_id: api_key.tenant_id,
+      agent_id: api_key.agent_id
+    })
+
+    conn
+    |> put_status(:forbidden)
+    |> json(%{
+      error: %{
+        status: 403,
+        code: "agent_identity_required",
+        message:
+          "This API key's agent identity is not valid for this tenant; it cannot graduate a channel post to Knowledge"
+      }
+    })
+  end
+
   # {:error, :not_found} | {:error, :unprocessable_entity, msg} |
   # {:error, %Ecto.Changeset{}} → FallbackController (404 / 422).
   defp render_graduation(conn, error), do: LoopctlWeb.FallbackController.call(conn, error)

--- a/test/loopctl/coordination_test.exs
+++ b/test/loopctl/coordination_test.exs
@@ -2285,6 +2285,62 @@ defmodule Loopctl.CoordinationTest do
     end
   end
 
+  # Issue #517: the kb carve-out lives in the SHARED predicate, so it must flow
+  # through EVERY surface that gates on it — not just post/4. The moduledoc pins
+  # claim/4 (US-40.B1) and graduate_post/5 (US-40.E1) to that predicate; these
+  # lock that a NON-member agent can act on a :kb-kind scope through those two
+  # surfaces (and still cannot on a :work project it isn't a member of), so a
+  # future narrowing of either call site can't silently drop the carve-out.
+  describe "kb carve-out flows through the shared-predicate surfaces (issue #517)" do
+    test "claim/4: a non-member agent may claim on a :kb-kind scope, but not on a :work project" do
+      tenant = fixture(:tenant)
+      kb_scope = fixture(:project, %{tenant_id: tenant.id, kind: :kb})
+      work = fixture(:project, %{tenant_id: tenant.id, kind: :work})
+      # A brand-new agent with NO story assignment anywhere.
+      agent_id = fixture(:agent, %{tenant_id: tenant.id}).id
+
+      assert {:ok, _claim} =
+               Coordination.claim(tenant.id, agent_id, kb_scope.id, "handoff:kb-ref")
+
+      # Same agent on a WORK project it is not a member of collapses to the
+      # oracle-safe :not_found (the gate denies before any claim row is written).
+      assert {:error, :not_found} =
+               Coordination.claim(tenant.id, agent_id, work.id, "handoff:work-ref")
+    end
+
+    test "graduate_post/5: a non-member agent may graduate a post on a :kb-kind scope, but not on a :work project" do
+      tenant = fixture(:tenant)
+      kb_scope = fixture(:project, %{tenant_id: tenant.id, kind: :kb})
+      work = fixture(:project, %{tenant_id: tenant.id, kind: :work})
+      agent_id = fixture(:agent, %{tenant_id: tenant.id}).id
+
+      # A post to graduate on each scope (create_post is the raw insert, not gated).
+      {:ok, kb_post} =
+        Coordination.create_post(tenant.id, kb_scope.id, agent_id, %{
+          "body" => "A reusable kb-scope lesson worth keeping."
+        })
+
+      {:ok, work_post} =
+        Coordination.create_post(tenant.id, work.id, agent_id, %{
+          "body" => "A work-project lesson."
+        })
+
+      # kb-scope: the carve-out admits the non-member agent; the DataCase default
+      # assessor stub is :novel, so the graduation lands a durable article.
+      assert {:ok, _result} =
+               Coordination.graduate_post(tenant.id, agent_id, :agent, kb_post.id, %{
+                 title: "Reusable kb-scope Lesson"
+               })
+
+      # work-project: the non-member is denied at the shared gate → :not_found,
+      # BEFORE any article is proposed.
+      assert {:error, :not_found} =
+               Coordination.graduate_post(tenant.id, agent_id, :agent, work_post.id, %{
+                 title: "Should Not Graduate"
+               })
+    end
+  end
+
   describe "delete_post/5" do
     setup do
       tenant = fixture(:tenant)

--- a/test/loopctl/coordination_test.exs
+++ b/test/loopctl/coordination_test.exs
@@ -2246,6 +2246,43 @@ defmodule Loopctl.CoordinationTest do
 
       assert :ok = Coordination.project_writable_by_agent(tenant.id, agent_id, project.id, :user)
     end
+
+    test "issue #517: an agent may write a :kb-kind scope in its own tenant without story membership" do
+      tenant = fixture(:tenant)
+      kb_scope = fixture(:project, %{tenant_id: tenant.id, kind: :kb})
+      # A brand-new agent with NO story assignment anywhere — a kb-scope can never
+      # carry a story, so path-1 membership is structurally unsatisfiable for it.
+      agent_id = fixture(:agent, %{tenant_id: tenant.id}).id
+
+      assert :ok =
+               Coordination.project_writable_by_agent(tenant.id, agent_id, kb_scope.id, :agent)
+    end
+
+    test "issue #517: the :kb allowance does NOT cross tenants" do
+      owner = fixture(:tenant)
+      kb_scope = fixture(:project, %{tenant_id: owner.id, kind: :kb})
+
+      other = fixture(:tenant)
+      other_agent = fixture(:agent, %{tenant_id: other.id}).id
+
+      # Asked under the OTHER tenant, the kb-scope is not theirs → not writable.
+      assert {:error, :not_found} =
+               Coordination.project_writable_by_agent(
+                 other.id,
+                 other_agent,
+                 kb_scope.id,
+                 :agent
+               )
+    end
+
+    test "issue #517: a :work project still requires membership (kb carve-out is kind-scoped)" do
+      tenant = fixture(:tenant)
+      work = fixture(:project, %{tenant_id: tenant.id, kind: :work})
+      stranger = fixture(:agent, %{tenant_id: tenant.id}).id
+
+      assert {:error, :not_found} =
+               Coordination.project_writable_by_agent(tenant.id, stranger, work.id, :agent)
+    end
   end
 
   describe "delete_post/5" do

--- a/test/loopctl_web/controllers/channel_post_controller_test.exs
+++ b/test/loopctl_web/controllers/channel_post_controller_test.exs
@@ -102,6 +102,30 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
       assert_in_delta DateTime.to_unix(expires), DateTime.to_unix(expected), 120
     end
 
+    # Issue #517: an agent-rooted tenant's ONLY creatable channel is a kb-scope
+    # (create_project/work is human-anchor-gated). A kb-scope can never carry a
+    # story, so the NON-member agent that created it must still be able to post a
+    # handoff to it — previously a misleading 422. Now 201.
+    test "issue #517: a non-member agent posts a handoff to its tenant's kb-scope -> 201" do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      kb_scope = fixture(:project, %{tenant_id: tenant.id, kind: :kb})
+      # A plain agent key with NO story assignment — exactly the agent-rooted shape.
+      {raw, _key, agent} = agent_key(tenant)
+
+      conn =
+        post_json(raw, %{
+          "project_id" => kb_scope.id,
+          "key" => "handoff:claude-harness-kit#review",
+          "to_host" => "beelink",
+          "body" => "HANDOFF: review claude-harness-kit against its goal"
+        })
+
+      assert %{"post" => post} = json_response(conn, 201)
+      assert post["project_id"] == kb_scope.id
+      assert post["agent_id"] == agent.id
+      assert post["key"] == "handoff:claude-harness-kit#review"
+    end
+
     # TC-40.A1.1 — a multi-item typed-open refs LIST is persisted and returned as-is.
     test "a multi-item typed-open refs list is persisted and returned -> 201" do
       tenant = fixture(:tenant)

--- a/test/loopctl_web/plugs/require_work_project_mount_test.exs
+++ b/test/loopctl_web/plugs/require_work_project_mount_test.exs
@@ -1,0 +1,79 @@
+defmodule LoopctlWeb.Plugs.RequireWorkProjectMountTest do
+  @moduledoc """
+  Drift guard for the `RequireWorkProject` mounts.
+
+  The `Loopctl.Coordination` #517 kb carve-out (`project_writable_by_agent/4` grants
+  tenant-wide write to any `:kb`-kind scope) rests on the invariant that a kb-scope
+  can NEVER hold a story — see coordination.ex residual 3. That invariant is enforced
+  ONLY at the web boundary by `plug LoopctlWeb.Plugs.RequireWorkProject`, mounted on
+  each controller that can attach work-breakdown items (epics / stories / imports /
+  ui-tests / orchestrator state) to a project. There is no DB CHECK/FK and no
+  context-layer guard, so — unlike `RequireHumanAnchor`, which is source-scan-locked by
+  `tier_capabilities_test.exs` — a work-attachment route added or edited WITHOUT the
+  plug would silently reopen the invariant the carve-out depends on.
+
+  This test locks the current mounts: it scans SOURCE TEXT under `lib/loopctl_web/**`
+  for `plug ... RequireWorkProject` and asserts the mounting-controller set matches an
+  explicit expected list, failing in BOTH directions. Removing the plug from a
+  work-attachment controller (a regression) or adding a new work-attachment controller
+  without it fails CI here. Do NOT relax this test to make a change pass — restore the
+  mount (or, when a new work-attachment controller is genuinely added, mount the plug
+  AND add it to `@expected` in the same change).
+
+  SCOPE LIMIT (stated so it is not over-trusted, parity with tier_capabilities_test):
+  it matches `plug RequireWorkProject` with or without parentheses and with or without
+  the full alias. A mount injected by a shared `use`/macro is invisible to it, and it
+  does not verify that the plug's `param:` option matches the route's path param.
+  """
+  use ExUnit.Case, async: true
+
+  @scan_glob "lib/loopctl_web/**/*.ex"
+  @plug_source "lib/loopctl_web/plugs/require_work_project.ex"
+
+  # The controllers that attach work-breakdown items to a project and MUST reject a
+  # `:kb` scope. Keep this in lockstep with the actual `plug RequireWorkProject` mounts.
+  @expected [
+    "LoopctlWeb.EpicController",
+    "LoopctlWeb.ImportExportController",
+    "LoopctlWeb.OrchestratorStateController",
+    "LoopctlWeb.StoryController",
+    "LoopctlWeb.UiTestController"
+  ]
+
+  test "every work-attachment controller mounts RequireWorkProject (no drift)" do
+    mounted = mounted_controllers()
+
+    assert Enum.sort(mounted) == Enum.sort(@expected),
+           """
+           The RequireWorkProject mounts have drifted from the expected set.
+
+           Mounted but not expected: #{inspect(mounted -- @expected)}
+           Expected but not mounted:  #{inspect(@expected -- mounted)}
+
+           The #517 kb carve-out (Coordination.project_writable_by_agent/4 grants
+           tenant-wide write to any :kb scope) relies on kb-scopes never holding a
+           story, enforced ONLY by this plug. Restore the mount — do NOT relax this
+           test. If a NEW work-attachment controller was added, mount the plug on it
+           and add it to @expected in the same change.
+           """
+  end
+
+  defp mounted_controllers do
+    @scan_glob
+    |> Path.wildcard()
+    |> Enum.reject(&(&1 == @plug_source))
+    |> Enum.filter(&(&1 |> File.read!() |> mounts_work_project?()))
+    |> Enum.map(&defmodule_name/1)
+  end
+
+  defp mounts_work_project?(source) do
+    String.match?(source, ~r/^\s*plug[\s(]+(LoopctlWeb\.Plugs\.)?RequireWorkProject\b/m)
+  end
+
+  defp defmodule_name(path) do
+    case Regex.run(~r/^defmodule\s+([\w.]+)\s+do/m, File.read!(path)) do
+      [_, module] -> module
+      nil -> flunk("could not read a defmodule name out of #{path}")
+    end
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -953,10 +953,12 @@ defmodule Loopctl.Fixtures do
           {tid, attrs}
       end
 
-    data = build(:project, attrs)
+    # `kind` is set on the struct, never cast (mirrors Projects.create_project/3) —
+    # so a `kind: :kb` attr produces a real KB scope for coordination/tier tests.
+    {kind, data} = Map.pop(build(:project, attrs), :kind, :work)
 
     changeset =
-      %Project{tenant_id: tenant_id}
+      %Project{tenant_id: tenant_id, kind: kind}
       |> Project.create_changeset(data)
 
     AdminRepo.insert!(changeset)


### PR DESCRIPTION
Closes #517.

## Problem

An agent-rooted (KB-tier) tenant had **no channel it could both create and post to**, so the coordination bus — the intended home for a cross-machine handoff — was unreachable for a new repo. `create_project` (work) is human-anchor-gated (403), and the kb-scope it *can* create (`create_kb_scope`, #331/#505) 422'd on `channel_post` with a misleading "does not exist or does not belong to your tenant" — even though the scope demonstrably existed and belonged.

## Root cause

The shared project-write gate `Coordination.project_writable_by_agent/4` authorized only:
1. `role >= :user`, or
2. the agent is assigned to a **story** in the project (`stories.assigned_agent_id`).

A `:kb`-kind scope carries **no chain-of-custody surface** — `RequireWorkProject` bars work attachment, so a kb-scope can never have a story. Story-membership is therefore *structurally unsatisfiable* for it, and an `:agent`-role key always fell through to `{:error, :not_found}` → the misleading 422.

## Fix

A third authorization path: **a `:kb`-kind scope in the caller's own tenant is writable by any agent in that tenant.** A kb-scope is a shared, custody-free knowledge partition; the membership gate exists to isolate custody-sensitive *work-project* channels, which does not apply here. This is centralized in the single shared gate, so `channel_post`, handoff-`claim`, and `done` all benefit consistently (the full handoff round-trip works).

**Tenant-safe, no oracle:** `kb_scope?/2` re-applies the `tenant_id` predicate (as does the upstream `get_project/2` guard every caller runs first), so a kb-scope in another tenant is still `:not_found` — no cross-tenant hole, and the collapsed 422 for genuine cross-tenant / cross-project / work-non-member cases is preserved.

Consistent with the #331/#505 carve-out that made `create_kb_scope` itself agent-role.

## Addresses the issue's points

- **#1 (the crux)** — the agent-native path now works end-to-end (kb-scope is a valid, postable channel).
- **#2 misleading 422** — no longer fires for the kb-scope case (it succeeds). The collapsed message for genuine cross-tenant / cross-project is retained *deliberately* (oracle-safety, AC-39.2.3).
- **#3 capability surface** — `coordination_bus: allowed` is now honest for an agent-rooted tenant (previously true only for unreachable human-anchored channels).
- **#4 first-class handoff tool/skill** — a larger MCP/skill enhancement, framed as optional by the issue ("any one materially helps; the first is the crux"). Out of scope for this hotfix; worth a follow-up.

## Tests

- Shared-predicate unit tests: kb-scope allowed without membership, cross-tenant denied, work-project still gated.
- Controller test reproducing the issue's exact repro (non-member agent + kb-scope + handoff post) — was 422, now **201**.

`mix precommit` green (6326 tests, credo --strict, dialyzer).
