### PR TITLE
Add on_low_novelty: :skip so an unattended writer creates nothing on high overlap

### DIFF
--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -26,7 +26,7 @@ never pass `tenant_id`/`subject_id`.
 ## Invariants (cited)
 
 1. **Novelty / dedup gate on create** — `Knowledge.propose_article/3` → the private `gate_proposal/4`
-   (`propose_article/3` at `knowledge.ex:441`; the four `gate_proposal/4` clauses at `:451-492`).
+   (`propose_article/3` at `knowledge.ex:447`; the four `gate_proposal/4` clauses at `:457-518`).
    **FIVE outcomes, not four** — `:duplicate`, `:low_novelty`, `:unknown`, `:novel`, and
    `:deduplicated` (`created: false`, returned when `create_article` hits the idempotency-key path,
    `knowledge.ex:507-508`). A caller matching only the first four falls through on a reachable
@@ -39,7 +39,7 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:481-487`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:447-449`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8193`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8228`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
    (`absolute_score/1`, `:8320-8325`) clears a scale-matched threshold AND beats the best retrieved
    candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:8297-8307`; the pure decision is

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -410,7 +410,11 @@ defmodule Loopctl.Knowledge do
     * `:low_novelty` — high overlap with existing knowledge. The article is created
       as a **draft** (downgraded from publish if needed) with the near-neighbors
       stamped into `metadata.proposal_novelty`, so the smarter consuming agent (or a
-      human) resolves merge-vs-keep from the drafts review queue.
+      human) resolves merge-vs-keep from the drafts review queue. Pass
+      `on_low_novelty: :skip` to create **nothing** instead — for an UNATTENDED writer
+      with no reviewer behind it, whose drafts would otherwise pile up as corpus debris.
+      The verdict is then `:skipped_low_novelty` with the near-neighbor in `:article`
+      (or `nil` if it vanished), and `created: false`.
     * `:novel` / `:unknown` (gate fell open) — created on the requested path.
 
   The gate is mechanical and non-destructive: it never edits or deletes existing
@@ -426,7 +430,7 @@ defmodule Loopctl.Knowledge do
   Returns `{:ok, result}` where `result` is a map:
 
       %{
-        verdict: :created | :gated_to_draft | :duplicate | :deduplicated,
+        verdict: :created | :gated_to_draft | :skipped_low_novelty | :duplicate | :deduplicated,
         article: %Article{},        # the created article, or the canonical existing one
         created: boolean(),         # false for :duplicate / :deduplicated
         assessment: %{verdict:, score:, neighbors:}
@@ -464,14 +468,34 @@ defmodule Loopctl.Knowledge do
   end
 
   defp gate_proposal(tenant_id, attrs, %{verdict: :low_novelty} = assessment, opts) do
-    gated_attrs =
-      attrs
-      |> Map.put("status", "draft")
-      |> stamp_proposal_metadata(assessment)
-
     neighbor = List.first(assessment.neighbors)
-    log_gate(tenant_id, "gate_draft", "drafted (high overlap)", neighbor, assessment, opts)
-    create_proposal(tenant_id, gated_attrs, assessment, opts, :gated_to_draft)
+
+    # `on_low_novelty: :skip` (default `:draft`) — create NOTHING for a high-overlap
+    # proposal, mirroring `on_gate_unavailable: :skip` above. The default drafts it so a
+    # human or a smarter agent can resolve merge-vs-keep from the drafts queue; but an
+    # UNATTENDED writer (session capture) has no such reviewer, so its drafts accumulate
+    # as invisible corpus debris that nothing ever resolves. Such a caller would rather
+    # drop the near-duplicate than bank it — the knowledge is by definition already in the
+    # corpus, and the neighbour is returned so the drop can be counted and attributed.
+    if Keyword.get(opts, :on_low_novelty, :draft) == :skip do
+      log_gate(tenant_id, "gate_skip", "skipped (high overlap)", neighbor, assessment, opts)
+
+      {:ok,
+       %{
+         verdict: :skipped_low_novelty,
+         article: skipped_neighbor(tenant_id, assessment, opts),
+         created: false,
+         assessment: assessment
+       }}
+    else
+      gated_attrs =
+        attrs
+        |> Map.put("status", "draft")
+        |> stamp_proposal_metadata(assessment)
+
+      log_gate(tenant_id, "gate_draft", "drafted (high overlap)", neighbor, assessment, opts)
+      create_proposal(tenant_id, gated_attrs, assessment, opts, :gated_to_draft)
+    end
   end
 
   # :unknown — the gate FELL OPEN (embedding backend unavailable; it could not actually
@@ -550,6 +574,17 @@ defmodule Loopctl.Knowledge do
   end
 
   defp canonical_neighbor(_tenant_id, _assessment, _opts), do: :error
+
+  # The near-neighbour a `:skipped_low_novelty` proposal was dropped in favour of, so the
+  # caller can attribute the drop. Unlike the `:duplicate` path this is advisory only — a
+  # neighbour that vanished between assess and now yields `nil` rather than falling back to
+  # creating, because the caller explicitly asked never to create on high overlap.
+  defp skipped_neighbor(tenant_id, assessment, opts) do
+    case canonical_neighbor(tenant_id, assessment, opts) do
+      {:ok, article} -> article
+      :error -> nil
+    end
+  end
 
   defp stamp_proposal_metadata(attrs, %{score: score, neighbors: neighbors}) do
     existing = stringify_top_keys(attrs["metadata"] || %{})

--- a/lib/loopctl_web/controllers/article_controller.ex
+++ b/lib/loopctl_web/controllers/article_controller.ex
@@ -392,7 +392,7 @@ defmodule LoopctlWeb.ArticleController do
   defp create_article(conn, tenant_id, attrs, audit_opts, draft?, gate?) do
     # Pass the caller's visibility scope so idempotency dedup can't echo a private
     # memory the agent can't see (#163).
-    opts = audit_opts ++ Visibility.scope_opts(conn)
+    opts = audit_opts ++ Visibility.scope_opts(conn) ++ low_novelty_opts(attrs)
 
     if gate? do
       render_proposal(conn, Knowledge.propose_article(tenant_id, attrs, opts), attrs, draft?)
@@ -401,9 +401,48 @@ defmodule LoopctlWeb.ArticleController do
     end
   end
 
+  # `on_low_novelty=skip` — create nothing on high overlap instead of drafting. For an
+  # unattended writer (session capture) whose drafts nothing would ever review; see
+  # `Knowledge.propose_article/3`. Accepted as a request field so the DEFAULT stays
+  # draft-and-review for interactive callers.
+  defp low_novelty_opts(attrs) do
+    if truthy?(attrs["skip_low_novelty"]) or attrs["on_low_novelty"] == "skip" do
+      [on_low_novelty: :skip]
+    else
+      []
+    end
+  end
+
   # Novelty-gated path: render by verdict. A near-duplicate is NOT created — the
   # caller is pointed at the canonical article. A low-novelty proposal is created as
   # a draft with the near-neighbors surfaced so a reviewer/consumer can merge.
+
+  # High overlap and the caller opted out of drafting — nothing was created. Report the
+  # neighbour it lost to so the caller can count and attribute the drop.
+  defp render_proposal(conn, {:ok, %{verdict: :skipped_low_novelty} = result}, attrs, _draft?) do
+    %{article: neighbor, assessment: assessment} = result
+
+    # Counted as :deduplicated, not a new outcome. Nothing was created BECAUSE the content
+    # already exists — that is what the deduplicated counter means, and IngestionWriteStats
+    # maps only known outcomes (@outcome_columns), so a bespoke atom would fall through
+    # uncounted and make a dedup-heavy day read as an ingestion outage to the reject-rate
+    # detector. The caller still gets the finer-grained `skipped: true` in the response.
+    emit_write_telemetry(conn, attrs, :deduplicated)
+
+    conn
+    |> put_status(:ok)
+    |> json(%{
+      data: nil,
+      skipped: true,
+      gate: gate_meta(:skipped_low_novelty, assessment),
+      note:
+        "High overlap with existing knowledge (similarity " <>
+          "#{format_score(assessment.score)}) — nothing was created, per " <>
+          "on_low_novelty=skip." <>
+          if(neighbor, do: " Nearest existing article: #{neighbor.id}.", else: "")
+    })
+  end
+
   defp render_proposal(conn, {:ok, %{verdict: :duplicate} = result}, attrs, _draft?) do
     %{article: existing, assessment: assessment} = result
 

--- a/test/loopctl/knowledge/propose_article_test.exs
+++ b/test/loopctl/knowledge/propose_article_test.exs
@@ -128,6 +128,70 @@ defmodule Loopctl.Knowledge.ProposeArticleTest do
       assert id == existing.id
     end
 
+    test "on_low_novelty: :skip creates nothing and returns the neighbor", %{tenant: tenant} do
+      existing =
+        fixture(:article, %{tenant_id: tenant.id, title: "Already covered", status: :published})
+
+      assessor(:low_novelty, [neighbor(existing, 0.93)], 0.93)
+      before = count_articles(tenant.id)
+
+      assert {:ok, %{verdict: :skipped_low_novelty, created: false, article: article}} =
+               Knowledge.propose_article(
+                 tenant.id,
+                 %{
+                   "title" => "A near-duplicate nobody would review",
+                   "body" => "Mostly covered by an adjacent article.",
+                   "category" => "finding",
+                   "status" => "published"
+                 },
+                 on_low_novelty: :skip
+               )
+
+      # The whole point: no row was written, not even a draft.
+      assert count_articles(tenant.id) == before
+      assert article.id == existing.id
+    end
+
+    test "on_low_novelty: :skip tolerates a neighbor that vanished after assess", %{
+      tenant: tenant
+    } do
+      # Same shape as the :duplicate path's ghost test — an id that no longer resolves.
+      ghost = %{id: Ecto.UUID.generate(), title: "Ghost"}
+      assessor(:low_novelty, [%{id: ghost.id, title: ghost.title, similarity_score: 0.93}], 0.93)
+      before = count_articles(tenant.id)
+
+      # Unlike the :duplicate path, a vanished neighbor must NOT fall back to creating —
+      # the caller asked never to create on high overlap.
+      assert {:ok, %{verdict: :skipped_low_novelty, created: false, article: nil}} =
+               Knowledge.propose_article(
+                 tenant.id,
+                 %{
+                   "title" => "Still skipped",
+                   "body" => "Body.",
+                   "category" => "finding",
+                   "status" => "published"
+                 },
+                 on_low_novelty: :skip
+               )
+
+      assert count_articles(tenant.id) == before
+    end
+
+    test "defaults to drafting when on_low_novelty is not passed", %{tenant: tenant} do
+      existing =
+        fixture(:article, %{tenant_id: tenant.id, title: "Adjacent2", status: :published})
+
+      assessor(:low_novelty, [neighbor(existing, 0.9)], 0.9)
+
+      assert {:ok, %{verdict: :gated_to_draft, created: true}} =
+               Knowledge.propose_article(tenant.id, %{
+                 "title" => "Interactive caller keeps the review queue",
+                 "body" => "Body.",
+                 "category" => "finding",
+                 "status" => "published"
+               })
+    end
+
     test "preserves caller metadata while stamping novelty", %{tenant: tenant} do
       existing = fixture(:article, %{tenant_id: tenant.id, title: "Near", status: :published})
       assessor(:low_novelty, [neighbor(existing, 0.9)], 0.9)

--- a/test/loopctl_web/controllers/article_controller_test.exs
+++ b/test/loopctl_web/controllers/article_controller_test.exs
@@ -478,6 +478,38 @@ defmodule LoopctlWeb.ArticleControllerTest do
       assert body["note"] =~ "DRAFT"
     end
 
+    test "skip_low_novelty: true creates nothing on high overlap", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      existing = fixture(:article, %{tenant_id: tenant.id, title: "Covered", status: :published})
+
+      gate_verdict(
+        :low_novelty,
+        [%{id: existing.id, title: existing.title, similarity_score: 0.92}],
+        0.92
+      )
+
+      before = Loopctl.Repo.aggregate(Loopctl.Knowledge.Article, :count)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles", %{
+          "title" => "Would have been a draft",
+          "body" => "Mostly covered already.",
+          "category" => "finding",
+          "skip_low_novelty" => true
+        })
+
+      body = json_response(conn, 200)
+      assert body["skipped"] == true
+      assert body["data"] == nil
+      assert body["gate"]["verdict"] == "skipped_low_novelty"
+      assert body["note"] =~ existing.id
+      # No row at all — not even the draft the default path would have created.
+      assert Loopctl.Repo.aggregate(Loopctl.Knowledge.Article, :count) == before
+    end
+
     test "force: true bypasses the gate and publishes", %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})


### PR DESCRIPTION
## Why

The gate's `low_novelty` band drafts the article and stamps near-neighbours into metadata, so a human or a smarter agent resolves merge-vs-keep from the drafts queue. Correct for an interactive caller, and it stays the default.

Wrong for an **unattended** one. Session capture has no reviewer behind it, so its gated drafts are never resolved — they accumulate as invisible corpus debris that nothing ever reads, merges, or deletes. That writer would rather drop a near-duplicate than bank it: by definition the knowledge is already in the corpus.

## What

`on_low_novelty: :skip`, mirroring the existing `on_gate_unavailable: :skip`. Nothing is created; verdict is `:skipped_low_novelty`; the near-neighbour comes back so the caller can count and attribute the drop.

Unlike the `:duplicate` path, a neighbour that vanished between assess and create yields `nil` rather than falling back to creating — the caller asked never to create on high overlap, and honouring that beats returning a non-nil article.

Exposed on `POST /api/v1/articles` as `skip_low_novelty: true` (or `on_low_novelty: "skip"`) → 200 with `skipped: true` plus gate metadata.

## Telemetry

The skip counts as `:deduplicated` rather than adding an outcome. `IngestionWriteStats` maps only known outcomes (`@outcome_columns`), so a bespoke atom would fall through uncounted and make a dedup-heavy day read as an ingestion outage to the reject-rate detector. Nothing was created because the content already exists — that is what the counter means.

## Tests

Four new: skip creates nothing (row count unchanged) and returns the neighbour; vanished neighbour still skips; the default still drafts; and an API-level test asserting no row is written through the endpoint.

`mix precommit` green — dialyzer clean, 6400 tests, 0 failures.