### PR TITLE
#493 Encrypt ingestion document content at rest in Oban job args

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -553,6 +553,14 @@ config :loopctl, Loopctl.Vault,
   retired_ciphers: [
     # Add previous keys here during key rotation, e.g.:
     # {Cloak.Ciphers.AES.GCM, tag: "AES.GCM.V0", key: Base.decode64!("OLD_KEY"), iv_length: 12}
+    #
+    # ROTATION RUNBOOK (#493): ingestion document content is encrypted into
+    # oban_jobs.args (Loopctl.Ingestion.ContentEnvelope). Queued :ingestion jobs live
+    # up to the 3600s unique window (longer under snooze). When rotating CLOAK_KEY,
+    # keep the OUTGOING cipher listed here until the :ingestion queue has drained —
+    # otherwise every in-flight ingestion job fails AES-GCM decrypt and is silently
+    # {:discard}ed. ContentIngestionWorker logs a Logger.warning on each such failure
+    # so a mis-sequenced rotation is alertable.
   ]
 
 # DI: Content extractor for knowledge ingestion.

--- a/lib/loopctl/ingestion/content_envelope.ex
+++ b/lib/loopctl/ingestion/content_envelope.ex
@@ -44,6 +44,24 @@ defmodule Loopctl.Ingestion.ContentEnvelope do
   end
 
   @doc """
+  Probes the vault, raising the SAME boot-level fault `wrap/1` raises on a
+  misconfiguration (missing/invalid `CLOAK_KEY`) — but without a document in hand.
+
+  Callers that encrypt inline content inside a crash-isolated boundary — e.g. the
+  batch ingest path's `Task.Supervisor.async_stream_nolink`, where a `wrap/1` raise
+  is caught as an opaque per-item `{:exit, reason}` and would otherwise be flattened
+  into a generic "validation_failed" per-item error — probe the vault ONCE up front
+  so a real key-provisioning failure surfaces LOUDLY (propagating as a 500) instead
+  of being masked behind a per-item result. The fault is global and deterministic,
+  so one probe suffices for the whole batch.
+  """
+  @spec ensure_ready!() :: :ok
+  def ensure_ready! do
+    _ = Vault.encrypt!("")
+    :ok
+  end
+
+  @doc """
   Decrypts an envelope produced by `wrap/1`.
 
   Returns `{:ok, content}` or, on ANY malformed/tampered input (bad Base64, wrong

--- a/lib/loopctl/ingestion/content_envelope.ex
+++ b/lib/loopctl/ingestion/content_envelope.ex
@@ -14,20 +14,44 @@ defmodule Loopctl.Ingestion.ContentEnvelope do
   Base64-wraps it for JSON transport; `unwrap/1` reverses it. This mirrors
   `Loopctl.Workers.OrphanedSecretCleanupWorker`'s restore-value handling and the
   app's other Cloak-encrypted secrets (tenant LLM keys, webhook signing secrets) —
-  content is never plaintext in `oban_jobs`, and when the job is pruned the
-  ciphertext goes with it.
+  the document `content` is never plaintext in `oban_jobs`, and when the job is
+  pruned the ciphertext goes with it.
 
   Encryption is UNCONDITIONAL (every ingested inline document, not only private-tier
   scopes): the cost is negligible against a ~6-minute LLM ingestion job, and a
   uniform path is simpler and strictly safer than branching on the scope's marking.
+
+  ## `content_hash` is a keyed blind index, not a plaintext fingerprint
+
   Uniqueness/fair-share key off `content_hash` and `tenant_id` (never the content),
-  so the non-deterministic AES-GCM ciphertext does not perturb them.
+  so the non-deterministic AES-GCM ciphertext does not perturb them. `content_hash`
+  itself is a per-tenant HMAC-SHA256 blind index (see
+  `LoopctlWeb.KnowledgeIngestionController.compute_content_hash/2`), NOT a bare
+  SHA256 of the plaintext: a bare digest beside the ciphertext would be an offline
+  confirmation oracle (a DB-read attacker could hash a known/guessable document and
+  match). The HMAC keeps dedup deterministic while making the value uncomputable
+  without the app secret, and its per-tenant key also prevents correlating identical
+  documents across tenants.
+
+  ## Decrypt failure: tamper OR key-config, fail closed + alert
 
   AES-GCM is AUTHENTICATED: a tampered, truncated, or non-Base64 envelope fails
   `unwrap/1` CLOSED with `{:error, :corrupt_content_envelope}` rather than yielding
-  garbage plaintext. The worker maps that to `{:discard, ...}` — a corrupt envelope
-  is a poison pill no retry can heal — consistent with the worker's other
-  discard-don't-crash-loop guards.
+  garbage plaintext, and the worker maps that to `{:discard, ...}` — consistent with
+  its other discard-don't-crash-loop guards. AES-GCM CANNOT distinguish tampering
+  from a wrong/rotated key, so this same failure also fires when `CLOAK_KEY` is
+  rotated and the outgoing cipher is dropped while ingestion jobs are still queued
+  (they live up to the 3600s unique window, longer under snooze). That case is
+  RECOVERABLE — re-adding the prior cipher to `Loopctl.Vault`'s `retired_ciphers`
+  (see `config/config.exs`) lets the queued jobs decrypt — so a decrypt failure is
+  NOT unconditionally "a poison pill no retry can heal".
+
+  OPERATIONAL RULE: when rotating `CLOAK_KEY`, keep the outgoing cipher in
+  `retired_ciphers` until the `:ingestion` queue has drained, or in-flight jobs will
+  silently discard. The worker logs a distinct `Logger.warning` on every decrypt
+  failure (with tenant_id + content_hash, never the envelope) so a tampering or
+  mis-sequenced-rotation incident is an alertable signal, not buried in
+  `oban_jobs.errors`.
   """
 
   alias Loopctl.Vault

