### PR TITLE
fix(migrations): tolerate + heal pgvector-skipped legacy embedding columns on fresh installs (#495)

### DIFF
--- a/priv/repo/migrations/20260721000300_pin_existing_tenant_embedding_dimensions.exs
+++ b/priv/repo/migrations/20260721000300_pin_existing_tenant_embedding_dimensions.exs
@@ -16,21 +16,65 @@ defmodule Loopctl.Repo.Migrations.PinExistingTenantEmbeddingDimensions do
   anything yet. Moving a pinned tenant to a new dimension is then exactly one
   supported operation — the AC-41.1.10 re-embed, which flips the pin only after the
   whole corpus is present at the target.
+
+  ## Fresh-DB / no-pgvector tolerance (#495)
+
+  On a fresh install where `CREATE EXTENSION vector` was unavailable at
+  `20260410022854` (migrations run as the non-superuser `loopctl_admin`), the early
+  guard SKIPPED the legacy `articles.embedding` / `memories.embedding` columns and
+  marked itself done, so they never exist when this migration runs. Referencing them
+  unconditionally raised `42703 column a.embedding does not exist` and wedged the
+  whole chain. Each corpus source is now probed for existence first, so a missing
+  legacy column or side table simply contributes no rows — which is CORRECT: a tenant
+  with no such storage has no corpus to pin, and on a fresh DB there is nothing to pin
+  at all. The `20260724180000` heal migration re-adds the legacy columns once pgvector
+  becomes available.
   """
 
   use Ecto.Migration
 
   def up do
+    # One guarded UPDATE per corpus source. Splitting the original single OR into
+    # independent, existence-guarded statements is equivalent (each is idempotent:
+    # SET ... WHERE tenant_embedding_dimension IS NULL) while tolerating a source
+    # whose column/table the pgvector guard skipped on this deployment.
     execute("""
-    UPDATE tenants t
-       SET tenant_embedding_dimension = 1536
-     WHERE t.tenant_embedding_dimension IS NULL
-       AND (
-         EXISTS (SELECT 1 FROM articles a WHERE a.tenant_id = t.id AND a.embedding IS NOT NULL)
-         OR EXISTS (SELECT 1 FROM memories m WHERE m.tenant_id = t.id AND m.embedding IS NOT NULL)
-         OR EXISTS (SELECT 1 FROM article_embeddings ae WHERE ae.tenant_id = t.id AND ae.dim = 1536)
-         OR EXISTS (SELECT 1 FROM memory_embeddings me WHERE me.tenant_id = t.id AND me.dim = 1536)
-       )
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'articles' AND column_name = 'embedding'
+      ) THEN
+        UPDATE tenants t
+           SET tenant_embedding_dimension = 1536
+         WHERE t.tenant_embedding_dimension IS NULL
+           AND EXISTS (SELECT 1 FROM articles a WHERE a.tenant_id = t.id AND a.embedding IS NOT NULL);
+      END IF;
+
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'memories' AND column_name = 'embedding'
+      ) THEN
+        UPDATE tenants t
+           SET tenant_embedding_dimension = 1536
+         WHERE t.tenant_embedding_dimension IS NULL
+           AND EXISTS (SELECT 1 FROM memories m WHERE m.tenant_id = t.id AND m.embedding IS NOT NULL);
+      END IF;
+
+      IF to_regclass('public.article_embeddings') IS NOT NULL THEN
+        UPDATE tenants t
+           SET tenant_embedding_dimension = 1536
+         WHERE t.tenant_embedding_dimension IS NULL
+           AND EXISTS (SELECT 1 FROM article_embeddings ae WHERE ae.tenant_id = t.id AND ae.dim = 1536);
+      END IF;
+
+      IF to_regclass('public.memory_embeddings') IS NOT NULL THEN
+        UPDATE tenants t
+           SET tenant_embedding_dimension = 1536
+         WHERE t.tenant_embedding_dimension IS NULL
+           AND EXISTS (SELECT 1 FROM memory_embeddings me WHERE me.tenant_id = t.id AND me.dim = 1536);
+      END IF;
+    END $$;
     """)
   end
 

--- a/priv/repo/migrations/20260724180000_heal_skipped_legacy_embedding_columns.exs
+++ b/priv/repo/migrations/20260724180000_heal_skipped_legacy_embedding_columns.exs
@@ -1,0 +1,56 @@
+defmodule Loopctl.Repo.Migrations.HealSkippedLegacyEmbeddingColumns do
+  @moduledoc """
+  #495 — re-add the legacy `articles.embedding` / `memories.embedding` columns that
+  the pgvector guard in `20260410022854` / `20260709000000` SKIPPED on a fresh install
+  where `CREATE EXTENSION vector` was unavailable at migrate time (migrations run as
+  the non-superuser `loopctl_admin`).
+
+  Those guard migrations are marked done and never re-run, so once an operator enables
+  pgvector (superuser `CREATE EXTENSION vector`) the columns stay missing — yet the
+  DEFAULT read path (`Embeddings.side_table_reads_enabled?/0` is off by default) and
+  the dim-1536 dual-write both use them, so the app is broken until they exist. Alex's
+  self-host recovery (issue #495) was exactly this `ALTER TABLE ... ADD COLUMN` by
+  hand; this migration does it idempotently so the next self-hoster does not have to.
+
+  Guarded + `IF NOT EXISTS`, so on any deployment where pgvector was available all
+  along (the hosted instance, CI, dev) the columns already exist and this is a no-op.
+  When pgvector is STILL absent it stays a no-op (semantic search is unavailable
+  wholesale there — nothing to heal).
+
+  Scope note: this restores the COLUMNS (correctness — reads and the dual-write need
+  them). The legacy HNSW indexes (`20260410022906` etc.) are also guard-skipped on
+  such installs; without them the legacy `<->` read is an exact sequential scan —
+  correct, and fine for a fresh small corpus. Re-adding those indexes is a
+  performance-only follow-up.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') THEN
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name = 'articles' AND column_name = 'embedding'
+        ) THEN
+          ALTER TABLE articles ADD COLUMN embedding vector(1536);
+        END IF;
+
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name = 'memories' AND column_name = 'embedding'
+        ) THEN
+          ALTER TABLE memories ADD COLUMN embedding vector(1536);
+        END IF;
+      END IF;
+    END $$;
+    """)
+  end
+
+  # No-op: this migration only ADDS columns that earlier migrations already own.
+  # Dropping them here would fight `20260410022854`/`20260709000000` ownership and
+  # could destroy a healed column's data. Reversal belongs to those migrations.
+  def down, do: :ok
+end

--- a/test/loopctl/migrations/fresh_db_embedding_guard_test.exs
+++ b/test/loopctl/migrations/fresh_db_embedding_guard_test.exs
@@ -1,0 +1,80 @@
+defmodule Loopctl.Migrations.FreshDbEmbeddingGuardTest do
+  @moduledoc """
+  #495: fresh-DB / no-pgvector migration tolerance.
+
+  Proves the pin migration `20260721000300` no longer raises `42703 column
+  a.embedding does not exist` when the legacy `articles.embedding` column was
+  skipped by the pgvector guard on a non-superuser install, and that the heal
+  migration `20260724180000` re-adds it once pgvector is available. The column is
+  dropped INSIDE the sandbox transaction and restored on rollback.
+
+  `async: false` — it takes an ACCESS EXCLUSIVE DDL lock on `articles`.
+  """
+  use Loopctl.DataCase, async: false
+
+  alias Loopctl.AdminRepo
+
+  # Mirrors the `articles` branch of the guarded UPDATE in
+  # `20260721000300_pin_existing_tenant_embedding_dimensions.exs`. The
+  # information_schema guard is what must make it a no-op when the column is absent.
+  @pin_articles_guarded_sql """
+  DO $$
+  BEGIN
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_name = 'articles' AND column_name = 'embedding'
+    ) THEN
+      UPDATE tenants t
+         SET tenant_embedding_dimension = 1536
+       WHERE t.tenant_embedding_dimension IS NULL
+         AND EXISTS (SELECT 1 FROM articles a WHERE a.tenant_id = t.id AND a.embedding IS NOT NULL);
+    END IF;
+  END $$;
+  """
+
+  # Mirrors the `articles` branch of `20260724180000_heal_skipped_legacy_embedding_columns.exs`.
+  @heal_articles_sql """
+  DO $$
+  BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') THEN
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'articles' AND column_name = 'embedding'
+      ) THEN
+        ALTER TABLE articles ADD COLUMN embedding vector(1536);
+      END IF;
+    END IF;
+  END $$;
+  """
+
+  defp embedding_column_exists? do
+    %{rows: [[n]]} =
+      AdminRepo.query!(
+        "SELECT count(*) FROM information_schema.columns WHERE table_name = $1 AND column_name = $2",
+        ["articles", "embedding"]
+      )
+
+    n == 1
+  end
+
+  test "the pin guard is a no-op when articles.embedding is absent (no 42703 crash)" do
+    AdminRepo.query!("ALTER TABLE articles DROP COLUMN embedding CASCADE")
+    refute embedding_column_exists?()
+
+    # Pre-#495 this raised `42703 column a.embedding does not exist`.
+    assert %Postgrex.Result{} = AdminRepo.query!(@pin_articles_guarded_sql)
+  end
+
+  test "the heal migration re-adds articles.embedding when pgvector is present" do
+    AdminRepo.query!("ALTER TABLE articles DROP COLUMN embedding CASCADE")
+    refute embedding_column_exists?()
+
+    AdminRepo.query!(@heal_articles_sql)
+    assert embedding_column_exists?()
+  end
+
+  test "the guarded pin migration still runs cleanly when the column IS present (no regression)" do
+    assert embedding_column_exists?()
+    assert %Postgrex.Result{} = AdminRepo.query!(@pin_articles_guarded_sql)
+  end
+end


### PR DESCRIPTION
Closes #495.

## Problem
Fresh self-hosted installs where `CREATE EXTENSION vector` was unavailable at migrate time (migrations run as the non-superuser `loopctl_admin`) wedge the migration chain: the early guards silently SKIP the legacy `articles.embedding` / `memories.embedding` columns and mark themselves done, then `20260721000300` references `a.embedding`/`m.embedding` unconditionally → `42703 column does not exist`. Worse, even past that the app's DEFAULT read path (`side_table_reads` off) and the dim-1536 dual-write both need those columns, so the install is non-functional. Reported by a self-hoster (@alex) whose recovery was a manual `ALTER TABLE ... ADD COLUMN`.

## Fix
- **`20260721000300`** — split the single `OR` into per-source existence-guarded `UPDATE`s (`information_schema` / `to_regclass`). A missing legacy column or side table simply contributes no rows — correct (no corpus ⇒ nothing to pin) and never crashes. Identical result where the columns exist (prod/CI/dev already ran it, so no re-run there; editing it only affects fresh installs).
- **`20260724180000`** (new) — idempotently `ADD` the legacy columns when pgvector is present and they're missing, so once an operator enables pgvector the columns the app needs exist. No-op where they already exist; no-op where pgvector is still absent.

## Tests
`fresh_db_embedding_guard_test.exs` (async:false, drops the column inside the sandbox txn): the pin guard is a no-op with the column absent (no `42703`), the heal re-adds it, and no regression when present. `mix precommit` green (6342 tests).

## Scope note
Legacy HNSW indexes on those columns are also guard-skipped on such installs; without them the legacy `<->` read is an exact seq scan (correct, fine for a fresh small corpus). Re-adding those indexes is a performance-only follow-up.