### PR TITLE
feat(onboarding): make fresh self-hosted browser signup work end to end (#494, #496, #500)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -46,6 +46,18 @@ if System.get_env("RATE_LIMITER") == "postgres" do
   config :loopctl, :rate_limiter, Loopctl.RateLimiter.Postgres
 end
 
+# #496: self-hosted (non-Fly) secret storage. The default `Loopctl.Secrets.FlyAdapter`
+# reads secrets from process env (Fly injects them) and writes via the Fly GraphQL API —
+# both unavailable off Fly, so signup's audit-key storage returns `:fly_not_configured`
+# and tenant creation is impossible. `SECRETS_ADAPTER=local_file` selects a 0600 JSON
+# file-backed adapter (read the threat model in `Loopctl.Secrets.LocalFileAdapter` before
+# using). The file defaults to a persistent-volume path; override with `SECRETS_FILE`.
+# Anything other than "local_file" (incl. unset) leaves the Fly default in place.
+if System.get_env("SECRETS_ADAPTER") == "local_file" do
+  config :loopctl, :secrets_adapter, Loopctl.Secrets.LocalFileAdapter
+  config :loopctl, :secrets_file, System.get_env("SECRETS_FILE") || "/data/loopctl/secrets.json"
+end
+
 # sec-4: OPT-IN override of the node-local Hammer poolboy pool that fronts EVERY
 # `check_rate/3`. The base sizing lives in config/config.exs (20 / 10, up from
 # Hammer's 4 / 0 defaults) to keep the fail-CLOSED `AuthPathThrottle` from

--- a/config/test.exs
+++ b/config/test.exs
@@ -527,6 +527,17 @@ config :loopctl, :webauthn,
 # DI: Use mock secrets adapter in tests
 config :loopctl, :secrets_adapter, Loopctl.MockSecrets
 
+# #496: file path for the SELF-HOST `Loopctl.Secrets.LocalFileAdapter`. Unused by the
+# suite at large (`:secrets_adapter` is the mock above); only its own async:false unit
+# test exercises the adapter, and reads this path. Partition-suffixed so parallel CI
+# partitions never share the file.
+config :loopctl,
+       :secrets_file,
+       Path.join(
+         System.tmp_dir!(),
+         "loopctl_local_secrets_test#{System.get_env("MIX_TEST_PARTITION")}.json"
+       )
+
 # DI (US-27.3): suggested-links executor. The default stub in
 # DataCase.stub_all_defaults/0 delegates to the real Loopctl.Knowledge, so
 # existing tests exercise the genuine query; the DB-error-surfacing test

--- a/lib/loopctl/secrets/local_file_adapter.ex
+++ b/lib/loopctl/secrets/local_file_adapter.ex
@@ -1,0 +1,140 @@
+defmodule Loopctl.Secrets.LocalFileAdapter do
+  @moduledoc """
+  File-backed `Loopctl.Secrets.Behaviour` for SELF-HOSTED, single-machine installs
+  that are not on Fly (#496). Select it in `config/runtime.exs` with
+  `SECRETS_ADAPTER=local_file`; the file path defaults to `SECRETS_FILE` (see
+  `runtime.exs`).
+
+  Secrets (currently only the per-tenant audit signing private keys) are stored as a
+  single JSON object `{name => base64(value)}` on disk. Writes are ATOMIC — a sibling
+  temp file is written then `rename/2`d over the target (a same-directory rename is
+  atomic on POSIX) — and the file is created `0600` (owner read/write only), so a
+  crash mid-write never leaves a torn file and other local users cannot read it.
+
+  ## Threat model — read before using in production
+
+  This is for a TRUSTED, SINGLE-MACHINE deployment (one operator, one host). Secret
+  VALUES are base64 (encoding, NOT encryption): anyone who can read the file as the
+  app user, or who has root, reads the raw keys. That is the SAME exposure as Fly's
+  own model, where secrets are injected as plaintext process env vars readable by the
+  app user — this adapter is not weaker than the production default, but it is also
+  not a KMS. Do NOT use it on shared/multi-tenant hosts, and keep the file on an
+  encrypted volume + backed up (losing it loses every tenant's audit key). For
+  hardened deployments, back this behaviour with a real KMS/HSM adapter instead.
+
+  ## Concurrency
+
+  `set/2` and `delete/1` are read-modify-write. Two writes to DIFFERENT names racing
+  can lose one update (last atomic rename wins). Acceptable for the single-operator
+  model — the only writer today is tenant signup, which is rare and operator-driven —
+  and documented rather than papered over. A KMS adapter or a serializing GenServer
+  is the path if concurrent secret writes ever become common.
+  """
+
+  @behaviour Loopctl.Secrets.Behaviour
+
+  require Logger
+
+  @impl true
+  @spec get(String.t()) :: {:ok, binary()} | {:error, term()}
+  def get(name) when is_binary(name) do
+    with {:ok, map} <- read_all(),
+         {:ok, b64} <- fetch(map, name) do
+      decode(b64, name)
+    end
+  end
+
+  @impl true
+  @spec set(String.t(), binary()) :: :ok | {:error, term()}
+  def set(name, value) when is_binary(name) and is_binary(value) do
+    with {:ok, map} <- read_all() do
+      map
+      |> Map.put(name, Base.encode64(value))
+      |> write_all()
+    end
+  end
+
+  @impl true
+  @spec delete(String.t()) :: :ok | {:error, term()}
+  def delete(name) when is_binary(name) do
+    with {:ok, map} <- read_all() do
+      map
+      |> Map.delete(name)
+      |> write_all()
+    end
+  end
+
+  # --- internals ---
+
+  defp fetch(map, name) do
+    case Map.fetch(map, name) do
+      {:ok, b64} -> {:ok, b64}
+      :error -> {:error, :not_found}
+    end
+  end
+
+  defp decode(b64, name) do
+    case Base.decode64(b64) do
+      {:ok, value} ->
+        {:ok, value}
+
+      :error ->
+        Logger.error("Secrets.LocalFileAdapter: secret #{inspect(name)} is not valid base64")
+        {:error, :corrupt_secret}
+    end
+  end
+
+  # A MISSING file is an empty store, not an error — first write creates it.
+  defp read_all do
+    path = path()
+
+    case File.read(path) do
+      {:ok, ""} -> {:ok, %{}}
+      {:ok, contents} -> decode_json(contents, path)
+      {:error, :enoent} -> {:ok, %{}}
+      {:error, reason} -> {:error, {:secrets_file_unreadable, reason}}
+    end
+  end
+
+  defp decode_json(contents, path) do
+    case Jason.decode(contents) do
+      {:ok, map} when is_map(map) ->
+        {:ok, map}
+
+      _ ->
+        Logger.error("Secrets.LocalFileAdapter: #{path} is not a JSON object; refusing to use it")
+        {:error, :corrupt_secrets_file}
+    end
+  end
+
+  defp write_all(map) do
+    path = path()
+    tmp = path <> ".tmp.#{System.unique_integer([:positive])}"
+
+    with :ok <- ensure_dir(path),
+         :ok <- File.write(tmp, Jason.encode!(map)),
+         :ok <- File.chmod(tmp, 0o600),
+         :ok <- File.rename(tmp, path) do
+      :ok
+    else
+      {:error, reason} ->
+        _ = File.rm(tmp)
+        Logger.error("Secrets.LocalFileAdapter: write to #{path} failed: #{inspect(reason)}")
+        {:error, {:secrets_file_write_failed, reason}}
+    end
+  end
+
+  defp ensure_dir(path) do
+    dir = Path.dirname(path)
+
+    case File.mkdir_p(dir) do
+      :ok -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp path do
+    Application.get_env(:loopctl, :secrets_file) ||
+      raise "Secrets.LocalFileAdapter is selected but :secrets_file (SECRETS_FILE) is not configured"
+  end
+end

--- a/lib/loopctl/secrets/local_file_adapter.ex
+++ b/lib/loopctl/secrets/local_file_adapter.ex
@@ -24,6 +24,11 @@ defmodule Loopctl.Secrets.LocalFileAdapter do
   filesystems, revert to the pre-rename state. Keep the file on a journaled filesystem
   and backed up (see the threat model below).
 
+  A hard crash BETWEEN creating the temp file and the rename leaks a `<path>.tmp.<n>`
+  sibling (the same-invocation error path never runs on a SIGKILL/power loss). To bound
+  that accumulation, each write first sweeps any orphaned `.tmp.` siblings — safe
+  because it runs under the write lock, so no concurrent write owns a temp file.
+
   ## Threat model — read before using in production
 
   This is for a TRUSTED, SINGLE-MACHINE deployment (one operator, one host). Secret
@@ -103,7 +108,12 @@ defmodule Loopctl.Secrets.LocalFileAdapter do
     end
   end
 
-  defp decode(b64, name) do
+  # A hand-corrupted secrets.json may hold a non-string value (number/array/object)
+  # under a secret name — `decode_json/2` only validates the TOP level is a map. Guard
+  # on `is_binary/1` so such a value returns `{:error, :corrupt_secret}` (like invalid
+  # base64) instead of crashing `Base.decode64/1` with a FunctionClauseError on the
+  # audit-key read path.
+  defp decode(b64, name) when is_binary(b64) do
     case Base.decode64(b64) do
       {:ok, value} ->
         {:ok, value}
@@ -112,6 +122,11 @@ defmodule Loopctl.Secrets.LocalFileAdapter do
         Logger.error("Secrets.LocalFileAdapter: secret #{inspect(name)} is not valid base64")
         {:error, :corrupt_secret}
     end
+  end
+
+  defp decode(_b64, name) do
+    Logger.error("Secrets.LocalFileAdapter: secret #{inspect(name)} is not a string value")
+    {:error, :corrupt_secret}
   end
 
   # A MISSING file is an empty store, not an error — first write creates it.
@@ -141,6 +156,13 @@ defmodule Loopctl.Secrets.LocalFileAdapter do
     path = path()
     tmp = path <> ".tmp.#{System.unique_integer([:positive])}"
 
+    # Bound the temp-file leak: a hard crash (power loss / SIGKILL) between
+    # `File.touch/1` and `File.rename/2` leaves a `.tmp.N` sibling that the
+    # same-invocation error path never reaches. This runs under `with_write_lock/1`,
+    # so no other write is in flight and every existing sibling temp is a genuine
+    # orphan — best-effort remove them before creating our own.
+    sweep_stale_temps(path)
+
     with :ok <- ensure_dir(path),
          :ok <- write_private_tmp(tmp, Jason.encode!(map)),
          :ok <- File.rename(tmp, path) do
@@ -150,6 +172,25 @@ defmodule Loopctl.Secrets.LocalFileAdapter do
         _ = File.rm(tmp)
         Logger.error("Secrets.LocalFileAdapter: write to #{path} failed: #{inspect(reason)}")
         {:error, {:secrets_file_write_failed, reason}}
+    end
+  end
+
+  # Best-effort cleanup of orphaned `<path>.tmp.<n>` siblings left by a hard crash
+  # mid-write. Safe under the write lock (no concurrent write owns a temp file). Any
+  # failure to list/remove is ignored — this only bounds an accumulation, it is never
+  # on the correctness path.
+  defp sweep_stale_temps(path) do
+    dir = Path.dirname(path)
+    prefix = Path.basename(path) <> ".tmp."
+
+    case File.ls(dir) do
+      {:ok, entries} ->
+        entries
+        |> Enum.filter(&String.starts_with?(&1, prefix))
+        |> Enum.each(fn name -> _ = File.rm(Path.join(dir, name)) end)
+
+      {:error, _reason} ->
+        :ok
     end
   end
 

--- a/lib/loopctl/secrets/local_file_adapter.ex
+++ b/lib/loopctl/secrets/local_file_adapter.ex
@@ -6,10 +6,23 @@ defmodule Loopctl.Secrets.LocalFileAdapter do
   `runtime.exs`).
 
   Secrets (currently only the per-tenant audit signing private keys) are stored as a