--- a/lib/loopctl/ingestion/content_envelope.ex
+++ b/lib/loopctl/ingestion/content_envelope.ex
@@ -1,0 +1,75 @@
+defmodule Loopctl.Ingestion.ContentEnvelope do
+  @moduledoc """
+  #493 — encrypts ingestion document content AT REST inside Oban job args.
+
+  Raw document `content` posted to `POST /api/v1/knowledge/ingest` used to sit as
+  plaintext JSON in `oban_jobs.args` (including `retryable`/`discarded` rows) until
+  pruning — the one at-rest exposure Epic 41 didn't cover. For a `local_only` scope
+  the pipeline can be fully egress-free and the persisted article bodies handled by
+  the US-41 work, while the RAWEST form of the document still sat unencrypted in a
+  side table, undermining the private tier's "encrypted at rest" guarantee on a
+  shared deployment.
+
+  `wrap/1` encrypts the content with `Loopctl.Vault` (Cloak AES-256-GCM) and
+  Base64-wraps it for JSON transport; `unwrap/1` reverses it. This mirrors
+  `Loopctl.Workers.OrphanedSecretCleanupWorker`'s restore-value handling and the
+  app's other Cloak-encrypted secrets (tenant LLM keys, webhook signing secrets) —
+  content is never plaintext in `oban_jobs`, and when the job is pruned the
+  ciphertext goes with it.
+
+  Encryption is UNCONDITIONAL (every ingested inline document, not only private-tier
+  scopes): the cost is negligible against a ~6-minute LLM ingestion job, and a
+  uniform path is simpler and strictly safer than branching on the scope's marking.
+  Uniqueness/fair-share key off `content_hash` and `tenant_id` (never the content),
+  so the non-deterministic AES-GCM ciphertext does not perturb them.
+
+  AES-GCM is AUTHENTICATED: a tampered, truncated, or non-Base64 envelope fails
+  `unwrap/1` CLOSED with `{:error, :corrupt_content_envelope}` rather than yielding
+  garbage plaintext. The worker maps that to `{:discard, ...}` — a corrupt envelope
+  is a poison pill no retry can heal — consistent with the worker's other
+  discard-don't-crash-loop guards.
+  """
+
+  alias Loopctl.Vault
+
+  @doc """
+  Encrypts `content` and returns a Base64-wrapped, JSON-safe envelope string.
+
+  Raises if the vault is misconfigured (no `CLOAK_KEY`) — a boot-level fault the
+  caller should never mask, matching the app's other `Vault.encrypt!/1` sites.
+  """
+  @spec wrap(binary()) :: binary()
+  def wrap(content) when is_binary(content) do
+    content |> Vault.encrypt!() |> Base.encode64()
+  end
+
+  @doc """
+  Decrypts an envelope produced by `wrap/1`.
+
+  Returns `{:ok, content}` or, on ANY malformed/tampered input (bad Base64, wrong
+  key, GCM auth failure, truncation), `{:error, :corrupt_content_envelope}` — never
+  raises, so the worker can `{:discard}` a poison pill instead of crash-looping.
+  """
+  @spec unwrap(binary()) :: {:ok, binary()} | {:error, :corrupt_content_envelope}
+  def unwrap(envelope) when is_binary(envelope) do
+    with {:ok, ciphertext} <- Base.decode64(envelope),
+         {:ok, content} <- safe_decrypt(ciphertext) do
+      {:ok, content}
+    else
+      _ -> {:error, :corrupt_content_envelope}
+    end
+  end
+
+  # Vault.decrypt!/1 does NOT uniformly raise: on an unrecognized Cloak cipher tag
+  # (e.g. a byte flipped in the header) it returns the atom `:error` rather than a
+  # binary. Accept ONLY a binary plaintext as success; every other outcome — an
+  # `:error` return, a `{:error, _}`, or a GCM-auth raise — collapses to `:error`.
+  defp safe_decrypt(ciphertext) do
+    case Vault.decrypt!(ciphertext) do
+      plaintext when is_binary(plaintext) -> {:ok, plaintext}
+      _ -> :error
+    end
+  rescue
+    _ -> :error
+  end
+end

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -287,6 +287,21 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     content |> ContentChunker.chunk() |> length()
   end
 
+  # #493: new inline jobs carry the document as an ENCRYPTED envelope, not
+  # plaintext `content`. Without this clause an encrypted multi-chunk document
+  # falls through to the `_ -> 1` catch-all and gets a flat one-chunk (60s)
+  # budget, re-introducing the exact multi-chunk Oban.TimeoutError kill #264
+  # fixed. Decrypt is cheap (once per attempt) and lets timeout/1 scale exactly
+  # as it does for legacy plaintext. A corrupt envelope is a poison pill perform/1
+  # {:discard}s anyway; grant it the full capped budget (max_chunks/0) so the
+  # timeout is never the thing that kills it first.
+  defp chunk_count_for_timeout(%{"content_encrypted" => envelope}) when is_binary(envelope) do
+    case ContentEnvelope.unwrap(envelope) do
+      {:ok, content} -> content |> ContentChunker.chunk() |> length()
+      {:error, _reason} -> max_chunks()
+    end
+  end
+
   defp chunk_count_for_timeout(%{"url" => url}) when is_binary(url) and url != "" do
     max_chunks()
   end

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -282,19 +282,27 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     |> min(max_job_timeout_ms())
   end
 
