### PR TITLE
Document the remaining 24 operator env vars and gate the blind spot mechanically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,9 +49,14 @@ Operator-facing changes for deployments outside the hosted instance.
   (#494)** — the browser pipeline was missing `put_root_layout`. Fixed at the
   `live_session` level so the `layout: false` marketing pages do not double-wrap.
 
-> **Note on this file's coverage.** Entries below predate a sustained run of merges
-> that were not recorded here. `git log --first-parent` is the authoritative history;
-> this file is best-effort for operator-facing changes.
+> **Scope of this file.** loopctl's changelog records **operator-facing** changes
+> only: environment variables, deploy ordering, migrations with manual steps,
+> breaking or behaviour-changing API changes, and security-relevant changes to how
+> data is stored. Refactors, test fixes, internal hardening, and dependency bumps
+> are deliberately out of scope — `git log --first-parent` is the complete history.
+> The trigger is narrow on purpose: a changelog that tries to record every merge
+> is the kind that stops being written, which is what happened to the stretch of
+> entries between this line and the one below it. See `CONTRIBUTING.md`.
 
 ## [Earlier] — 2026-07-16 — Agent-memory substrate: project scope, merged recall, graduation (#411)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,6 +320,31 @@ tally — e.g. AdminRepo's 3-connection pool (`config/runtime.exs:190`), which i
 *why* a heavy read starves the admin pool. Cite it at `file:line` so it can be
 re-checked.
 
+### Doc hygiene: ALWAYS document a new env var or API constraint
+
+The inverse rule, and the one that actually bit us. Two things are easy to ship
+and impossible for a user to discover — both are required in the SAME PR:
+
+1. **A new environment variable** → document it in `deploy/FLY_SECRETS.md` with
+   its DEFAULT and what breaks if it is wrong. `mix loopctl.check_env_docs`
+   (in `mix precommit`) fails the build otherwise.
+2. **A new/changed API constraint** — a size cap, a new 4xx, changed field
+   semantics, what is or is not encrypted at rest → the endpoint's `operation/2`
+   OpenAPI spec, not just the controller guard. When a limit is both enforced and
+   documented, reference ONE module attribute from both sites so they cannot drift
+   (see `@max_inline_content_bytes` in `knowledge_ingestion_controller.ex`).
+
+Why this is a rule and not a nicety: this failure is SILENT. Nothing in review
+flags a `System.get_env/1` with no doc line, so it accumulated to 24 undocumented
+variables — including `SECRETS_ADAPTER` and `FTS_REGCONFIG`, without which a
+self-hoster literally cannot run the app. The audience who needs these is the one
+audience that cannot read our source tree.
+
+`CHANGELOG.md` is operator-facing changes ONLY (env vars, deploy ordering,
+migrations with manual steps, breaking API changes, security-relevant storage
+changes). Refactors, test fixes, and internal hardening stay out — `git log
+--first-parent` is the full history. See `CONTRIBUTING.md`.
+
 ### Domain skill routing
 
 | You are touching... | Load |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,45 @@ All contributions must pass:
 - `mix credo --strict` -- Static analysis
 - `mix dialyzer` -- Type checking
 - `mix test` -- Full test suite with 100% pass rate
+- `mix loopctl.check_env_docs` -- Every `runtime.exs` env var is documented for operators
+- `mix loopctl.check_skill_citations` -- `file:line` citations in skills/CLAUDE.md still resolve
+
+The last two run inside `mix precommit`. They exist because both failures are
+SILENT: nothing else in the pipeline notices an undocumented knob or a citation
+that rotted after a refactor.
+
+## Documenting Operator-Facing Changes
+
+Two things are easy to ship and impossible for a user to discover, so both are
+required in the same PR that introduces them:
+
+**1. A new environment variable.** Document it in the appropriate table in
+[`deploy/FLY_SECRETS.md`](deploy/FLY_SECRETS.md) with its **default** and **what
+breaks if it is wrong**. `mix loopctl.check_env_docs` fails the build otherwise.
+An operator cannot read our source tree; a knob that lives only in
+`config/runtime.exs` effectively does not exist for them.
+
+**2. A new or changed API constraint.** Size caps, new `4xx` conditions, changed
+field semantics, and what is or is not encrypted at rest all belong in the
+endpoint's `operation/2` OpenAPI spec — not only in the controller guard. Where a
+limit is both enforced and documented, reference ONE module attribute from both
+sites so they cannot drift.
+
+## Changelog
+
+`CHANGELOG.md` records **operator-facing** changes only — things that alter how
+someone runs, upgrades, or calls loopctl:
+
+- a new or changed environment variable, or a change to required deploy ordering
+- a migration with an ordering requirement or a manual step
+- a breaking or behaviour-changing API change (new limits, changed field meaning)
+- a security-relevant change in how data is stored or protected
+
+Everything else — refactors, test de-flaking, internal hardening, dependency
+bumps — is deliberately **out of scope**. `git log --first-parent` is the complete
+history and needs no duplication. This narrow trigger is the point: a changelog
+that tries to record every merge is the kind that stops being written at all,
+which is exactly what happened to this one before the boundary was drawn.
 
 ## Reporting Issues
 

--- a/deploy/FLY_SECRETS.md
+++ b/deploy/FLY_SECRETS.md
@@ -53,6 +53,60 @@ fly secrets set CLOAK_KEY="GENERATED_BASE64_KEY"
 | `SECRETS_FILE`      | `/data/loopctl/secrets.json` | Path for the `local_file` adapter. Put it on a PERSISTENT volume |
 | `FTS_REGCONFIG`     | `english` | Postgres text-search config for keyword FTS (see below) |
 
+#### Connection pools and query budgets
+
+| Variable                          | Default | Description |
+|-----------------------------------|---------|-------------|
+| `REPLICA_DATABASE_URL`            | -       | Read DSN for the `HeavyReadRepo` pool (US-38.1). **Defaults off** — unset, heavy reads run against the primary. Pointing this at a replica is a deliberate, gated infra operation: verify replication lag before enabling, since heavy/vector reads then serve possibly-stale rows |
+| `HEAVY_READ_POOL_SIZE`            | `8`     | `HeavyReadRepo` pool size. This pool exists so a heavy analytical/vector read cannot starve the 3-connection AdminRepo pool |
+| `HEAVY_READ_STATEMENT_TIMEOUT_MS` | `10000` | Per-statement timeout on the heavy-read pool — the backstop that keeps one pathological vector scan from pinning a connection |
+| `SLOW_QUERY_THRESHOLD_MS`         | `1000`  | Queries slower than this are logged for diagnosis |
+
+#### Rate limiting and auth-path throttle
+
+| Variable                            | Default | Description |
+|-------------------------------------|---------|-------------|
+| `RATE_LIMITER`                      | node-local ETS | Set to `postgres` to select the shared Postgres-backed limiter so a MULTI-NODE deployment enforces one cluster-wide budget instead of `limit × node_count`. Provisions nothing (the counter table ships in a migration). Any other value keeps the node-local ETS behaviour |
+| `AUTH_THROTTLE_MAX_REQUESTS_PER_IP` | `3000`  | Per-IP request cap on the API-key auth path, per window. Raise it for a shared-egress/NAT deployment where many legitimate keys share one outbound IP |
+| `AUTH_THROTTLE_WINDOW_MS`           | `60000` | Window for the per-IP auth throttle |
+| `HAMMER_POOL_SIZE`                  | `20`    | Poolboy worker pool fronting every rate-limit check. Sized above Hammer's default of 4 so the fail-CLOSED auth throttle cannot saturate the pool under a single-IP flood |
+| `HAMMER_POOL_MAX_OVERFLOW`          | `10`    | Overflow workers for that pool |
+
+> All five accept only a **positive integer** (where numeric). An unset, blank, or
+> malformed value leaves the compiled default in place rather than crashing release
+> boot — a deliberate choice after the `STH_SWEEP_CRON` incident, so a bad
+> placeholder can never take the app down at startup.
+
+#### Metrics and scale alerting
+
+| Variable                    | Default | Description |
+|-----------------------------|---------|-------------|
+| `METRICS_PORT`              | `9568`  | INTERNAL Prometheus listener (never the public `8080` service); scraped over Fly's private 6PN network. **Must stay in lockstep with the `[metrics]` block in `fly.toml`** |
+| `METRICS_TENANT_LABEL_CAP`  | `1000`  | Max distinct tenant label values before the per-tenant metric dimension is collapsed — bounds Prometheus cardinality |
+| `SCALE_ALERT_WEBHOOK_URL`   | -       | **Alerting is opt-in until this is set.** With no URL, threshold breaches are only logged, never POSTed. Point it at a Slack / PagerDuty / generic webhook |
+| `SCALE_ALERT_CHECK_INTERVAL_MS`         | `60000`  | How often thresholds are evaluated |
+| `SCALE_ALERT_RENOTIFY_INTERVAL_MS`      | `900000` | Re-notify interval for a breach that stays open (15 min) |
+| `SCALE_ALERT_P95_LATENCY_MS`            | `2000`   | Request p95 latency breach threshold |
+| `SCALE_ALERT_QUEUE_TIME_P95_MS`         | `500`    | Oban queue-time p95 breach threshold |
+| `SCALE_ALERT_TIMEOUT_RATE_PER_MIN`      | `5`      | Request-timeout rate breach threshold |
+| `SCALE_ALERT_OBAN_DISCARD_RATE_PER_MIN` | `10`     | Oban job-discard rate breach threshold |
+| `SCALE_ALERT_PROVIDER_ERROR_RATE_PER_MIN` | `10`   | LLM/embedding provider error rate breach threshold |
+| `SCALE_ALERT_UNDER_FILL_RATE_PER_MIN`   | `30`     | Under-fill rate breach threshold |
+
+#### LLM / embedding provider
+
+| Variable                  | Default | Description |
+|---------------------------|---------|-------------|
+| `OPENAI_BASE_URL`         | `https://api.openai.com/v1` | Override to point embeddings at an OpenAI-compatible endpoint (e.g. a local Ollama / vLLM server) |
+| `OPENAI_EMBEDDING_MODEL`  | `text-embedding-3-small` | Embedding model name |
+| `LOCAL_ENDPOINT_ALLOWLIST` | -      | Comma-separated hosts/CIDRs that the egress guard may reach despite being private/loopback — e.g. `127.0.0.1,localhost,ollama.internal,10.1.0.0/16`. Required to use a LOCAL model endpoint, since the SSRF denylist otherwise refuses private addresses |
+
+#### Feature flags
+
+| Variable                               | Default | Description |
+|----------------------------------------|---------|-------------|
+| `RLS_REROUTE_LIST_STORIES_BY_PROJECT`  | `false` | Set to `true`/`1` to route `list_stories` through the project-scoped RLS path |
+
 #### Self-hosting off Fly: `SECRETS_ADAPTER=local_file`
 
 Tenant signup mints a per-tenant Ed25519 audit keypair and stores the private key

--- a/lib/mix/tasks/loopctl.check_env_docs.ex
+++ b/lib/mix/tasks/loopctl.check_env_docs.ex
@@ -1,0 +1,134 @@
+defmodule Mix.Tasks.Loopctl.CheckEnvDocs do
+  @moduledoc """
+  Guards operator-facing environment variables against being shipped undocumented.
+
+  `config/runtime.exs` is where every operator-tunable knob is read, and an env var
+  that exists only there is effectively invisible: the audience who needs it (someone
+  deploying loopctl) is exactly the audience who cannot read our source tree. This
+  failure is silent — nothing in review flags a `System.get_env/1` with no matching
+  doc line — and it accumulated to 24 undocumented variables before anyone noticed,
+  including the two self-hosting knobs (`SECRETS_ADAPTER`, `FTS_REGCONFIG`) that a
+  self-hoster could not run the app without.
+
+  Same guardrail idea as `mix loopctl.check_skill_citations` and
+  `mix loopctl.check_wiki_links`, applied to operator configuration.
+
+  ## What is checked
+
+  Every `System.get_env("X")` / `System.fetch_env!("X")` read in `config/runtime.exs`
+  must have its name documented in `deploy/FLY_SECRETS.md`.
+
+  Lines that are entirely a `#` comment are skipped, so the commented-out `phx.new`
+  TLS boilerplate (`SOME_APP_SSL_KEY_PATH`) is not demanded to be documented. The
+  scan is textual, not an AST walk: a var name built by string interpolation is not
+  detected. That is an accepted limit — operator knobs are read by literal name.
+
+  ## Adding a variable
+
+  Document it in the appropriate table in `deploy/FLY_SECRETS.md` with its DEFAULT
+  and what breaks if it is wrong. If a variable is genuinely internal (never set by
+  an operator), add it to `@exempt` WITH a reason — an exemption without a rationale
+  is how the undocumented set grew in the first place.
+
+  ## Usage
+
+      mix loopctl.check_env_docs
+
+  Exits non-zero listing every undocumented variable.
+  """
+
+  use Mix.Task
+
+  @shortdoc "Check that runtime.exs env vars are documented for operators"
+
+  @config_file "config/runtime.exs"
+  @docs_file "deploy/FLY_SECRETS.md"
+
+  # Variables deliberately NOT in the operator docs. Each needs a reason.
+  # (Empty today — every runtime.exs variable is documented.)
+  @exempt %{}
+
+  # Vacuity guard: runtime.exs reads dozens of variables, so a scan returning
+  # almost nothing means the regex or the file moved — a guard that silently
+  # checks nothing is worse than no guard (the check_skill_citations lesson).
+  @min_expected_vars 20
+
+  @impl Mix.Task
+  def run(_args) do
+    for file <- [@config_file, @docs_file] do
+      File.exists?(file) ||
+        Mix.raise("check_env_docs: #{file} not found. Run from the repo root.")
+    end
+
+    vars = scan_env_vars(File.read!(@config_file))
+
+    if MapSet.size(vars) < @min_expected_vars do
+      Mix.raise(
+        "check_env_docs scanned #{@config_file} and found only #{MapSet.size(vars)} " <>
+          "env var(s), expected at least #{@min_expected_vars}. The scan is broken — " <>
+          "fix it rather than lowering the floor, or this guard passes vacuously."
+      )
+    end
+
+    report(undocumented(vars, File.read!(@docs_file)), MapSet.size(vars))
+  end
+
+  @doc """
+  The scanned variables that are neither exempt nor named in `docs`, sorted.
+
+  Public so the guard's FAILING behaviour is testable — a doc guard that has only
+  ever been observed passing is indistinguishable from one that can never fail.
+  """
+  @spec undocumented(MapSet.t(binary()) | [binary()], binary()) :: [binary()]
+  def undocumented(vars, docs) do
+    vars
+    |> Enum.reject(&(Map.has_key?(@exempt, &1) or documented?(docs, &1)))
+    |> Enum.sort()
+  end
+
+  @doc """
+  The env var names read (outside full-line comments) in the given source text.
+  """
+  @spec scan_env_vars(binary()) :: MapSet.t(binary())
+  def scan_env_vars(source) do
+    source
+    |> String.split("\n")
+    |> Enum.reject(&comment_line?/1)
+    |> Enum.flat_map(fn line ->
+      ~r/System\.(?:get_env|fetch_env!)\(\s*"([A-Z][A-Z0-9_]*)"/
+      |> Regex.scan(line, capture: :all_but_first)
+      |> List.flatten()
+    end)
+    |> MapSet.new()
+  end
+
+  defp comment_line?(line), do: String.match?(line, ~r/^\s*#/)
+
+  # The name must appear as a whole word, so `POOL_SIZE` is not satisfied by an
+  # unrelated `ADMIN_POOL_SIZE` row (substring matching is how a doc guard goes
+  # quietly vacuous).
+  defp documented?(docs, var) do
+    String.match?(docs, ~r/(?<![A-Z0-9_])#{Regex.escape(var)}(?![A-Z0-9_])/)
+  end
+
+  defp report([], scanned) do
+    Mix.shell().info("#{scanned} runtime env var(s) documented in #{@docs_file}")
+  end
+
+  defp report(undocumented, _scanned) do
+    list = Enum.map_join(undocumented, "\n", &"  - #{&1}")
+
+    Mix.raise("""
+    Undocumented operator environment variable(s):
+
+    #{list}
+
+    Each is read in #{@config_file} but appears nowhere in #{@docs_file}, so an
+    operator cannot discover it without reading our source.
+
+    Document each in the appropriate table in #{@docs_file} — its DEFAULT and what
+    breaks if it is wrong. If one is genuinely internal, add it to @exempt in
+    #{__MODULE__ |> Module.split() |> Enum.join(".")} with a reason.
+    """)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -181,6 +181,7 @@ defmodule Loopctl.MixProject do
         "format --check-formatted",
         "credo --strict",
         "loopctl.check_skill_citations",
+        "loopctl.check_env_docs",
         "dialyzer",
         "test"
       ]

--- a/test/mix/tasks/loopctl_check_env_docs_test.exs
+++ b/test/mix/tasks/loopctl_check_env_docs_test.exs
@@ -1,0 +1,96 @@
+defmodule Mix.Tasks.Loopctl.CheckEnvDocsTest do
+  @moduledoc """
+  Tests for the operator env-var doc guard.
+
+  The point of these tests is the FAILING direction. A doc guard that has only ever
+  been observed passing is indistinguishable from one that can never fail — which is
+  exactly how the repo accumulated 24 undocumented variables while every gate stayed
+  green. So each test asserts a non-empty violation set, not just "no crash".
+  """
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.Loopctl.CheckEnvDocs
+
+  describe "scan_env_vars/1" do
+    test "finds get_env and fetch_env! reads" do
+      source = """
+      config :app, url: System.get_env("DATABASE_URL")
+      secret = System.fetch_env!("SECRET_KEY_BASE")
+      """
+
+      assert CheckEnvDocs.scan_env_vars(source) ==
+               MapSet.new(["DATABASE_URL", "SECRET_KEY_BASE"])
+    end
+
+    test "skips full-line comments (the commented-out phx.new TLS boilerplate)" do
+      source = """
+      #         keyfile: System.get_env("SOME_APP_SSL_KEY_PATH"),
+        # certfile: System.get_env("SOME_APP_SSL_CERT_PATH")
+      real = System.get_env("METRICS_PORT")
+      """
+
+      assert CheckEnvDocs.scan_env_vars(source) == MapSet.new(["METRICS_PORT"])
+    end
+
+    test "tolerates whitespace inside the call and dedupes repeats" do
+      source = """
+      a = System.get_env( "FTS_REGCONFIG")
+      b = System.get_env("FTS_REGCONFIG") || "english"
+      """
+
+      assert CheckEnvDocs.scan_env_vars(source) == MapSet.new(["FTS_REGCONFIG"])
+    end
+
+    test "ignores non-literal and lowercase reads" do
+      source = ~S"""
+      x = System.get_env(var_name)
+      y = System.get_env("#{prefix}_URL")
+      z = System.get_env("lowercase_name")
+      """
+
+      assert CheckEnvDocs.scan_env_vars(source) == MapSet.new([])
+    end
+  end
+
+  describe "undocumented/2 — the failing direction" do
+    test "flags a variable that appears nowhere in the docs" do
+      vars = MapSet.new(["DOCUMENTED_ONE", "MISSING_ONE"])
+      docs = "| `DOCUMENTED_ONE` | `5` | Something. |"
+
+      assert CheckEnvDocs.undocumented(vars, docs) == ["MISSING_ONE"]
+    end
+
+    test "a SUBSTRING match does not count as documented" do
+      # The failure mode that makes doc guards go quietly vacuous: `POOL_SIZE`
+      # must not be satisfied by an unrelated `ADMIN_POOL_SIZE` row.
+      docs = "| `ADMIN_POOL_SIZE` | `3` | AdminRepo pool. |"
+
+      assert CheckEnvDocs.undocumented(["POOL_SIZE"], docs) == ["POOL_SIZE"]
+      assert CheckEnvDocs.undocumented(["ADMIN_POOL_SIZE"], docs) == []
+    end
+
+    test "returns every missing variable, sorted" do
+      vars = ["ZED_VAR", "ALPHA_VAR", "MID_VAR"]
+      assert CheckEnvDocs.undocumented(vars, "nothing here") == ~w(ALPHA_VAR MID_VAR ZED_VAR)
+    end
+
+    test "an empty docs file flags everything (guard cannot pass on a blank doc)" do
+      vars = ["A_VAR", "B_VAR"]
+      assert CheckEnvDocs.undocumented(vars, "") == ["A_VAR", "B_VAR"]
+    end
+  end
+
+  describe "the live repo" do
+    test "every runtime.exs env var is documented, and the scan is not vacuous" do
+      vars = CheckEnvDocs.scan_env_vars(File.read!("config/runtime.exs"))
+
+      # Non-vacuity: assert the scan actually matched a substantial set. Without
+      # this, a broken regex would make the assertion below trivially true.
+      assert MapSet.size(vars) >= 20,
+             "scan found only #{MapSet.size(vars)} vars in runtime.exs — the scan is broken"
+
+      assert CheckEnvDocs.undocumented(vars, File.read!("deploy/FLY_SECRETS.md")) == [],
+             "undocumented operator env vars — run: mix loopctl.check_env_docs"
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to #526. Addresses the two open items from that PR's discussion: the changelog policy, and the doc blind spot itself.

## The blind spot was systemic, not a one-off
A survey of `config/runtime.exs` found **24 of its 38 env vars documented nowhere** in any markdown — every scale-alerting threshold, the replica DSN, the metrics port, and `LOCAL_ENDPOINT_ALLOWLIST` (without which you cannot point embeddings at a local model). `SECRETS_ADAPTER` and `FTS_REGCONFIG` were just the two a self-hoster tripped over first.

The failure is silent by construction: nothing in review flags a `System.get_env` with no doc line, and the code reading it is self-documenting to its author and invisible to everyone else. A checklist item was not going to hold — so this is mechanical.

## `mix loopctl.check_env_docs` (wired into `mix precommit`)
Follows the precedent of `loopctl.check_skill_citations` / `check_wiki_links`. Every literal env var read outside a comment in `runtime.exs` must appear in `deploy/FLY_SECRETS.md`.

**Built to fail, not to pass:**
- Refuses to run if the scan yields <20 vars — a broken regex is an error, not a silently green build.
- Whole-word matching, so `POOL_SIZE` is not "documented" by an unrelated `ADMIN_POOL_SIZE` row.
- Skips full-line comments (the commented-out `phx.new` TLS boilerplate is not demanded).
- Exemptions require a written reason; there are currently none.
- The **failing** direction is unit-tested, and verified end to end: exit 1 with a violation present, exit 0 clean.

All 24 vars are documented with their real defaults read from `runtime.exs` (not guessed), grouped into pools/budgets, rate limiting, metrics/alerting, provider, and feature flags.

## Changelog scope is now defined rather than aspirational
Operator-facing changes only: env vars, deploy ordering, migrations with manual steps, breaking API changes, security-relevant storage changes. Refactors, test fixes, and internal hardening are explicitly out — `git log --first-parent` is already the complete history. The narrow trigger is the point: a changelog that tries to record every merge is the kind that stops being written, which is what happened here.

Both rules also land in `CLAUDE.md`, since most PRs in this repo are authored by agents that read it and never open `CONTRIBUTING.md`.

Full quality gate green: compile-clean, credo --strict, dialyzer, 6396 tests 0 failures.
