### PR TITLE
docs: document the self-host env vars and the ingest content constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,58 @@
 
 All notable changes to loopctl are documented here.
 
-## [Unreleased] — 2026-07-16 — Agent-memory substrate: project scope, merged recall, graduation (#411)
+## [Unreleased] — 2026-07-24 — Self-hosting: fresh-install fixes, multilingual search, at-rest ingestion encryption
+
+Operator-facing changes for deployments outside the hosted instance.
+
+### Added
+
+- **`FTS_REGCONFIG` — per-deployment keyword-search language (#492).** Keyword FTS
+  was hardwired to the `english` stemmer, so a non-English corpus silently degraded
+  (Russian «отчёты» never matched «отчёт»). `Loopctl.Search.Regconfig` is now the
+  single source of truth, set from `FTS_REGCONFIG` (default `english`, so the hosted
+  instance is unchanged). **Set it before the first `migrate`** — the
+  `apply_fts_regconfig` migration bakes the value into the stored `search_vector`s
+  and is a no-op on the default. A well-formed but uninstalled config (e.g.
+  `ukrainian`) fails the migration loudly rather than building an unusable index.
+- **`SECRETS_ADAPTER=local_file` + `SECRETS_FILE` — signup off Fly (#496).** Tenant
+  signup stores a per-tenant Ed25519 audit key via `Loopctl.Secrets`, which defaulted
+  to the Fly secrets API — so signup was impossible on any other host. The local
+  adapter writes `0600` with fsync and atomic tmp+rename under a write lock. Put
+  `SECRETS_FILE` on a persistent volume and back it up with the database.
+- **Browser signup mints a usable root API key (#500).** The HTML signup ceremony
+  previously completed without issuing credentials, leaving a browser-onboarded
+  tenant with no authenticated path forward. The key is surfaced exactly once, in
+  LiveView memory only — never in a URL, session, or persisted record.
+
+### Changed
+
+- **Ingestion document content is encrypted at rest (#493).** Raw `content` posted to
+  `POST /api/v1/knowledge/ingest` was persisted as plaintext JSON in `oban_jobs.args`
+  (including `retryable`/`discarded` rows) until pruning — the one at-rest exposure
+  Epic 41 did not cover. It is now Cloak AES-256-GCM encrypted via
+  `Loopctl.Ingestion.ContentEnvelope`. `url`, `source_type`, and `metadata` are **not**
+  encrypted. Inline `content` is capped at 1,000,000 bytes (`422` over cap).
+  `content_hash` changed from `sha256(plaintext)` to a per-tenant HMAC blind index —
+  still an opaque deterministic string (dedup unaffected), but no longer an offline
+  confirmation oracle for a DB-read attacker.
+  **Operational:** when rotating `CLOAK_KEY`, keep the outgoing cipher in
+  `retired_ciphers` until the `:ingestion` queue drains, or in-flight jobs discard.
+
+### Fixed
+
+- **Fresh installs no longer break in the Epic-41 migrations (#495).** The pgvector
+  guard silently skipped embedding columns that a later migration then required. The
+  migration now tolerates and heals the skipped state (idempotent, `IF NOT EXISTS`).
+- **`/signup` rendered unstyled and non-functional on a fresh self-hosted install
+  (#494)** — the browser pipeline was missing `put_root_layout`. Fixed at the
+  `live_session` level so the `layout: false` marketing pages do not double-wrap.
+
+> **Note on this file's coverage.** Entries below predate a sustained run of merges
+> that were not recorded here. `git log --first-parent` is the authoritative history;
+> this file is best-effort for operator-facing changes.
+
+## [Earlier] — 2026-07-16 — Agent-memory substrate: project scope, merged recall, graduation (#411)
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,19 @@ mix phx.gen.secret
 elixir -e ':crypto.strong_rand_bytes(32) |> Base.encode64() |> IO.puts()'
 ```
 
+### Self-Hosting (outside Fly.io)
+
+Two knobs matter on a non-Fly deployment; both default to the hosted behaviour, so
+they are easy to miss. Full details in [`deploy/FLY_SECRETS.md`](deploy/FLY_SECRETS.md).
+
+| Variable | Set it when | Why |
+|----------|-------------|-----|
+| `SECRETS_ADAPTER=local_file` (+ `SECRETS_FILE`) | Always, off Fly | Signup stores each tenant's Ed25519 audit private key via `Loopctl.Secrets`, which defaults to the **Fly** secrets API. Without this, tenant creation fails on any other host. Put `SECRETS_FILE` on a persistent volume and back it up with the DB. |
+| `FTS_REGCONFIG=<config>` | Non-English content | Keyword search defaults to the `english` stemmer. Set it **before the first `migrate`** — the value is baked into the stored `search_vector`s. |
+
+Rotating `CLOAK_KEY` has an ordering requirement (drain the `:ingestion` queue, or
+keep the outgoing cipher in `retired_ciphers`) — see the deployment guide.
+
 > **Ports:** Local development runs on `http://localhost:4030`. Production is `https://loopctl.com` (Fly.io). All examples below use the local dev URL.
 
 ## API Overview

--- a/deploy/FLY_SECRETS.md
+++ b/deploy/FLY_SECRETS.md
@@ -23,7 +23,15 @@ fly secrets set CLOAK_KEY="GENERATED_BASE64_KEY"
 | `DATABASE_URL`     | Yes      | Ecto URL for `Loopctl.Repo` (loopctl_app role, RLS enforced) |
 | `ADMIN_DATABASE_URL` | Yes    | Ecto URL for `Loopctl.AdminRepo` (loopctl_admin role, BYPASSRLS) |
 | `SECRET_KEY_BASE`  | Yes      | Phoenix cookie signing/encryption key               |
-| `CLOAK_KEY`        | Yes      | AES-256-GCM encryption key for API key hashing      |
+| `CLOAK_KEY`        | Yes      | AES-256-GCM key for every field encrypted at rest: API key hashing, tenant LLM keys, webhook signing secrets, and ingestion document content |
+
+> **Rotating `CLOAK_KEY`:** keep the OUTGOING cipher in `Loopctl.Vault`'s
+> `retired_ciphers` (see `config/config.exs`) until the `:ingestion` queue has
+> drained. Ingestion jobs carry their document encrypted in `oban_jobs.args` and
+> live up to the 3600s uniqueness window (longer under snooze); a rotation that
+> drops the old cipher first makes those in-flight jobs undecryptable, and they
+> discard. The worker logs a distinct warning on every decrypt failure — alert on
+> it, since the same signal also means at-rest tampering.
 
 ### Environment Variables (set in fly.toml, not secrets)
 
@@ -41,6 +49,49 @@ fly secrets set CLOAK_KEY="GENERATED_BASE64_KEY"
 | `ADMIN_POOL_SIZE`   | `3`     | AdminRepo connection pool size           |
 | `ECTO_IPV6`         | -       | Set to `true` to enable IPv6 for DB     |
 | `DNS_CLUSTER_QUERY` | -       | DNS query for clustering (not needed for single machine) |
+| `SECRETS_ADAPTER`   | Fly GraphQL | Set to `local_file` to store the per-tenant audit keypairs on disk instead of in Fly secrets — REQUIRED when self-hosting off Fly (see below) |
+| `SECRETS_FILE`      | `/data/loopctl/secrets.json` | Path for the `local_file` adapter. Put it on a PERSISTENT volume |
+| `FTS_REGCONFIG`     | `english` | Postgres text-search config for keyword FTS (see below) |
+
+#### Self-hosting off Fly: `SECRETS_ADAPTER=local_file`
+
+Tenant signup mints a per-tenant Ed25519 audit keypair and stores the private key
+through `Loopctl.Secrets`. The default adapter writes to **Fly secrets**, so on a
+non-Fly host signup fails and no tenant can be created. Switch it:
+
+```bash
+SECRETS_ADAPTER=local_file
+SECRETS_FILE=/data/loopctl/secrets.json   # must be on a persistent volume
+```
+
+The local adapter writes `0600`, fsyncs, and uses an atomic tmp+rename under a
+write lock. **Back this file up with the database** — losing it breaks audit-chain
+signature verification for every tenant it holds a key for.
+
+#### Non-English knowledge bases: `FTS_REGCONFIG`
+
+Keyword full-text search ships hardwired to the `english` stemmer, which does not
+unify inflected forms in other languages (Russian «отчёты» never matches «отчёт»)
+and applies the wrong stop-words. Set the deployment's Postgres text-search
+configuration:
+
+```bash
+FTS_REGCONFIG=russian   # any name in pg_ts_config: simple, french, german, ...
+```
+
+**Set it BEFORE the first `migrate` on a fresh install.** The `apply_fts_regconfig`
+migration bakes the value into the stored `search_vector`s (a generated column cannot
+read runtime config), and it is a no-op on the `english` default. Changing the value
+on an already-migrated corpus does NOT re-run that migration — rebuilding a populated
+corpus's vectors is a separate operator action.
+
+A name that is well-formed but **not installed** (e.g. `ukrainian`, which stock
+Postgres does not ship) fails the migration loudly rather than silently building an
+unusable index — install the dictionary first. Verify with:
+
+```sql
+SELECT cfgname FROM pg_ts_config ORDER BY cfgname;
+```
 
 ## Database Setup
 

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -29,6 +29,11 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
                         "loopctl is BYO — provision it ONCE via the set_llm_config MCP tool " <>
                         "(user role), or PATCH /api/v1/tenants/me/llm-config. See the response " <>
                         "`remediation` for the exact call."
+
+  # Inline-content ceiling (#493 review, findings 5/7). Declared HERE, above the
+  # `operation/2` specs, so the published OpenAPI `maxLength` and the enforcing
+  # `validate_content_length/1` read the SAME number and cannot drift.
+  @max_inline_content_bytes 1_000_000
   alias LoopctlWeb.Helpers.Pagination
   alias LoopctlWeb.Helpers.ProjectId
 
@@ -46,7 +51,10 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
         "articles via LLM, and inserts them. Extracted articles are created as " <>
         "**drafts by default** (lower-trust LLM output, staged for review) — unlike " <>
         "direct POST /articles which publishes by default. Pass `publish: true` to " <>
-        "publish them on extraction instead. Role: orchestrator+.",
+        "publish them on extraction instead. Role: orchestrator+.\n\n" <>
+        "**At rest:** inline `content` is encrypted (AES-256-GCM) in the job record " <>
+        "and is never persisted in the clear. `url`, `source_type`, and `metadata` " <>
+        "are NOT encrypted — do not put sensitive values in `metadata`.",
     request_body:
       {"Ingestion request", "application/json",
        %OpenApiSpex.Schema{
@@ -58,7 +66,11 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
            },
            content: %OpenApiSpex.Schema{
              type: :string,
-             description: "Raw content to extract from (exactly one of url or content required)"
+             maxLength: @max_inline_content_bytes,
+             description:
+               "Raw content to extract from (exactly one of url or content required). " <>
+                 "Capped at #{@max_inline_content_bytes} bytes — a larger body is rejected " <>
+                 "with 422; fetch bigger documents via `url` instead. Encrypted at rest."
            },
            source_type: %OpenApiSpex.Schema{
              type: :string,
@@ -202,7 +214,9 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
                "Array of ingestion items (max 50). Each item has the same shape as " <>
                  "POST /knowledge/ingest: url or content, source_type (required), " <>
                  "project_id (optional), publish (optional, default false → draft), " <>
-                 "metadata (optional).",
+                 "metadata (optional). Per-item `content` obeys the same " <>
+                 "#{@max_inline_content_bytes}-byte cap and is encrypted at rest; " <>
+                 "`metadata` is not encrypted.",
              maxItems: 50
            }
          },
@@ -716,7 +730,8 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # and per-attempt CPU/memory. Reject an over-cap body as a clean 422 here (before any
   # crypto or enqueue) rather than after. Sized well above a large document (an ~87KB
   # newsletter) but bounded. URL-only ingests (content nil) skip this.
-  @max_inline_content_bytes 1_000_000
+  # (@max_inline_content_bytes is declared at the top of the module so the OpenAPI
+  # `maxLength` and this guard share one source of truth.)
   defp validate_content_length(content) when is_binary(content) do
     if byte_size(content) > @max_inline_content_bytes do
       {:error, :unprocessable_entity,


### PR DESCRIPTION
Follow-up to the four self-hosting PRs (#495, #494/#496/#500, #492, #493). The code shipped clean, but their operator-facing knobs were undiscoverable.

## The gap
`FTS_REGCONFIG`, `SECRETS_ADAPTER`, and `SECRETS_FILE` appeared in **no markdown anywhere** — the only way to find them was to read `config/runtime.exs`. Both are self-host enablement knobs, so the audience that needs them is exactly the audience that cannot read our source tree.

## Changes

**deploy/FLY_SECRETS.md**
- All three vars added to the optional-env table.
- New section on the `local_file` secrets adapter: why signup fails off Fly, the persistent-volume requirement, and that the file must be backed up with the DB (losing it breaks audit-chain verification).
- New section on `FTS_REGCONFIG`: the set-it-before-first-migrate ordering, that changing it later does not re-run the rebuild, and that a well-formed but uninstalled name (e.g. ukrainian) fails the migration loudly.
- `CLOAK_KEY` now names every field it protects, and carries the rotation ordering rule from #493 — keep the outgoing cipher in retired_ciphers until the ingestion queue drains, or in-flight jobs discard.

**README.md** — a short Self-Hosting table pointing at the guide.

**OpenAPI (both ingest endpoints)** — documents the 1MB inline content cap #493 added (a 422 clients would otherwise hit blind) and states which fields are encrypted at rest: content is; url, source_type, and metadata are not. The cap constant moved to the top of the module so the published maxLength and the enforcing guard share one source of truth and cannot drift.

**CHANGELOG.md** — an entry for the four PRs. The file had fallen far behind; rather than reconstruct dozens of entries from commit subjects (make-work that rots), the stale boundary is stated explicitly and points at `git log --first-parent` as authoritative.

## Verified unchanged
`mcp-server/` needs no update — none of the four PRs added or changed a tool or param, so 2.61.0 and its README/CHANGELOG remain correct.

Full quality gate green: compile-clean, credo --strict, dialyzer, 6387 tests 0 failures.