+  # #493 review (finding 6): new inline jobs carry a CLEARTEXT `content_chunk_count`
+  # computed from the plaintext at enqueue time. Prefer it so timeout/1 sizes the
+  # budget WITHOUT decrypting + chunking the envelope (the encrypted clause below did
+  # a full decrypt + full chunk on every attempt, redundant with perform/1's own
+  # decrypt + chunk). The count leaks no content. Placed FIRST so it wins over the
+  # `content_encrypted` fallback when both keys are present.
+  defp chunk_count_for_timeout(%{"content_chunk_count" => n}) when is_integer(n) and n > 0, do: n
+
   defp chunk_count_for_timeout(%{"content" => content})
        when is_binary(content) and content != "" do
     content |> ContentChunker.chunk() |> length()
   end
 
-  # #493: new inline jobs carry the document as an ENCRYPTED envelope, not
-  # plaintext `content`. Without this clause an encrypted multi-chunk document
-  # falls through to the `_ -> 1` catch-all and gets a flat one-chunk (60s)
-  # budget, re-introducing the exact multi-chunk Oban.TimeoutError kill #264
-  # fixed. Decrypt is cheap (once per attempt) and lets timeout/1 scale exactly
-  # as it does for legacy plaintext. A corrupt envelope is a poison pill perform/1
-  # {:discard}s anyway; grant it the full capped budget (max_chunks/0) so the
-  # timeout is never the thing that kills it first.
+  # #493: a pre-review or in-flight inline job may carry the ENCRYPTED envelope
+  # WITHOUT the cleartext `content_chunk_count` (jobs enqueued before finding 6's fix,
+  # still queued at deploy). Without this fallback such a job falls through to the
+  # `_ -> 1` catch-all and gets a flat one-chunk (60s) budget, re-introducing the exact
+  # multi-chunk Oban.TimeoutError kill #264 fixed. Decrypt is cheap (once per attempt)
+  # and lets timeout/1 scale as it does for legacy plaintext. A corrupt envelope is a
+  # poison pill perform/1 {:discard}s anyway; grant it the full capped budget
+  # (max_chunks/0) so the timeout is never the thing that kills it first.
   defp chunk_count_for_timeout(%{"content_encrypted" => envelope}) when is_binary(envelope) do
     case ContentEnvelope.unwrap(envelope) do
       {:ok, content} -> content |> ContentChunker.chunk() |> length()
@@ -675,15 +683,32 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   # (`content_encrypted`: Cloak AES-256-GCM + Base64) — never plaintext in `oban_jobs`.
   # Decrypt it here. A pre-#493 job still in flight at deploy carries legacy plaintext
   # `content`; accept it too so the queue drains without loss. The URL path has neither,
-  # so inline content is nil and `resolve_content` fetches. A tampered/corrupt envelope
-  # is a poison pill no retry can heal — {:discard} it cleanly, mirroring the project_id
-  # and no-key guards, rather than crash-looping to max_attempts.
-  defp inline_content(%{"content_encrypted" => envelope}) when is_binary(envelope) do
+  # so inline content is nil and `resolve_content` fetches.
+  #
+  # A decrypt failure is {:discard}ed cleanly (no crash-loop to max_attempts), mirroring
+  # the project_id and no-key guards. AES-GCM is authenticated but CANNOT distinguish
+  # tampering from a WRONG/ROTATED key: this branch fires both for at-rest tampering of
+  # the args row AND for a CLOAK_KEY rotation that dropped the outgoing cipher before the
+  # ingestion queue drained (in which case re-adding it to `retired_ciphers` heals the
+  # job — so it is NOT unconditionally "a poison pill no retry can heal"). Because it is
+  # security-relevant either way, and the sibling {:discard} guards
+  # (unsupported_content_discard, require_tenant_llm_key) log before discarding, emit an
+  # explicit Logger.warning here: a distinct, alertable signal so a tampering or
+  # key-config incident is observable rather than buried in oban_jobs.errors (#493
+  # review, findings 2/3/9/10). Log tenant_id + content_hash, NEVER the envelope.
+  defp inline_content(%{"content_encrypted" => envelope} = args) when is_binary(envelope) do
     case ContentEnvelope.unwrap(envelope) do
       {:ok, content} ->
         {:ok, content}
 
       {:error, reason} ->
+        Logger.warning(
+          "ContentIngestionWorker: discarding job — content envelope decrypt failed " <>
+            "(#{reason}); indicates at-rest tampering OR a CLOAK_KEY rotation that " <>
+            "dropped the prior cipher before the ingestion queue drained. " <>
+            "tenant=#{args["tenant_id"]} content_hash=#{args["content_hash"]}"
+        )
+
         {:discard, {reason, "ingestion content envelope could not be decrypted"}}
     end
   end

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -58,6 +58,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   import Loopctl.Egress, only: [is_egress_refusal: 1]
   import Loopctl.Llm.ShapeError, only: [is_shape_error: 1]
   alias Loopctl.Egress.Scope, as: EgressScope
+  alias Loopctl.Ingestion.ContentEnvelope
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ContentChunker
@@ -189,7 +190,6 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
 
   defp ingest(tenant_id, source_type, content_hash, args) do
     url = args["url"]
-    raw_content = args["content"]
     # Normalize "" -> nil (a blank project_id is "tenant-wide", not a value to dump
     # against the :binary_id column).
     project_id = normalize_project_id(args["project_id"])
@@ -209,6 +209,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     # the controller boundary 422s before enqueue, this is defense in depth.
     with :ok <- validate_project_id(project_id),
          :ok <- require_tenant_llm_key(tenant_id),