-  single JSON object `{name => base64(value)}` on disk. Writes are ATOMIC — a sibling
-  temp file is written then `rename/2`d over the target (a same-directory rename is
-  atomic on POSIX) — and the file is created `0600` (owner read/write only), so a
-  crash mid-write never leaves a torn file and other local users cannot read it.
+  single JSON object `{name => base64(value)}` on disk.
+
+  ## Atomicity, permissions, and durability
+
+  Writes are ATOMIC — a sibling temp file is written then `rename/2`d over the target
+  (a same-directory rename is atomic on POSIX), so a crash mid-write never leaves a
+  torn file. The temp file is created and `chmod 0600` (owner read/write only) BEFORE
+  any secret bytes are written into it, and the containing directory is `chmod 0700`,
+  so at no point is a file holding secret material group/other-readable.
+
+  For DURABILITY the temp file is `fsync`'d before the rename, so a committed secret's
+  bytes reach stable storage before it becomes the live file. Note that fsync of the
+  parent DIRECTORY (which is what guarantees the rename itself survives a power loss)
+  is NOT reachable from the BEAM — `:file.open/2` on a directory returns `:eisdir` —
+  so on a hard crash immediately after a rename the directory entry may, on some
+  filesystems, revert to the pre-rename state. Keep the file on a journaled filesystem
+  and backed up (see the threat model below).
 
   ## Threat model — read before using in production
 
@@ -24,11 +37,15 @@ defmodule Loopctl.Secrets.LocalFileAdapter do
 
   ## Concurrency
 
-  `set/2` and `delete/1` are read-modify-write. Two writes to DIFFERENT names racing
-  can lose one update (last atomic rename wins). Acceptable for the single-operator
-  model — the only writer today is tenant signup, which is rare and operator-driven —
-  and documented rather than papered over. A KMS adapter or a serializing GenServer
-  is the path if concurrent secret writes ever become common.
+  `set/2` and `delete/1` are read-modify-write over the whole file. A lost update here
+  is NOT cosmetic: the losing tenant is already COMMITTED with its public audit key,
+  so silently dropping its private key from disk permanently breaks that tenant's
+  audit-chain signing/verification (a custody invariant). Both mutating paths are
+  therefore serialized through a cluster-/node-wide lock (`:global.trans/2` keyed on
+  the file path) so two concurrent signups apply their writes one-after-another
+  instead of last-rename-wins. `get/1` is not locked — the atomic rename means a read
+  always sees a complete old-or-new file. A KMS/HSM adapter remains the path for
+  hardened deployments.
   """
 
   @behaviour Loopctl.Secrets.Behaviour
@@ -47,24 +64,37 @@ defmodule Loopctl.Secrets.LocalFileAdapter do
   @impl true
   @spec set(String.t(), binary()) :: :ok | {:error, term()}
   def set(name, value) when is_binary(name) and is_binary(value) do
-    with {:ok, map} <- read_all() do
-      map
-      |> Map.put(name, Base.encode64(value))
-      |> write_all()
-    end
+    with_write_lock(fn ->
+      with {:ok, map} <- read_all() do
+        map
+        |> Map.put(name, Base.encode64(value))
+        |> write_all()
+      end
+    end)
   end
 
   @impl true
   @spec delete(String.t()) :: :ok | {:error, term()}
   def delete(name) when is_binary(name) do
-    with {:ok, map} <- read_all() do
-      map
-      |> Map.delete(name)
-      |> write_all()
-    end
+    with_write_lock(fn ->
+      with {:ok, map} <- read_all() do
+        map
+        |> Map.delete(name)
+        |> write_all()
+      end
+    end)
   end
 
   # --- internals ---
+
+  # Serialize the read-modify-write so two concurrent signups cannot both read the
+  # pre-write map and last-rename-wins-drop one tenant's audit key. `:global.trans/2`
+  # defaults to infinite retries, so it blocks until the lock is acquired and then
+  # returns the function's own result. The lock id is keyed on the target path so
+  # distinct files (should there ever be more than one) don't contend.
+  defp with_write_lock(fun) do
+    :global.trans({{__MODULE__, path()}, self()}, fun)
+  end
 
   defp fetch(map, name) do
     case Map.fetch(map, name) do
@@ -112,8 +142,7 @@ defmodule Loopctl.Secrets.LocalFileAdapter do
     tmp = path <> ".tmp.#{System.unique_integer([:positive])}"
 
     with :ok <- ensure_dir(path),
-         :ok <- File.write(tmp, Jason.encode!(map)),
-         :ok <- File.chmod(tmp, 0o600),
+         :ok <- write_private_tmp(tmp, Jason.encode!(map)),
          :ok <- File.rename(tmp, path) do
       :ok
     else
@@ -124,12 +153,33 @@ defmodule Loopctl.Secrets.LocalFileAdapter do
     end
   end
 
+  # Create the temp file and lock it down to 0600 BEFORE writing any secret bytes, so
+  # the plaintext-adjacent base64 is never present in a group/other-readable file (the
+  # old order — File.write then chmod — left a readable window). Then fsync the bytes
+  # to stable storage before the caller renames it into place.
+  defp write_private_tmp(tmp, content) do
+    with :ok <- File.touch(tmp),
+         :ok <- File.chmod(tmp, 0o600),
+         {:ok, io} <- File.open(tmp, [:write, :binary, :raw]) do
+      try do
+        with :ok <- IO.binwrite(io, content) do
+          :file.sync(io)
+        end
+      after
+        File.close(io)
+      end
+    end
+  end
+
   defp ensure_dir(path) do
     dir = Path.dirname(path)
 
-    case File.mkdir_p(dir) do
-      :ok -> :ok
-      {:error, reason} -> {:error, reason}
+    with :ok <- File.mkdir_p(dir) do
+      # Owner-only on the secrets directory so a newly created temp file can never be
+      # listed/traversed by other local users even for the instant before its own
+      # 0600 is applied. Best-effort on a pre-existing operator-owned dir.
+      _ = File.chmod(dir, 0o700)
+      :ok
     end
   end
 

--- a/lib/loopctl/tenants.ex
+++ b/lib/loopctl/tenants.ex
@@ -96,6 +96,10 @@ defmodule Loopctl.Tenants do
           | {:error, {:audit_key_storage_failed, term()}}
           | {:error, :root_key_mint_failed}
           | {:error, Ecto.Changeset.t()}
+          # do_signup/2's generic branch (`{:error, _step, reason, _changes} ->
+          # {:error, reason}`) can surface any bare term from an unexpected Multi
+          # step failure. Declared so callers must handle it (LiveView catch-all).
+          | {:error, term()}
   def signup(attrs) when is_map(attrs) do
     authenticators = Map.get(attrs, :authenticators) || Map.get(attrs, "authenticators") || []
 
@@ -177,7 +181,11 @@ defmodule Loopctl.Tenants do
       # the LiveView surfaces a "signup failed internally, no tenant created" banner
       # instead of rendering the ApiKey changeset as bogus tenant-field validation
       # errors ("Please correct the highlighted fields" pointing at nothing).
-      {:error, :root_api_key, _reason, _changes} ->
+      # Log the discarded reason (no secret material is present in a root-key
+      # changeset) so an operator can diagnose the underlying DB/constraint cause —
+      # the collapsed atom alone is undebuggable from the logs.
+      {:error, :root_api_key, reason, _changes} ->
+        Logger.error("Tenants.signup: root :user API key mint failed: #{inspect(reason)}")
         {:error, :root_key_mint_failed}
 
       {:error, _step, %Ecto.Changeset{} = changeset, _changes} ->
@@ -228,13 +236,16 @@ defmodule Loopctl.Tenants do
   - `{:ok, %{tenant: %Tenant{}, raw_key: String.t()}}` — `raw_key` is
     returned exactly once and is never persisted in plaintext.
   - `{:error, :slug_taken} | {:error, :email_taken}`
+  - `{:error, :root_key_mint_failed}` — the root `:user` API key could not be
+    minted (an internal DB failure, not fixable input); the whole signup rolled back
   - `{:error, %Ecto.Changeset{}}` — validation failure
-  - `{:error, term()}` — keypair storage or root-key-minting failure
+  - `{:error, term()}` — keypair storage failure
   """
   @spec self_signup(map()) ::
           {:ok, %{tenant: Tenant.t(), raw_key: String.t()}}
           | {:error, :slug_taken}
           | {:error, :email_taken}
