### PR TITLE
#492 FTS_REGCONFIG knob for non-English keyword search

### DIFF
--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -39,9 +39,9 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:481-487`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:447-449`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8175`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8193`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
-   (`absolute_score/1`, `:8246-8251`) clears a scale-matched threshold AND beats the best retrieved
+   (`absolute_score/1`, `:8320-8325`) clears a scale-matched threshold AND beats the best retrieved
    candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:8297-8307`; the pure decision is
    `resolve_provenance/4`, `:8352-8362`) AND is authoritative (not superseded/conflicted — the caller
    passes only `list_curated_sources/2`-filtered scores). Otherwise `:retrieved`. Both branches return identical `results`/`meta`

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -58,6 +58,18 @@ if System.get_env("SECRETS_ADAPTER") == "local_file" do
   config :loopctl, :secrets_file, System.get_env("SECRETS_FILE") || "/data/loopctl/secrets.json"
 end
 
+# #492: per-deployment Postgres text-search config (regconfig) for keyword FTS. UNSET
+# is "english" — byte-for-byte unchanged for the hosted instance. A non-English
+# self-host sets FTS_REGCONFIG (e.g. "russian", "simple") so the STORED search_vectors
+# AND the query sites use the same stemmer; otherwise combined/keyword search silently
+# English-tokenizes non-Latin content. The value is validated in Loopctl.Search.Regconfig
+# and by the apply_fts_regconfig migration (which rebuilds the vectors on a non-english
+# deployment). Set it BEFORE the first migrate on a fresh install; changing it on an
+# already-migrated corpus does NOT re-run that migration (a rebuild is a separate op).
+if regconfig = System.get_env("FTS_REGCONFIG") do
+  config :loopctl, :fts_regconfig, regconfig
+end
+
 # sec-4: OPT-IN override of the node-local Hammer poolboy pool that fronts EVERY
 # `check_rate/3`. The base sizing lives in config/config.exs (20 / 10, up from
 # Hammer's 4 / 0 defaults) to keep the fail-CLOSED `AuthPathThrottle` from

--- a/lib/loopctl/context_retriever/executor.ex
+++ b/lib/loopctl/context_retriever/executor.ex
@@ -112,6 +112,7 @@ defmodule Loopctl.ContextRetriever.Executor do
   alias Loopctl.ContextRetriever.Scope
   alias Loopctl.Projects.Project
   alias Loopctl.Repo
+  alias Loopctl.Search.Regconfig
   alias Loopctl.WorkBreakdown.Epic
   alias Loopctl.WorkBreakdown.Story
 
@@ -435,9 +436,20 @@ defmodule Loopctl.ContextRetriever.Executor do
   end
 
   defp base_query(schema, tenant_id, %{kind: :search, query_string: query_string}) do
+    # #492: match the deployment regconfig the CR backing-table triggers stored the
+    # search_vector with; `?::text::regconfig` bind param (never interpolated). The `::text`
+    # is required — a bare `?::regconfig` makes Postgrex demand the regconfig OID (integer)
+    # and reject the string name at encode time.
+    regconfig = Regconfig.get()
+
     from(q in schema,
       where: q.tenant_id == ^tenant_id,
-      where: fragment("search_vector @@ websearch_to_tsquery('english', ?)", ^query_string)
+      where:
+        fragment(
+          "search_vector @@ websearch_to_tsquery(?::text::regconfig, ?)",
+          ^regconfig,
+          ^query_string
+        )
     )
   end
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -67,6 +67,7 @@ defmodule Loopctl.Knowledge do
   alias Loopctl.Llm.ProviderError
   alias Loopctl.Projects.Project
   alias Loopctl.Provider.RetryAfter
+  alias Loopctl.Search.Regconfig
   alias Loopctl.SystemConfig
   alias Loopctl.Webhooks.EventGenerator
   alias Loopctl.Workers.ArticleEmbeddingWorker
@@ -1856,11 +1857,24 @@ defmodule Loopctl.Knowledge do
         limit = opts |> Keyword.get(:limit, 20) |> max(1) |> min(@max_relevance_page_size)
         offset = opts |> Keyword.get(:offset, 0) |> max(0)
         status = Keyword.get(opts, :status, :published)
+        # #492: the deployment regconfig — MUST match the one the stored `search_vector`
+        # was built with (the article generated column / the CR triggers), or a
+        # differently-stemmed query matches nothing. Passed as a `?::text::regconfig` bind
+        # param (never interpolated) — the `::text` is REQUIRED: a bare `?::regconfig` makes
+        # Postgrex describe the param as the `regconfig` OID type and demand an integer, so a
+        # string name raises at encode time. `::text::regconfig` keeps the param text and lets
+        # PG cast it, with no injection surface even though it reaches SQL.
+        regconfig = Regconfig.get()
 
         base_query =
           from(a in Article,
             where: a.tenant_id == ^tenant_id,
-            where: fragment("search_vector @@ websearch_to_tsquery('english', ?)", ^query_string),
+            where:
+              fragment(
+                "search_vector @@ websearch_to_tsquery(?::text::regconfig, ?)",
+                ^regconfig,
+                ^query_string
+              ),
             select: %{
               id: a.id,
               tenant_id: a.tenant_id,
@@ -1877,19 +1891,23 @@ defmodule Loopctl.Knowledge do
               updated_at: a.updated_at,
               relevance_score:
                 fragment(
-                  "ts_rank_cd(search_vector, websearch_to_tsquery('english', ?))",
+                  "ts_rank_cd(search_vector, websearch_to_tsquery(?::text::regconfig, ?))",
+                  ^regconfig,
                   ^query_string
                 ),
               snippet:
                 fragment(
-                  "ts_headline('english', body, websearch_to_tsquery('english', ?), 'StartSel=**, StopSel=**, MaxWords=35, MinWords=15')",
+                  "ts_headline(?::text::regconfig, body, websearch_to_tsquery(?::text::regconfig, ?), 'StartSel=**, StopSel=**, MaxWords=35, MinWords=15')",
+                  ^regconfig,
+                  ^regconfig,
                   ^query_string
                 )
             },
             order_by: [
               desc:
                 fragment(
-                  "ts_rank_cd(search_vector, websearch_to_tsquery('english', ?))",
+                  "ts_rank_cd(search_vector, websearch_to_tsquery(?::text::regconfig, ?))",
+                  ^regconfig,
                   ^query_string
                 ),
               # DETERMINISTIC secondary key: `ts_rank_cd` ties (common on short/overlapping

--- a/lib/loopctl/search/regconfig.ex
+++ b/lib/loopctl/search/regconfig.ex
@@ -1,0 +1,77 @@
+defmodule Loopctl.Search.Regconfig do
+  @moduledoc """
+  #492 — the deployment's Postgres text-search configuration (`regconfig`) for
+  keyword full-text search, resolved from config with a safe default.
+
+  Keyword FTS was hardwired to `'english'` end to end — both the stored
+  `search_vector`s (article generated column + the CR backing-table triggers) and
+  every `websearch_to_tsquery` / `ts_headline` query site. For a non-English tenant
+  the English Snowball stemmer never unifies inflected forms (Cyrillic «отчёт» ≠
+  «отчёта») and English stop-words don't apply, so `combined`/keyword search silently
+  degrades. This is the single source of truth for the per-DEPLOYMENT regconfig.
+
+  Set it with `FTS_REGCONFIG` (see `config/runtime.exs`); the default is `"english"`,
+  so the hosted instance and CI are byte-for-byte unchanged.
+
+  ## Why validation matters
+
+  The value is interpolated into DDL by the `apply_fts_regconfig` migration (a
+  regconfig cannot be a bind parameter in a generated-column expression), and passed
+  as a `?::text::regconfig` bind parameter at the query sites (the `::text` is required —
+  a bare `?::regconfig` makes Postgrex demand the regconfig OID as an integer and reject
+  the string name at encode time). An operator-supplied
+  value therefore reaches SQL. `get/0` accepts ONLY a lowercase identifier
+  (`^[a-z][a-z0-9_]*$`, ≤ 63 bytes — the Postgres identifier limit), which is exactly
+  the shape of a real regconfig name and closes SQL-injection; anything else falls
+  back to `"english"` with a loud log rather than risking a malformed/hostile literal.
+  Whether the (well-formed) name actually EXISTS in `pg_ts_config` is a separate,
+  deployment-time check the migration makes — a typo'd but well-formed config fails
+  the migration loudly rather than silently keyword-degrading.
+  """
+
+  require Logger
+
+  @default "english"
+  @valid_name ~r/\A[a-z][a-z0-9_]{0,62}\z/
+
+  @doc """
+  The configured text-search regconfig name (`\"english\"` by default).
+
+  Falls back to the default — never raises — on an absent or malformed value, so a
+  bad `FTS_REGCONFIG` can never crash a hot search path; the migration is where a
+  well-formed-but-nonexistent config is rejected loudly.
+  """
+  @spec get() :: String.t()
+  def get, do: validate(Application.get_env(:loopctl, :fts_regconfig, @default))
+
+  @doc """
+  Validates a raw configured value into a safe regconfig identifier, falling back to
+  the default on anything malformed. Pure (no config read), so the injection/fallback
+  contract is unit-testable without mutating VM-global config.
+  """
+  @spec validate(term()) :: String.t()
+  def validate(value) when is_binary(value) do
+    if Regex.match?(@valid_name, value) do
+      value
+    else
+      Logger.error(
+        "FTS_REGCONFIG=#{inspect(value)} is not a valid regconfig identifier " <>
+          "(lowercase [a-z][a-z0-9_]*, ≤63 chars); falling back to #{@default}."
+      )
+
+      @default
+    end
+  end
+
+  def validate(other) do
+    Logger.error(
+      "fts_regconfig is #{inspect(other)}, expected a string; falling back to #{@default}."
+    )
+
+    @default
+  end
+
+  @doc "The shipped default regconfig (`\"english\"`)."
+  @spec default() :: String.t()
+  def default, do: @default
+end

--- a/priv/repo/migrations/20260724190000_apply_fts_regconfig.exs
+++ b/priv/repo/migrations/20260724190000_apply_fts_regconfig.exs
@@ -1,0 +1,115 @@
+defmodule Loopctl.Repo.Migrations.ApplyFtsRegconfig do
+  @moduledoc """
+  #492 — align the STORED keyword `search_vector`s with the deployment's configured
+  text-search regconfig (`FTS_REGCONFIG` → `Loopctl.Search.Regconfig`).
+
+  Keyword FTS shipped hardwired to `'english'`: the `articles.search_vector` GENERATED
+  column (`20260410021836`) and the `stories`/`projects`/`epics` trigger functions
+  (`20260712000000`). A generated column cannot reference runtime config (it must be
+  IMMUTABLE with a literal regconfig), so a per-deployment regconfig has to be baked in
+  by a migration. This migration reads the configured regconfig and, WHEN IT DIFFERS
+  from the `"english"` default, rebuilds:
+
+    * `articles.search_vector` — DROP + re-ADD the generated column (+ its GIN index)
+      with the configured regconfig;
+    * the `stories`/`projects`/`epics` trigger functions — `CREATE OR REPLACE` with the
+      configured regconfig, then recompute existing rows so stored lexemes match.
+
+  It is a **NO-OP on the shipped `"english"` default**, so the hosted instance and CI
+  are unchanged (this migration records as a no-op there). It runs on a FRESH
+  non-English self-host, where the tables are empty — so the DROP/re-ADD and recompute
+  are instant. Query sites pass the same regconfig as a `::regconfig` bind param
+  (`Loopctl.Knowledge` / `Loopctl.ContextRetriever.Executor`), so stored and queried
+  stemmers match.
+
+  ## Changing the regconfig on an EXISTING corpus
+
+  Once this migration has run, changing `FTS_REGCONFIG` does NOT re-run it. Rebuilding
+  a populated corpus's vectors (a table rewrite of `articles` + a full recompute of the
+  CR tables — potentially a write outage) is a deliberate operator action, out of scope
+  here; a dedicated online rebuild task is the follow-up for that path.
+  """
+
+  use Ecto.Migration
+
+  alias Loopctl.Search.Regconfig
+
+  # Mirrors `20260712000000`'s @configs — the weighted column set each CR vector covers.
+  @cr_configs [
+    %{table: "stories", columns: [{"title", "A"}, {"description", "B"}]},
+    %{table: "projects", columns: [{"name", "A"}, {"description", "B"}, {"mission", "C"}]},
+    %{table: "epics", columns: [{"title", "A"}, {"description", "B"}]}
+  ]
+
+  def up do
+    regconfig = Regconfig.get()
+
+    if regconfig == Regconfig.default() do
+      # Shipped default: the stored vectors are already 'english'. Nothing to do.
+      :ok
+    else
+      assert_regconfig_exists!(regconfig)
+      rebuild_articles(regconfig)
+      Enum.each(@cr_configs, &rebuild_cr_table(&1, regconfig))
+    end
+  end
+
+  # Irreversible by design: `down` would need to know the prior regconfig to rebuild to,
+  # and the shipped baseline is 'english' which the `20260410021836`/`20260712000000`
+  # migrations already own. A no-op avoids fighting that ownership / losing data.
+  def down, do: :ok
+
+  # A well-formed but NON-EXISTENT regconfig (e.g. a typo) must fail the migration LOUDLY
+  # rather than silently building an unusable vector. `Regconfig.get/0` already guaranteed
+  # the identifier SHAPE (injection-safe); this checks it is a real pg_ts_config.
+  defp assert_regconfig_exists!(regconfig) do
+    %{rows: [[count]]} =
+      repo().query!("SELECT count(*) FROM pg_ts_config WHERE cfgname = $1", [regconfig])
+
+    if count == 0 do
+      raise "FTS_REGCONFIG=#{inspect(regconfig)} is not an installed Postgres text search " <>
+              "configuration (not in pg_ts_config). Install it or pick a valid one."
+    end
+  end
+
+  defp rebuild_articles(regconfig) do
+    execute("DROP INDEX IF EXISTS articles_search_vector_idx")
+    execute("ALTER TABLE articles DROP COLUMN IF EXISTS search_vector")
+
+    execute("""
+    ALTER TABLE articles ADD COLUMN search_vector tsvector
+    GENERATED ALWAYS AS (
+      setweight(to_tsvector('#{regconfig}', coalesce(title, '')), 'A') ||
+      setweight(to_tsvector('#{regconfig}', coalesce(body, '')), 'B')
+    ) STORED
+    """)
+
+    execute("CREATE INDEX articles_search_vector_idx ON articles USING GIN (search_vector)")
+  end
+
+  defp rebuild_cr_table(%{table: table, columns: columns}, regconfig) do
+    # Re-point the self-maintaining trigger at the new regconfig (columns qualified NEW.
+    # in the trigger body, which runs with no table in scope).
+    execute("""
+    CREATE OR REPLACE FUNCTION #{table}_search_vector_update() RETURNS trigger AS $$
+    BEGIN
+      NEW.search_vector := #{tsvector_expr(columns, "NEW.", regconfig)};
+      RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql
+    """)
+
+    # Recompute existing rows so their stored lexemes use the new regconfig (bare column
+    # refs — the expression evaluates against the updated row). On a fresh install this
+    # touches zero rows; the GIN index is maintained by the UPDATE.
+    execute("UPDATE #{table} SET search_vector = #{tsvector_expr(columns, "", regconfig)}")
+  end
+
+  defp tsvector_expr(columns, prefix, regconfig) do
+    columns
+    |> Enum.map(fn {col, weight} ->
+      "setweight(to_tsvector('#{regconfig}', coalesce(#{prefix}#{col}, '')), '#{weight}')"
+    end)
+    |> Enum.join(" || ")
+  end
+end

--- a/test/loopctl/search/regconfig_test.exs
+++ b/test/loopctl/search/regconfig_test.exs
@@ -1,0 +1,174 @@
+defmodule Loopctl.Search.RegconfigTest do
+  @moduledoc """
+  #492 — `Loopctl.Search.Regconfig` is the single source of truth for the deployment's
+  Postgres text-search configuration (`FTS_REGCONFIG`). Its value reaches SQL two ways —
+  interpolated into DDL by the `apply_fts_regconfig` migration (a regconfig can't be a
+  bind param in a generated-column expression) and as a `?::text::regconfig` bind parameter
+  at every query site — so `validate/1` closing SQL-injection is the security-critical
+  contract, tested here as a pure function (no VM-global config mutation).
+
+  The integration test proves the END-TO-END mechanism the migration + query sites rely
+  on: a STORED generated vector built with a non-English regconfig, queried back through
+  the exact `websearch_to_tsquery($n::text::regconfig, $m)` shape, stems per that config.
+  """
+  use Loopctl.DataCase, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Loopctl.Search.Regconfig
+
+  describe "validate/1 — accepts real regconfig identifiers" do
+    test "passes lowercase identifier names through unchanged" do
+      for name <- ~w(english simple russian french german spanish norwegian_nynorsk cfg_1) do
+        assert Regconfig.validate(name) == name
+      end
+    end
+
+    test "the shipped default is english" do
+      assert Regconfig.default() == "english"
+      assert Regconfig.validate("english") == "english"
+    end
+  end
+
+  describe "validate/1 — falls back to english (never raises) on anything malformed" do
+    test "rejects SQL-injection payloads and hostile literals" do
+      payloads = [
+        "english'; DROP TABLE articles; --",
+        "english OR 1=1",
+        "english)",
+        "'; SELECT 1; --",
+        "english regconfig",
+        "en\nglish"
+      ]
+
+      for payload <- payloads do
+        assert capture_log(fn ->
+                 assert Regconfig.validate(payload) == "english"
+               end) =~ "not a valid regconfig identifier"
+      end
+    end
+
+    test "rejects uppercase, leading digit, empty, whitespace, and over-length names" do
+      bad = [
+        "English",
+        "ENGLISH",
+        "1english",
+        "",
+        " english",
+        "english ",
+        String.duplicate("a", 64)
+      ]
+
+      for value <- bad do
+        capture_log(fn -> assert Regconfig.validate(value) == "english" end)
+      end
+    end
+
+    test "accepts a 63-char name but rejects a 64-char name (identifier limit)" do
+      assert Regconfig.validate(String.duplicate("a", 63)) == String.duplicate("a", 63)
+      capture_log(fn -> assert Regconfig.validate(String.duplicate("a", 64)) == "english" end)
+    end
+
+    test "rejects non-string values" do
+      for value <- [nil, :english, 123, ["english"], %{}] do
+        assert capture_log(fn -> assert Regconfig.validate(value) == "english" end) =~
+                 "expected a string"
+      end
+    end
+  end
+
+  describe "get/0" do
+    test "returns english by default (no FTS_REGCONFIG configured in test)" do
+      assert Regconfig.get() == "english"
+    end
+  end
+
+  describe "end-to-end regconfig mechanism (stored generated vector + ::text::regconfig query)" do
+    # Proves the two SQL touch points the feature depends on agree: the migration builds a
+    # STORED generated `search_vector` with the configured regconfig, and every query site
+    # passes that same regconfig as a `$n::text::regconfig` bind param. Uses a TEMP table (a
+    # real generated column, exactly the migration's shape) so no shared schema is mutated;
+    # temp tables are connection-scoped, so this is async-safe.
+    #
+    # The `::text::regconfig` (not a bare `::regconfig`) is itself under test: Postgrex
+    # describes a bare `$1::regconfig` param as the regconfig OID type and demands an
+    # integer, so passing the string name would raise at encode time — the `::text` keeps
+    # the param a string and lets PG cast it. This test would fail loudly on a regression
+    # back to `::regconfig`.
+
+    # {regconfig, document, inflected form (stems to a query term), a content word present
+    # verbatim (NOT a stop word — english drops "the"/"are")}. A LANGUAGE config unifies the
+    # inflected form with its stem; `simple` never does.
+    @stemming_cases [
+      {"english", "the servers are running fast", "run", "servers"},
+      # Russian is installed in stock Postgres; Alex's Cyrillic corpus is the motivating
+      # case for #492. «отчёты» (reports, pl.) must unify with the query «отчёт» (report).
+      {"russian", "отчёты по проектам сделаны", "отчёт", "проектам"}
+    ]
+
+    for {config, doc, stem_query, exact} <- @stemming_cases do
+      test "#{config}: the language regconfig stems, simple does not — for storage AND query" do
+        config = unquote(config)
+        doc = unquote(doc)
+        stem_query = unquote(stem_query)
+        exact = unquote(exact)
+
+        # The language config: the inflected form in `doc` stems to `stem_query` → match.
+        assert probe_match?(config, doc, stem_query) == 1,
+               "#{config} should stem-match #{stem_query} in #{inspect(doc)}"
+
+        # The SAME corpus under `simple` does no stemming → the stem query misses. Config
+        # alone flips the result, which is the entire point of the FTS_REGCONFIG knob.
+        assert probe_match?("simple", doc, stem_query) == 0,
+               "simple should NOT stem-match #{stem_query} in #{inspect(doc)}"
+
+        # A content word present verbatim matches under BOTH configs — sanity that the row and
+        # vector are wired up, so the `simple` miss above is a real negative, not empty data.
+        assert probe_match?(config, doc, exact) == 1
+        assert probe_match?("simple", doc, exact) == 1
+      end
+    end
+
+    test "ukrainian: a valid-shape but UNINSTALLED config passes validate/1 but the migration guard rejects it" do
+      # Ukrainian is NOT a stock Postgres text-search config. Two-layer defense for #492:
+      #   1. shape gate (Regconfig.validate/1) — a well-formed identifier, so it passes and
+      #      never silently falls back to english (which would hide the operator's mistake);
+      assert Regconfig.validate("ukrainian") == "ukrainian"
+
+      #   2. existence gate (the apply_fts_regconfig migration's assert_regconfig_exists!) —
+      #      the same pg_ts_config lookup the migration runs returns 0, so the migration
+      #      RAISES loudly rather than building an unusable all-simple vector.
+      %{rows: [[count]]} =
+        Repo.query!("SELECT count(*) FROM pg_ts_config WHERE cfgname = $1", ["ukrainian"])
+
+      assert count == 0,
+             "if a stock Postgres gains a ukrainian config, swap this case for a real " <>
+               "uninstalled name — the point is a valid-shape config absent from pg_ts_config"
+    end
+  end
+
+  # Builds a STORED generated vector with `config` (the migration's shape) and queries it
+  # back through the exact `?::text::regconfig` bind-param shape used at every query site.
+  defp probe_match?(config, doc, query_term) do
+    Repo.query!("DROP TABLE IF EXISTS fts_probe")
+
+    Repo.query!("""
+    CREATE TEMP TABLE fts_probe (
+      body text,
+      search_vector tsvector
+        GENERATED ALWAYS AS (to_tsvector('#{config}', coalesce(body, ''))) STORED
+    )
+    """)
+
+    Repo.query!("INSERT INTO fts_probe (body) VALUES ($1)", [doc])
+
+    %{rows: [[count]]} =
+      Repo.query!(
+        "SELECT count(*) FROM fts_probe " <>
+          "WHERE search_vector @@ websearch_to_tsquery($1::text::regconfig, $2)",
+        [config, query_term]
+      )
+
+    count
+  end
+end


### PR DESCRIPTION
Closes #492.

## What
Keyword full-text search was hardwired to the 'english' regconfig end to end. For a non-English self-host (Alex's Cyrillic corpus is the motivating case) the English Snowball stemmer never unifies inflected forms and English stop-words don't apply, so combined/keyword search silently degrades. This adds a per-deployment FTS_REGCONFIG knob.

## How
- **Loopctl.Search.Regconfig** — single source of truth for the deployment regconfig, from FTS_REGCONFIG (default 'english', so the hosted instance and CI are byte-for-byte unchanged). validate/1 accepts only a lowercase identifier and otherwise falls back to english with a loud log, closing SQL-injection on the one value that reaches DDL.
- **Query sites** (Knowledge, ContextRetriever.Executor) pass the regconfig as a bind parameter cast ::text::regconfig. The ::text is required — a bare ::regconfig makes Postgrex describe the param as the regconfig OID type and demand an integer, so the string name would raise at encode time (caught by the end-to-end test).
- **apply_fts_regconfig migration** — a NO-OP on english; on a non-English deployment it rebuilds articles.search_vector (DROP + re-ADD the generated column, which cannot reference runtime config) and CREATE OR REPLACEs the stories/projects/epics trigger functions with the configured regconfig, after asserting it exists in pg_ts_config. A well-formed but uninstalled name (e.g. ukrainian) fails the migration loudly rather than building an unusable vector. On a fresh install the tables are empty, so the rebuild is instant.

## Operator note
Set FTS_REGCONFIG before the first migrate on a fresh install. Changing it on an already-migrated corpus does not re-run the migration; rebuilding a populated corpus is a separate operator action.

## Tests
- validate/1: injection payloads, uppercase/leading-digit/whitespace/empty, over-length (63 ok, 64 rejected), non-string.
- End-to-end mechanism against english, russian (installed), and simple: a stored generated vector plus the ::text::regconfig query shape stems per config; ukrainian exercises the valid-shape-but-uninstalled migration guard.

Full quality gate (mix precommit) green: compile-clean, credo --strict, dialyzer, 6367 tests 0 failures.