+         {:ok, raw_content} <- inline_content(args),
          {:ok, content} <- resolve_content(egress_scope(tenant_id, project_id), url, raw_content) do
       ctx = %{
         tenant_id: tenant_id,
@@ -654,6 +655,26 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   # otherwise. `Loopctl.Egress.Policy` resolves the effective marking as
   # MOST-RESTRICTIVE (project OR tenant).
   defp egress_scope(tenant_id, project_id), do: EgressScope.new(tenant_id, project_id)
+
+  # #493: inline document content is stored in job args ENCRYPTED at rest
+  # (`content_encrypted`: Cloak AES-256-GCM + Base64) — never plaintext in `oban_jobs`.
+  # Decrypt it here. A pre-#493 job still in flight at deploy carries legacy plaintext
+  # `content`; accept it too so the queue drains without loss. The URL path has neither,
+  # so inline content is nil and `resolve_content` fetches. A tampered/corrupt envelope
+  # is a poison pill no retry can heal — {:discard} it cleanly, mirroring the project_id
+  # and no-key guards, rather than crash-looping to max_attempts.
+  defp inline_content(%{"content_encrypted" => envelope}) when is_binary(envelope) do
+    case ContentEnvelope.unwrap(envelope) do
+      {:ok, content} ->
+        {:ok, content}
+
+      {:error, reason} ->
+        {:discard, {reason, "ingestion content envelope could not be decrypted"}}
+    end
+  end
+
+  defp inline_content(%{"content" => content}) when is_binary(content), do: {:ok, content}
+  defp inline_content(_args), do: {:ok, nil}
 
   defp resolve_content(_scope, nil, content) when is_binary(content) and content != "" do
     # Direct-content path: no Content-Type to consult, so the UTF-8 validity

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -361,6 +361,16 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # relied on); Ecto Sandbox + Mox resolve via the `$callers` chain that
   # Task.Supervisor.async_stream_nolink propagates.
   defp process_batch_items(tenant_id, items) do
+    # #493 fail-loud: ContentEnvelope's contract states a vault misconfiguration
+    # (missing CLOAK_KEY) is a boot-level fault the caller must never mask. Per-item
+    # encryption below runs inside async_stream_nolink, where a Vault.encrypt! raise
+    # is caught as {:exit, reason} and flattened into an opaque per-item
+    # "validation_failed" — hiding a real key-provisioning failure. The fault is
+    # global and deterministic, so probe the vault ONCE here (request process, before
+    # the async boundary) when any item carries inline content; a misconfig then
+    # propagates as a 500 exactly as it does on the single-item path.
+    if Enum.any?(items, &inline_content_item?/1), do: ContentEnvelope.ensure_ready!()
+
     Loopctl.TaskSupervisor
     |> Task.Supervisor.async_stream_nolink(
       items,
@@ -655,6 +665,14 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # encrypted at rest before it ever reaches `oban_jobs.args`.
   defp encrypt_inline_content(nil), do: nil
   defp encrypt_inline_content(content) when is_binary(content), do: ContentEnvelope.wrap(content)
+
+  # Does this batch item carry inline document content (vs a URL-only item)?
+  # Used to gate the pre-async vault readiness probe so a URL-only batch does no
+  # needless crypto work.
+  defp inline_content_item?(%{"content" => content}) when is_binary(content) and content != "",
+    do: true
+
+  defp inline_content_item?(_), do: false
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -14,6 +14,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.HeavyRead
   alias Loopctl.Ingestion.ContentEnvelope
+  alias Loopctl.Knowledge.ContentChunker
   alias Loopctl.Llm
   alias Loopctl.Net.UrlGuard
   alias Loopctl.Oban.FairShare
@@ -507,14 +508,19 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     # the uniqueness key excludes project_id, crash-loop as a poison pill.
     with :ok <- validate_ingest_project_id(project_id),
          :ok <- validate_content_source(url, content),
+         :ok <- validate_content_length(content),
          :ok <- validate_source_type(source_type),
          :ok <- validate_url_egress(url) do
-      content_hash = compute_content_hash(url || content)
+      content_hash = compute_content_hash(tenant_id, url || content)
 
       # #493: inline document content is encrypted at rest (Cloak AES-256-GCM) BEFORE it
       # is written to `oban_jobs.args` — never plaintext in the jobs table. The URL path
       # carries no inline content (nil), so `maybe_put` drops the key exactly as before;
-      # `content_hash` (over url||content) is unchanged and still keys uniqueness.
+      # `content_hash` (a per-tenant HMAC blind index over url||content) still keys
+      # uniqueness. `content_chunk_count` is the CLEARTEXT chunk count computed here from
+      # the plaintext (a coarse size hint that leaks no content) so the worker's
+      # `timeout/1` can size its budget WITHOUT decrypting+chunking the envelope on every
+      # attempt (#493 review, finding 6).
       job_args =
         %{
           "tenant_id" => tenant_id,
@@ -523,6 +529,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
         }
         |> maybe_put("url", url)
         |> maybe_put("content_encrypted", encrypt_inline_content(content))
+        |> maybe_put("content_chunk_count", inline_chunk_count(content))
         |> maybe_put("project_id", project_id)
         |> maybe_put("metadata", metadata)
         |> maybe_put("publish", if(publish, do: true))
@@ -602,8 +609,17 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     {:error, :unprocessable_entity, "Exactly one of 'url' or 'content' is required"}
   end
 
-  defp validate_content_source(_url, nil), do: :ok
-  defp validate_content_source(nil, _content), do: :ok
+  defp validate_content_source(url, nil) when is_binary(url), do: :ok
+  defp validate_content_source(nil, content) when is_binary(content), do: :ok
+
+  # A non-string `url`/`content` (e.g. a JSON object/array/number in the body) would
+  # slip past the nil-checks above but then raise FunctionClauseError in
+  # compute_content_hash/2 or encrypt_inline_content/1 (both is_binary-guarded),
+  # turning adversarial/malformed input into a 500. Reject it as a clean 422 at the
+  # write-path boundary instead (#493 review, finding 4).
+  defp validate_content_source(_url, _content) do
+    {:error, :unprocessable_entity, "'url' and 'content' must be strings"}
+  end
 
   # Ingestion is a WRITE path: a non-UUID project_id becomes a poison-pill job, so
   # be strict — nil/"" is absent (:ok), a valid UUID is :ok, and anything else
@@ -657,14 +673,71 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     end
   end
 
-  defp compute_content_hash(input) when is_binary(input) do
-    :crypto.hash(:sha256, input) |> Base.encode16(case: :lower)
+  # #493 review: `content_hash` is a KEYED BLIND INDEX (HMAC-SHA256 under the app
+  # secret, per tenant), NOT a bare SHA256 of the plaintext. A bare digest of the
+  # document sitting in cleartext next to the ciphertext is an offline confirmation
+  # oracle: a DB-read attacker could compute sha256(known_document) and match-to-
+  # confirm whether that exact content was ingested — partially defeating #493's
+  # "encrypted at rest" guarantee. Keying it under a server secret keeps the value
+  # DETERMINISTIC (so Oban's [content_hash, tenant_id] dedup and the worker's derived
+  # source_id still work) while making it uncomputable without the secret, and the
+  # per-tenant key also stops correlation of identical documents across tenants.
+  # Mirrors the `Loopctl.KeysetCursor` per-tenant HMAC-from-secret_key_base pattern.
+  defp compute_content_hash(tenant_id, input) when is_binary(input) do
+    :hmac
+    |> :crypto.mac(:sha256, content_hash_secret(tenant_id), input)
+    |> Base.encode16(case: :lower)
+  end
+
+  # Per-tenant HMAC key for the content_hash blind index: app secret_key_base +
+  # a namespace infix + tenant_id. Stable across nodes without storing a per-tenant
+  # secret. FAIL CLOSED: secret_key_base is fetched (not defaulted) — signing with a
+  # guessable constant would defeat the blind index; runtime.exs requires
+  # SECRET_KEY_BASE in prod and the test/dev configs set it, so this raise is a guard,
+  # not a path.
+  defp content_hash_secret(tenant_id) do
+    base =
+      :loopctl
+      |> Application.fetch_env!(LoopctlWeb.Endpoint)
+      |> Keyword.fetch!(:secret_key_base)
+
+    base <> ":knowledge_ingest_content_hash:" <> to_string(tenant_id)
   end
 
   # #493: nil (URL path) stays nil so `maybe_put` omits the key; inline content is
   # encrypted at rest before it ever reaches `oban_jobs.args`.
   defp encrypt_inline_content(nil), do: nil
   defp encrypt_inline_content(content) when is_binary(content), do: ContentEnvelope.wrap(content)
+
+  # Cap inline `content` at the controller boundary (#493 review, findings 5/7).
+  # Inline content is otherwise bounded only by the HTTP body limit; #493 now ENCRYPTS
+  # + Base64-wraps it (~+33%) into oban_jobs.args JSONB, and the worker decrypts +
+  # chunks the full body on EVERY attempt — so an oversized body amplifies both storage
+  # and per-attempt CPU/memory. Reject an over-cap body as a clean 422 here (before any
+  # crypto or enqueue) rather than after. Sized well above a large document (an ~87KB
+  # newsletter) but bounded. URL-only ingests (content nil) skip this.
+  @max_inline_content_bytes 1_000_000
+  defp validate_content_length(content) when is_binary(content) do
+    if byte_size(content) > @max_inline_content_bytes do
+      {:error, :unprocessable_entity,
+       "'content' exceeds the #{@max_inline_content_bytes}-byte inline limit; " <>
+         "fetch larger documents via 'url' instead"}
+    else
+      :ok
+    end
+  end
+
+  defp validate_content_length(_), do: :ok
+
+  # #493 review (finding 6): compute the chunk count from the PLAINTEXT once, here at
+  # enqueue, and persist it as a cleartext job arg so `ContentIngestionWorker.timeout/1`
+  # can scale its wall-clock budget WITHOUT decrypting + chunking the envelope on every
+  # attempt. The count is a coarse size hint that leaks no content. nil (URL path) omits
+  # the arg via `maybe_put`.
+  defp inline_chunk_count(nil), do: nil
+
+  defp inline_chunk_count(content) when is_binary(content),
+    do: content |> ContentChunker.chunk() |> length()
 
   # Does this batch item carry inline document content (vs a URL-only item)?
   # Used to gate the pre-async vault readiness probe so a URL-only batch does no

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -13,6 +13,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
 
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.HeavyRead
+  alias Loopctl.Ingestion.ContentEnvelope
   alias Loopctl.Llm
   alias Loopctl.Net.UrlGuard
   alias Loopctl.Oban.FairShare
@@ -500,6 +501,10 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
          :ok <- validate_url_egress(url) do
       content_hash = compute_content_hash(url || content)
 
+      # #493: inline document content is encrypted at rest (Cloak AES-256-GCM) BEFORE it
+      # is written to `oban_jobs.args` — never plaintext in the jobs table. The URL path
+      # carries no inline content (nil), so `maybe_put` drops the key exactly as before;
+      # `content_hash` (over url||content) is unchanged and still keys uniqueness.
       job_args =
         %{
           "tenant_id" => tenant_id,
@@ -507,7 +512,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
           "source_type" => source_type
         }
         |> maybe_put("url", url)
-        |> maybe_put("content", content)
+        |> maybe_put("content_encrypted", encrypt_inline_content(content))
         |> maybe_put("project_id", project_id)
         |> maybe_put("metadata", metadata)
         |> maybe_put("publish", if(publish, do: true))
@@ -645,6 +650,11 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   defp compute_content_hash(input) when is_binary(input) do
     :crypto.hash(:sha256, input) |> Base.encode16(case: :lower)
   end
+
+  # #493: nil (URL path) stays nil so `maybe_put` omits the key; inline content is
+  # encrypted at rest before it ever reaches `oban_jobs.args`.
+  defp encrypt_inline_content(nil), do: nil
+  defp encrypt_inline_content(content) when is_binary(content), do: ContentEnvelope.wrap(content)
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)

--- a/test/loopctl/ingestion/content_envelope_test.exs
+++ b/test/loopctl/ingestion/content_envelope_test.exs
@@ -1,0 +1,82 @@
+defmodule Loopctl.Ingestion.ContentEnvelopeTest do
+  @moduledoc """
+  #493 — `Loopctl.Ingestion.ContentEnvelope` encrypts ingestion document content at rest
+  inside Oban job args. The contract: `wrap/1` output is Cloak ciphertext (NOT the
+  plaintext, so `oban_jobs.args` never holds the document in the clear), round-trips
+  through `unwrap/1`, and `unwrap/1` fails CLOSED on any tampered/malformed input so the
+  worker can discard a poison pill instead of yielding garbage.
+  """
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Ingestion.ContentEnvelope
+
+  describe "wrap/1 + unwrap/1 round-trip" do
+    test "round-trips ASCII, Cyrillic, and multi-line content" do
+      for content <- [
+            "Some raw content about Elixir patterns",
+            "Некоторый секретный документ по проектам",
+            "line one\n\n# heading\n\nline two with émojis 🔐 and quotes \"x\"",
+            String.duplicate("large payload ", 5000)
+          ] do
+        envelope = ContentEnvelope.wrap(content)
+        assert {:ok, ^content} = ContentEnvelope.unwrap(envelope)
+      end
+    end
+
+    test "the envelope is ciphertext — never the plaintext, and is Base64" do
+      content = "sensitive document body that must not sit in oban_jobs plaintext"
+      envelope = ContentEnvelope.wrap(content)
+
+      refute envelope == content
+      refute String.contains?(envelope, "sensitive document body")
+      # Valid Base64 (JSON-safe transport).
+      assert {:ok, _ciphertext} = Base.decode64(envelope)
+    end
+
+    test "encryption is non-deterministic (random IV) but both envelopes decrypt" do
+      content = "same input, different ciphertext each time"
+      e1 = ContentEnvelope.wrap(content)
+      e2 = ContentEnvelope.wrap(content)
+
+      refute e1 == e2
+      assert {:ok, ^content} = ContentEnvelope.unwrap(e1)
+      assert {:ok, ^content} = ContentEnvelope.unwrap(e2)
+    end
+
+    test "round-trips the empty string" do
+      assert {:ok, ""} = ContentEnvelope.unwrap(ContentEnvelope.wrap(""))
+    end
+  end
+
+  describe "unwrap/1 fails closed on malformed input" do
+    test "non-Base64 input" do
+      assert {:error, :corrupt_content_envelope} = ContentEnvelope.unwrap("not-base64!!!")
+    end
+
+    test "valid Base64 that is not valid ciphertext" do
+      not_ciphertext = Base.encode64("just some plaintext bytes, no Cloak header")
+      assert {:error, :corrupt_content_envelope} = ContentEnvelope.unwrap(not_ciphertext)
+    end
+
+    test "a truncated (tampered) envelope" do
+      envelope = ContentEnvelope.wrap("authenticated content")
+      truncated = String.slice(envelope, 0, div(String.length(envelope), 2))
+      assert {:error, :corrupt_content_envelope} = ContentEnvelope.unwrap(truncated)
+    end
+
+    test "a bit-flipped (tampered) ciphertext fails the GCM auth tag" do
+      envelope = ContentEnvelope.wrap("authenticated content")
+      {:ok, ciphertext} = Base.decode64(envelope)
+      # Flip a byte in the middle of the ciphertext, re-wrap as Base64.
+      mid = div(byte_size(ciphertext), 2)
+      <<head::binary-size(mid), byte, tail::binary>> = ciphertext
+      tampered = Base.encode64(<<head::binary, Bitwise.bxor(byte, 0xFF), tail::binary>>)
+
+      assert {:error, :corrupt_content_envelope} = ContentEnvelope.unwrap(tampered)
+    end
+
+    test "the empty string is not a valid envelope" do
+      assert {:error, :corrupt_content_envelope} = ContentEnvelope.unwrap("")
+    end
+  end
+end

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -203,6 +203,84 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
     end
   end
 
+  # --- #493: encrypted-at-rest inline content (content_encrypted) ---
+
+  describe "perform/1 with encrypted inline content (#493)" do
+    alias Loopctl.Ingestion.ContentEnvelope
+
+    test "decrypts content_encrypted and extracts from the plaintext" do
+      %{tenant: tenant} = setup_tenant()
+      plaintext = "Некоторый секретный документ about Elixir patterns"
+
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id, content, opts ->
+        # The extractor must see the DECRYPTED plaintext, never the envelope.
+        assert content == plaintext
+        assert opts[:source_type] == "newsletter"
+
+        {:ok,
+         [%{title: "From encrypted", body: "Decrypted fine.", category: :pattern, tags: ["x"]}]}
+      end)
+
+      assert :ok =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 4930,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "content_encrypted" => ContentEnvelope.wrap(plaintext),
+                   "content_hash" => "enc123",
+                   "source_type" => "newsletter"
+                 }
+               })
+
+      %{data: [article]} = Knowledge.list_articles(tenant.id, source_type: "newsletter")
+      assert article.title == "From encrypted"
+    end
+
+    test "discards cleanly (no crash, no retry) on a corrupt/tampered envelope" do
+      %{tenant: tenant} = setup_tenant()
+
+      # A well-formed job whose envelope is not decryptable is a poison pill: no
+      # retry can heal it, so it must {:discard} — never reach the extractor.
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _t, _c, _o ->
+        flunk("extractor must not run on a corrupt content envelope")
+      end)
+
+      assert {:discard, {:corrupt_content_envelope, _msg}} =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 4931,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "content_encrypted" => "not-a-valid-base64-envelope!!!",
+                   "content_hash" => "corrupt123",
+                   "source_type" => "newsletter"
+                 }
+               })
+    end
+
+    test "legacy plaintext content arg (pre-#493 in-flight job) still ingests" do
+      %{tenant: tenant} = setup_tenant()
+
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _t, content, _o ->
+        assert content == "legacy plaintext still accepted"
+        {:ok, [%{title: "Legacy", body: "ok", category: :pattern, tags: []}]}
+      end)
+
+      assert :ok =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 4932,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "content" => "legacy plaintext still accepted",
+                   "content_hash" => "legacy123",
+                   "source_type" => "newsletter"
+                 }
+               })
+
+      %{data: [article]} = Knowledge.list_articles(tenant.id, source_type: "newsletter")
+      assert article.title == "Legacy"
+    end
+  end
+
   # Collect all {:batch_call, n} messages currently in the mailbox (batch workers ran
   # inline before perform/1 returned, so they're all already delivered).
   defp drain_batch_calls(acc) do

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -15,6 +15,7 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
 
   setup :verify_on_exit!
 