+          | {:error, :root_key_mint_failed}
           | {:error, Ecto.Changeset.t()}
           | {:error, term()}
   def self_signup(attrs) when is_map(attrs) do
@@ -277,6 +288,14 @@ defmodule Loopctl.Tenants do
       {:error, :tenant, %Ecto.Changeset{} = changeset, _changes} ->
         signup_changeset_error(changeset)
 
+      # Mirror do_signup/2: a root-key mint failure is an INTERNAL DB failure, not
+      # fixable input. Collapse it to a distinct atom (logged first) so the API
+      # SignupController renders a 500 "internal failure" instead of the raw ApiKey
+      # changeset as bogus 422 tenant-field validation errors.
+      {:error, :root_api_key, reason, _changes} ->
+        Logger.error("Tenants.self_signup: root :user API key mint failed: #{inspect(reason)}")
+        {:error, :root_key_mint_failed}
+
       {:error, _step, %Ecto.Changeset{} = changeset, _changes} ->
         {:error, changeset}
 
@@ -314,6 +333,18 @@ defmodule Loopctl.Tenants do
   # `:store_secret` runs AFTER `:tenant` (and, for signup, `:authenticators`)
   # so a duplicate-slug / validation failure never reaches the external write —
   # the compensation `write_step` guard keys on this step name.
