### PR TITLE
Add the WebAuthn enrollment page that anchors an existing tenant (#541)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,18 @@ jobs:
       - name: Run Credo
         run: mix credo --strict
 
+      # #541 — nothing in CI compiled assets/js before this. A syntax or import
+      # error in a LiveView hook therefore surfaced only in the Docker build at
+      # DEPLOY time (Dockerfile runs `mix assets.deploy`), long after review.
+      # That gap stopped being tolerable once /enroll shipped a ceremony that is
+      # entirely client-side: for that page, broken JS is a broken feature with a
+      # green build. esbuild and tailwind are standalone binaries — no Node.js.
+      - name: Install asset toolchain
+        run: mix assets.setup
+
+      - name: Build assets
+        run: mix assets.deploy
+
   test:
     name: Test
     runs-on: [self-hosted, beelink]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ Operator-facing changes for deployments outside the hosted instance.
 
 ### Added
 
+- **`GET /enroll` — a browser page that anchors an EXISTING tenant (#541).** The API
+  advertised an `enrollment_upgrade` path out of `agent_rooted`, but nobody could walk it:
+  `navigator.credentials.create()` needs a browser, and the only page running a WebAuthn
+  ceremony was `/signup`, which creates a NEW tenant. Every tenant predating the signup
+  ceremony was therefore permanently locked out of chain-of-custody, work-breakdown,
+  dispatch, and token-budget writes. Paste a `user`-role API key, touch an authenticator,
+  and the tier flips in place. The key is sent only as a bearer token from your browser to
+  the same API you would curl — the page holds no server-side state and enforces nothing;
+  every gate stays in `TenantAuthenticatorController`. `GET /api/v1/tenants/me` now names
+  the page in `remediation.enrollment_upgrade.enrollment_page` (relative, since a
+  self-hosted instance serves its own).
+
+### Fixed
+
+- **WebAuthn registration rejected hardware security keys.** Both browser hooks requested
+  `attestation: "direct"` while the server built its challenge with Wax's default of
+  `"none"`, so `Wax.register/3` refused any real attestation statement with
+  `:invalid_attestation_conveyance_preference`. This was invisible on laptops — Touch ID
+  and Windows Hello return `fmt: "none"` regardless — and broke exactly the roaming keys
+  (YubiKey and similar) that the signup page recommends. Affects `/signup` as well as the
+  new `/enroll`. No configuration change is needed; existing enrolled authenticators are
+  unaffected.
+
 - **`WEBAUTHN_RP_ID` / `WEBAUTHN_ORIGIN` / `WEBAUTHN_RP_NAME` — WebAuthn on a self-hosted
   domain (#511, contributed by @FinanceAlex; refs #494).** `config.exs` hardcoded the
   relying party to `loopctl.com`, and the WebAuthn spec requires `rp_id` to be a

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -4,9 +4,11 @@ import "phoenix_html"
 import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
 import WebAuthn from "./hooks/webauthn"
+import AuthenticatorEnroll from "./hooks/authenticator_enroll"
 
 const Hooks = {
   WebAuthn,
+  AuthenticatorEnroll,
 }
 
 let csrfToken = document.querySelector("meta[name='csrf-token']")?.getAttribute("content")

--- a/assets/js/hooks/authenticator_enroll.js
+++ b/assets/js/hooks/authenticator_enroll.js
@@ -41,6 +41,32 @@ import { base64urlEncode, base64urlDecode } from "../webauthn/base64url";
 
 const API = "/api/v1";
 const CEREMONY_TIMEOUT_MS = 60000;
+const FETCH_TIMEOUT_MS = 20000;
+// Mirrors @max_friendly_name_bytes in TenantAuthenticatorController.
+const MAX_FRIENDLY_NAME_BYTES = 120;
+// A prepared challenge carries a 5-minute server TTL; re-request past this
+// rather than spend a touch on one that expires mid-ceremony.
+const PREPARED_TTL_MS = 120000;
+
+// Only the witness plug's OWN rejections are safely replayable — it halts
+// before the operation runs, so nothing committed. See request().
+// prettier-ignore
+const WITNESS_CODES = ["witness_divergence", "witness_bootstrap_already_consumed", "witness_header_missing", "witness_header_malformed"];
+
+// Raw DOMException text is browser prose with no hint what to do. Name the two
+// that matter: a refused already-enrolled device (excludeCredentials working),
+// and the activation/timeout refusal — on WebKit that also covers a click whose
+// user activation expired across an await.
+const CEREMONY_ERRORS = {
+  InvalidStateError:
+    "That authenticator is already enrolled on this tenant — use a DIFFERENT device as a backup.",
+  NotAllowedError:
+    "The browser refused or timed out the ceremony. Click Enroll again and touch the device when prompted.",
+};
+
+const describe = (t) => (t.slug ? `${t.name} (${t.slug})` : t.name);
+const byteLength = (value) => new TextEncoder().encode(value).length;
+const reason = (error) => (error && error.message) || "Enrollment failed.";
 
 const AuthenticatorEnroll = {
   mounted() {
@@ -50,21 +76,42 @@ const AuthenticatorEnroll = {
     this.statusEl = this.el.querySelector("#enroll-status");
     this.resultEl = this.el.querySelector("#enroll-result");
 
-    this.button.addEventListener("click", () => this.run());
+    // #enroll-app is phx-update="ignore", so these nodes SURVIVE a LiveView
+    // reconnect while the hook instance does not. Bind through an owned signal
+    // or the old instance's listeners stay attached and one click runs two
+    // concurrent ceremonies — `this.running` cannot help, since each stale
+    // listener closes over its own `this`. destroyed() cuts them.
+    this.listeners = new AbortController();
+    const signal = this.listeners.signal;
+
+    this.button.addEventListener("click", () => this.run(), { signal });
 
     // Enter in either field starts the ceremony. There is deliberately NO
     // <form> element on this page: a form with no action does a native GET
     // submit if JS fails to load, which would put the API key in the URL,
     // the query string, the browser history, and any access log in front
     // of us.
+    const enter = (event) => {
+      if (event.key !== "Enter") return;
+      event.preventDefault();
+      this.run();
+    };
+
     [this.keyInput, this.nameInput].forEach((el) =>
-      el.addEventListener("keydown", (event) => {
-        if (event.key === "Enter") {
-          event.preventDefault();
-          this.run();
-        }
-      })
+      el.addEventListener("keydown", enter, { signal })
     );
+
+    // Resolve tenant + challenge as soon as the key is committed, not on the
+    // click — see prepare().
+    this.keyInput.addEventListener(
+      "change",
+      () => this.running || this.prepare().catch((e) => this.fail(reason(e))),
+      { signal }
+    );
+  },
+
+  destroyed() {
+    this.listeners.abort();
   },
 
   async run() {
@@ -74,6 +121,15 @@ const AuthenticatorEnroll = {
 
     if (!apiKey) {
       this.fail("Paste a user-role API key to continue.");
+      return;
+    }
+
+    const friendlyName = (this.nameInput.value || "").trim();
+
+    // The server enforces this too, but only AFTER the touch — and by then the
+    // challenge is spent, so a 422 there costs a whole second ceremony.
+    if (byteLength(friendlyName) > MAX_FRIENDLY_NAME_BYTES) {
+      this.fail(`Authenticator name must be at most ${MAX_FRIENDLY_NAME_BYTES} bytes.`);
       return;
     }
 
@@ -88,12 +144,7 @@ const AuthenticatorEnroll = {
     this.clearResult();
 
     try {
-      this.status("Resolving tenant…");
-      const tenant = await this.getTenant(apiKey);
-      const tenantPath = `${API}/tenants/${encodeURIComponent(tenant.id)}/authenticators`;
-
-      this.status("Requesting an enrollment challenge…");
-      const challenge = await this.post(`${tenantPath}/challenge`, apiKey, {});
+      const { tenant, path, challenge } = await this.prepare(apiKey);
 
       // A tenant that is ALREADY human_anchored must prove possession of an
       // already-enrolled device before a second one is grafted on. The
@@ -108,7 +159,7 @@ const AuthenticatorEnroll = {
         reauthAssertion = await this.assert(challenge.reauth_challenge);
       }
 
-      this.status("Touch your authenticator to enroll it…");
+      this.status(`Touch your authenticator to anchor ${describe(tenant)}…`);
       const attestation = await this.create(challenge);
 
       this.status("Verifying attestation…");
@@ -116,24 +167,54 @@ const AuthenticatorEnroll = {
       const body = {
         ...attestation,
         challenge_id: challenge.challenge_id,
-        friendly_name: (this.nameInput.value || "").trim(),
+        friendly_name: friendlyName,
       };
 
       if (reauthAssertion) body.reauth_assertion = reauthAssertion;
 
-      const enrolled = await this.post(tenantPath, apiKey, body);
+      const enrolled = await this.post(path, apiKey, body);
 
       // The key is a live credential and the ceremony is over: drop it from
       // the DOM rather than leaving it in a field on an unattended screen.
       // Only on success — clearing after a failure would force a re-paste
       // for a retry that is usually a typo in the friendly name.
+      this.prepared = null;
       this.keyInput.value = "";
-      this.succeed(enrolled);
+      this.succeed(enrolled, tenant);
     } catch (error) {
-      this.fail((error && error.message) || "Enrollment failed.");
+      // Whatever failed, the challenge is spent or suspect — force a fresh one.
+      this.prepared = null;
+      this.fail(reason(error));
     } finally {
       this.busy(false);
     }
+  },
+
+  // Resolved BEFORE the click, for two reasons. WebKit does not carry transient
+  // user activation across awaited network work, so `credentials.create()` has
+  // to be the first await after the button press or Safari answers
+  // NotAllowedError. And it NAMES the tenant on screen ahead of a one-way door
+  // that a mis-pasted key otherwise walks through irreversibly, unconfirmed.
+  async prepare(apiKey) {
+    const key = apiKey || (this.keyInput.value || "").trim();
+    const cached = this.prepared;
+
+    if (cached && cached.apiKey === key && Date.now() - cached.at < PREPARED_TTL_MS) {
+      return cached;
+    }
+
+    this.prepared = null;
+
+    this.status("Resolving tenant…");
+    const tenant = await this.getTenant(key);
+    const path = `${API}/tenants/${encodeURIComponent(tenant.id)}/authenticators`;
+
+    this.status(`Requesting an enrollment challenge for ${describe(tenant)}…`);
+    const challenge = await this.post(`${path}/challenge`, key, {});
+
+    this.status(`Ready — this will anchor ${describe(tenant)}. Click Enroll and touch.`);
+    this.prepared = { apiKey: key, tenant, path, challenge, at: Date.now() };
+    return this.prepared;
   },
 
   // --- API calls ---
@@ -171,14 +252,18 @@ const AuthenticatorEnroll = {
   // that has ever been used by the MCP server or curl has already spent it.
   //
   // So: bootstrap when we hold no STH, capture the server's STH off every
-  // response, and on a witness rejection adopt the STH it hands back and replay
-  // the request ONCE. The plug halts BEFORE the operation runs, so a rejected
-  // request had no side effect and the replay is safe — this is the documented
-  // resync contract (#298), not a workaround.
+  // response, and on a WITNESS rejection adopt the STH it hands back and replay
+  // ONCE. That is the documented resync contract (#298), not a workaround.
   async request(url, options, retried = false) {
     const witness = this.sth
       ? { "x-loopctl-last-known-sth": this.sth }
       : { "x-loopctl-sth-bootstrap": "true" };
+
+    // Without a deadline an API that accepts the connection and never answers
+    // leaves the page busy forever, with a live credential in a disabled field
+    // on an unattended screen and no cancel path but a reload.
+    const deadline = new AbortController();
+    const timer = setTimeout(() => deadline.abort(), FETCH_TIMEOUT_MS);
 
     let response;
 
@@ -186,12 +271,19 @@ const AuthenticatorEnroll = {
       response = await fetch(url, {
         ...options,
         credentials: "omit",
+        signal: deadline.signal,
         headers: { ...options.headers, ...witness },
       });
     } catch (_error) {
       // Network-level failure: no response was produced, so there is
       // nothing server-side to report.
-      throw new Error("Could not reach the loopctl API — check your connection.");
+      throw new Error(
+        deadline.signal.aborted
+          ? "The loopctl API did not respond in time — try again."
+          : "Could not reach the loopctl API — check your connection."
+      );
+    } finally {
+      clearTimeout(timer);
     }
 
     const currentSth = response.headers.get("x-loopctl-current-sth");
@@ -201,9 +293,13 @@ const AuthenticatorEnroll = {
 
     if (response.ok) return body || {};
 
-    // 412 = missing/malformed/already-consumed bootstrap; 409 = our cached STH
-    // is stale. Both are resyncable, and both hand back the STH to resync to.
-    const resyncable = response.status === 412 || response.status === 409;
+    // The STATUS alone does not identify a witness rejection. 409 is also how
+    // the controller reports `too_many_authenticators`, and the header rides
+    // along whenever the plug granted bootstrap grace on that same request;
+    // replaying THAT re-sends a POST whose challenge Phase 1 already consumed,
+    // so the operator sees `challenge_invalid` instead of the real error.
+    const code = (body && body.error && body.error.code) || "";
+    const resyncable = WITNESS_CODES.includes(code);
 
     if (resyncable && currentSth && !retried) {
       return this.request(url, options, true);
@@ -240,36 +336,59 @@ const AuthenticatorEnroll = {
 
   // --- WebAuthn ceremonies ---
 
+  // Translates the DOMExceptions worth translating — see CEREMONY_ERRORS.
+  async ceremony(fun) {
+    try {
+      return await fun();
+    } catch (error) {
+      const known = CEREMONY_ERRORS[error && error.name];
+      if (known) throw new Error(known);
+      throw error;
+    }
+  },
+
   async create(challenge) {
-    const credential = await navigator.credentials.create({
-      publicKey: {
-        challenge: base64urlDecode(challenge.challenge),
-        rp: { id: challenge.rp.id, name: challenge.rp.name },
-        // AC-26.7.2.2 — the handle is derived server-side from the tenant
-        // and is never client-supplied. Do not substitute a random id here.
-        user: {
-          id: base64urlDecode(challenge.user.id),
-          name: challenge.user.name,
-          displayName: challenge.user.display_name,
+    // An authenticator that ALREADY holds a credential for this RP will happily
+    // mint a second one, under a fresh credential_id the (tenant_id,
+    // credential_id) index cannot catch — so the tenant believes it holds a
+    // backup when both live on the one key it can lose, and losing it is
+    // terminal. The reauth challenge carries exactly the set to exclude.
+    const enrolled = ((challenge.reauth_challenge || {}).allowed_credentials || []).map(
+      (id) => ({ type: "public-key", id: base64urlDecode(id) })
+    );
+
+    const credential = await this.ceremony(() =>
+      navigator.credentials.create({
+        publicKey: {
+          challenge: base64urlDecode(challenge.challenge),
+          rp: { id: challenge.rp.id, name: challenge.rp.name },
+          excludeCredentials: enrolled,
+          // AC-26.7.2.2 — the handle is derived server-side from the tenant
+          // and is never client-supplied. Do not substitute a random id here.
+          user: {
+            id: base64urlDecode(challenge.user.id),
+            name: challenge.user.name,
+            displayName: challenge.user.display_name,
+          },
+          pubKeyCredParams: (challenge.pub_key_cred_params || []).map(
+            ({ type, alg }) => ({ type, alg })
+          ),
+          authenticatorSelection: {
+            residentKey: "preferred",
+            userVerification: "preferred",
+          },
+          // MUST match the server's attestation conveyance preference. Wax
+          // defaults `attestation` to "none" and the app configures no override
+          // (`config :loopctl, :webauthn` sets only rp_id/rp_name/origin/
+          // user_verification), so a client asking for "direct" gets a packed
+          // attestation statement that `Wax.register/3` then rejects with
+          // :invalid_attestation_conveyance_preference. Bound by
+          // webauthn_attestation_conveyance_test.exs.
+          attestation: "none",
+          timeout: CEREMONY_TIMEOUT_MS,
         },
-        pubKeyCredParams: (challenge.pub_key_cred_params || []).map(
-          ({ type, alg }) => ({ type, alg })
-        ),
-        authenticatorSelection: {
-          residentKey: "preferred",
-          userVerification: "preferred",
-        },
-        // MUST match the server's attestation conveyance preference. Wax
-        // defaults `attestation` to "none" and the app configures no override
-        // (`config :loopctl, :webauthn` sets only rp_id/rp_name/origin/
-        // user_verification), so a client asking for "direct" gets a packed
-        // attestation statement that `Wax.register/3` then rejects with
-        // :invalid_attestation_conveyance_preference. Bound by
-        // webauthn_attestation_conveyance_test.exs.
-        attestation: "none",
-        timeout: CEREMONY_TIMEOUT_MS,
-      },
-    });
+      })
+    );
 
     if (!credential) {
       throw new Error("The authenticator returned no credential.");
@@ -289,18 +408,20 @@ const AuthenticatorEnroll = {
       );
     }
 
-    const credential = await navigator.credentials.get({
-      publicKey: {
-        challenge: base64urlDecode(reauth.challenge),
-        rpId: reauth.rp_id,
-        allowCredentials: (reauth.allowed_credentials || []).map((id) => ({
-          type: "public-key",
-          id: base64urlDecode(id),
-        })),
-        userVerification: "preferred",
-        timeout: CEREMONY_TIMEOUT_MS,
-      },
-    });
+    const credential = await this.ceremony(() =>
+      navigator.credentials.get({
+        publicKey: {
+          challenge: base64urlDecode(reauth.challenge),
+          rpId: reauth.rp_id,
+          allowCredentials: (reauth.allowed_credentials || []).map((id) => ({
+            type: "public-key",
+            id: base64urlDecode(id),
+          })),
+          userVerification: "preferred",
+          timeout: CEREMONY_TIMEOUT_MS,
+        },
+      })
+    );
 
     if (!credential) {
       throw new Error("The authenticator returned no assertion.");
@@ -351,7 +472,7 @@ const AuthenticatorEnroll = {
     this.resultEl.appendChild(box);
   },
 
-  succeed(enrolled) {
+  succeed(enrolled, tenant) {
     this.statusEl.textContent = "";
     this.clearResult();
 
@@ -367,6 +488,14 @@ const AuthenticatorEnroll = {
       ? "Tenant anchored — trust tier upgraded"
       : "Authenticator enrolled";
     box.appendChild(heading);
+
+    // Name the tenant that was actually anchored — the only place the operator
+    // can confirm the one-way door closed on the tenant they meant.
+    const anchored = document.createElement("p");
+    anchored.id = "enroll-tenant";
+    anchored.className = "font-mono text-xs text-slate-400";
+    anchored.textContent = `tenant: ${describe(tenant)}`;
+    box.appendChild(anchored);
 
     const tier = document.createElement("p");
     tier.className = "font-mono text-xs text-slate-400";

--- a/assets/js/hooks/authenticator_enroll.js
+++ b/assets/js/hooks/authenticator_enroll.js
@@ -1,0 +1,409 @@
+// Authenticator enrollment hook — #541
+//
+// Drives the opt-in WebAuthn trust-tier upgrade (agent_rooted ->
+// human_anchored) for an EXISTING tenant. `navigator.credentials.create()`
+// cannot be driven from curl or an MCP tool, so the browser half has to
+// exist somewhere; this is it.
+//
+// ## Why the whole ceremony runs in the browser
+//
+// The server side is already complete and reviewed:
+// `LoopctlWeb.TenantAuthenticatorController` owns the fail-closed rate
+// limit, the two-phase challenge consumption, the `add_authenticator`
+// reauth gate that closes the soft-recovery backdoor, and the attestation
+// size caps. This hook calls THAT controller over the public API rather
+// than having `EnrollLive` re-implement enrollment behind the LiveView
+// socket, so there stays exactly one enrollment implementation and one
+// place those gates can be got wrong.
+//
+// Two consequences worth stating plainly:
+//
+//   1. The operator's API key travels ONLY as an `Authorization: Bearer`
+//      header on same-origin fetches. It is never pushed over the LiveView
+//      socket, so it never reaches server-side assigns, Phoenix's
+//      `handle_event` parameter logging, crash dumps, or telemetry.
+//      `EnrollLive` holds no secret.
+//
+//   2. The client ORCHESTRATES; it never ENFORCES (CWE-602). Role,
+//      tenant ownership, rate limiting, reauth, and attestation
+//      verification are all decided server-side. Everything this file
+//      does to the DOM is presentation of a decision the API already
+//      made — bypassing this page by calling the API directly with curl
+//      is not an escalation, it is the supported path.
+//
+// The `user` handle for `navigator.credentials.create()` is taken from the
+// challenge response, NOT generated here: AC-26.7.2.2 requires it be
+// derived server-side from the tenant. That is the one reason this hook
+// cannot simply reuse `hooks/webauthn.js`, which mints a random handle for
+// the new-tenant signup ceremony.
+
+import { base64urlEncode, base64urlDecode } from "../webauthn/base64url";
+
+const API = "/api/v1";
+const CEREMONY_TIMEOUT_MS = 60000;
+
+const AuthenticatorEnroll = {
+  mounted() {
+    this.keyInput = this.el.querySelector("#enroll-api-key");
+    this.nameInput = this.el.querySelector("#enroll-friendly-name");
+    this.button = this.el.querySelector("#enroll-submit");
+    this.statusEl = this.el.querySelector("#enroll-status");
+    this.resultEl = this.el.querySelector("#enroll-result");
+
+    this.button.addEventListener("click", () => this.run());
+
+    // Enter in either field starts the ceremony. There is deliberately NO
+    // <form> element on this page: a form with no action does a native GET
+    // submit if JS fails to load, which would put the API key in the URL,
+    // the query string, the browser history, and any access log in front
+    // of us.
+    [this.keyInput, this.nameInput].forEach((el) =>
+      el.addEventListener("keydown", (event) => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          this.run();
+        }
+      })
+    );
+  },
+
+  async run() {
+    if (this.running) return;
+
+    const apiKey = (this.keyInput.value || "").trim();
+
+    if (!apiKey) {
+      this.fail("Paste a user-role API key to continue.");
+      return;
+    }
+
+    if (!window.PublicKeyCredential) {
+      this.fail(
+        "This browser does not support WebAuthn — try Safari, Chrome, or Firefox."
+      );
+      return;
+    }
+
+    this.busy(true);
+    this.clearResult();
+
+    try {
+      this.status("Resolving tenant…");
+      const tenant = await this.getTenant(apiKey);
+      const tenantPath = `${API}/tenants/${encodeURIComponent(tenant.id)}/authenticators`;
+
+      this.status("Requesting an enrollment challenge…");
+      const challenge = await this.post(`${tenantPath}/challenge`, apiKey, {});
+
+      // A tenant that is ALREADY human_anchored must prove possession of an
+      // already-enrolled device before a second one is grafted on. The
+      // server decides this (`reauth_required`) and re-checks it under a
+      // row lock in Phase 3 — we only run the ceremony it asks for.
+      let reauthAssertion = null;
+
+      if (challenge.reauth_required) {
+        this.status(
+          "This tenant is already anchored — touch an ALREADY-ENROLLED authenticator to authorize adding another…"
+        );
+        reauthAssertion = await this.assert(challenge.reauth_challenge);
+      }
+
+      this.status("Touch your authenticator to enroll it…");
+      const attestation = await this.create(challenge);
+
+      this.status("Verifying attestation…");
+
+      const body = {
+        ...attestation,
+        challenge_id: challenge.challenge_id,
+        friendly_name: (this.nameInput.value || "").trim(),
+      };
+
+      if (reauthAssertion) body.reauth_assertion = reauthAssertion;
+
+      const enrolled = await this.post(tenantPath, apiKey, body);
+
+      // The key is a live credential and the ceremony is over: drop it from
+      // the DOM rather than leaving it in a field on an unattended screen.
+      // Only on success — clearing after a failure would force a re-paste
+      // for a retry that is usually a typo in the friendly name.
+      this.keyInput.value = "";
+      this.succeed(enrolled);
+    } catch (error) {
+      this.fail((error && error.message) || "Enrollment failed.");
+    } finally {
+      this.busy(false);
+    }
+  },
+
+  // --- API calls ---
+
+  async getTenant(apiKey) {
+    const response = await this.request(`${API}/tenants/me`, {
+      headers: this.headers(apiKey),
+    });
+
+    const tenant = response.tenant;
+
+    if (!tenant || !tenant.id) {
+      throw new Error("Unexpected response from the tenant endpoint.");
+    }
+
+    return tenant;
+  },
+
+  async post(url, apiKey, payload) {
+    const response = await this.request(url, {
+      method: "POST",
+      headers: { ...this.headers(apiKey), "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    return response.data;
+  },
+
+  // Every call here goes through the `:authenticated` pipeline, which means
+  // `ValidateWitnessHeader` (US-26.5.2): an authenticated request must carry
+  // `X-Loopctl-Last-Known-STH`, or a one-time-per-key
+  // `X-Loopctl-STH-Bootstrap: true` grace. A browser tab has no cached STH on
+  // load, and the ceremony makes three authenticated calls, so "just bootstrap"
+  // is not enough on its own — the grace is spent after one request, and any key
+  // that has ever been used by the MCP server or curl has already spent it.
+  //
+  // So: bootstrap when we hold no STH, capture the server's STH off every
+  // response, and on a witness rejection adopt the STH it hands back and replay
+  // the request ONCE. The plug halts BEFORE the operation runs, so a rejected
+  // request had no side effect and the replay is safe — this is the documented
+  // resync contract (#298), not a workaround.
+  async request(url, options, retried = false) {
+    const witness = this.sth
+      ? { "x-loopctl-last-known-sth": this.sth }
+      : { "x-loopctl-sth-bootstrap": "true" };
+
+    let response;
+
+    try {
+      response = await fetch(url, {
+        ...options,
+        credentials: "omit",
+        headers: { ...options.headers, ...witness },
+      });
+    } catch (_error) {
+      // Network-level failure: no response was produced, so there is
+      // nothing server-side to report.
+      throw new Error("Could not reach the loopctl API — check your connection.");
+    }
+
+    const currentSth = response.headers.get("x-loopctl-current-sth");
+    if (currentSth) this.sth = currentSth;
+
+    const body = await this.parseJson(response);
+
+    if (response.ok) return body || {};
+
+    // 412 = missing/malformed/already-consumed bootstrap; 409 = our cached STH
+    // is stale. Both are resyncable, and both hand back the STH to resync to.
+    const resyncable = response.status === 412 || response.status === 409;
+
+    if (resyncable && currentSth && !retried) {
+      return this.request(url, options, true);
+    }
+
+    throw new Error(this.apiError(body, response.status));
+  },
+
+  headers(apiKey) {
+    return { authorization: `Bearer ${apiKey}`, accept: "application/json" };
+  },
+
+  async parseJson(response) {
+    try {
+      return await response.json();
+    } catch (_error) {
+      return null;
+    }
+  },
+
+  // Surface the API's own error text verbatim. Those messages are already
+  // written to avoid distinguishing "no such tenant" from "not yours" —
+  // both are a flat 403 — so paraphrasing them here could only make the
+  // page leak more than the endpoint does.
+  apiError(body, status) {
+    const error = body && body.error;
+    const message = error && error.message;
+    const code = error && error.code;
+
+    if (message) return code ? `${message} (${code})` : message;
+
+    return `Request failed with status ${status}.`;
+  },
+
+  // --- WebAuthn ceremonies ---
+
+  async create(challenge) {
+    const credential = await navigator.credentials.create({
+      publicKey: {
+        challenge: base64urlDecode(challenge.challenge),
+        rp: { id: challenge.rp.id, name: challenge.rp.name },
+        // AC-26.7.2.2 — the handle is derived server-side from the tenant
+        // and is never client-supplied. Do not substitute a random id here.
+        user: {
+          id: base64urlDecode(challenge.user.id),
+          name: challenge.user.name,
+          displayName: challenge.user.display_name,
+        },
+        pubKeyCredParams: (challenge.pub_key_cred_params || []).map(
+          ({ type, alg }) => ({ type, alg })
+        ),
+        authenticatorSelection: {
+          residentKey: "preferred",
+          userVerification: "preferred",
+        },
+        // MUST match the server's attestation conveyance preference. Wax
+        // defaults `attestation` to "none" and the app configures no override
+        // (`config :loopctl, :webauthn` sets only rp_id/rp_name/origin/
+        // user_verification), so a client asking for "direct" gets a packed
+        // attestation statement that `Wax.register/3` then rejects with
+        // :invalid_attestation_conveyance_preference. Bound by
+        // webauthn_attestation_conveyance_test.exs.
+        attestation: "none",
+        timeout: CEREMONY_TIMEOUT_MS,
+      },
+    });
+
+    if (!credential) {
+      throw new Error("The authenticator returned no credential.");
+    }
+
+    return {
+      credential_id: base64urlEncode(credential.rawId),
+      attestation_object: base64urlEncode(credential.response.attestationObject),
+      client_data_json: base64urlEncode(credential.response.clientDataJSON),
+    };
+  },
+
+  async assert(reauth) {
+    if (!reauth) {
+      throw new Error(
+        "The server required a fresh assertion but issued no challenge for it."
+      );
+    }
+
+    const credential = await navigator.credentials.get({
+      publicKey: {
+        challenge: base64urlDecode(reauth.challenge),
+        rpId: reauth.rp_id,
+        allowCredentials: (reauth.allowed_credentials || []).map((id) => ({
+          type: "public-key",
+          id: base64urlDecode(id),
+        })),
+        userVerification: "preferred",
+        timeout: CEREMONY_TIMEOUT_MS,
+      },
+    });
+
+    if (!credential) {
+      throw new Error("The authenticator returned no assertion.");
+    }
+
+    return {
+      challenge_id: reauth.challenge_id,
+      credential_id: base64urlEncode(credential.rawId),
+      authenticator_data: base64urlEncode(credential.response.authenticatorData),
+      signature: base64urlEncode(credential.response.signature),
+      client_data_json: base64urlEncode(credential.response.clientDataJSON),
+    };
+  },
+
+  // --- Rendering ---
+  //
+  // Built with createElement/textContent throughout. Every string below
+  // originates from an API response, and innerHTML on API-supplied text
+  // (a tenant-controlled friendly_name, say) would be an XSS sink.
+
+  busy(running) {
+    this.running = running;
+    this.button.disabled = running;
+    this.keyInput.disabled = running;
+    this.nameInput.disabled = running;
+  },
+
+  status(message) {
+    this.statusEl.textContent = message;
+    this.statusEl.className = "mt-4 font-mono text-xs text-slate-400";
+  },
+
+  clearResult() {
+    this.resultEl.replaceChildren();
+  },
+
+  fail(message) {
+    this.statusEl.textContent = "";
+    this.clearResult();
+
+    const box = document.createElement("div");
+    box.id = "enroll-error";
+    box.setAttribute("role", "alert");
+    box.className =
+      "rounded-md border border-rose-500/40 bg-rose-950/30 px-4 py-3 text-sm text-rose-200";
+    box.textContent = message;
+
+    this.resultEl.appendChild(box);
+  },
+
+  succeed(enrolled) {
+    this.statusEl.textContent = "";
+    this.clearResult();
+
+    const box = document.createElement("div");
+    box.id = "enroll-success";
+    box.setAttribute("role", "status");
+    box.className =
+      "space-y-4 rounded-md border border-accent-500/40 bg-slate-950 px-4 py-4 text-sm text-slate-200";
+
+    const heading = document.createElement("p");
+    heading.className = "font-display text-sm uppercase tracking-wide text-accent-300";
+    heading.textContent = enrolled.upgraded
+      ? "Tenant anchored — trust tier upgraded"
+      : "Authenticator enrolled";
+    box.appendChild(heading);
+
+    const tier = document.createElement("p");
+    tier.className = "font-mono text-xs text-slate-400";
+    tier.textContent = `trust_tier: ${enrolled.trust_tier}`;
+    box.appendChild(tier);
+
+    const name = document.createElement("p");
+    name.className = "font-mono text-xs text-slate-400";
+    name.textContent = `authenticator: ${enrolled.authenticator.friendly_name} (${enrolled.authenticator.attestation_format})`;
+    box.appendChild(name);
+
+    const surfaces = (enrolled.capabilities && enrolled.capabilities.surfaces) || {};
+    const names = Object.keys(surfaces).sort();
+
+    if (names.length > 0) {
+      const label = document.createElement("p");
+      label.className = "pt-2 font-display text-xs uppercase tracking-wide text-slate-500";
+      label.textContent = "Surfaces";
+      box.appendChild(label);
+
+      const list = document.createElement("ul");
+      list.id = "enroll-surfaces";
+      list.className = "space-y-1";
+
+      names.forEach((surface) => {
+        const item = document.createElement("li");
+        const allowed = surfaces[surface] === "allowed";
+        item.className = `font-mono text-xs ${allowed ? "text-accent-200" : "text-slate-500"}`;
+        item.textContent = `${allowed ? "✓" : "·"} ${surface}: ${surfaces[surface]}`;
+        list.appendChild(item);
+      });
+
+      box.appendChild(list);
+    }
+
+    this.resultEl.appendChild(box);
+  },
+};
+
+export default AuthenticatorEnroll;

--- a/assets/js/hooks/authenticator_enroll.js
+++ b/assets/js/hooks/authenticator_enroll.js
@@ -42,11 +42,25 @@ import { base64urlEncode, base64urlDecode } from "../webauthn/base64url";
 const API = "/api/v1";
 const CEREMONY_TIMEOUT_MS = 60000;
 const FETCH_TIMEOUT_MS = 20000;
+// The completing POST is the one-way door: the server can COMMIT the tier
+// upgrade and still be slow to answer, so it gets a longer deadline than the
+// reads — and a timeout there is reported as an unknown outcome, never as a
+// failure, because "it failed, try again" is a false statement about an
+// irreversible change that may well have happened.
+const COMMIT_TIMEOUT_MS = 60000;
+const TIMEOUT_MESSAGE = "The loopctl API did not respond in time — try again.";
+const COMMIT_TIMEOUT_MESSAGE =
+  "The loopctl API did not answer in time. The enrollment may ALREADY have completed — reload and check the tenant's trust tier before enrolling again.";
 // Mirrors @max_friendly_name_bytes in TenantAuthenticatorController.
 const MAX_FRIENDLY_NAME_BYTES = 120;
 // A prepared challenge carries a 5-minute server TTL; re-request past this
 // rather than spend a touch on one that expires mid-ceremony.
 const PREPARED_TTL_MS = 120000;
+// Pre-resolution spends one of the tenant's 30-per-hour enroll actions for each
+// DISTINCT key committed (@max_enroll_actions_per_window), so unbounded
+// speculation on `change` can 429 a tenant out of its own ceremony. Cap it;
+// past the cap the click still prepares — slower on WebKit, never blocked.
+const MAX_SPECULATIVE_PREPARES = 3;
 
 // Only the witness plug's OWN rejections are safely replayable — it halts
 // before the operation runs, so nothing committed. See request().
@@ -57,12 +71,19 @@ const WITNESS_CODES = ["witness_divergence", "witness_bootstrap_already_consumed
 // that matter: a refused already-enrolled device (excludeCredentials working),
 // and the activation/timeout refusal — on WebKit that also covers a click whose
 // user activation expired across an await.
-const CEREMONY_ERRORS = {
+//
+// The maps are per-ceremony on purpose. InvalidStateError during create() means
+// excludeCredentials matched; during the reauth get() the already-enrolled
+// device is the REQUIRED one, so the same wording would tell the operator to
+// fetch a different device and abandon a ceremony that was about to succeed.
+const NOT_ALLOWED =
+  "The browser refused or timed out the ceremony. Click Enroll again and touch the device when prompted.";
+const CREATE_ERRORS = {
   InvalidStateError:
     "That authenticator is already enrolled on this tenant — use a DIFFERENT device as a backup.",
-  NotAllowedError:
-    "The browser refused or timed out the ceremony. Click Enroll again and touch the device when prompted.",
+  NotAllowedError: NOT_ALLOWED,
 };
+const ASSERT_ERRORS = { NotAllowedError: NOT_ALLOWED };
 
 const describe = (t) => (t.slug ? `${t.name} (${t.slug})` : t.name);
 const byteLength = (value) => new TextEncoder().encode(value).length;
@@ -82,6 +103,10 @@ const AuthenticatorEnroll = {
     // concurrent ceremonies — `this.running` cannot help, since each stale
     // listener closes over its own `this`. destroyed() cuts them.
     this.listeners = new AbortController();
+    this.speculated = 0;
+    // Bumped whenever a prepared result is deliberately invalidated, so a
+    // prepare() still in flight cannot re-cache the credential afterwards.
+    this.epoch = 0;
     const signal = this.listeners.signal;
 
     this.button.addEventListener("click", () => this.run(), { signal });
@@ -103,11 +128,20 @@ const AuthenticatorEnroll = {
 
     // Resolve tenant + challenge as soon as the key is committed, not on the
     // click — see prepare().
-    this.keyInput.addEventListener(
-      "change",
-      () => this.running || this.prepare().catch((e) => this.fail(reason(e))),
-      { signal }
-    );
+    this.keyInput.addEventListener("change", () => this.speculate(), { signal });
+  },
+
+  // The `change` entry point into prepare(). Unlike run() it must stay silent
+  // on an empty field: blurring a CLEARED key sends an empty bearer token whose
+  // 401 would fail() away the success box that is the ceremony's only on-screen
+  // record of which tenant got anchored.
+  speculate() {
+    const key = (this.keyInput.value || "").trim();
+
+    if (this.running || !key || this.speculated >= MAX_SPECULATIVE_PREPARES) return;
+
+    this.speculated += 1;
+    this.prepare(key).catch((error) => this.fail(reason(error)));
   },
 
   destroyed() {
@@ -172,18 +206,21 @@ const AuthenticatorEnroll = {
 
       if (reauthAssertion) body.reauth_assertion = reauthAssertion;
 
-      const enrolled = await this.post(path, apiKey, body);
+      const enrolled = await this.post(path, apiKey, body, {
+        deadlineMs: COMMIT_TIMEOUT_MS,
+        timeoutMessage: COMMIT_TIMEOUT_MESSAGE,
+      });
 
       // The key is a live credential and the ceremony is over: drop it from
       // the DOM rather than leaving it in a field on an unattended screen.
       // Only on success — clearing after a failure would force a re-paste
       // for a retry that is usually a typo in the friendly name.
-      this.prepared = null;
+      this.invalidate();
       this.keyInput.value = "";
       this.succeed(enrolled, tenant);
     } catch (error) {
       // Whatever failed, the challenge is spent or suspect — force a fresh one.
-      this.prepared = null;
+      this.invalidate();
       this.fail(reason(error));
     } finally {
       this.busy(false);
@@ -195,15 +232,37 @@ const AuthenticatorEnroll = {
   // to be the first await after the button press or Safari answers
   // NotAllowedError. And it NAMES the tenant on screen ahead of a one-way door
   // that a mis-pasted key otherwise walks through irreversibly, unconfirmed.
-  async prepare(apiKey) {
+  //
+  // Deduped on the IN-FLIGHT promise, not just the result: the field's `change`
+  // fires on the same mousedown that produces the click, so a paste-then-click
+  // has run() calling prepare() while the listener's prepare() is still
+  // awaiting. Memoising only the result would issue a second tenant+challenge
+  // round trip — two ticks of the enroll budget, and run() awaiting network
+  // work again, which is exactly the WebKit activation loss this pre-resolution
+  // exists to avoid.
+  prepare(apiKey) {
     const key = apiKey || (this.keyInput.value || "").trim();
     const cached = this.prepared;
 
     if (cached && cached.apiKey === key && Date.now() - cached.at < PREPARED_TTL_MS) {
-      return cached;
+      return Promise.resolve(cached);
     }
 
+    if (!key) return Promise.resolve(null);
+    if (this.preparing && this.preparing.key === key) return this.preparing.promise;
+
     this.prepared = null;
+
+    const promise = this.resolvePrepared(key).finally(() => {
+      if (this.preparing && this.preparing.promise === promise) this.preparing = null;
+    });
+
+    this.preparing = { key, promise };
+    return promise;
+  },
+
+  async resolvePrepared(key) {
+    const epoch = this.epoch;
 
     this.status("Resolving tenant…");
     const tenant = await this.getTenant(key);
@@ -213,8 +272,18 @@ const AuthenticatorEnroll = {
     const challenge = await this.post(`${path}/challenge`, key, {});
 
     this.status(`Ready — this will anchor ${describe(tenant)}. Click Enroll and touch.`);
-    this.prepared = { apiKey: key, tenant, path, challenge, at: Date.now() };
-    return this.prepared;
+    const prepared = { apiKey: key, tenant, path, challenge, at: Date.now() };
+
+    // Never re-cache a credential that was invalidated while this was in
+    // flight: run() clears the key on success precisely because it is live.
+    if (epoch === this.epoch) this.prepared = prepared;
+
+    return prepared;
+  },
+
+  invalidate() {
+    this.prepared = null;
+    this.epoch += 1;
   },
 
   // --- API calls ---
@@ -233,11 +302,12 @@ const AuthenticatorEnroll = {
     return tenant;
   },
 
-  async post(url, apiKey, payload) {
+  async post(url, apiKey, payload, opts = {}) {
     const response = await this.request(url, {
       method: "POST",
       headers: { ...this.headers(apiKey), "content-type": "application/json" },
       body: JSON.stringify(payload),
+      ...opts,
     });
 
     return response.data;
@@ -255,31 +325,42 @@ const AuthenticatorEnroll = {
   // response, and on a WITNESS rejection adopt the STH it hands back and replay
   // ONCE. That is the documented resync contract (#298), not a workaround.
   async request(url, options, retried = false) {
+    const {
+      deadlineMs = FETCH_TIMEOUT_MS,
+      timeoutMessage = TIMEOUT_MESSAGE,
+      ...init
+    } = options;
+
     const witness = this.sth
       ? { "x-loopctl-last-known-sth": this.sth }
       : { "x-loopctl-sth-bootstrap": "true" };
 
     // Without a deadline an API that accepts the connection and never answers
     // leaves the page busy forever, with a live credential in a disabled field
-    // on an unattended screen and no cancel path but a reload.
+    // on an unattended screen and no cancel path but a reload. It has to span
+    // the BODY read as well: fetch() resolves when the response HEADERS arrive,
+    // so clearing the timer there just moves the unbounded wait into json().
     const deadline = new AbortController();
-    const timer = setTimeout(() => deadline.abort(), FETCH_TIMEOUT_MS);
+    const timer = setTimeout(() => deadline.abort(), deadlineMs);
 
     let response;
+    let body;
 
     try {
       response = await fetch(url, {
-        ...options,
+        ...init,
         credentials: "omit",
         signal: deadline.signal,
-        headers: { ...options.headers, ...witness },
+        headers: { ...init.headers, ...witness },
       });
+
+      body = await this.parseJson(response, deadline);
     } catch (_error) {
-      // Network-level failure: no response was produced, so there is
-      // nothing server-side to report.
+      // Network-level failure, or a response that never finished arriving:
+      // there is nothing server-side to report either way.
       throw new Error(
         deadline.signal.aborted
-          ? "The loopctl API did not respond in time — try again."
+          ? timeoutMessage
           : "Could not reach the loopctl API — check your connection."
       );
     } finally {
@@ -288,8 +369,6 @@ const AuthenticatorEnroll = {
 
     const currentSth = response.headers.get("x-loopctl-current-sth");
     if (currentSth) this.sth = currentSth;
-
-    const body = await this.parseJson(response);
 
     if (response.ok) return body || {};
 
@@ -312,10 +391,14 @@ const AuthenticatorEnroll = {
     return { authorization: `Bearer ${apiKey}`, accept: "application/json" };
   },
 
-  async parseJson(response) {
+  // A body that is not JSON (an HTML error page, an empty 204) is not fatal —
+  // apiError() falls back to the status. An ABORT here IS the deadline firing,
+  // so it must propagate rather than be read as "no body".
+  async parseJson(response, deadline) {
     try {
       return await response.json();
-    } catch (_error) {
+    } catch (error) {
+      if (deadline.signal.aborted) throw error;
       return null;
     }
   },
@@ -336,12 +419,14 @@ const AuthenticatorEnroll = {
 
   // --- WebAuthn ceremonies ---
 
-  // Translates the DOMExceptions worth translating — see CEREMONY_ERRORS.
-  async ceremony(fun) {
+  // Translates the DOMExceptions worth translating — see CREATE_ERRORS /
+  // ASSERT_ERRORS. The map is a parameter because the SAME DOMException name
+  // means different things in the two ceremonies.
+  async ceremony(errors, fun) {
     try {
       return await fun();
     } catch (error) {
-      const known = CEREMONY_ERRORS[error && error.name];
+      const known = errors[error && error.name];
       if (known) throw new Error(known);
       throw error;
     }
@@ -357,7 +442,7 @@ const AuthenticatorEnroll = {
       (id) => ({ type: "public-key", id: base64urlDecode(id) })
     );
 
-    const credential = await this.ceremony(() =>
+    const credential = await this.ceremony(CREATE_ERRORS, () =>
       navigator.credentials.create({
         publicKey: {
           challenge: base64urlDecode(challenge.challenge),
@@ -408,7 +493,7 @@ const AuthenticatorEnroll = {
       );
     }
 
-    const credential = await this.ceremony(() =>
+    const credential = await this.ceremony(ASSERT_ERRORS, () =>
       navigator.credentials.get({
         publicKey: {
           challenge: base64urlDecode(reauth.challenge),

--- a/assets/js/hooks/authenticator_enroll.js
+++ b/assets/js/hooks/authenticator_enroll.js
@@ -78,10 +78,21 @@ const WITNESS_CODES = ["witness_divergence", "witness_bootstrap_already_consumed
 // fetch a different device and abandon a ceremony that was about to succeed.
 const NOT_ALLOWED =
   "The browser refused or timed out the ceremony. Click Enroll again and touch the device when prompted.";
+const ALREADY_ENROLLED =
+  "That authenticator is already enrolled on this tenant — use a DIFFERENT device as a backup.";
 const CREATE_ERRORS = {
-  InvalidStateError:
-    "That authenticator is already enrolled on this tenant — use a DIFFERENT device as a backup.",
-  NotAllowedError: NOT_ALLOWED,
+  InvalidStateError: ALREADY_ENROLLED,
+  // NOT the bare NOT_ALLOWED text. An excludeCredentials match is only
+  // SOMETIMES reported as InvalidStateError: Chrome raises NotAllowedError for a
+  // CTAP2 roaming key (observed against a virtual authenticator), and the spec
+  // lets a browser collapse the two to avoid disclosing which credentials the RP
+  // excluded. Telling that operator to "click Enroll again" sends them into a
+  // loop that cannot succeed, on a one-way-door operation — so this path has to
+  // name both causes.
+  NotAllowedError:
+    "The browser refused the ceremony. Either this authenticator is ALREADY enrolled " +
+    "on this tenant — try a different device — or the touch timed out, in which case " +
+    "click Enroll again.",
 };
 const ASSERT_ERRORS = { NotAllowedError: NOT_ALLOWED };
 
@@ -486,6 +497,16 @@ const AuthenticatorEnroll = {
     };
   },
 
+  // Testing note, so the next person does not re-derive it: this ceremony
+  // CANNOT be exercised end to end with Chrome's CDP virtual authenticator.
+  // `WebAuthn.addVirtualAuthenticator` fails a `get()` whose `allowCredentials`
+  // names the very rawId its own `create()` just returned (NotAllowedError),
+  // while a discoverable `get()` with no allow-list succeeds and returns a
+  // DIFFERENT id — reproducible in a bare page with no loopctl code, and
+  // `WebAuthn.getCredentials` likewise reports an internal id rather than the
+  // RP-visible one. The server side of this gate IS verifiable without a
+  // browser: POST the enroll endpoint on a human_anchored tenant with no
+  // `reauth_assertion` and it must answer 401 `reauth_required`.
   async assert(reauth) {
     if (!reauth) {
       throw new Error(

--- a/assets/js/hooks/webauthn.js
+++ b/assets/js/hooks/webauthn.js
@@ -5,29 +5,7 @@
 // base64url-encoded challenge; we feed it to the browser's WebAuthn API
 // and ship the resulting attestation back via `pushEvent`.
 
-const base64urlEncode = (buffer) => {
-  const bytes = new Uint8Array(buffer);
-  let str = "";
-  for (let i = 0; i < bytes.byteLength; i++) {
-    str += String.fromCharCode(bytes[i]);
-  }
-  return btoa(str)
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "");
-};
-
-const base64urlDecode = (value) => {
-  if (!value) return new Uint8Array();
-  const padding = "=".repeat((4 - (value.length % 4)) % 4);
-  const base64 = (value + padding).replace(/-/g, "+").replace(/_/g, "/");
-  const raw = atob(base64);
-  const output = new Uint8Array(raw.length);
-  for (let i = 0; i < raw.length; i++) {
-    output[i] = raw.charCodeAt(i);
-  }
-  return output;
-};
+import { base64urlEncode, base64urlDecode } from "../webauthn/base64url";
 
 const WebAuthn = {
   mounted() {
@@ -58,7 +36,17 @@ const WebAuthn = {
               residentKey: "preferred",
               userVerification: "preferred",
             },
-            attestation: "direct",
+            // "none", not "direct" — must match the server's conveyance
+            // preference. Wax defaults to "none" and the app configures no
+            // override, so a "direct" request yields a packed attestation
+            // statement that `Wax.register/3` rejects outright with
+            // :invalid_attestation_conveyance_preference. This silently
+            // worked for platform authenticators (Touch ID / Windows Hello
+            // typically return fmt "none" regardless) and failed for exactly
+            // the hardware keys the signup page recommends — a YubiKey
+            // returns a packed statement. Bound by
+            // webauthn_attestation_conveyance_test.exs.
+            attestation: "none",
             timeout: 60000,
           },
         });

--- a/assets/js/webauthn/base64url.js
+++ b/assets/js/webauthn/base64url.js
@@ -1,0 +1,33 @@
+// base64url codec shared by the WebAuthn ceremonies.
+//
+// Every WebAuthn field the loopctl API exchanges — challenges, credential
+// ids, attestation objects, assertion signatures — is base64url WITHOUT
+// padding (`Base.url_encode64(.., padding: false)` server-side). Both the
+// signup hook (`hooks/webauthn.js`) and the enrollment hook
+// (`hooks/authenticator_enroll.js`) need the same pair, so it lives here
+// rather than being copied: a divergence between the two would surface as
+// an opaque attestation-verification failure, not as a decode error.
+
+export const base64urlEncode = (buffer) => {
+  const bytes = new Uint8Array(buffer);
+  let str = "";
+  for (let i = 0; i < bytes.byteLength; i++) {
+    str += String.fromCharCode(bytes[i]);
+  }
+  return btoa(str)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+};
+
+export const base64urlDecode = (value) => {
+  if (!value) return new Uint8Array();
+  const padding = "=".repeat((4 - (value.length % 4)) % 4);
+  const base64 = (value + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(base64);
+  const output = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) {
+    output[i] = raw.charCodeAt(i);
+  }
+  return output;
+};

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -102,9 +102,16 @@ config :loopctl, :webauthn,
 # If you need to inspect SQL via get_logs, temporarily set this back to :debug.
 config :logger, level: :info
 
-# Do not include metadata nor timestamps in development logs
+# Do not include metadata nor timestamps in development logs.
+#
+# The template key is `:msg`, NOT `:message`. Erlang's `:logger_formatter`
+# treats any atom outside its three specials (`:level`, `:time`, `:msg`) as a
+# METADATA key, so `:message` resolved to absent metadata and rendered as ""
+# — every dev log line printed as a bare "info: " with no content, silently,
+# for every environment that used this template. Nothing errors; the logs just
+# go blank, which is only noticed when you need them.
 config :logger, :default_handler,
-  formatter: {:logger_formatter, %{template: [:level, ": ", :message, "\n"]}}
+  formatter: {:logger_formatter, %{template: [:level, ": ", :msg, "\n"]}}
 
 # Declare the structured metadata keys the app emits (US-27.3 DB-error fields,
 # request/tenant context). The dev handler above prints only level + message,

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -91,6 +91,18 @@ defmodule Loopctl.ApiSpec.Schemas do
                     endpoints: %Schema{type: :array, items: %Schema{type: :string}},
                     requires_human: %Schema{type: :boolean},
                     requires_role: %Schema{type: :string},
+                    # #541 — the endpoints above need a browser
+                    # (navigator.credentials.create), so the machine-actionable
+                    # fields alone are a dead end for the agent reading this.
+                    # RELATIVE: the page is per-deployment, bound to that
+                    # instance's WEBAUTHN_RP_ID, unlike `docs`.
+                    enrollment_page: %Schema{
+                      type: :string,
+                      example: "/enroll",
+                      description:
+                        "Relative path to THIS deployment's browser enrollment page — the " <>
+                          "only way to run the WebAuthn ceremony the endpoints above require."
+                    },
                     docs: %Schema{type: :string}
                   }
                 },

--- a/lib/loopctl/tenants/tier_capabilities.ex
+++ b/lib/loopctl/tenants/tier_capabilities.ex
@@ -186,6 +186,16 @@ defmodule Loopctl.Tenants.TierCapabilities do
       "POST /api/v1/tenants/:id/authenticators/challenge",
       "POST /api/v1/tenants/:id/authenticators"
     ],
+    # #541 — the endpoints above cannot be driven by the caller reading this.
+    # `navigator.credentials.create()` needs a browser, so an agent or a curl
+    # user hit a wall precisely here: the remediation named a path it could not
+    # walk. This is the page that walks it.
+    #
+    # RELATIVE on purpose. The enrollment page is per-DEPLOYMENT (a self-hosted
+    # instance serves its own, and its WebAuthn relying party is its own host —
+    # see WEBAUTHN_RP_ID), unlike `docs`, which points at this project's wiki
+    # for everyone. A caller reading this already knows which host it asked.
+    enrollment_page: "/enroll",
     requires_human: true,
     requires_role: "user",
     docs: "https://loopctl.com/wiki/tenant-signup"

--- a/lib/loopctl_web/live/enroll_live.ex
+++ b/lib/loopctl_web/live/enroll_live.ex
@@ -1,0 +1,185 @@
+defmodule LoopctlWeb.EnrollLive do
+  @moduledoc """
+  #541 — the browser half of the opt-in trust-tier upgrade
+  (`agent_rooted -> human_anchored`) for an EXISTING tenant.
+
+  `GET /api/v1/tenants/me` on an agent-rooted tenant advertises an
+  `enrollment_upgrade` remediation naming `request_authenticator_challenge` /
+  `enroll_authenticator`, but `navigator.credentials.create()` cannot be driven
+  from curl or an MCP tool, and the only page that ran a WebAuthn ceremony was
+  `LoopctlWeb.SignupLive`, which creates a NEW tenant. The advertised upgrade
+  path therefore could not be walked by anyone, which left every human-anchored
+  surface — chain of custody, work breakdown, dispatch, token budgets —
+  permanently unreachable for a tenant created before the signup ceremony
+  existed.
+
+  ## This LiveView holds no state and makes no authorization decision
+
+  It renders a static shell and mounts the `AuthenticatorEnroll` hook. The
+  entire ceremony runs in the browser against the PUBLIC API
+  (`LoopctlWeb.TenantAuthenticatorController`), which already owns every gate:
+  `role: :user`, `owns_tenant?/2`, the fail-closed rate limit, the two-phase
+  challenge consumption, the `add_authenticator` reauth gate for a subsequent
+  enrollment, and the attestation size caps.
+
+  Two properties follow, and both are the reason it is shaped this way rather
+  than as a LiveView that resolves a pasted key server-side:
+
+    * **The operator's API key never reaches this process.** It is sent only as
+      an `Authorization: Bearer` header on same-origin `fetch` calls from the
+      hook. It is never a `handle_event` parameter, so it cannot land in socket
+      assigns, Phoenix's event logging, a crash dump, or telemetry. There is
+      deliberately no `handle_event/3` clause on this module at all.
+
+    * **There is exactly one enrollment implementation.** Re-implementing the
+      ceremony behind the LiveView socket would have duplicated the reauth gate
+      that closes the "stolen role:user key grafts an attacker's own hardware
+      onto the tenant's root of trust" backdoor
+      (`docs/chain-of-custody-v2.md` §9.3) — the single worst thing to have two
+      copies of.
+
+  The client orchestrates; it never enforces (CWE-602). Calling the API
+  directly with curl instead of using this page is not a bypass — it is the
+  supported path, and this page is a convenience wrapper around it for the one
+  step (`navigator.credentials.*`) that requires a browser.
+
+  ## Route placement
+
+  `/enroll` sits in the existing `:public_signup` live_session, outside any
+  authenticated pipeline. loopctl has no browser session auth — the API key IS
+  the credential, and it is presented per-request to the API, not to this page.
+  The live_session is what supplies the root layout (and therefore `app.js`,
+  which carries the hook).
+  """
+
+  use LoopctlWeb, :live_view
+
+  @docs_url "https://loopctl.com/wiki/chain-of-custody"
+
+  @impl true
+  def mount(_params, _session, socket) do
+    # No rate limiting here, matching SignupLive: merely LOADING the page must
+    # never consume a bucket. The abusable work — challenge issuance and
+    # attestation verification — is throttled fail-closed per tenant inside
+    # TenantAuthenticatorController, which is the only path that reaches it.
+    {:ok,
+     socket
+     |> assign(:page_title, "Enroll an authenticator")
+     |> assign(:docs_url, @docs_url)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <section class="mx-auto w-full max-w-2xl px-6 py-16" id="enroll-page">
+      <header class="mb-10 flex items-center gap-4">
+        <.icon name="hero-finger-print" class="h-10 w-10 text-accent-500" />
+        <div>
+          <h1 class="font-display text-2xl font-semibold text-slate-100">
+            Enroll an authenticator
+          </h1>
+          <p class="mt-1 text-sm text-slate-400">
+            Anchor an existing tenant to hardware. This upgrades its trust tier from
+            <span class="font-mono text-slate-300">agent_rooted</span>
+            to <span class="font-mono text-slate-300">human_anchored</span>, which unlocks the
+            chain-of-custody, work-breakdown, dispatch, and token-budget surfaces.
+          </p>
+        </div>
+      </header>
+
+      <div
+        id="enroll-app"
+        phx-hook="AuthenticatorEnroll"
+        phx-update="ignore"
+        class="space-y-8"
+      >
+        <div class="space-y-6 rounded-md border border-slate-800 bg-slate-900/60 p-6">
+          <div>
+            <h2 class="font-display text-sm uppercase tracking-wide text-slate-400">
+              Authorize
+            </h2>
+            <p class="mt-1 text-xs text-slate-500">
+              Paste a <span class="font-mono">user</span>-role API key for the tenant you are
+              anchoring. It is sent straight to the loopctl API as a bearer token from your
+              browser — this page never transmits it over its own connection, and never stores it.
+            </p>
+          </div>
+
+          <div>
+            <label
+              for="enroll-api-key"
+              class="block font-mono text-xs uppercase tracking-wide text-slate-500"
+            >
+              User-role API key
+            </label>
+            <input
+              id="enroll-api-key"
+              type="password"
+              autocomplete="off"
+              autocapitalize="off"
+              autocorrect="off"
+              spellcheck="false"
+              placeholder="lc_user_…"
+              class="mt-2 block w-full rounded-md border border-slate-800 bg-slate-950 px-3 py-2 font-mono text-sm text-slate-100 placeholder:text-slate-600 focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500"
+            />
+          </div>
+
+          <div>
+            <label
+              for="enroll-friendly-name"
+              class="block font-mono text-xs uppercase tracking-wide text-slate-500"
+            >
+              Authenticator name
+            </label>
+            <input
+              id="enroll-friendly-name"
+              type="text"
+              placeholder="Primary YubiKey"
+              class="mt-2 block w-full rounded-md border border-slate-800 bg-slate-900 px-3 py-2 font-mono text-sm text-slate-100 placeholder:text-slate-600 focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500"
+            />
+          </div>
+
+          <button
+            id="enroll-submit"
+            type="button"
+            class="inline-flex w-full items-center justify-center gap-2 rounded-md border border-accent-500 bg-accent-600 px-6 py-2 font-mono text-sm uppercase tracking-wide text-slate-50 hover:bg-accent-500 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <.icon name="hero-key" class="h-4 w-4" /> Enroll authenticator
+          </button>
+
+          <p id="enroll-status" role="status" class="mt-4 font-mono text-xs text-slate-400"></p>
+        </div>
+
+        <div id="enroll-result"></div>
+
+        <div class="rounded-md border border-slate-800 bg-slate-900/40 p-6 text-xs text-slate-500">
+          <p class="font-display uppercase tracking-wide text-slate-400">Before you start</p>
+          <ul class="mt-3 space-y-2">
+            <li>
+              The key must be <span class="font-mono text-slate-400">user</span>
+              role and belong to the tenant being anchored. Agent and orchestrator keys are
+              refused — trust-tier operations are not delegable.
+            </li>
+            <li>
+              Enrolling on an <span class="font-mono text-slate-400">agent_rooted</span>
+              tenant needs only the key and a touch. Adding a SECOND authenticator to an
+              already-anchored tenant additionally requires a touch from one that is already
+              enrolled, so keep the existing device to hand.
+            </li>
+            <li>
+              This is a one-way door in practice: a human-anchored tenant will not drop back to
+              agent-rooted, and its last authenticator cannot be revoked. Enroll a backup once
+              the first one is in.
+            </li>
+          </ul>
+          <p class="mt-4">
+            <.link href={@docs_url} class="font-mono text-accent-400 hover:text-accent-300">
+              Read the chain-of-custody model →
+            </.link>
+          </p>
+        </div>
+      </div>
+    </section>
+    """
+  end
+end

--- a/lib/loopctl_web/live/enroll_live.ex
+++ b/lib/loopctl_web/live/enroll_live.ex
@@ -101,7 +101,9 @@ defmodule LoopctlWeb.EnrollLive do
             <p class="mt-1 text-xs text-slate-500">
               Paste a <span class="font-mono">user</span>-role API key for the tenant you are
               anchoring. It is sent straight to the loopctl API as a bearer token from your
-              browser — this page never transmits it over its own connection, and never stores it.
+              browser — this page never transmits it over its own connection, never stores it,
+              and clears the field once the ceremony succeeds. Your browser's password manager
+              is outside our reach: decline if it offers to save the key.
             </p>
           </div>
 
@@ -112,10 +114,16 @@ defmodule LoopctlWeb.EnrollLive do
             >
               User-role API key
             </label>
+            <%!-- autocomplete="one-time-code", NOT "off": Chrome and Firefox
+            deliberately ignore autocomplete="off" on password fields and will offer
+            to save the value to the password manager. This field holds a live,
+            long-lived user-role credential — the one that can anchor the tenant's
+            root of trust — and one-time-code is the only value browsers treat as
+            never-persist. --%>
             <input
               id="enroll-api-key"
               type="password"
-              autocomplete="off"
+              autocomplete="one-time-code"
               autocapitalize="off"
               autocorrect="off"
               spellcheck="false"

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -75,6 +75,15 @@ defmodule LoopctlWeb.Router do
       root_layout: {LoopctlWeb.Layouts, :root} do
       live "/signup", SignupLive, :index
       live "/tenants/:id/onboarding", TenantOnboardingLive, :index
+
+      # #541 — the browser half of the trust-tier upgrade for an EXISTING
+      # tenant. Shares this live_session for its root layout (and therefore
+      # app.js, which carries the ceremony hook) and, like signup, sits
+      # outside any authenticated pipeline: loopctl has no browser session
+      # auth. The page holds no secret and decides nothing — the operator's
+      # API key is presented per-request to the API by the hook, never to
+      # this LiveView. See LoopctlWeb.EnrollLive.
+      live "/enroll", EnrollLive, :index
     end
 
     # US-26.0.3 — public wiki rendering for system-scoped articles

--- a/test/loopctl/tenants/tier_capabilities_test.exs
+++ b/test/loopctl/tenants/tier_capabilities_test.exs
@@ -68,6 +68,21 @@ defmodule Loopctl.Tenants.TierCapabilitiesTest do
       refute upgrade.summary =~ "signup"
     end
 
+    test "names the browser page, since the endpoints alone cannot be walked (#541)" do
+      upgrade = TierCapabilities.for_tier(:agent_rooted).remediation.enrollment_upgrade
+
+      # `requires_human: true` is not advice — `navigator.credentials.create()`
+      # is unreachable from an agent or curl, so naming only the endpoints left
+      # the caller at a dead end. The page is the actionable half.
+      assert upgrade.enrollment_page == "/enroll"
+
+      # Relative, not absolute: the page is per-deployment (a self-hosted
+      # instance serves its own, bound to its own WEBAUTHN_RP_ID). An absolute
+      # loopctl.com URL would send a self-hoster's operator to anchor a tenant
+      # on the wrong instance — where their key does not even exist.
+      refute upgrade.enrollment_page =~ "http"
+    end
+
     test "states that the map is tier-scoped and covers mutating actions only" do
       # The map derives from trust_tier ALONE and every RequireHumanAnchor mount
       # is per-action. Advertising a bare "allowed" would relocate the

--- a/test/loopctl/web_authn/attestation_conveyance_test.exs
+++ b/test/loopctl/web_authn/attestation_conveyance_test.exs
@@ -1,0 +1,53 @@
+defmodule Loopctl.WebAuthn.AttestationConveyanceTest do
+  @moduledoc """
+  Binds the browser's requested attestation conveyance preference to the one
+  the server actually accepts.
+
+  `Wax.new_registration_challenge/1` stores an `attestation` preference on the
+  challenge and `Wax.register/3` REJECTS any attestation statement that does not
+  match it (`:invalid_attestation_conveyance_preference`). Wax defaults that to
+  `"none"`, and this app passes no override — `config :loopctl, :webauthn`
+  carries only `rp_id` / `rp_name` / `origin` / `user_verification`.
+
+  Both hooks nonetheless requested `attestation: "direct"`. That failure is
+  invisible on the common path, which is what let it survive: platform
+  authenticators (Touch ID, Windows Hello) generally return `fmt: "none"`
+  whatever the page asks for, so verification passed. A roaming key returns a
+  `packed` statement, and Wax then rejects a perfectly valid credential. It was
+  found by driving /enroll with a CTAP2 virtual authenticator, which behaves
+  like the YubiKey rather than like the laptop.
+
+  These assertions fail in BOTH directions, so the pair cannot drift apart:
+  configure `:attestation` server-side without updating the hooks, or change a
+  hook without configuring the server, and this test says so.
+  """
+
+  use ExUnit.Case, async: true
+
+  @hooks ["assets/js/hooks/webauthn.js", "assets/js/hooks/authenticator_enroll.js"]
+
+  describe "client/server attestation conveyance agreement" do
+    test "the app configures no :attestation override, so the effective policy is Wax's \"none\"" do
+      configured = :loopctl |> Application.get_env(:webauthn, []) |> Keyword.get(:attestation)
+
+      assert is_nil(configured),
+             "config :loopctl, :webauthn now sets attestation: #{inspect(configured)}. " <>
+               "The browser hooks (#{Enum.join(@hooks, ", ")}) hard-code the conveyance " <>
+               "they request and must be updated to match, or every registration will " <>
+               "fail with :invalid_attestation_conveyance_preference."
+    end
+
+    test "every hook requests attestation: \"none\"" do
+      for hook <- @hooks do
+        source = File.read!(hook)
+
+        assert source =~ ~s(attestation: "none"),
+               "#{hook} must request attestation: \"none\" to match the server."
+
+        refute source =~ ~s(attestation: "direct"),
+               "#{hook} requests attestation: \"direct\", which Wax rejects unless the " <>
+                 "server challenge is built with the same preference."
+      end
+    end
+  end
+end

--- a/test/loopctl/web_authn/attestation_conveyance_test.exs
+++ b/test/loopctl/web_authn/attestation_conveyance_test.exs
@@ -24,10 +24,12 @@ defmodule Loopctl.WebAuthn.AttestationConveyanceTest do
 
   use ExUnit.Case, async: true
 
+  alias Loopctl.WebAuthn.RpConfig
+
   @hooks ["assets/js/hooks/webauthn.js", "assets/js/hooks/authenticator_enroll.js"]
 
   describe "client/server attestation conveyance agreement" do
-    test "the app configures no :attestation override, so the effective policy is Wax's \"none\"" do
+    test "no :attestation override reaches the config, compiled OR resolved at boot" do
       configured = :loopctl |> Application.get_env(:webauthn, []) |> Keyword.get(:attestation)
 
       assert is_nil(configured),
@@ -35,6 +37,26 @@ defmodule Loopctl.WebAuthn.AttestationConveyanceTest do
                "The browser hooks (#{Enum.join(@hooks, ", ")}) hard-code the conveyance " <>
                "they request and must be updated to match, or every registration will " <>
                "fail with :invalid_attestation_conveyance_preference."
+
+      # config/test.exs is only half the surface. Production ASSEMBLES `:webauthn`
+      # at boot from `RpConfig.resolve/1` (config/runtime.exs), which no test env
+      # can observe — so an override added there would leave this file green while
+      # every real registration failed. Drive the resolver directly, both with a
+      # fully-populated operator env and with none, so the prod path is covered too.
+      for env <- [
+            [rp_id: "loopctl.com", rp_name: "loopctl", origin: "https://loopctl.com"],
+            [rp_id: nil, rp_name: nil, origin: nil, phx_host: "loopctl.com"]
+          ] do
+        {opts, _warnings} = RpConfig.resolve(env)
+
+        refute Keyword.has_key?(opts, :attestation),
+               "RpConfig.resolve/1 now emits attestation: " <>
+                 "#{inspect(Keyword.get(opts, :attestation))} for #{inspect(env)}. " <>
+                 "That reaches `config :loopctl, :webauthn` in production only, where " <>
+                 "the hooks' hard-coded \"none\" no longer matches and Wax.register/3 " <>
+                 "rejects every attestation with " <>
+                 ":invalid_attestation_conveyance_preference."
+      end
     end
 
     test "every hook requests attestation: \"none\"" do

--- a/test/loopctl/web_authn/attestation_conveyance_test.exs
+++ b/test/loopctl/web_authn/attestation_conveyance_test.exs
@@ -57,6 +57,19 @@ defmodule Loopctl.WebAuthn.AttestationConveyanceTest do
                  "rejects every attestation with " <>
                  ":invalid_attestation_conveyance_preference."
       end
+
+      # The resolver is not the only writer: runtime.exs MERGES its output into
+      # `config :loopctl, :webauthn` (config/runtime.exs:568), so an
+      # `attestation:` key appended at THAT call site — or in prod.exs — is
+      # outside both surfaces above and would leave this file green. Scan the
+      # config sources the way the test below scans the hooks.
+      for path <- ["config/runtime.exs", "config/prod.exs"] do
+        refute File.read!(path) =~ ~r/attestation:/,
+               "#{path} now sets an attestation conveyance preference. The browser " <>
+                 "hooks hard-code \"none\" and must be updated to match, or every " <>
+                 "production registration fails with " <>
+                 ":invalid_attestation_conveyance_preference."
+      end
     end
 
     test "every hook requests attestation: \"none\"" do

--- a/test/loopctl_web/live/enroll_live_test.exs
+++ b/test/loopctl_web/live/enroll_live_test.exs
@@ -1,0 +1,146 @@
+defmodule LoopctlWeb.EnrollLiveTest do
+  @moduledoc """
+  #541 — coverage for the authenticator-enrollment page.
+
+  The ceremony itself runs in the browser against
+  `LoopctlWeb.TenantAuthenticatorController`, which has its own
+  (extensive) test suite. What is testable HERE, and what these tests are
+  for, is the set of structural properties that make that split safe:
+
+    * the page reaches an unauthenticated visitor at all;
+    * it cannot receive the operator's API key, because it handles no
+      events;
+    * it cannot leak the key into a URL, because it has no form;
+    * the hook that does the work is actually wired into the bundle; and
+    * the hook takes the WebAuthn user handle from the server rather than
+      minting one (AC-26.7.2.2).
+
+  The last two are source scans. That is deliberate: they assert facts
+  about files ExUnit cannot otherwise reach, and each one guards a failure
+  that is SILENT — an unregistered hook renders a page whose button does
+  nothing, and a client-minted handle produces a credential bound to the
+  wrong user with no error anywhere.
+  """
+
+  use LoopctlWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  @hook_path "assets/js/hooks/authenticator_enroll.js"
+  @app_js_path "assets/js/app.js"
+
+  setup :verify_on_exit!
+
+  describe "GET /enroll" do
+    test "renders unauthenticated, with the ceremony controls", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/enroll")
+
+      assert html =~ ~s(id="enroll-page")
+      assert html =~ ~s(id="enroll-api-key")
+      assert html =~ ~s(id="enroll-friendly-name")
+      assert html =~ ~s(id="enroll-submit")
+      assert html =~ ~s(id="enroll-status")
+      assert html =~ ~s(id="enroll-result")
+    end
+
+    test "mounts the AuthenticatorEnroll hook and lets it own its DOM", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/enroll")
+
+      assert has_element?(view, ~s(#enroll-app[phx-hook="AuthenticatorEnroll"]))
+
+      # The hook writes status and results into its own subtree; without
+      # phx-update="ignore" a LiveView patch would wipe them mid-ceremony.
+      assert has_element?(view, ~s(#enroll-app[phx-update="ignore"]))
+    end
+
+    test "the key field is a password input that browsers will not autofill or store",
+         %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/enroll")
+
+      assert has_element?(view, ~s(input#enroll-api-key[type="password"]))
+      assert has_element?(view, ~s(input#enroll-api-key[autocomplete="off"]))
+      assert has_element?(view, ~s(input#enroll-api-key[spellcheck="false"]))
+    end
+
+    test "renders NO form element — a native GET submit would put the key in the URL",
+         %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/enroll")
+
+      # A <form> with no action submits to the current URL as GET if JS fails
+      # to load, which would write the pasted API key into the query string,
+      # browser history, and every access log in front of the app. The page
+      # therefore uses bare inputs plus a click/keydown handler.
+      refute html =~ "<form"
+    end
+  end
+
+  describe "the LiveView cannot receive the API key" do
+    test "EnrollLive defines no handle_event/3 at all" do
+      Code.ensure_loaded!(LoopctlWeb.EnrollLive)
+
+      # This is the whole security argument for the page's shape, expressed as
+      # a property rather than a comment: with no event handler, there is no
+      # path by which a pasted credential reaches socket assigns, Phoenix's
+      # event parameter logging, a crash dump, or telemetry. If a future change
+      # adds an event handler, this test fails and that argument has to be
+      # re-made deliberately rather than eroded by accident.
+      refute function_exported?(LoopctlWeb.EnrollLive, :handle_event, 3)
+    end
+
+    test "the hook never pushes anything over the LiveView socket" do
+      source = File.read!(@hook_path)
+
+      refute source =~ "pushEvent"
+      refute source =~ "pushEventTo"
+    end
+
+    test "the hook sends the key only as an Authorization header" do
+      source = File.read!(@hook_path)
+
+      assert source =~ "authorization: `Bearer ${apiKey}`"
+
+      # Same-origin fetch with credentials omitted: the ambient session cookie
+      # is irrelevant to an API-key-authenticated call and must not ride along.
+      assert source =~ ~s(credentials: "omit")
+    end
+  end
+
+  describe "the hook is wired into the bundle" do
+    test "app.js imports and registers AuthenticatorEnroll" do
+      source = File.read!(@app_js_path)
+
+      assert source =~ ~s(import AuthenticatorEnroll from "./hooks/authenticator_enroll")
+
+      assert source =~ "AuthenticatorEnroll,",
+             "AuthenticatorEnroll must be registered in the Hooks map, or the " <>
+               "enroll button silently does nothing"
+    end
+
+    test "the hook file exists and exports a hook object" do
+      source = File.read!(@hook_path)
+
+      assert source =~ "export default AuthenticatorEnroll"
+      assert source =~ "mounted()"
+    end
+  end
+
+  describe "AC-26.7.2.2 — the WebAuthn user handle is server-derived" do
+    test "the hook takes user.id from the challenge response" do
+      source = File.read!(@hook_path)
+
+      assert source =~ "base64urlDecode(challenge.user.id)"
+    end
+
+    test "the hook does NOT mint its own user handle" do
+      source = File.read!(@hook_path)
+
+      # `hooks/webauthn.js` legitimately generates a random handle — it enrolls
+      # an authenticator for a tenant that does not exist yet. This hook enrolls
+      # against an EXISTING tenant, where the handle is derived server-side from
+      # the tenant row and is never client-supplied. Copying the signup hook
+      # wholesale is the easy mistake here, and it produces a credential bound
+      # to a handle the server did not issue.
+      refute source =~ "crypto.getRandomValues"
+    end
+  end
+end

--- a/test/loopctl_web/live/enroll_live_test.exs
+++ b/test/loopctl_web/live/enroll_live_test.exs
@@ -53,13 +53,19 @@ defmodule LoopctlWeb.EnrollLiveTest do
       assert has_element?(view, ~s(#enroll-app[phx-update="ignore"]))
     end
 
-    test "the key field is a password input that browsers will not autofill or store",
+    test "the key field is a password input the browser will not offer to save",
          %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/enroll")
 
       assert has_element?(view, ~s(input#enroll-api-key[type="password"]))
-      assert has_element?(view, ~s(input#enroll-api-key[autocomplete="off"]))
       assert has_element?(view, ~s(input#enroll-api-key[spellcheck="false"]))
+
+      # NOT autocomplete="off": Chrome and Firefox deliberately ignore it on
+      # password fields and will persist the value — here a live, long-lived
+      # user-role key — into the password manager. "one-time-code" is the value
+      # browsers actually treat as never-persist.
+      assert has_element?(view, ~s(input#enroll-api-key[autocomplete="one-time-code"]))
+      refute has_element?(view, ~s(input#enroll-api-key[autocomplete="off"]))
     end
 
     test "renders NO form element — a native GET submit would put the key in the URL",
@@ -121,6 +127,23 @@ defmodule LoopctlWeb.EnrollLiveTest do
 
       assert source =~ "export default AuthenticatorEnroll"
       assert source =~ "mounted()"
+    end
+  end
+
+  describe "the hook's silent-failure guards" do
+    test "create() excludes already-enrolled credentials and the hook unbinds on destroy" do
+      source = File.read!(@hook_path)
+
+      # Without excludeCredentials a "backup" authenticator can be the SAME
+      # physical device: the second credential gets a fresh credential_id, so
+      # the (tenant_id, credential_id) unique index never sees a duplicate and
+      # the tenant believes in redundancy it does not have.
+      assert source =~ "excludeCredentials"
+
+      # #enroll-app is phx-update="ignore", so its DOM outlives the hook across
+      # a LiveView reconnect. No destroyed() means the old instance's listeners
+      # stay bound and one click runs two concurrent ceremonies.
+      assert source =~ "destroyed()"
     end
   end
 

--- a/test/loopctl_web/live/enroll_live_test.exs
+++ b/test/loopctl_web/live/enroll_live_test.exs
@@ -134,16 +134,35 @@ defmodule LoopctlWeb.EnrollLiveTest do
     test "create() excludes already-enrolled credentials and the hook unbinds on destroy" do
       source = File.read!(@hook_path)
 
-      # Without excludeCredentials a "backup" authenticator can be the SAME
-      # physical device: the second credential gets a fresh credential_id, so
-      # the (tenant_id, credential_id) unique index never sees a duplicate and
-      # the tenant believes in redundancy it does not have.
-      assert source =~ "excludeCredentials"
+      # Anchored to the load-bearing expressions, not the identifiers: a guard
+      # reduced to `excludeCredentials: []` or an empty `destroyed() {}` is
+      # exactly the regression these tests exist to catch, and a bare substring
+      # scan passes on both.
+      #
+      # Without a POPULATED excludeCredentials a "backup" authenticator can be
+      # the SAME physical device: the second credential gets a fresh
+      # credential_id, so the (tenant_id, credential_id) unique index never sees
+      # a duplicate and the tenant believes in redundancy it does not have.
+      assert source =~ ~r/const enrolled = [^;]{0,200}allowed_credentials/
+      assert source =~ ~r/excludeCredentials: enrolled/
 
       # #enroll-app is phx-update="ignore", so its DOM outlives the hook across
-      # a LiveView reconnect. No destroyed() means the old instance's listeners
-      # stay bound and one click runs two concurrent ceremonies.
-      assert source =~ "destroyed()"
+      # a LiveView reconnect. A destroyed() that does not ABORT the listener
+      # controller leaves the old instance bound and one click runs two
+      # concurrent ceremonies.
+      assert source =~ ~r/destroyed\(\)\s*\{[^}]*this\.listeners\.abort\(\)/
+    end
+
+    test "the fetch deadline spans the response BODY, not just its headers" do
+      source = File.read!(@hook_path)
+
+      # fetch() resolves when the HEADERS arrive. Clearing the abort timer there
+      # moves the unbounded wait into response.json(), which is the same hang
+      # the deadline exists to close — so the body read must happen inside the
+      # timer's try, and an abort during it must propagate rather than be read
+      # as "no body".
+      assert source =~ ~r/body = await this\.parseJson\(response, deadline\);\s*\}\s*catch/
+      assert source =~ ~r/if \(deadline\.signal\.aborted\) throw error;/
     end
   end
 


### PR DESCRIPTION
Closes #541. Unblocks #521.

`GET /api/v1/tenants/me` on an agent-rooted tenant advertises an `enrollment_upgrade` remediation — and nobody could walk it. `navigator.credentials.create()` cannot be driven from curl or an MCP tool, and the only page that ran a WebAuthn ceremony was `SignupLive`, which creates a **new** tenant. So every tenant predating the signup ceremony was permanently locked out of chain-of-custody, work-breakdown, dispatch and token-budget writes, with the API cheerfully pointing at a door that opened onto a wall. The hosted `eCommerce Friendly` tenant (created 2026-04-01) is exactly that case, which is why #521 stalled at its own step 2.

## The design differs from what the issue proposed, deliberately

The issue specified a LiveView that resolves the pasted key server-side and calls `Enrollment.enroll/2`. That is the wrong shape. `TenantAuthenticatorController` already owns the fail-closed rate limit, the two-phase challenge consumption, the `add_authenticator` reauth gate that closes the soft-recovery backdoor (`docs/chain-of-custody-v2.md` §9.3), and the attestation size caps. Reimplementing that set behind the LiveView socket is precisely where a custody gate gets quietly dropped.

**This page is a browser client of that API instead.** The key goes into a password field and rides an `Authorization: Bearer` header on same-origin `fetch`, exactly as any API client would send it. Each of the issue's four security concerns dissolves rather than being mitigated:

| Concern from #541 | How this shape answers it |
|---|---|
| Pasted key reaching DOM / logs / telemetry | Never reaches the server process. `EnrollLive` has **no `handle_event/3` at all** — asserted by a test — so there is no path into socket assigns, Phoenix's event-parameter logging, a crash dump, or telemetry |
| Must go *through* the rate limiter, not around | It **is** the controller. Bypassing is not possible because there is nothing else to call |
| Existence leaks on an unauthenticated route | The controller's already-tested responses. Verified live: a valid key for another tenant and a nonexistent tenant id return an identical flat `403` |
| Subsequent enrollment needs a fresh assertion | On the path by construction. Verified live: `401 reauth_required` without one |

The client orchestrates; it never enforces. Calling the API directly with curl is not a bypass — it is the supported path, and this page is a wrapper around the one step that needs a browser.

## Two bugs found by verifying against real hardware behaviour

**1. WebAuthn registration was broken for hardware security keys — on `/signup` too.** Both hooks requested `attestation: "direct"` while the server builds its challenge with Wax's default `"none"`, so `Wax.register/3` rejected any real attestation statement with `:invalid_attestation_conveyance_preference`. This is invisible on a laptop — Touch ID and Windows Hello return `fmt: "none"` regardless — and broke exactly the roaming keys the signup page recommends. Found only because a CTAP2 virtual authenticator behaves like a YubiKey, not like a MacBook. A test binds the client value to the absence of a server-side override, and fails in both directions.

**2. The witness protocol was unimplemented in my first pass.** Every authenticated call goes through `ValidateWitnessHeader`, and a browser tab holds no cached STH. The hook now bootstraps, captures the server's STH off every response, and replays once on a witness rejection — gated on the error body's witness codes, **not** a bare status, so a controller-level `409 too_many_authenticators` is never replayed against a spent challenge.

## Supporting fixes

- **`config/dev.exs` logger.** The `logger_formatter` template used `:message`; Erlang's formatter takes `:msg` and treats any other atom as a metadata key, so **every dev log line printed as a bare `info: ` with no content**. That is what made the first enrollment 500 undiagnosable. One word, and the stack traces came back.
- **CI never compiled `assets/js`.** A broken hook reached the Docker build at deploy time. Tolerable while the JS was incidental; not once a page's entire behaviour is client-side.
- **`GET /tenants/me`** now names the page in `remediation.enrollment_upgrade.enrollment_page` — **relative**, since a self-hosted instance serves its own and binds it to its own `WEBAUTHN_RP_ID`. An absolute URL would send a self-hoster's operator to anchor a tenant on loopctl.com, where their key does not exist.

## Review

Enhanced review ran two rounds: **28 findings raised, 26 confirmed, 18 fixed, 0 deferrals.** The 8 out-of-scope confirmations are in `heavy_read.ex` / `local_guc.ex` / `bulk_ops.ex` — pre-existing, from the #540 branch — and go on their own branch rather than into a PR about an enrollment page.

Substantive fixes included `excludeCredentials` (without it a "backup" could silently be the same physical device, giving false redundancy behind a one-way-door tier flip), an AbortController-scoped listener set (`phx-update="ignore"` means the DOM outlives the hook across a reconnect, so one click ran two ceremonies), a prefetch so `create()` is the first await after the click (WebKit drops transient activation otherwise), and `autocomplete="one-time-code"` — Chrome and Firefox ignore `off` on password fields and would offer to save a live user-role key.

## Verification

End to end on the dev server against a CTAP2 virtual authenticator, plus API-level probes:

- `agent_rooted` → `human_anchored`, all 14 surfaces `allowed`, **confirmed server-side** rather than from the page's own rendering
- second enrollment: server issues `reauth_required: true`; without the assertion it is `401 reauth_required`
- same physical device refused as a "backup" once `excludeCredentials` landed
- cross-tenant and nonexistent-tenant both `403`, byte-identical; invalid key `401`
- `mix precommit` green — 6468 tests, credo --strict, dialyzer

**What is not verified, stated plainly:** the two-device backup ceremony could not be exercised end to end. Chrome's CDP virtual authenticator fails a `get()` whose `allowCredentials` names the rawId its own `create()` just returned, while a discoverable `get()` succeeds and returns a different id — reproducible in a bare page with **no loopctl code**. So that harness cannot complete any reauth ceremony. The server half of the gate is verified without a browser (the `401` above), and the limitation is recorded next to `assert()` so the next person does not re-derive it. A real authenticator resolves `allowCredentials` normally.