+  alias Loopctl.Ingestion.ContentEnvelope
   alias Loopctl.Knowledge
   alias Loopctl.Test.AllowlistSource
   alias Loopctl.Workers.ContentIngestionWorker
@@ -1565,6 +1566,38 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
 
     test "a URL job (unknown size pre-fetch) is granted the full capped budget" do
       job = %Oban.Job{args: %{"url" => "https://example.com/x", "source_type" => "x"}}
+      assert ContentIngestionWorker.timeout(job) == :timer.minutes(6)
+    end
+
+    # #493: new inline jobs carry content_encrypted, NOT plaintext content. The
+    # timeout must scale off the DECRYPTED chunk count, identically to the legacy
+    # plaintext path — otherwise every encrypted multi-chunk document silently
+    # regresses to the flat 60s (one-chunk) budget #264 was written to prevent.
+    test "an encrypted multi-chunk job scales exactly like its plaintext twin" do
+      plaintext = multi_chunk_content(4)
+
+      plain = %Oban.Job{args: %{"content" => plaintext, "source_type" => "x"}}
+
+      encrypted = %Oban.Job{
+        args: %{
+          "content_encrypted" => ContentEnvelope.wrap(plaintext),
+          "source_type" => "x"
+        }
+      }
+
+      # 4 chunks * 60s = 240s, under the 6-min cap — and NOT the 60s catch-all.
+      assert ContentIngestionWorker.timeout(encrypted) == 4 * :timer.seconds(60)
+      assert ContentIngestionWorker.timeout(encrypted) == ContentIngestionWorker.timeout(plain)
+      assert ContentIngestionWorker.timeout(encrypted) > :timer.seconds(60)
+    end
+
+    test "a corrupt encrypted envelope gets the full capped budget, never the 60s floor" do
+      job = %Oban.Job{
+        args: %{"content_encrypted" => "not-a-valid-base64-envelope!!!", "source_type" => "x"}
+      }
+
+      # A poison-pill envelope can't be chunked; perform/1 {:discard}s it, so grant
+      # the full capped budget rather than let a 60s timeout cut it off first.
       assert ContentIngestionWorker.timeout(job) == :timer.minutes(6)
     end
   end

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -2,9 +2,11 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
   use LoopctlWeb.ConnCase, async: true
 
   alias Loopctl.AdminRepo