+  #
+  # RESOURCE COUPLING (accepted at current scale): `:store_secret` runs the
+  # `Secrets.set/2` write INSIDE the enclosing `AdminRepo.transaction/1`, so it
+  # holds one of AdminRepo's scarce connections (3-conn pool,
+  # config/runtime.exs) for the duration of the secret write. On the self-host
+  # `LocalFileAdapter`, that write also does blocking file I/O + fsync and
+  # acquires a node-wide `:global.trans/2` lock — so under concurrent signups a
+  # slow disk or global-lock contention pins an admin connection. This is
+  # acceptable because signups are rare (single-operator self-host) and the Fly
+  # adapter already does an in-transaction external call. If signup concurrency
+  # ever grows, move the secret write OUT of the DB transaction (write-then-verify
+  # with compensation) so disk/lock stalls cannot back-pressure the admin pool.
   defp append_keypair_and_genesis(
          multi,
          secret_name,

--- a/lib/loopctl/tenants.ex
+++ b/lib/loopctl/tenants.ex
@@ -70,18 +70,28 @@ defmodule Loopctl.Tenants do
 
   ## Returns
 
-  - `{:ok, %{tenant: %Tenant{}, root_authenticators: [%RootAuthenticator{}]}}`
+  - `{:ok, %{tenant: %Tenant{}, root_authenticators: [%RootAuthenticator{}], raw_key: String.t()}}`
+    — `raw_key` is the tenant's root `:user` API key, returned ONCE and never persisted
+    in plaintext (#500).
   - `{:error, :no_authenticators}` — empty list
   - `{:error, :too_many_authenticators}` — more than 5
   - `{:error, :slug_taken}` | `{:error, :email_taken}`
+  - `{:error, {:audit_key_storage_failed, term()}}` — the secret store rejected the audit
+    key (e.g. off Fly with no `SECRETS_ADAPTER`); the whole signup rolled back (#496)
   - `{:error, %Ecto.Changeset{}}` — validation failure
   """
   @spec signup(map()) ::
-          {:ok, %{tenant: Tenant.t(), root_authenticators: [RootAuthenticator.t()]}}
+          {:ok,
+           %{
+             tenant: Tenant.t(),
+             root_authenticators: [RootAuthenticator.t()],
+             raw_key: String.t()
+           }}
           | {:error, :no_authenticators}
           | {:error, :too_many_authenticators}
           | {:error, :slug_taken}
           | {:error, :email_taken}
+          | {:error, {:audit_key_storage_failed, term()}}
           | {:error, Ecto.Changeset.t()}
   def signup(attrs) when is_map(attrs) do
     authenticators = Map.get(attrs, :authenticators) || Map.get(attrs, "authenticators") || []
@@ -123,6 +133,20 @@ defmodule Loopctl.Tenants do
         "human:webauthn",
         &signup_new_state/2
       )
+      # #500: mint the tenant's root `:user` API key in the SAME transaction, mirroring
+      # `self_signup/2`. Without it a browser-onboarded tenant has an anchored tenant but
+      # an empty `api_keys` — no authenticated path forward (the onboarding page tells you
+      # to call `set_llm_config`, but you have no key to authenticate that call). The raw
+      # key is returned ONCE (never persisted in plaintext) for the LiveView to surface;
+      # agent/orchestrator keys are minted later, after registering an agent identity.
+      |> Multi.run(:root_api_key, fn _repo, %{activate: tenant} ->
+        Auth.generate_api_key(%{
+          tenant_id: tenant.id,
+          name: "root",
+          role: :user,
+          agent_id: nil
+        })
+      end)
 
     result =
       with_secret_compensation({:delete, secret_name}, :store_secret, fn ->
@@ -130,8 +154,9 @@ defmodule Loopctl.Tenants do
       end)
 
     case result do
-      {:ok, %{activate: tenant, authenticators: authenticators}} ->
-        {:ok, %{tenant: tenant, root_authenticators: authenticators}}
+      {:ok,
+       %{activate: tenant, authenticators: authenticators, root_api_key: {raw_key, _api_key}}} ->
+        {:ok, %{tenant: tenant, root_authenticators: authenticators, raw_key: raw_key}}
 
       {:error, :tenant, %Ecto.Changeset{} = changeset, _changes} ->
         signup_changeset_error(changeset)

--- a/lib/loopctl/tenants.ex
+++ b/lib/loopctl/tenants.ex
@@ -78,6 +78,8 @@ defmodule Loopctl.Tenants do
   - `{:error, :slug_taken}` | `{:error, :email_taken}`
   - `{:error, {:audit_key_storage_failed, term()}}` — the secret store rejected the audit
     key (e.g. off Fly with no `SECRETS_ADAPTER`); the whole signup rolled back (#496)
+  - `{:error, :root_key_mint_failed}` — the root `:user` API key could not be minted
+    (an internal DB failure, not fixable input); the whole signup rolled back
   - `{:error, %Ecto.Changeset{}}` — validation failure
   """
   @spec signup(map()) ::
@@ -92,6 +94,7 @@ defmodule Loopctl.Tenants do
           | {:error, :slug_taken}
           | {:error, :email_taken}
           | {:error, {:audit_key_storage_failed, term()}}
+          | {:error, :root_key_mint_failed}
           | {:error, Ecto.Changeset.t()}
   def signup(attrs) when is_map(attrs) do
     authenticators = Map.get(attrs, :authenticators) || Map.get(attrs, "authenticators") || []
@@ -125,6 +128,25 @@ defmodule Loopctl.Tenants do
       Multi.new()
       |> Multi.insert(:tenant, Tenant.signup_changeset(tenant_attrs))
       |> insert_authenticators(authenticators)
+      # #500: mint the tenant's root `:user` API key in the SAME transaction, mirroring
+      # `self_signup/2`. Without it a browser-onboarded tenant has an anchored tenant but
+      # an empty `api_keys` — no authenticated path forward (the onboarding page tells you
+      # to call `set_llm_config`, but you have no key to authenticate that call). The raw
+      # key is returned ONCE (never persisted in plaintext) for the LiveView to surface;
+      # agent/orchestrator keys are minted later, after registering an agent identity.
+      #
+      # Ordered BEFORE append_keypair_and_genesis (which does the external
+      # `:store_secret` write) so this pure DB insert's validation runs while a failure
+      # can still roll back without touching the secret store — the module's documented
+      # "all DB validation precedes the irreversible external write" invariant.
+      |> Multi.run(:root_api_key, fn _repo, %{tenant: tenant} ->
+        Auth.generate_api_key(%{
+          tenant_id: tenant.id,
+          name: "root",
+          role: :user,
+          agent_id: nil
+        })
+      end)
       |> append_keypair_and_genesis(
         secret_name,
         priv,
@@ -133,20 +155,6 @@ defmodule Loopctl.Tenants do
         "human:webauthn",
         &signup_new_state/2
       )
-      # #500: mint the tenant's root `:user` API key in the SAME transaction, mirroring
-      # `self_signup/2`. Without it a browser-onboarded tenant has an anchored tenant but
-      # an empty `api_keys` — no authenticated path forward (the onboarding page tells you
-      # to call `set_llm_config`, but you have no key to authenticate that call). The raw
-      # key is returned ONCE (never persisted in plaintext) for the LiveView to surface;
-      # agent/orchestrator keys are minted later, after registering an agent identity.
-      |> Multi.run(:root_api_key, fn _repo, %{activate: tenant} ->
-        Auth.generate_api_key(%{
-          tenant_id: tenant.id,
-          name: "root",
-          role: :user,
-          agent_id: nil
-        })
-      end)
 
     result =
       with_secret_compensation({:delete, secret_name}, :store_secret, fn ->
@@ -163,6 +171,14 @@ defmodule Loopctl.Tenants do
 
       {:error, {:authenticator, _index}, %Ecto.Changeset{} = changeset, _changes} ->
         {:error, changeset}
+
+      # A root-key mint failure is an INTERNAL failure (a DB constraint on the
+      # api_keys insert), not operator input the form can fix. Tag it distinctly so
+      # the LiveView surfaces a "signup failed internally, no tenant created" banner
+      # instead of rendering the ApiKey changeset as bogus tenant-field validation
+      # errors ("Please correct the highlighted fields" pointing at nothing).
+      {:error, :root_api_key, _reason, _changes} ->
+        {:error, :root_key_mint_failed}
 
       {:error, _step, %Ecto.Changeset{} = changeset, _changes} ->
         {:error, changeset}
@@ -229,6 +245,17 @@ defmodule Loopctl.Tenants do
     multi =
       Multi.new()
       |> Multi.insert(:tenant, Tenant.self_signup_changeset(attrs))
+      # Ordered BEFORE append_keypair_and_genesis so this pure DB insert's validation
+      # runs while a failure can still roll back without touching the external secret
+      # store (matches do_signup/2 and the module's documented ordering invariant).
+      |> Multi.run(:root_api_key, fn _repo, %{tenant: tenant} ->
+        Auth.generate_api_key(%{
+          tenant_id: tenant.id,
+          name: "root",
+          role: :user,
+          agent_id: nil
+        })
+      end)
       |> append_keypair_and_genesis(
         secret_name,
         priv,
@@ -237,14 +264,6 @@ defmodule Loopctl.Tenants do
         "agent:self-signup",
         &self_signup_new_state/2
       )
-      |> Multi.run(:root_api_key, fn _repo, %{activate: tenant} ->
-        Auth.generate_api_key(%{
-          tenant_id: tenant.id,
-          name: "root",
-          role: :user,
-          agent_id: nil
-        })
-      end)
 
     result =
       with_secret_compensation({:delete, secret_name}, :store_secret, fn ->

--- a/lib/loopctl_web/live/signup_live.ex
+++ b/lib/loopctl_web/live/signup_live.ex
@@ -124,6 +124,9 @@ defmodule LoopctlWeb.SignupLive do
      |> assign(:learn_more_url, @learn_more_url)
      |> assign(:friendly_name_draft, "")
      |> assign(:rate_key, signup_rate_key(session, socket))
+     # #500: nil until signup completes; then holds %{tenant, raw_key, onboarding_path}
+     # and the render switches from the form to the one-time "save your key" panel.
+     |> assign(:completed, nil)
      |> assign(:error, nil)}
   end
 
@@ -479,13 +482,26 @@ defmodule LoopctlWeb.SignupLive do
     attrs = Map.put(params, "authenticators", auths)
 
     case Tenants.signup(attrs) do
-      {:ok, %{tenant: tenant}} ->
+      {:ok, %{tenant: tenant, raw_key: raw_key}} ->
         token = Phoenix.Token.sign(LoopctlWeb.Endpoint, "onboarding", tenant.id)
 
+        # #500: DON'T navigate away yet — the root API key (`raw_key`) is shown ONCE and
+        # is never persisted in plaintext. Hold it in this connected LiveView's memory
+        # (never a URL, never the session) and render the "save your key" panel; the
+        # operator copies it, then follows the onboarding link. Navigating immediately
+        # would drop the only copy of the key on the floor.
         {:noreply,
-         socket
-         |> put_flash(:info, "Tenant signup complete — welcome to loopctl")
-         |> push_navigate(to: ~p"/tenants/#{tenant.id}/onboarding?token=#{token}")}
+         assign(socket, :completed, %{
+           tenant: tenant,
+           raw_key: raw_key,
+           onboarding_path: ~p"/tenants/#{tenant.id}/onboarding?token=#{token}"
+         })}
+
+      # #496: audit-key storage failed (e.g. off Fly with no SECRETS_ADAPTER). The signup
+      # transaction rolled back, so no tenant exists — surface an actionable banner instead
+      # of crashing the LiveView with a CaseClauseError (the old silent "button does nothing").
+      {:error, {:audit_key_storage_failed, reason}} ->
+        {:noreply, assign(socket, :error, audit_key_storage_error_message(reason))}
 
       {:error, :slug_taken} ->
         {:noreply,
@@ -522,6 +538,20 @@ defmodule LoopctlWeb.SignupLive do
          |> assign(:form, to_form(changeset, as: :tenant))
          |> assign(:error, "Please correct the highlighted fields")}
     end
+  end
+
+  # #496: turn an audit-key storage failure into an actionable operator message. The most
+  # common cause on a fresh self-hosted (non-Fly) install is the default FlyAdapter having
+  # no Fly API access; the fix is the file-backed adapter.
+  defp audit_key_storage_error_message(:fly_not_configured) do
+    "Could not store this tenant's audit signing key: the secret store is not configured. " <>
+      "On a self-hosted (non-Fly) install, set SECRETS_ADAPTER=local_file (and optionally " <>
+      "SECRETS_FILE) and restart — see docs/self-hosting.md. No tenant was created; retry after configuring it."
+  end
+
+  defp audit_key_storage_error_message(_reason) do
+    "Could not store this tenant's audit signing key, so signup was rolled back and no tenant " <>
+      "was created. Check the secret store configuration and try again."
   end
 
   defp new_challenge do
@@ -622,145 +652,193 @@ defmodule LoopctlWeb.SignupLive do
         </div>
       </header>
 
-      <.form
-        for={@form}
-        id="signup-form"
-        phx-change="validate"
-        phx-submit="signup"
-        class="space-y-8"
-      >
-        <div class="space-y-6 rounded-md border border-slate-800 bg-slate-900/60 p-6">
-          <h2 class="font-display text-sm uppercase tracking-wide text-slate-400">
-            Tenant metadata
-          </h2>
-
-          <.input
-            field={@form[:name]}
-            type="text"
-            label="Display name"
-            placeholder="Acme Robotics"
-            required
-            id="tenant-name-input"
-          />
-
-          <.input
-            field={@form[:slug]}
-            type="text"
-            label="Slug"
-            placeholder="acme-robotics"
-            required
-            id="tenant-slug-input"
-          />
-
-          <.input
-            field={@form[:email]}
-            type="email"
-            label="Contact email"
-            placeholder="admin@acme.example"
-            required
-            id="tenant-email-input"
-          />
-        </div>
-
-        <div class="space-y-4 rounded-md border border-slate-800 bg-slate-900/60 p-6">
-          <div class="flex items-start justify-between gap-4">
-            <div>
-              <h2 class="font-display text-sm uppercase tracking-wide text-slate-400">
-                Root authenticators
+      <%= if @completed do %>
+        <div id="signup-complete" class="space-y-6">
+          <div class="rounded-md border border-accent-500/40 bg-slate-900/60 p-6">
+            <div class="flex items-center gap-3">
+              <.icon name="hero-check-circle" class="h-6 w-6 text-accent-400" />
+              <h2 class="font-display text-lg font-semibold text-slate-100">
+                Tenant <span class="font-mono text-accent-300">{@completed.tenant.slug}</span> created
               </h2>
-              <p class="mt-1 text-xs text-slate-500">
-                Enroll at least one FIDO2 authenticator ({length(@authenticators)} of {@max_authenticators} used).
-                YubiKeys, Touch ID, Windows Hello, and other platform keys all work.
-              </p>
             </div>
-            <.icon name="hero-key" class="h-10 w-10 text-accent-400" />
+            <p class="mt-2 text-sm text-slate-400">
+              This is your root <span class="font-mono text-slate-300">user</span>-role API key. It
+              is shown <strong class="text-rose-300">once</strong> and is never stored in a form you
+              can recover — copy it now and keep it somewhere safe.
+            </p>
           </div>
 
-          <ul id="enrolled-authenticators" class="space-y-2">
-            <li
-              :for={{auth, index} <- Enum.with_index(@authenticators)}
-              id={"authenticator-#{index}"}
-              class="flex items-center justify-between rounded-md border border-accent-500/40 bg-slate-950 px-4 py-3 text-sm"
+          <div class="rounded-md border border-rose-500/40 bg-rose-950/20 p-6">
+            <label
+              for="root-api-key"
+              class="block font-mono text-[10px] uppercase tracking-wide text-slate-500"
             >
-              <div class="flex items-center gap-3">
-                <.icon name="hero-check-circle" class="h-5 w-5 text-accent-400" />
-                <span class="font-mono text-xs uppercase tracking-wide text-slate-300">
-                  {auth.friendly_name}
-                </span>
-                <span class="font-mono text-[10px] text-slate-600">
-                  {auth.attestation_result.attestation_format}
-                </span>
+              LOOPCTL_USER_KEY
+            </label>
+            <code
+              id="root-api-key"
+              class="mt-2 block w-full select-all break-all rounded-md border border-slate-800 bg-slate-950 px-3 py-3 font-mono text-sm text-accent-200"
+            >
+              {@completed.raw_key}
+            </code>
+            <p class="mt-3 text-xs text-slate-500">
+              Use it as your user-role key (e.g. <span class="font-mono">LOOPCTL_USER_KEY</span>
+              in <span class="font-mono">.mcp.json</span>). Provision your BYO LLM keys, then register
+              an agent to mint agent / orchestrator keys.
+            </p>
+          </div>
+
+          <div class="flex items-center justify-end">
+            <a
+              href={@completed.onboarding_path}
+              id="continue-to-onboarding"
+              class="inline-flex items-center justify-center gap-2 rounded-md border border-accent-500 bg-accent-600 px-6 py-2 font-mono text-sm uppercase tracking-wide text-slate-50 hover:bg-accent-500"
+            >
+              I saved my key — continue →
+            </a>
+          </div>
+        </div>
+      <% else %>
+        <.form
+          for={@form}
+          id="signup-form"
+          phx-change="validate"
+          phx-submit="signup"
+          class="space-y-8"
+        >
+          <div class="space-y-6 rounded-md border border-slate-800 bg-slate-900/60 p-6">
+            <h2 class="font-display text-sm uppercase tracking-wide text-slate-400">
+              Tenant metadata
+            </h2>
+
+            <.input
+              field={@form[:name]}
+              type="text"
+              label="Display name"
+              placeholder="Acme Robotics"
+              required
+              id="tenant-name-input"
+            />
+
+            <.input
+              field={@form[:slug]}
+              type="text"
+              label="Slug"
+              placeholder="acme-robotics"
+              required
+              id="tenant-slug-input"
+            />
+
+            <.input
+              field={@form[:email]}
+              type="email"
+              label="Contact email"
+              placeholder="admin@acme.example"
+              required
+              id="tenant-email-input"
+            />
+          </div>
+
+          <div class="space-y-4 rounded-md border border-slate-800 bg-slate-900/60 p-6">
+            <div class="flex items-start justify-between gap-4">
+              <div>
+                <h2 class="font-display text-sm uppercase tracking-wide text-slate-400">
+                  Root authenticators
+                </h2>
+                <p class="mt-1 text-xs text-slate-500">
+                  Enroll at least one FIDO2 authenticator ({length(@authenticators)} of {@max_authenticators} used).
+                  YubiKeys, Touch ID, Windows Hello, and other platform keys all work.
+                </p>
               </div>
-              <button
-                type="button"
-                phx-click="remove_authenticator"
-                phx-value-index={index}
-                class="rounded-md px-2 py-1 text-xs text-slate-500 hover:text-rose-300"
+              <.icon name="hero-key" class="h-10 w-10 text-accent-400" />
+            </div>
+
+            <ul id="enrolled-authenticators" class="space-y-2">
+              <li
+                :for={{auth, index} <- Enum.with_index(@authenticators)}
+                id={"authenticator-#{index}"}
+                class="flex items-center justify-between rounded-md border border-accent-500/40 bg-slate-950 px-4 py-3 text-sm"
               >
-                <.icon name="hero-x-mark" class="h-4 w-4" />
+                <div class="flex items-center gap-3">
+                  <.icon name="hero-check-circle" class="h-5 w-5 text-accent-400" />
+                  <span class="font-mono text-xs uppercase tracking-wide text-slate-300">
+                    {auth.friendly_name}
+                  </span>
+                  <span class="font-mono text-[10px] text-slate-600">
+                    {auth.attestation_result.attestation_format}
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  phx-click="remove_authenticator"
+                  phx-value-index={index}
+                  class="rounded-md px-2 py-1 text-xs text-slate-500 hover:text-rose-300"
+                >
+                  <.icon name="hero-x-mark" class="h-4 w-4" />
+                </button>
+              </li>
+            </ul>
+
+            <div
+              id="webauthn-hook"
+              phx-hook="WebAuthn"
+              phx-update="ignore"
+              data-challenge={@challenge_payload}
+              data-rp-id={Keyword.get(WebAuthn.rp_opts(), :rp_id, "loopctl.com")}
+              data-rp-name="loopctl"
+            >
+            </div>
+
+            <div class="flex flex-col gap-3 sm:flex-row" id="enrollment-controls">
+              <input
+                id="authenticator-friendly-name"
+                type="text"
+                name="friendly_name"
+                form="signup-form"
+                value={@friendly_name_draft}
+                placeholder="Primary YubiKey"
+                class="block flex-1 rounded-md border border-slate-800 bg-slate-900 px-3 py-2 font-mono text-sm text-slate-100 placeholder:text-slate-600 focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500"
+              />
+              <button
+                id="enroll-authenticator-btn"
+                type="button"
+                phx-click="request_attestation"
+                disabled={length(@authenticators) >= @max_authenticators}
+                class="inline-flex items-center justify-center gap-2 rounded-md border border-accent-500 bg-accent-600/20 px-4 py-2 font-mono text-xs uppercase tracking-wide text-accent-100 hover:bg-accent-600/40 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <.icon name="hero-key" class="h-4 w-4" /> Enroll authenticator
               </button>
-            </li>
-          </ul>
+            </div>
+          </div>
 
           <div
-            id="webauthn-hook"
-            phx-hook="WebAuthn"
-            phx-update="ignore"
-            data-challenge={@challenge_payload}
-            data-rp-id={Keyword.get(WebAuthn.rp_opts(), :rp_id, "loopctl.com")}
-            data-rp-name="loopctl"
+            :if={@error}
+            id="signup-error"
+            role="alert"
+            class="rounded-md border border-rose-500/40 bg-rose-950/30 px-4 py-3 text-sm text-rose-200"
           >
+            {@error}
           </div>
 
-          <div class="flex flex-col gap-3 sm:flex-row" id="enrollment-controls">
-            <input
-              id="authenticator-friendly-name"
-              type="text"
-              name="friendly_name"
-              form="signup-form"
-              value={@friendly_name_draft}
-              placeholder="Primary YubiKey"
-              class="block flex-1 rounded-md border border-slate-800 bg-slate-900 px-3 py-2 font-mono text-sm text-slate-100 placeholder:text-slate-600 focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500"
-            />
-            <button
-              id="enroll-authenticator-btn"
-              type="button"
-              phx-click="request_attestation"
-              disabled={length(@authenticators) >= @max_authenticators}
-              class="inline-flex items-center justify-center gap-2 rounded-md border border-accent-500 bg-accent-600/20 px-4 py-2 font-mono text-xs uppercase tracking-wide text-accent-100 hover:bg-accent-600/40 disabled:cursor-not-allowed disabled:opacity-50"
+          <div class="flex items-center justify-between gap-4">
+            <a
+              href={@learn_more_url}
+              class="font-mono text-xs uppercase tracking-wide text-slate-500 hover:text-accent-400"
+              id="signup-learn-more"
             >
-              <.icon name="hero-key" class="h-4 w-4" /> Enroll authenticator
+              learn more about the ceremony →
+            </a>
+            <button
+              id="signup-submit-btn"
+              type="submit"
+              class="inline-flex items-center justify-center gap-2 rounded-md border border-accent-500 bg-accent-600 px-6 py-2 font-mono text-sm uppercase tracking-wide text-slate-50 hover:bg-accent-500 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={@authenticators == []}
+            >
+              Complete signup
             </button>
           </div>
-        </div>
-
-        <div
-          :if={@error}
-          id="signup-error"
-          role="alert"
-          class="rounded-md border border-rose-500/40 bg-rose-950/30 px-4 py-3 text-sm text-rose-200"
-        >
-          {@error}
-        </div>
-
-        <div class="flex items-center justify-between gap-4">
-          <a
-            href={@learn_more_url}
-            class="font-mono text-xs uppercase tracking-wide text-slate-500 hover:text-accent-400"
-            id="signup-learn-more"
-          >
-            learn more about the ceremony →
-          </a>
-          <button
-            id="signup-submit-btn"
-            type="submit"
-            class="inline-flex items-center justify-center gap-2 rounded-md border border-accent-500 bg-accent-600 px-6 py-2 font-mono text-sm uppercase tracking-wide text-slate-50 hover:bg-accent-500 disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={@authenticators == []}
-          >
-            Complete signup
-          </button>
-        </div>
-      </.form>
+        </.form>
+      <% end %>
     </section>
     """
   end

--- a/lib/loopctl_web/live/signup_live.ex
+++ b/lib/loopctl_web/live/signup_live.ex
@@ -340,6 +340,16 @@ defmodule LoopctlWeb.SignupLive do
   # with/else could run, and an oversized index would crash Integer.parse.
   def handle_event("remove_authenticator", _params, socket), do: {:noreply, socket}
 
+  # Idempotency guard: once signup has succeeded (@completed is set) the form and
+  # submit button are hidden, but a replayed/stale "signup" websocket frame would
+  # still re-enter the full flow — burning rate-limit budget on a rollback-destined
+  # DB transaction + secret-store write. No-op instead.
+  @impl true
+  def handle_event("signup", _params, %{assigns: %{completed: completed}} = socket)
+      when not is_nil(completed) do
+    {:noreply, socket}
+  end
+
   @impl true
   def handle_event("signup", %{"tenant" => params}, socket) when is_map(params) do
     # `is_map(params)` guards a crafted non-map "tenant"; anything else falls to
@@ -497,60 +507,92 @@ defmodule LoopctlWeb.SignupLive do
            onboarding_path: ~p"/tenants/#{tenant.id}/onboarding?token=#{token}"
          })}
 
-      # #496: audit-key storage failed (e.g. off Fly with no SECRETS_ADAPTER). The signup
-      # transaction rolled back, so no tenant exists — surface an actionable banner instead
-      # of crashing the LiveView with a CaseClauseError (the old silent "button does nothing").
-      {:error, {:audit_key_storage_failed, reason}} ->
-        {:noreply, assign(socket, :error, audit_key_storage_error_message(reason))}
-
-      # Internal mint failure (a DB constraint on the root api_key), NOT operator
-      # input the form can fix. The signup transaction rolled back — no tenant exists —
-      # so surface a distinct "internal failure" banner rather than the misleading
-      # "correct the highlighted fields" form-validation message.
-      {:error, :root_key_mint_failed} ->
-        {:noreply,
-         assign(
-           socket,
-           :error,
-           "Signup failed internally while provisioning your root API key. " <>
-             "No tenant was created — please try again."
-         )}
-
-      {:error, :slug_taken} ->
-        {:noreply,
-         assign(
-           socket,
-           :form,
-           to_form(params, as: :tenant, errors: [slug: {"slug_taken", []}])
-         )
-         |> assign(:error, "That slug is already in use")}
-
-      {:error, :email_taken} ->
-        {:noreply,
-         assign(
-           socket,
-           :form,
-           to_form(params, as: :tenant, errors: [email: {"email_taken", []}])
-         )
-         |> assign(:error, "That email is already associated with a tenant")}
-
-      {:error, :no_authenticators} ->
-        {:noreply, assign(socket, :error, "Enroll at least one authenticator")}
-
-      {:error, :too_many_authenticators} ->
-        {:noreply,
-         assign(
-           socket,
-           :error,
-           "At most #{socket.assigns.max_authenticators} authenticators can be enrolled"
-         )}
-
-      {:error, %Ecto.Changeset{} = changeset} ->
-        {:noreply,
-         socket
-         |> assign(:form, to_form(changeset, as: :tenant))
-         |> assign(:error, "Please correct the highlighted fields")}
+      {:error, reason} ->
+        handle_signup_error(reason, params, socket)
     end
+  end
+
+  # #496: audit-key storage failed (e.g. off Fly with no SECRETS_ADAPTER). The signup
+  # transaction rolled back, so no tenant exists — surface an actionable banner instead
+  # of crashing the LiveView with a CaseClauseError (the old silent "button does nothing").
+  defp handle_signup_error({:audit_key_storage_failed, reason}, _params, socket) do
+    # Log the underlying store reason (no secret material — it's a store/adapter
+    # error term, e.g. :fly_not_configured or {:secrets_file_write_failed, :enospc})
+    # so an operator whose signups fail has something to diagnose from the logs.
+    Logger.error("SignupLive: audit-key storage failed: #{inspect(reason)}")
+    {:noreply, assign(socket, :error, audit_key_storage_error_message(reason))}
+  end
+
+  # Internal mint failure (a DB constraint on the root api_key), NOT operator
+  # input the form can fix. The signup transaction rolled back — no tenant exists —
+  # so surface a distinct "internal failure" banner rather than the misleading
+  # "correct the highlighted fields" form-validation message.
+  defp handle_signup_error(:root_key_mint_failed, _params, socket) do
+    {:noreply,
+     assign(
+       socket,
+       :error,
+       "Signup failed internally while provisioning your root API key. " <>
+         "No tenant was created — please try again."
+     )}
+  end
+
+  defp handle_signup_error(:slug_taken, params, socket) do
+    {:noreply,
+     assign(
+       socket,
+       :form,
+       to_form(params, as: :tenant, errors: [slug: {"slug_taken", []}])
+     )
+     |> assign(:error, "That slug is already in use")}
+  end
+
+  defp handle_signup_error(:email_taken, params, socket) do
+    {:noreply,
+     assign(
+       socket,
+       :form,
+       to_form(params, as: :tenant, errors: [email: {"email_taken", []}])
+     )
+     |> assign(:error, "That email is already associated with a tenant")}
+  end
+
+  defp handle_signup_error(:no_authenticators, _params, socket) do
+    {:noreply, assign(socket, :error, "Enroll at least one authenticator")}
+  end
+
+  defp handle_signup_error(:too_many_authenticators, _params, socket) do
+    {:noreply,
+     assign(
+       socket,
+       :error,
+       "At most #{socket.assigns.max_authenticators} authenticators can be enrolled"
+     )}
+  end
+
+  defp handle_signup_error(%Ecto.Changeset{} = changeset, _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:form, to_form(changeset, as: :tenant))
+     |> assign(:error, "Please correct the highlighted fields")}
+  end
+
+  # Defensive catch-all. `Tenants.signup/1`'s own generic branch
+  # (`{:error, _step, reason, _changes} -> {:error, reason}`) can surface any
+  # non-changeset, non-mapped error term from an unexpected Multi step failure
+  # (e.g. :set_public_key / :activate / :audit_genesis returning a bare term).
+  # Without this clause such a term would raise CaseClauseError and crash the
+  # LiveView — reintroducing the exact silent "button does nothing" failure #496
+  # set out to eliminate. Surface a generic internal-failure banner instead.
+  defp handle_signup_error(reason, _params, socket) do
+    Logger.error("SignupLive: signup failed with unexpected reason: #{inspect(reason)}")
+
+    {:noreply,
+     assign(
+       socket,
+       :error,
+       "Signup failed internally and no tenant was created — please try again."
+     )}
   end
 
   # #496: turn an audit-key storage failure into an actionable operator message. The most
@@ -560,6 +602,15 @@ defmodule LoopctlWeb.SignupLive do
     "Could not store this tenant's audit signing key: the secret store is not configured. " <>
       "On a self-hosted (non-Fly) install, set SECRETS_ADAPTER=local_file (and optionally " <>
       "SECRETS_FILE to the secrets file path) and restart. No tenant was created; retry after configuring it."
+  end
+
+  # Local-file adapter write failure (disk full, read-only volume, bad permissions).
+  # The secret store IS configured here — pointing the operator at "configuration" would
+  # misdirect triage — so name the actual cause: the SECRETS_FILE volume.
+  defp audit_key_storage_error_message({:secrets_file_write_failed, _reason}) do
+    "Could not write this tenant's audit signing key to the local secret store, so signup was " <>
+      "rolled back and no tenant was created. Check that the SECRETS_FILE volume has free disk " <>
+      "space and is writable by the app user, then try again."
   end
 
   defp audit_key_storage_error_message(_reason) do
@@ -679,6 +730,23 @@ defmodule LoopctlWeb.SignupLive do
               is shown <strong class="text-rose-300">once</strong> and is never stored in a form you
               can recover — copy it now and keep it somewhere safe.
             </p>
+          </div>
+
+          <div
+            id="root-key-loss-warning"
+            role="alert"
+            class="rounded-md border border-rose-500/60 bg-rose-950/40 p-4"
+          >
+            <div class="flex items-start gap-3">
+              <.icon name="hero-exclamation-triangle" class="mt-0.5 h-5 w-5 shrink-0 text-rose-300" />
+              <p class="text-sm text-rose-100">
+                <strong>Do not refresh or close this tab until you have copied the key.</strong>
+                This is the tenant's only credential and it is not stored anywhere. If this page
+                reloads or the connection drops before you save it, the key is
+                <strong class="text-rose-200">gone permanently</strong>
+                and the tenant can only be recovered by a superadmin. Save it first, then click continue.
+              </p>
+            </div>
           </div>
 
           <div class="rounded-md border border-rose-500/40 bg-rose-950/20 p-6">

--- a/lib/loopctl_web/live/signup_live.ex
+++ b/lib/loopctl_web/live/signup_live.ex
@@ -503,6 +503,19 @@ defmodule LoopctlWeb.SignupLive do
       {:error, {:audit_key_storage_failed, reason}} ->
         {:noreply, assign(socket, :error, audit_key_storage_error_message(reason))}
 
+      # Internal mint failure (a DB constraint on the root api_key), NOT operator
+      # input the form can fix. The signup transaction rolled back — no tenant exists —
+      # so surface a distinct "internal failure" banner rather than the misleading
+      # "correct the highlighted fields" form-validation message.
+      {:error, :root_key_mint_failed} ->
+        {:noreply,
+         assign(
+           socket,
+           :error,
+           "Signup failed internally while provisioning your root API key. " <>
+             "No tenant was created — please try again."
+         )}
+
       {:error, :slug_taken} ->
         {:noreply,
          assign(
@@ -546,7 +559,7 @@ defmodule LoopctlWeb.SignupLive do
   defp audit_key_storage_error_message(:fly_not_configured) do
     "Could not store this tenant's audit signing key: the secret store is not configured. " <>
       "On a self-hosted (non-Fly) install, set SECRETS_ADAPTER=local_file (and optionally " <>
-      "SECRETS_FILE) and restart — see docs/self-hosting.md. No tenant was created; retry after configuring it."
+      "SECRETS_FILE to the secrets file path) and restart. No tenant was created; retry after configuring it."
   end
 
   defp audit_key_storage_error_message(_reason) do

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -4,6 +4,14 @@ defmodule LoopctlWeb.Router do
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
+    # #494: a LiveView renders its DEAD (first HTTP) response through the ROOT layout,
+    # which is what carries <head> + the app.css/app.js links. `use LiveView, layout:`
+    # sets only the APP (inner) layout, so without an explicit root layout the /signup
+    # dead render came out bare — no <!DOCTYPE>, no assets, WebAuthn JS never loaded —
+    # bricking self-hosted onboarding. `fetch_live_flash` is required by the layout's
+    # <.flash_group>.
+    plug :fetch_live_flash
+    plug :put_root_layout, html: {LoopctlWeb.Layouts, :root}
     plug :protect_from_forgery
 
     plug :put_secure_browser_headers, %{

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -4,14 +4,20 @@ defmodule LoopctlWeb.Router do
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
-    # #494: a LiveView renders its DEAD (first HTTP) response through the ROOT layout,
-    # which is what carries <head> + the app.css/app.js links. `use LiveView, layout:`
-    # sets only the APP (inner) layout, so without an explicit root layout the /signup
-    # dead render came out bare — no <!DOCTYPE>, no assets, WebAuthn JS never loaded —
-    # bricking self-hosted onboarding. `fetch_live_flash` is required by the layout's
-    # <.flash_group>.
+    # `fetch_live_flash` is required by the app layout's <.flash_group> on the
+    # LiveView routes below.
+    #
+    # #494/#516: the ROOT layout is deliberately NOT set here. A LiveView renders its
+    # DEAD (first HTTP) response through the ROOT layout, which carries <head> +
+    # app.css/app.js; `use LiveView, layout:` sets only the APP (inner) layout. But
+    # PageController (/, /docs, /terms, /privacy) shares this pipeline and renders
+    # SELF-CONTAINED full HTML documents with `layout: false` — and `layout: false`
+    # disables only the inner layout, NOT the root, so a pipeline-wide root layout
+    # double-wrapped those pages (two <!DOCTYPE>, two <head>, assets loaded twice).
+    # The root layout is therefore scoped to the `:public_signup` and `:public_wiki`
+    # live_sessions instead (see `root_layout:` below), which is where the dead-render
+    # <head>/asset injection is actually needed.
     plug :fetch_live_flash
-    plug :put_root_layout, html: {LoopctlWeb.Layouts, :root}
     plug :protect_from_forgery
 
     plug :put_secure_browser_headers, %{
@@ -65,13 +71,14 @@ defmodule LoopctlWeb.Router do
     # the session, so SignupLive gets an unspoofable per-IP rate-limit key on
     # both the disconnected and connected mount. See SignupLive.signup_session/1.
     live_session :public_signup,
-      session: {LoopctlWeb.SignupLive, :signup_session, []} do
+      session: {LoopctlWeb.SignupLive, :signup_session, []},
+      root_layout: {LoopctlWeb.Layouts, :root} do
       live "/signup", SignupLive, :index
       live "/tenants/:id/onboarding", TenantOnboardingLive, :index
     end
 
     # US-26.0.3 — public wiki rendering for system-scoped articles
-    live_session :public_wiki do
+    live_session :public_wiki, root_layout: {LoopctlWeb.Layouts, :root} do
       live "/wiki", WikiIndexLive, :index
       live "/wiki/:slug", WikiShowLive, :show
     end

--- a/test/loopctl/secrets/local_file_adapter_test.exs
+++ b/test/loopctl/secrets/local_file_adapter_test.exs
@@ -1,0 +1,59 @@
+defmodule Loopctl.Secrets.LocalFileAdapterTest do
+  @moduledoc """
+  #496 — the self-host file-backed secrets adapter. `async: false`: it reads/writes a
+  single VM-global file path (`:secrets_file`) shared across tests, so concurrent tests
+  would clobber each other's store.
+  """
+  use ExUnit.Case, async: false
+
+  alias Loopctl.Secrets.LocalFileAdapter
+
+  setup do
+    path = Application.fetch_env!(:loopctl, :secrets_file)
+    File.rm(path)
+    on_exit(fn -> File.rm(path) end)
+    %{path: path}
+  end
+
+  test "set then get round-trips a raw binary value (not just strings)" do
+    value = :crypto.strong_rand_bytes(32)
+    assert :ok = LocalFileAdapter.set("TENANT_AUDIT_KEY_ACME", value)
+    assert {:ok, ^value} = LocalFileAdapter.get("TENANT_AUDIT_KEY_ACME")
+  end
+
+  test "get on a missing name returns :not_found" do
+    assert {:error, :not_found} = LocalFileAdapter.get("NOPE")
+  end
+
+  test "get on a missing FILE is an empty store, not an error" do
+    assert {:error, :not_found} = LocalFileAdapter.get("ANY")
+  end
+
+  test "delete removes a name" do
+    :ok = LocalFileAdapter.set("K", "v")
+    assert {:ok, "v"} = LocalFileAdapter.get("K")
+    assert :ok = LocalFileAdapter.delete("K")
+    assert {:error, :not_found} = LocalFileAdapter.get("K")
+  end
+
+  test "set overwrites an existing value and preserves other keys", %{path: _path} do
+    :ok = LocalFileAdapter.set("A", "1")
+    :ok = LocalFileAdapter.set("B", "2")
+    :ok = LocalFileAdapter.set("A", "1-updated")
+
+    assert {:ok, "1-updated"} = LocalFileAdapter.get("A")
+    assert {:ok, "2"} = LocalFileAdapter.get("B")
+  end
+
+  test "the on-disk file is 0600 (owner-only)", %{path: path} do
+    :ok = LocalFileAdapter.set("K", "v")
+    %File.Stat{mode: mode} = File.stat!(path)
+    # low 9 bits are the rwx perms; 0o600 = owner rw only.
+    assert Bitwise.band(mode, 0o777) == 0o600
+  end
+
+  test "a corrupt (non-JSON) file is refused rather than silently treated as empty", %{path: path} do
+    File.write!(path, "this is not json{")
+    assert {:error, :corrupt_secrets_file} = LocalFileAdapter.get("K")
+  end
+end

--- a/test/loopctl/secrets/local_file_adapter_test.exs
+++ b/test/loopctl/secrets/local_file_adapter_test.exs
@@ -56,4 +56,33 @@ defmodule Loopctl.Secrets.LocalFileAdapterTest do
     File.write!(path, "this is not json{")
     assert {:error, :corrupt_secrets_file} = LocalFileAdapter.get("K")
   end
+
+  test "a non-string JSON value is reported as corrupt, not a FunctionClauseError crash", %{
+    path: path
+  } do
+    # A hand-corrupted secrets.json where a value is a number (not base64 string).
+    File.write!(path, Jason.encode!(%{"AUDIT_KEY" => 123}))
+    assert {:error, :corrupt_secret} = LocalFileAdapter.get("AUDIT_KEY")
+  end
+
+  test "concurrent set/2 with distinct names never loses a key (write-lock serialization)" do
+    # This is the load-bearing property of the `:global.trans/2` write lock: without
+    # it, two concurrent read-modify-write cycles last-rename-wins-drop each other's
+    # key — permanently breaking the losing tenant's audit-chain signing. Spawn many
+    # concurrent writers of DISTINCT keys and assert every key survives.
+    names = for n <- 1..25, do: "CONCURRENT_KEY_#{n}"
+
+    names
+    |> Task.async_stream(
+      fn name -> :ok = LocalFileAdapter.set(name, "value-#{name}") end,
+      max_concurrency: 25,
+      timeout: 30_000
+    )
+    |> Stream.run()
+
+    for name <- names do
+      assert {:ok, value} = LocalFileAdapter.get(name)
+      assert value == "value-#{name}"
+    end
+  end
 end

--- a/test/loopctl/tenants/signup_test.exs
+++ b/test/loopctl/tenants/signup_test.exs
@@ -43,13 +43,23 @@ defmodule Loopctl.Tenants.SignupTest do
         authenticators: [valid_attestation()]
       }
 
-      assert {:ok, %{tenant: tenant, root_authenticators: [auth]}} = Tenants.signup(attrs)
+      assert {:ok, %{tenant: tenant, root_authenticators: [auth], raw_key: raw_key}} =
+               Tenants.signup(attrs)
+
       assert tenant.status == :active
       assert tenant.slug == "test-signup"
       assert tenant.email == "admin@test-signup.example"
       assert auth.tenant_id == tenant.id
       assert auth.friendly_name == "Primary YubiKey"
       assert auth.attestation_format == "none"
+
+      # #500: signup mints a usable root user-role key and returns it ONCE, so a
+      # browser-onboarded tenant has an authenticated path forward (was: empty api_keys).
+      assert is_binary(raw_key) and raw_key != ""
+      assert {:ok, verified} = Auth.verify_api_key(raw_key)
+      assert verified.tenant_id == tenant.id
+      assert verified.role == :user
+      assert is_nil(verified.agent_id)
 
       # Idempotent persistence: re-reading surfaces the same row.
       [persisted] = RootAuthenticators.list_by_tenant(tenant.id)

--- a/test/loopctl_web/controllers/page_controller_test.exs
+++ b/test/loopctl_web/controllers/page_controller_test.exs
@@ -154,6 +154,28 @@ defmodule LoopctlWeb.PageControllerTest do
     end
   end
 
+  # #516 regression guard: PageController pages render self-contained full HTML
+  # documents with `layout: false`. A pipeline-wide root layout would double-wrap
+  # them (two <!DOCTYPE>, two <html>, two <head>, assets loaded twice). The existing
+  # `=~` assertions all survive a double-wrapped document, so these count occurrences
+  # to fail if the root layout ever leaks back onto the shared :browser pipeline.
+  describe "single HTML document (no root-layout double-wrap)" do
+    for path <- ["/", "/docs", "/terms", "/privacy"] do
+      test "GET #{path} returns exactly one HTML document", %{conn: conn} do
+        body = conn |> get(unquote(path)) |> html_response(200)
+
+        assert count_occurrences(body, "<!DOCTYPE html>") == 1
+        assert count_occurrences(body, "<html") == 1
+        assert count_occurrences(body, "<head>") == 1
+        assert count_occurrences(body, "<body") == 1
+      end
+    end
+  end
+
+  defp count_occurrences(string, substring) do
+    string |> String.split(substring) |> length() |> Kernel.-(1)
+  end
+
   # TC-18.1.5: GET /nonexistent-page returns 404 HTML
   describe "error pages" do
     test "GET /nonexistent-page returns 404 HTML", %{conn: conn} do

--- a/test/loopctl_web/live/signup_live_test.exs
+++ b/test/loopctl_web/live/signup_live_test.exs
@@ -56,6 +56,23 @@ defmodule LoopctlWeb.SignupLiveTest do
       assert has_element?(view, "#webauthn-hook")
       assert has_element?(view, "#signup-learn-more")
     end
+
+    test "#494: the DEAD render carries the root layout (head + assets) so WebAuthn JS loads", %{
+      conn: conn
+    } do
+      # The plain HTTP (disconnected) response — NOT the connected socket render `live/2`
+      # exercises. Before #494 the :browser pipeline had no put_root_layout, so this came
+      # back bare: no <!DOCTYPE>, no <head>, and app.js never loaded — bricking the ceremony.
+      html = conn |> get(~p"/signup") |> html_response(200)
+
+      assert html =~ "<!DOCTYPE html>"
+      assert html =~ "<head>"
+      # app.js runs the LiveView socket AND the WebAuthn credential hook.
+      assert html =~ "/assets/app.js"
+      assert html =~ "/assets/app.css"
+      # The LiveView content is present inside that layout.
+      assert html =~ ~s(id="signup-page")
+    end
   end
 
   describe "WebAuthn enrollment round-trip" do
@@ -137,7 +154,8 @@ defmodule LoopctlWeb.SignupLiveTest do
       refute AdminRepo.get_by(Tenant, slug: "skippy")
     end
 
-    test "successful signup redirects to /tenants/:id/onboarding", %{conn: conn} do
+    test "successful signup surfaces the root API key once + a continue-to-onboarding link (#500)",
+         %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/signup")
 
       view
@@ -155,21 +173,65 @@ defmodule LoopctlWeb.SignupLiveTest do
         "credential_id" => "Y3JlZC1pZA"
       })
 
-      assert {:error, {:live_redirect, %{to: redirect_to}}} =
-               view
-               |> form("#signup-form", %{
-                 "tenant" => %{
-                   "name" => "Successful Corp",
-                   "slug" => "successful-corp",
-                   "email" => "admin@successful.example"
-                 }
-               })
-               |> render_submit()
+      # #500: no redirect — the raw key is shown once in-page (never a URL / the session).
+      html =
+        view
+        |> form("#signup-form", %{
+          "tenant" => %{
+            "name" => "Successful Corp",
+            "slug" => "successful-corp",
+            "email" => "admin@successful.example"
+          }
+        })
+        |> render_submit()
 
-      assert redirect_to =~ "/tenants/"
-      assert redirect_to =~ "/onboarding"
+      assert has_element?(view, "#signup-complete")
+      assert has_element?(view, "#root-api-key")
+      # The continue link carries the onboarding path (with the signed token); no key in the URL.
+      assert has_element?(view, "#continue-to-onboarding")
+      refute html =~ "signup-form"
 
-      assert AdminRepo.get_by(Tenant, slug: "successful-corp")
+      tenant = AdminRepo.get_by(Tenant, slug: "successful-corp")
+      assert tenant
+
+      # #500: a real, usable root user-role key was minted for the new tenant.
+      key = AdminRepo.get_by(Loopctl.Auth.ApiKey, tenant_id: tenant.id, role: :user)
+      assert key
+      assert is_nil(key.agent_id)
+      # The rendered key must be the actual minted key (its prefix is stored).
+      assert html =~ key.key_prefix
+    end
+
+    test "audit-key storage failure surfaces a banner and creates no tenant, not a crash (#496)",
+         %{conn: conn} do
+      # Off Fly with no local adapter, Secrets.set fails; the signup multi rolls back.
+      stub(Loopctl.MockSecrets, :set, fn _name, _value -> {:error, :fly_not_configured} end)
+
+      {:ok, view, _html} = live(conn, ~p"/signup")
+
+      view |> element("#enroll-authenticator-btn") |> render_click()
+
+      render_hook(view, "attestation_captured", %{
+        "attestation_object" => "YWJjZA",
+        "client_data_json" => "eyJmb28iOiJiYXIifQ",
+        "credential_id" => "Y3JlZC1pZA"
+      })
+
+      html =
+        view
+        |> form("#signup-form", %{
+          "tenant" => %{
+            "name" => "Offline Corp",
+            "slug" => "offline-corp",
+            "email" => "admin@offline.example"
+          }
+        })
+        |> render_submit()
+
+      # Actionable banner (the old behaviour was a CaseClauseError crash / dead button).
+      assert html =~ "SECRETS_ADAPTER=local_file"
+      refute has_element?(view, "#signup-complete")
+      refute AdminRepo.get_by(Tenant, slug: "offline-corp")
     end
 
     test "duplicate slug surfaces a stable error code (TC-26.0.1.3 via LV)", %{conn: conn} do
@@ -291,18 +353,19 @@ defmodule LoopctlWeb.SignupLiveTest do
       {:ok, victim_view, _html} = live(fly_conn(conn, "203.0.113.9"), ~p"/signup")
       enroll_authenticator(victim_view)
 
-      assert {:error, {:live_redirect, %{to: redirect_to}}} =
-               victim_view
-               |> form("#signup-form", %{
-                 "tenant" => %{
-                   "name" => "Victim Corp",
-                   "slug" => "victim-corp",
-                   "email" => "victim@corp.example"
-                 }
-               })
-               |> render_submit()
+      victim_view
+      |> form("#signup-form", %{
+        "tenant" => %{
+          "name" => "Victim Corp",
+          "slug" => "victim-corp",
+          "email" => "victim@corp.example"
+        }
+      })
+      |> render_submit()
 
-      assert redirect_to =~ "/onboarding"
+      # #500: success now surfaces the one-time key panel in-page (no redirect).
+      assert has_element?(victim_view, "#signup-complete")
+      assert has_element?(victim_view, "#continue-to-onboarding")
       assert AdminRepo.get_by(Tenant, slug: "victim-corp")
     end
 


### PR DESCRIPTION
Closes #494, #496, #500.

Three interlocking blockers left a fresh **self-hosted, non-Fly** install unable to onboard a human via the browser. Fixed as one bundle since they only matter together (each is dead without the others).

## #494 — /signup rendered bare (WebAuthn couldn't run)
The `:browser` pipeline had no `put_root_layout`, so the LiveView **dead** render came out with no `<!DOCTYPE>`/`<head>` and no `app.css`/`app.js` — the WebAuthn ceremony's JS never loaded. Added `put_root_layout` + `fetch_live_flash`.

## #496 — signup hard-depended on Fly (crashed off Fly)
`Secrets` had only the Fly adapter; off Fly, audit-key storage returned `:fly_not_configured` and `complete_signup/3` **crashed** on an unhandled `CaseClauseError` (button did nothing). Two fixes:
- `Loopctl.Secrets.LocalFileAdapter` — a `0600` JSON store (base64 values, atomic tmp+rename), selected via `SECRETS_ADAPTER=local_file` / `SECRETS_FILE`. **Read its threat model** — trusted single-machine only; base64 is encoding not encryption (same exposure as Fly's plaintext env vars).
- `complete_signup/3` now handles `{:error, {:audit_key_storage_failed, _}}` with an actionable banner instead of crashing.

## #500 — browser signup minted no key (no path forward)
An anchored tenant had empty `api_keys`. `signup/1` now mints the root `:user` key in the same transaction (mirroring `self_signup/2`) and returns it once; `SignupLive` surfaces it in a **one-time "save your key" panel** — held in LiveView memory only, never a URL or the session — with a continue-to-onboarding link. Agent/orchestrator keys are minted later, after registering an agent identity.

## Tests
LocalFileAdapter (round-trip of raw binaries / `0600` perms / corrupt-file refusal / missing-file-as-empty); `signup/1` mints + returns a usable `:user` key; the LiveView shows the key panel (not a redirect) and handles the storage failure gracefully; and the **dead** `/signup` render carries the root layout + assets (#494). `mix precommit` green (6351 tests).