+  alias Loopctl.Ingestion.ContentEnvelope
   alias Loopctl.Knowledge
   alias Loopctl.Oban.FairShare
   alias Loopctl.ObanConfig
+  alias Loopctl.Repo
 
   setup :verify_on_exit!
 
@@ -38,6 +40,22 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
   defp auth_conn(conn, raw_key) do
     put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  # The single persisted ContentIngestionWorker row for a tenant. Oban.insert writes
+  # through `Loopctl.Repo` in the test process, so read it back via the SAME repo (a
+  # cross-repo AdminRepo read would miss the sandbox-scoped row); oban_jobs has no RLS.
+  # Asserts exactly one, so a stray/duplicate enqueue fails loudly.
+  defp ingestion_job_for(tenant_id) do
+    [job] =
+      Oban.Job
+      |> Repo.all()
+      |> Enum.filter(
+        &(&1.worker == "Loopctl.Workers.ContentIngestionWorker" and
+            &1.args["tenant_id"] == tenant_id)
+      )
+
+    job
   end
 
   # Mandatory BYO (Epic 28, #179): ingest requires the tenant to have configured an
@@ -165,6 +183,54 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       body = json_response(conn, 202)
       assert body["data"]["status"] == "queued"
       assert body["data"]["source_type"] == "newsletter"
+    end
+
+    test "#493: inline content is encrypted at rest in oban_jobs args (never plaintext)",
+         %{conn: conn} do
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      plaintext = "confidential document body that must never sit plaintext in oban_jobs"
+
+      # :manual so the job is PERSISTED (not run inline), letting us inspect the args
+      # actually written to oban_jobs. No extractor stub — the worker never runs here.
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest", %{content: plaintext, source_type: "newsletter"})
+        |> json_response(202)
+      end)
+
+      job = ingestion_job_for(tenant.id)
+
+      # The plaintext appears NOWHERE in the persisted args JSON.
+      refute Map.has_key?(job.args, "content")
+      refute String.contains?(Jason.encode!(job.args), "confidential document body")
+
+      # The encrypted envelope is present and decrypts back to the original plaintext.
+      assert is_binary(job.args["content_encrypted"])
+      refute job.args["content_encrypted"] == plaintext
+      assert {:ok, ^plaintext} = ContentEnvelope.unwrap(job.args["content_encrypted"])
+    end
+
+    test "URL ingests carry no inline content key in args (#493)", %{conn: conn} do
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest", %{
+          url: "https://example.com/article",
+          source_type: "web_article"
+        })
+        |> json_response(202)
+      end)
+
+      job = ingestion_job_for(tenant.id)
+
+      refute Map.has_key?(job.args, "content")
+      refute Map.has_key?(job.args, "content_encrypted")
+      assert job.args["url"] == "https://example.com/article"
     end
 
     test "extracted articles default to draft", %{conn: conn} do

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -212,6 +212,78 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert {:ok, ^plaintext} = ContentEnvelope.unwrap(job.args["content_encrypted"])
     end
 
+    test "#493 finding 4: a non-string content is a clean 422, not a 500", %{conn: conn} do
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest", %{
+          "content" => %{"x" => 1},
+          "source_type" => "newsletter"
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "must be strings"
+    end
+
+    test "#493 findings 5/7: oversized inline content is rejected with 422", %{conn: conn} do
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      oversized = String.duplicate("a", 1_000_001)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest", %{
+          content: oversized,
+          source_type: "newsletter"
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "inline limit"
+    end
+
+    test "#493 finding 6: encrypted inline job carries a cleartext content_chunk_count",
+         %{conn: conn} do
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest", %{
+          content: "Some raw content about patterns.",
+          source_type: "newsletter"
+        })
+        |> json_response(202)
+      end)
+
+      job = ingestion_job_for(tenant.id)
+      assert is_integer(job.args["content_chunk_count"])
+      assert job.args["content_chunk_count"] >= 1
+    end
+
+    test "#493 findings 1/8: content_hash is a keyed blind index, not sha256(plaintext)",
+         %{conn: conn} do
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      plaintext = "guessable memo content"
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest", %{content: plaintext, source_type: "newsletter"})
+
+      content_hash = json_response(conn, 202)["data"]["content_hash"]
+      bare_sha256 = :crypto.hash(:sha256, plaintext) |> Base.encode16(case: :lower)
+
+      # An attacker with DB read access must NOT be able to confirm-by-match with a
+      # plain sha256 of the known plaintext.
+      refute content_hash == bare_sha256
+    end
+
     test "URL ingests carry no inline content key in args (#493)", %{conn: conn} do
       tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})


### PR DESCRIPTION
Closes #493. Last of the four self-host requests from FinanceAlex (follow-up from #409).

## Problem
Raw document content posted to POST /api/v1/knowledge/ingest was written to oban_jobs.args as plaintext JSON (including retryable/discarded rows) until pruning — the one at-rest exposure Epic 41 did not cover. For a local_only scope the pipeline can be fully egress-free and the persisted article bodies handled by the US-41 work, while the rawest form of the document still sat unencrypted in a side table, undermining the private tier's encrypted-at-rest guarantee on any shared deployment.

## Approach
Add Loopctl.Ingestion.ContentEnvelope: wrap/1 encrypts content with Loopctl.Vault (Cloak AES-256-GCM) and Base64-wraps it for JSON; unwrap/1 reverses it. This mirrors OrphanedSecretCleanupWorker's restore-value handling and the app's other Cloak-encrypted secrets (tenant LLM keys, webhook signing secrets) — content is never plaintext in oban_jobs, and when the job is pruned the ciphertext goes with it.

Chosen over the issue's alternative (a dedicated payload table + RLS + an orphan-sweeper) because it fully meets the goal — no plaintext document at rest — with far fewer moving parts, reusing the codebase's own established pattern.

- The controller encrypts inline content into a content_encrypted arg; the URL path carries no inline content, so the key is simply omitted.
- The worker decrypts it and still accepts a legacy plaintext content arg, so pre-deploy in-flight jobs drain without loss.
- AES-GCM is authenticated: a tampered/truncated/non-Base64 envelope fails unwrap/1 closed, and the worker maps that to a clean discard rather than crash-looping (mirrors its project_id and no-key poison-pill guards).
- Encryption is unconditional (every inline ingest). Uniqueness (keys content_hash, tenant_id) and fair-share (args tenant_id) never key on the content field, so the non-deterministic ciphertext does not perturb dedup or scheduling.

## Tests
ContentEnvelope round-trip (ASCII/Cyrillic/multiline/large/empty), ciphertext-not-plaintext, non-determinism, and fail-closed on non-Base64 / non-ciphertext / truncated / bit-flipped input; the worker decrypts the new arg, discards a corrupt envelope, and still ingests a legacy plaintext arg; the controller persists ciphertext (never the plaintext) in oban_jobs args and omits the key for URL ingests.

Full quality gate (mix precommit) green: compile-clean, credo --strict, dialyzer, 6381 tests 0 failures.
