### PR TITLE
Stop a probe blip from silently disabling iterative scan, and close the last GUC leak

### DIFF
--- a/.claude/skills/tenancy-rls/SKILL.md
+++ b/.claude/skills/tenancy-rls/SKILL.md
@@ -54,16 +54,16 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 6. **On `AdminRepo`/`HeavyReadRepo`, RLS does NOTHING — the explicit `tenant_id` predicate is the only
    isolation there** (`knowledge.ex:9-14`, `heavy_read.ex:3-7`). This is the compensating invariant for
    the other two repos, and it is enforced structurally on the heavy path: the private `guard!/2`
-   (`heavy_read.ex:1072-1090`) RAISES unless EVERY base-table source — `from`, every join, and every
+   (`heavy_read.ex:1115-1133`) RAISES unless EVERY base-table source — `from`, every join, and every
    subquery, recursively — carries a conjunctive `x.tenant_id == ^tenant_id` bound to the passed
    `tenant_id`; `test/loopctl/heavy_read_guard_test.exs` additionally bars direct `HeavyReadRepo` calls.
-   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:833`) also requires a conjunctive
-   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1094-1116`), because `subject_id`
+   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:876`) also requires a conjunctive
+   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1137-1159`), because `subject_id`
    scoping is application-level only. Always go through `Loopctl.HeavyRead`, never `HeavyReadRepo`
    directly; on `AdminRepo` there is no guard at all, so the predicate is on you.
-7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:777`),
-   `one/3` (`heavy_read.ex:797`) and `all_memory/4` (`heavy_read.ex:833`) are specced to return it: the
-   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:862-882`) sheds over the cap —
+7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:820`),
+   `one/3` (`heavy_read.ex:840`) and `all_memory/4` (`heavy_read.ex:876`) are specced to return it: the
+   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:905-925`) sheds over the cap —
    `on_overload: :raise` (default) raises → 429, `on_overload: :tag` returns the tuple. Binding the
    result as a list crashes exactly under the load the gate exists for.
 8. **A consistency-coupled heavy read must be PRIMARY-PINNED.** `repo_for/1` (`heavy_read.ex:114-117`,
@@ -75,8 +75,8 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 ## The pgbouncer gotcha (US-27.13 — production outage, do not regress)
 
 `HeavyReadRepo` enforces a server-side `statement_timeout` **per-read via `SET LOCAL` inside the
-transaction** (`all/3` at `heavy_read.ex:777` and `one/3` at `:797`, both via
-`with_statement_timeout/5` at `:898`;
+transaction** (`all/3` at `heavy_read.ex:820` and `one/3` at `:840`, both via
+`with_statement_timeout/5` at `:941`;
 `heavy_read_repo.ex:19-32`) — NOT as a connection startup
 `:parameters` value. Fly MPG fronts Postgres with **pgbouncer**, which rejects a `statement_timeout`
 startup parameter with `FATAL 08P01 unsupported startup parameter`, crash-looping the whole pool so it

--- a/.claude/skills/tenancy-rls/SKILL.md
+++ b/.claude/skills/tenancy-rls/SKILL.md
@@ -57,12 +57,12 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
    (`heavy_read.ex:1175-1193`) RAISES unless EVERY base-table source — `from`, every join, and every
    subquery, recursively — carries a conjunctive `x.tenant_id == ^tenant_id` bound to the passed
    `tenant_id`; `test/loopctl/heavy_read_guard_test.exs` additionally bars direct `HeavyReadRepo` calls.
-   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:936`) also requires a conjunctive
+   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:944`) also requires a conjunctive
    `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1197-1219`), because `subject_id`
    scoping is application-level only. Always go through `Loopctl.HeavyRead`, never `HeavyReadRepo`
    directly; on `AdminRepo` there is no guard at all, so the predicate is on you.
-7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:880`),
-   `one/3` (`heavy_read.ex:900`) and `all_memory/4` (`heavy_read.ex:936`) are specced to return it: the
+7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:888`),
+   `one/3` (`heavy_read.ex:908`) and `all_memory/4` (`heavy_read.ex:944`) are specced to return it: the
    per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:965-985`) sheds over the cap —
    `on_overload: :raise` (default) raises → 429, `on_overload: :tag` returns the tuple. Binding the
    result as a list crashes exactly under the load the gate exists for.
@@ -75,7 +75,7 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 ## The pgbouncer gotcha (US-27.13 — production outage, do not regress)
 
 `HeavyReadRepo` enforces a server-side `statement_timeout` **per-read via `SET LOCAL` inside the
-transaction** (`all/3` at `heavy_read.ex:880` and `one/3` at `:900`, both via
+transaction** (`all/3` at `heavy_read.ex:888` and `one/3` at `:908`, both via
 `with_statement_timeout/5` at `:1001`;
 `heavy_read_repo.ex:19-32`) — NOT as a connection startup
 `:parameters` value. Fly MPG fronts Postgres with **pgbouncer**, which rejects a `statement_timeout`

--- a/.claude/skills/tenancy-rls/SKILL.md
+++ b/.claude/skills/tenancy-rls/SKILL.md
@@ -54,16 +54,16 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 6. **On `AdminRepo`/`HeavyReadRepo`, RLS does NOTHING — the explicit `tenant_id` predicate is the only
    isolation there** (`knowledge.ex:9-14`, `heavy_read.ex:3-7`). This is the compensating invariant for
    the other two repos, and it is enforced structurally on the heavy path: the private `guard!/2`
-   (`heavy_read.ex:1115-1133`) RAISES unless EVERY base-table source — `from`, every join, and every
+   (`heavy_read.ex:1175-1193`) RAISES unless EVERY base-table source — `from`, every join, and every
    subquery, recursively — carries a conjunctive `x.tenant_id == ^tenant_id` bound to the passed
    `tenant_id`; `test/loopctl/heavy_read_guard_test.exs` additionally bars direct `HeavyReadRepo` calls.
-   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:876`) also requires a conjunctive
-   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1137-1159`), because `subject_id`
+   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:936`) also requires a conjunctive
+   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1197-1219`), because `subject_id`
    scoping is application-level only. Always go through `Loopctl.HeavyRead`, never `HeavyReadRepo`
    directly; on `AdminRepo` there is no guard at all, so the predicate is on you.
-7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:820`),
-   `one/3` (`heavy_read.ex:840`) and `all_memory/4` (`heavy_read.ex:876`) are specced to return it: the
-   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:905-925`) sheds over the cap —
+7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:880`),
+   `one/3` (`heavy_read.ex:900`) and `all_memory/4` (`heavy_read.ex:936`) are specced to return it: the
+   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:965-985`) sheds over the cap —
    `on_overload: :raise` (default) raises → 429, `on_overload: :tag` returns the tuple. Binding the
    result as a list crashes exactly under the load the gate exists for.
 8. **A consistency-coupled heavy read must be PRIMARY-PINNED.** `repo_for/1` (`heavy_read.ex:114-117`,
@@ -75,8 +75,8 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 ## The pgbouncer gotcha (US-27.13 — production outage, do not regress)
 
 `HeavyReadRepo` enforces a server-side `statement_timeout` **per-read via `SET LOCAL` inside the
-transaction** (`all/3` at `heavy_read.ex:820` and `one/3` at `:840`, both via
-`with_statement_timeout/5` at `:941`;
+transaction** (`all/3` at `heavy_read.ex:880` and `one/3` at `:900`, both via
+`with_statement_timeout/5` at `:1001`;
 `heavy_read_repo.ex:19-32`) — NOT as a connection startup
 `:parameters` value. Fly MPG fronts Postgres with **pgbouncer**, which rejects a `statement_timeout`
 startup parameter with `FATAL 08P01 unsupported startup parameter`, crash-looping the whole pool so it

--- a/.claude/skills/tenancy-rls/SKILL.md
+++ b/.claude/skills/tenancy-rls/SKILL.md
@@ -54,16 +54,16 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 6. **On `AdminRepo`/`HeavyReadRepo`, RLS does NOTHING — the explicit `tenant_id` predicate is the only
    isolation there** (`knowledge.ex:9-14`, `heavy_read.ex:3-7`). This is the compensating invariant for
    the other two repos, and it is enforced structurally on the heavy path: the private `guard!/2`
-   (`heavy_read.ex:1002-1020`) RAISES unless EVERY base-table source — `from`, every join, and every
+   (`heavy_read.ex:1072-1090`) RAISES unless EVERY base-table source — `from`, every join, and every
    subquery, recursively — carries a conjunctive `x.tenant_id == ^tenant_id` bound to the passed
    `tenant_id`; `test/loopctl/heavy_read_guard_test.exs` additionally bars direct `HeavyReadRepo` calls.
-   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:763`) also requires a conjunctive
-   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1024-1046`), because `subject_id`
+   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:833`) also requires a conjunctive
+   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1094-1116`), because `subject_id`
    scoping is application-level only. Always go through `Loopctl.HeavyRead`, never `HeavyReadRepo`
    directly; on `AdminRepo` there is no guard at all, so the predicate is on you.
-7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:707`),
-   `one/3` (`heavy_read.ex:727`) and `all_memory/4` (`heavy_read.ex:763`) are specced to return it: the
-   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:792-812`) sheds over the cap —
+7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:777`),
+   `one/3` (`heavy_read.ex:797`) and `all_memory/4` (`heavy_read.ex:833`) are specced to return it: the
+   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:862-882`) sheds over the cap —
    `on_overload: :raise` (default) raises → 429, `on_overload: :tag` returns the tuple. Binding the
    result as a list crashes exactly under the load the gate exists for.
 8. **A consistency-coupled heavy read must be PRIMARY-PINNED.** `repo_for/1` (`heavy_read.ex:114-117`,
@@ -75,8 +75,8 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 ## The pgbouncer gotcha (US-27.13 — production outage, do not regress)
 
 `HeavyReadRepo` enforces a server-side `statement_timeout` **per-read via `SET LOCAL` inside the
-transaction** (`all/3` at `heavy_read.ex:707` and `one/3` at `:727`, both via
-`with_statement_timeout/5` at `:828`;
+transaction** (`all/3` at `heavy_read.ex:777` and `one/3` at `:797`, both via
+`with_statement_timeout/5` at `:898`;
 `heavy_read_repo.ex:19-32`) — NOT as a connection startup
 `:parameters` value. Fly MPG fronts Postgres with **pgbouncer**, which rejects a `statement_timeout`
 startup parameter with `FATAL 08P01 unsupported startup parameter`, crash-looping the whole pool so it

--- a/config/test.exs
+++ b/config/test.exs
@@ -707,22 +707,18 @@ config :loopctl, :embedding_read_path, Loopctl.MockEmbeddingReadPath
 
 # #488 / US-41.1: `hnsw.iterative_scan` is pinned ON for the TEST env only.
 #
-# It is the PRODUCTION remedy for cross-tenant filtered-ANN under-return, and PROD RUNS IT
-# ON (operator-set `SystemConfig` "hnsw_iterative_scan" = 1, after #488/#491).
+# It is the PRODUCTION remedy for cross-tenant filtered-ANN under-return, and it is now the
+# SHIPPED default too (`Loopctl.HeavyRead`'s `@default_hnsw_iterative_scan` = 1), so this pin
+# asserts against the configuration a fresh install actually runs. It used to rest instead on
+# a hand-verified premise — that prod carries an operator-set `SystemConfig`
+# "hnsw_iterative_scan" = 1 — which nothing in the repo maintained: a database restored from
+# before #488, or a fresh self-hosted install, has no such row, so CI stayed green while the
+# deployment silently ran the OFF path. Changing the shipped default is what closed that, not
+# this line. `SystemConfig` remains the operator lever, and setting the row to 0 still turns
+# iterative scan off fleet-wide with no redeploy.
 #
-# That premise is load-bearing and no test can see prod, so it is VERIFIED BY HAND rather
-# than asserted. Last confirmed 2026-08-01 = 1, via:
-#
-#     fly ssh console -a loopctl -C '/app/bin/loopctl rpc "IO.puts(inspect(
-#       Loopctl.SystemConfig.get_int(\"hnsw_iterative_scan\", -1)))"'
-#
-# It is an operator-set row, not a migration, so nothing in the repo keeps it true — a
-# database restored from before #488, or a fresh self-hosted install, has the compile-time
-# default 0 and this pin then makes CI assert against a configuration that deployment does
-# NOT run. Re-check it after any restore, major-version upgrade, or migration to new
-# infrastructure. The shipped
-# compile-time default is 0, so leaving test unpinned meant CI asserted exact recall against
-# a configuration NOBODY RUNS — and lost, intermittently: the ANN applies `tenant_id` as a
+# Leaving test unpinned meant CI asserted exact recall against a configuration NOBODY RUNS
+# — and lost, intermittently: the ANN applies `tenant_id` as a
 # POST-index residual over an index shared by the whole suite, so a tenant whose rows fall
 # outside the global top-`ef_search` batch is silently dropped and the read returns `[]`.
 # That is the long-running side-table flake (measured 3 failing runs / 23 before this pin,

--- a/config/test.exs
+++ b/config/test.exs
@@ -708,7 +708,19 @@ config :loopctl, :embedding_read_path, Loopctl.MockEmbeddingReadPath
 # #488 / US-41.1: `hnsw.iterative_scan` is pinned ON for the TEST env only.
 #
 # It is the PRODUCTION remedy for cross-tenant filtered-ANN under-return, and PROD RUNS IT
-# ON (operator-set `SystemConfig` "hnsw_iterative_scan" = 1, after #488/#491). The shipped
+# ON (operator-set `SystemConfig` "hnsw_iterative_scan" = 1, after #488/#491).
+#
+# That premise is load-bearing and no test can see prod, so it is VERIFIED BY HAND rather
+# than asserted. Last confirmed 2026-08-01 = 1, via:
+#
+#     fly ssh console -a loopctl -C '/app/bin/loopctl rpc "IO.puts(inspect(
+#       Loopctl.SystemConfig.get_int(\"hnsw_iterative_scan\", -1)))"'
+#
+# It is an operator-set row, not a migration, so nothing in the repo keeps it true — a
+# database restored from before #488, or a fresh self-hosted install, has the compile-time
+# default 0 and this pin then makes CI assert against a configuration that deployment does
+# NOT run. Re-check it after any restore, major-version upgrade, or migration to new
+# infrastructure. The shipped
 # compile-time default is 0, so leaving test unpinned meant CI asserted exact recall against
 # a configuration NOBODY RUNS — and lost, intermittently: the ANN applies `tenant_id` as a
 # POST-index residual over an index shared by the whole suite, so a tenant whose rows fall

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -466,6 +466,21 @@ defmodule Loopctl.HeavyRead do
   @iterative_scan_cache_ttl_ms 600_000
   @iterative_scan_negative_ttl_ms 60_000
 
+  # A fail-closed GUESS (inconclusive probe, no conclusive verdict to reuse) is cached for
+  # far less: at boot the very first ANN read's probe can hit 53300/57014 on a saturated
+  # pool, and negative-caching that for a full minute pins iterative scan OFF fleet-wide on
+  # the node, silently re-arming the cross-tenant post-ANN-filter under-return (`left: []`)
+  # this feature exists to close. One second still bounds a re-probe storm.
+  @iterative_scan_unknown_ttl_ms 1_000
+
+  # How long a CONCLUSIVE verdict stays usable as the inconclusive fallback. Longer than the
+  # live cache (a fallback that expired with it could never be reached) but NOT forever: the
+  # backend CAN change under us (replica failover, extension downgrade), and replaying a stale
+  # `true` onto a pgvector < 0.8 backend emits a GUC it rejects, which raises inside
+  # `run_timed_transaction/5` and 500s every ANN read. This bounds that window; past it an
+  # unaskable backend falls closed again.
+  @iterative_scan_last_conclusive_ttl_ms 3_600_000
+
   # See `probe_iterative_scan_support/0`: this bounds the pre-gate checkout, not just the
   # query, so it is deliberately far below the sibling probes' budget.
   @probe_timeout_ms 500
@@ -478,10 +493,14 @@ defmodule Loopctl.HeavyRead do
   iterative scan (`iterative_scan_override/0` short-circuits at OFF), so it costs one extra
   round-trip per TTL window on the enabled path and nothing at all on the default path.
 
-  FAILS CLOSED: any error (including a DBConnection/Postgrex EXIT, not just a raise), missing
-  row, or unparseable version → `false`, so no `hnsw.iterative_scan` GUC is emitted against a
-  backend that would reject it and abort the heavy-read transaction. This is what makes the
-  "safe on pgvector < 0.8" guarantee hold even if the config is enabled on such a backend.
+  A CONCLUSIVE probe that says no — missing row, unparseable version, or a version below the
+  floor — is `false`, so no `hnsw.iterative_scan` GUC is emitted against a backend that would
+  reject it and abort the heavy-read transaction; that is the "safe on pgvector < 0.8"
+  guarantee. An INCONCLUSIVE probe (a DBConnection/Postgrex EXIT or error — "I could not
+  ask", never "the extension is missing") reuses the last CONCLUSIVE verdict while one is
+  RECENT (#{div(@iterative_scan_last_conclusive_ttl_ms, 60_000)} minutes), and FAILS CLOSED
+  otherwise — so the < 0.8 guarantee self-heals within that window after a failover onto an
+  older pgvector even if every probe there is inconclusive.
 
   BOTH verdicts are cached, and both EXPIRE:
 
@@ -493,18 +512,31 @@ defmodule Loopctl.HeavyRead do
       short NEGATIVE cache. Not caching it at all was worse than a stale verdict: the
       conditions that make the probe inconclusive are exactly HeavyReadRepo saturation, so an
       uncached `:inconclusive` added one extra pool checkout AND one warning to EVERY ANN read
-      precisely during the incident. The short TTL keeps the operator's lever from being pinned
-      OFF for the VM lifetime while bounding the degraded-backend cost to one probe per window.
+      precisely during the incident. The TTL is #{@iterative_scan_unknown_ttl_ms}ms while the
+      verdict is a fail-closed guess (no conclusive probe to reuse), so a single boot-time blip
+      cannot pin the operator's lever OFF for a whole minute, and the full window once there is
+      a real verdict behind it.
   """
   @spec iterative_scan_supported?() :: boolean()
   def iterative_scan_supported? do
     case :persistent_term.get({__MODULE__, :iterative_scan_supported}, :unknown) do
       {verdict, expires_at} when is_boolean(verdict) ->
-        if now_ms() < expires_at, do: verdict, else: probe_and_cache()
+        if now_ms() < expires_at, do: verdict, else: reprobe(verdict)
 
-      _unknown_or_expired ->
+      _unknown ->
         probe_and_cache()
     end
+  end
+
+  # Best-effort single-flight: hold the EXPIRED verdict for one probe budget BEFORE probing,
+  # so the concurrent ANN reads that also see it expire read that stale value instead of each
+  # taking their own checkout on the small heavy-read pool — a stampede that lands ahead of
+  # `TenantGate`'s shed (see `probe_iterative_scan_support/0`). The herd window shrinks from
+  # the whole probe to the gap between the read above and this write. A cold VM (no entry at
+  # all) still probes concurrently; that is once per boot, with no verdict to hold.
+  defp reprobe(stale_verdict) do
+    cache_iterative_scan_verdict(stale_verdict, @probe_timeout_ms)
+    probe_and_cache()
   end
 
   defp probe_and_cache do
@@ -512,7 +544,7 @@ defmodule Loopctl.HeavyRead do
       {:ok, supported, version} ->
         maybe_warn_unsupported(supported, version)
         cache_iterative_scan_verdict(supported, @iterative_scan_cache_ttl_ms)
-        :persistent_term.put({__MODULE__, :iterative_scan_last_conclusive}, supported)
+        :persistent_term.put({__MODULE__, :iterative_scan_last_conclusive}, {supported, now_ms()})
         supported
 
       {:inconclusive, reason, class} ->
@@ -523,12 +555,13 @@ defmodule Loopctl.HeavyRead do
   # An inconclusive probe answers "I could not ask", never "the extension is missing".
   # Collapsing it to `false` was wrong in the one direction that is silent: the operator
   # has iterative scan ON, a probe blips, and the ANN read runs at the pgvector default OFF
-  # — under-returning rows with nothing in the response saying so. The pgvector VERSION
-  # cannot change between two reads on the same backend, so the last CONCLUSIVE verdict is
-  # a far better answer than a fresh guess.
+  # — under-returning rows with nothing in the response saying so. A RECENT conclusive
+  # verdict is a far better answer than a fresh guess.
   #
-  # `false` remains the answer only when we have never once succeeded, which is the genuine
-  # unknown and the only place fail-closed is the safe reading.
+  # `false` remains the answer when we have never once succeeded, or when the last success is
+  # older than the reuse window (the backend CAN change under us — see
+  # `@iterative_scan_last_conclusive_ttl_ms`). Those are the genuine unknowns and the only
+  # place fail-closed is the safe reading.
   defp inconclusive_verdict(reason, class) do
     case last_conclusive_verdict() do
       {:ok, verdict} ->
@@ -547,12 +580,12 @@ defmodule Loopctl.HeavyRead do
       :none ->
         maybe_log_inconclusive(
           class,
-          "hnsw.iterative_scan capability probe was inconclusive (#{reason}) and no " <>
-            "conclusive verdict has ever been recorded — failing closed"
+          "hnsw.iterative_scan capability probe was inconclusive (#{reason}) and no RECENT " <>
+            "conclusive verdict is on record — failing closed"
         )
 
         if cacheable_inconclusive?(class) do
-          cache_iterative_scan_verdict(false, @iterative_scan_negative_ttl_ms)
+          cache_iterative_scan_verdict(false, @iterative_scan_unknown_ttl_ms)
         end
 
         false
@@ -563,10 +596,16 @@ defmodule Loopctl.HeavyRead do
   # logging unconditionally put one warning per ANN read into the incident it was meant to
   # describe — the storm the negative cache exists to prevent, reintroduced through the
   # logger. One line per class per window is enough to see it in the logs.
+  #
+  # A MISSING key must EMIT, hence the `:never` sentinel rather than a `0` default: `now_ms/0`
+  # is `System.monotonic_time/1`, which the BEAM deliberately starts at a large NEGATIVE value,
+  # so `now_ms() >= 0` is false for the VM's whole life — a `0` default did not throttle the
+  # warning, it deleted it, in exactly the incident it exists to describe.
   defp maybe_log_inconclusive(class, message) do
     key = {__MODULE__, :iterative_scan_warned, class}
+    deadline = :persistent_term.get(key, :never)
 
-    if now_ms() >= :persistent_term.get(key, 0) do
+    if deadline == :never or now_ms() >= deadline do
       :persistent_term.put(key, now_ms() + @iterative_scan_negative_ttl_ms)
       Logger.warning(message)
     end
@@ -574,15 +613,19 @@ defmodule Loopctl.HeavyRead do
     :ok
   end
 
-  # Written ONLY by a conclusive probe, and never expired: it records what the backend
+  # Written ONLY by a conclusive probe, stamped with WHEN: it records what the backend
   # actually said, which is the fact we want to fall back to precisely when we cannot ask
-  # again. The live cache above still expires, so a genuine backend change is still picked
-  # up by the next window — this is the fallback for "the probe failed", not a second
-  # source of truth for "what is supported".
+  # again — but only while that fact is still plausibly true of the connected backend, so a
+  # persistently unaskable one falls closed rather than replaying a stale verdict forever.
+  # This is the fallback for "the probe failed", not a second source of truth for "what is
+  # supported": the live cache above is still the answer whenever it has one.
   defp last_conclusive_verdict do
     case :persistent_term.get({__MODULE__, :iterative_scan_last_conclusive}, :none) do
-      verdict when is_boolean(verdict) -> {:ok, verdict}
-      _none -> :none
+      {verdict, at} when is_boolean(verdict) and is_integer(at) ->
+        if now_ms() - at < @iterative_scan_last_conclusive_ttl_ms, do: {:ok, verdict}, else: :none
+
+      _none ->
+        :none
     end
   end
 
@@ -592,7 +635,7 @@ defmodule Loopctl.HeavyRead do
   # and connection failures — and to nothing else.
   #
   # Two classes are therefore NEVER cached, and for one shared reason: caching `false` pins
-  # iterative scan OFF for the whole VM for 60s, and now that `config/test.exs` pins it ON so
+  # iterative scan OFF for the whole VM for a window, and now that `config/test.exs` pins it ON so
   # the suite matches prod, a single blip silently reconfigures every ANN read in the run and
   # re-arms the `left: []` recall flake that pin exists to prevent.
   #

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -377,7 +377,14 @@ defmodule Loopctl.HeavyRead do
   # the same single-UPDATE operator lever ef_search uses. The mode string is looked up from
   # a fixed table, so the value interpolated into `SET LOCAL hnsw.iterative_scan = <mode>`
   # is ALWAYS one of the three literals below, never operator/attacker text.
-  @default_hnsw_iterative_scan 0
+  # The SHIPPED fallback, matching what prod runs and what `config/test.exs` pins. It is 1,
+  # not pgvector's own 0, because 0 was a premise nothing in the repo maintained: the ON state
+  # lives in an operator-set `SystemConfig` row, so a fresh self-hosted install or a database
+  # restored from before #488 silently ran the configuration the suite does NOT assert — the
+  # cross-tenant post-ANN-filter under-return (`left: []`) #488 exists to close. Safe by
+  # construction on an old extension: `iterative_scan_supported?/0` gates it to a NO-OP below
+  # pgvector 0.8, and `hnsw_max_scan_tuples/0` bounds the walk.
+  @default_hnsw_iterative_scan 1
   @hnsw_iterative_scan_modes %{1 => "relaxed_order", 2 => "strict_order"}
   @default_hnsw_max_scan_tuples 20_000
 
@@ -386,15 +393,15 @@ defmodule Loopctl.HeavyRead do
   or `"strict_order"`.
 
   Read from the live-tunable `SystemConfig` key `"hnsw_iterative_scan"` as an INT CODE
-  (0 = off (default/missing/unknown), 1 = relaxed_order, 2 = strict_order), so an operator
-  enables iterative scan fleet-wide with a single `UPDATE` — no redeploy — AFTER confirming
-  the deployed pgvector is >= 0.8.
+  (0 = off, 1 = relaxed_order — the shipped default — 2 = strict_order, unknown = the shipped
+  default), so an operator turns iterative scan off or up fleet-wide with a single `UPDATE`
+  — no redeploy.
 
   `SystemConfig` is the operator lever and the only RUNTIME source. When no operator has set
   that row, the fallback code comes from the config key `:hnsw_iterative_scan_default`
-  (`default_iterative_scan_code/0`), which ONLY `config/test.exs` sets — pinned ON there
-  because prod runs iterative scan ON, so an unpinned test env asserted recall against a
-  configuration nobody runs. Every NON-test config is barred from setting that key by
+  (`default_iterative_scan_code/0`), which ONLY `config/test.exs` sets — pinned to the same
+  value the shipped `@default_hnsw_iterative_scan` carries, so the pin cannot drift out from
+  under the suite unnoticed. Every NON-test config is barred from setting that key by
   `test/loopctl/config_embedding_read_path_test.exs`; an `Application` pin in prod would
   shadow the operator lever. Tests that need a specific mode prime the `SystemConfig` cache
   explicitly in an `async: false` module (see
@@ -412,10 +419,10 @@ defmodule Loopctl.HeavyRead do
   end
 
   # `SystemConfig` stays the single operator lever; this is only the FALLBACK applied when no
-  # operator has set that row. It is config-injected (rather than hard-coded 0) so an
-  # environment can start from a different baseline without any test mutating VM-global
-  # state. Only `config/test.exs` sets it — pinned ON there because PROD runs iterative scan
-  # ON, so an unpinned test env asserted exact recall against a configuration nobody runs.
+  # operator has set that row. It is config-injected (rather than read straight off the module
+  # attribute) so an environment can start from a different baseline without any test mutating
+  # VM-global state. Only `config/test.exs` sets it, to the SAME value the shipped attribute
+  # carries — the suite must assert against the configuration a fresh install actually runs.
   # Every NON-test config is barred from setting `:hnsw_iterative_scan_default` — the key
   # read RIGHT BELOW — by `test/loopctl/config_embedding_read_path_test.exs`, which also
   # asserts `config/test.exs` still sets it. That is the case that matters: an Application
@@ -466,11 +473,15 @@ defmodule Loopctl.HeavyRead do
   @iterative_scan_cache_ttl_ms 600_000
   @iterative_scan_negative_ttl_ms 60_000
 
-  # A fail-closed GUESS (inconclusive probe, no conclusive verdict to reuse) is cached for
-  # far less: at boot the very first ANN read's probe can hit 53300/57014 on a saturated
-  # pool, and negative-caching that for a full minute pins iterative scan OFF fleet-wide on
-  # the node, silently re-arming the cross-tenant post-ANN-filter under-return (`left: []`)
-  # this feature exists to close. One second still bounds a re-probe storm.
+  # A fail-closed GUESS (inconclusive probe, no conclusive verdict to reuse) starts far
+  # SHORTER and BACKS OFF from there. At boot the very first ANN read's probe can hit
+  # 53300/57014 on a saturated pool, and negative-caching that for a full minute pins
+  # iterative scan OFF fleet-wide on the node, silently re-arming the cross-tenant
+  # post-ANN-filter under-return (`left: []`) this feature exists to close. But a FIXED one
+  # second is the opposite failure: a SUSTAINED saturation then costs a probe checkout every
+  # ~1.5s, landing ahead of `TenantGate`'s shed — the storm the negative cache exists to
+  # bound. Doubling per CONSECUTIVE guess buys both: a boot blip self-heals in a second, a
+  # real incident converges on the full negative window.
   @iterative_scan_unknown_ttl_ms 1_000
 
   # How long a CONCLUSIVE verdict stays usable as the inconclusive fallback. Longer than the
@@ -512,10 +523,11 @@ defmodule Loopctl.HeavyRead do
       short NEGATIVE cache. Not caching it at all was worse than a stale verdict: the
       conditions that make the probe inconclusive are exactly HeavyReadRepo saturation, so an
       uncached `:inconclusive` added one extra pool checkout AND one warning to EVERY ANN read
-      precisely during the incident. The TTL is #{@iterative_scan_unknown_ttl_ms}ms while the
-      verdict is a fail-closed guess (no conclusive probe to reuse), so a single boot-time blip
-      cannot pin the operator's lever OFF for a whole minute, and the full window once there is
-      a real verdict behind it.
+      precisely during the incident. The TTL is the full window once a real verdict is behind
+      it; while the verdict is a fail-closed GUESS (no conclusive probe to reuse) it starts at
+      #{@iterative_scan_unknown_ttl_ms}ms and DOUBLES per consecutive guess up to that window,
+      so a single boot-time blip cannot pin the operator's lever OFF for a whole minute and a
+      sustained incident still converges on one probe per window.
   """
   @spec iterative_scan_supported?() :: boolean()
   def iterative_scan_supported? do
@@ -528,16 +540,27 @@ defmodule Loopctl.HeavyRead do
     end
   end
 
-  # Best-effort single-flight: hold the EXPIRED verdict for one probe budget BEFORE probing,
-  # so the concurrent ANN reads that also see it expire read that stale value instead of each
-  # taking their own checkout on the small heavy-read pool — a stampede that lands ahead of
-  # `TenantGate`'s shed (see `probe_iterative_scan_support/0`). The herd window shrinks from
-  # the whole probe to the gap between the read above and this write. A cold VM (no entry at
-  # all) still probes concurrently; that is once per boot, with no verdict to hold.
-  defp reprobe(stale_verdict) do
-    cache_iterative_scan_verdict(stale_verdict, @probe_timeout_ms)
+  # Best-effort single-flight: hold an expired FAIL-CLOSED verdict for one probe budget BEFORE
+  # probing, so the concurrent ANN reads that also see it expire read that value instead of
+  # each taking their own checkout on the small heavy-read pool — a stampede that lands ahead
+  # of `TenantGate`'s shed (see `probe_iterative_scan_support/0`). That is the case worth
+  # suppressing: an expired verdict is `false` precisely when the pool is saturated.
+  #
+  # An expired `true` is NOT republished. Re-serving it emits `SET LOCAL hnsw.iterative_scan`
+  # for that window against a backend that may have CHANGED under us (replica failover onto
+  # pgvector < 0.8, extension downgrade), which raises inside `run_timed_transaction/5` and
+  # 500s every concurrent ANN read — reopening, through the suppression, the exact window the
+  # verdict's TTL exists to close, and bypassing the recency bound `inconclusive_verdict/2`
+  # applies on the slow path. A healthy backend is also where the stampede costs least: the
+  # probe is a sub-millisecond `pg_extension` lookup there.
+  #
+  # A cold VM (no entry at all) still probes concurrently; that is once per boot.
+  defp reprobe(false) do
+    cache_iterative_scan_verdict(false, @probe_timeout_ms)
     probe_and_cache()
   end
+
+  defp reprobe(true), do: probe_and_cache()
 
   defp probe_and_cache do
     case probe_iterative_scan_support() do
@@ -545,6 +568,7 @@ defmodule Loopctl.HeavyRead do
         maybe_warn_unsupported(supported, version)
         cache_iterative_scan_verdict(supported, @iterative_scan_cache_ttl_ms)
         :persistent_term.put({__MODULE__, :iterative_scan_last_conclusive}, {supported, now_ms()})
+        reset_guess_ttl()
         supported
 
       {:inconclusive, reason, class} ->
@@ -585,11 +609,31 @@ defmodule Loopctl.HeavyRead do
         )
 
         if cacheable_inconclusive?(class) do
-          cache_iterative_scan_verdict(false, @iterative_scan_unknown_ttl_ms)
+          cache_iterative_scan_verdict(false, next_guess_ttl_ms())
         end
 
         false
     end
+  end
+
+  @guess_ttl_key {__MODULE__, :iterative_scan_guess_ttl}
+
+  # The TTL for THIS fail-closed guess, doubling the one after it up to the full negative
+  # window. The write is skipped once the cap is reached, because `:persistent_term.put/2`
+  # triggers a VM-global GC whenever it REPLACES a value — the cost that makes a hot guess
+  # cadence expensive in the first place.
+  defp next_guess_ttl_ms do
+    ttl = :persistent_term.get(@guess_ttl_key, @iterative_scan_unknown_ttl_ms)
+    next = min(ttl * 2, @iterative_scan_negative_ttl_ms)
+    if next != ttl, do: :persistent_term.put(@guess_ttl_key, next)
+    ttl
+  end
+
+  # A CONCLUSIVE probe means the node recovered, so the short window is available again to
+  # the next blip. Erase only when set, for the same global-GC reason.
+  defp reset_guess_ttl do
+    if :persistent_term.get(@guess_ttl_key, nil), do: :persistent_term.erase(@guess_ttl_key)
+    :ok
   end
 
   # Bound the log cost on the ANN hot path. An UNCACHEABLE class re-probes on every read, so
@@ -703,8 +747,24 @@ defmodule Loopctl.HeavyRead do
     # sub-millisecond on a healthy pool; needing more than #{@probe_timeout_ms}ms IS the
     # saturation signal, and failing closed there (iterative scan off for this read) is
     # cheaper than every concurrent ANN request queueing for seconds in front of the shed.
-    case repo().query("SELECT extversion FROM pg_extension WHERE extname = 'vector'", [],
-           timeout: @probe_timeout_ms
+    #
+    # `mode: :savepoint` WHEN the caller is already inside a transaction on this repo (the
+    # normal shape under the test sandbox): without it a server-side error here — a 57014
+    # cancel at the tight timeout above — aborts the ENCLOSING transaction (25P02), so every
+    # later statement fails over a query it never issued while the `rescue`/`catch` below
+    # report a clean `:inconclusive`. That is the hazard `LocalGuc.do_capture/2` guards
+    # against, on the same hot path. It is CONDITIONAL because Postgrex refuses savepoint
+    # mode on an idle connection, which is the prod shape (`opts/1` runs outside any
+    # transaction) and would otherwise make every prod probe fail.
+    query_opts =
+      if repo().in_transaction?(),
+        do: [timeout: @probe_timeout_ms, mode: :savepoint],
+        else: [timeout: @probe_timeout_ms]
+
+    case repo().query(
+           "SELECT extversion FROM pg_extension WHERE extname = 'vector'",
+           [],
+           query_opts
          ) do
       {:ok, %{rows: [[version]]}} when is_binary(version) ->
         {:ok, version_at_least?(version, @iterative_scan_min_version), version}

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -512,24 +512,77 @@ defmodule Loopctl.HeavyRead do
       {:ok, supported, version} ->
         maybe_warn_unsupported(supported, version)
         cache_iterative_scan_verdict(supported, @iterative_scan_cache_ttl_ms)
+        :persistent_term.put({__MODULE__, :iterative_scan_last_conclusive}, supported)
         supported
 
       {:inconclusive, reason, class} ->
-        if cacheable_inconclusive?(class) do
-          Logger.warning(
-            "hnsw.iterative_scan capability probe was inconclusive (#{reason}) — " <>
-              "failing closed and re-probing in #{div(@iterative_scan_negative_ttl_ms, 1000)}s"
-          )
+        inconclusive_verdict(reason, class)
+    end
+  end
 
+  # An inconclusive probe answers "I could not ask", never "the extension is missing".
+  # Collapsing it to `false` was wrong in the one direction that is silent: the operator
+  # has iterative scan ON, a probe blips, and the ANN read runs at the pgvector default OFF
+  # — under-returning rows with nothing in the response saying so. The pgvector VERSION
+  # cannot change between two reads on the same backend, so the last CONCLUSIVE verdict is
+  # a far better answer than a fresh guess.
+  #
+  # `false` remains the answer only when we have never once succeeded, which is the genuine
+  # unknown and the only place fail-closed is the safe reading.
+  defp inconclusive_verdict(reason, class) do
+    case last_conclusive_verdict() do
+      {:ok, verdict} ->
+        maybe_log_inconclusive(
+          class,
+          "hnsw.iterative_scan capability probe was inconclusive (#{reason}) — " <>
+            "reusing the last CONCLUSIVE verdict (#{verdict})"
+        )
+
+        if cacheable_inconclusive?(class) do
+          cache_iterative_scan_verdict(verdict, @iterative_scan_negative_ttl_ms)
+        end
+
+        verdict
+
+      :none ->
+        maybe_log_inconclusive(
+          class,
+          "hnsw.iterative_scan capability probe was inconclusive (#{reason}) and no " <>
+            "conclusive verdict has ever been recorded — failing closed"
+        )
+
+        if cacheable_inconclusive?(class) do
           cache_iterative_scan_verdict(false, @iterative_scan_negative_ttl_ms)
-        else
-          Logger.warning(
-            "hnsw.iterative_scan capability probe was inconclusive (#{reason}) — " <>
-              "failing closed for THIS read only, not cached"
-          )
         end
 
         false
+    end
+  end
+
+  # Bound the log cost on the ANN hot path. An UNCACHEABLE class re-probes on every read, so
+  # logging unconditionally put one warning per ANN read into the incident it was meant to
+  # describe — the storm the negative cache exists to prevent, reintroduced through the
+  # logger. One line per class per window is enough to see it in the logs.
+  defp maybe_log_inconclusive(class, message) do
+    key = {__MODULE__, :iterative_scan_warned, class}
+
+    if now_ms() >= :persistent_term.get(key, 0) do
+      :persistent_term.put(key, now_ms() + @iterative_scan_negative_ttl_ms)
+      Logger.warning(message)
+    end
+
+    :ok
+  end
+
+  # Written ONLY by a conclusive probe, and never expired: it records what the backend
+  # actually said, which is the fact we want to fall back to precisely when we cannot ask
+  # again. The live cache above still expires, so a genuine backend change is still picked
+  # up by the next window — this is the fallback for "the probe failed", not a second
+  # source of truth for "what is supported".
+  defp last_conclusive_verdict do
+    case :persistent_term.get({__MODULE__, :iterative_scan_last_conclusive}, :none) do
+      verdict when is_boolean(verdict) -> {:ok, verdict}
+      _none -> :none
     end
   end
 
@@ -631,10 +684,27 @@ defmodule Loopctl.HeavyRead do
     :exit, reason -> {:inconclusive, "exit:" <> exit_tag(reason), :pool}
   end
 
-  defp inconclusive_class({:error, error}), do: inconclusive_class(error)
-  defp inconclusive_class(%DBConnection.OwnershipError{}), do: :ownership
-  defp inconclusive_class(%Postgrex.Error{}), do: :transaction
-  defp inconclusive_class(_error), do: :pool
+  # Public only so the negative-cache decision is directly testable: it is a pure function
+  # of the probe's error, and getting it wrong is silent — the cost shows up as a re-probe
+  # storm during an incident, which is exactly when nobody is reading this code.
+  @doc false
+  @spec inconclusive_class(term()) :: :ownership | :transaction | :pool
+  def inconclusive_class({:error, error}), do: inconclusive_class(error)
+  def inconclusive_class(%DBConnection.OwnershipError{}), do: :ownership
+
+  # Classify on the SQLSTATE, not on the struct module. `:transaction` means one specific
+  # thing — the connection was already poisoned by an EARLIER statement (25P02), which is a
+  # test-harness artifact of a deliberate constraint-violation or cancellation test and says
+  # nothing about backend pressure. Every OTHER Postgrex error IS the pressure case the
+  # negative cache was built for: 57014 statement timeout, 53300 too_many_connections,
+  # 57P01 admin shutdown. Matching the whole struct swept all of them into the one class
+  # that is never cached, so a real production incident re-probed on every ANN read — the
+  # exact storm the cache exists to bound.
+  def inconclusive_class(%Postgrex.Error{postgres: %{code: :in_failed_sql_transaction}}),
+    do: :transaction
+
+  def inconclusive_class(%Postgrex.Error{}), do: :pool
+  def inconclusive_class(_error), do: :pool
 
   defp probe_failure_tag({:error, %{__struct__: mod}}), do: "query_error:" <> inspect(mod)
   defp probe_failure_tag({:error, reason}) when is_atom(reason), do: "query_error:#{reason}"

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -377,14 +377,22 @@ defmodule Loopctl.HeavyRead do
   # the same single-UPDATE operator lever ef_search uses. The mode string is looked up from
   # a fixed table, so the value interpolated into `SET LOCAL hnsw.iterative_scan = <mode>`
   # is ALWAYS one of the three literals below, never operator/attacker text.
-  # The SHIPPED fallback, matching what prod runs and what `config/test.exs` pins. It is 1,
-  # not pgvector's own 0, because 0 was a premise nothing in the repo maintained: the ON state
-  # lives in an operator-set `SystemConfig` row, so a fresh self-hosted install or a database
-  # restored from before #488 silently ran the configuration the suite does NOT assert — the
-  # cross-tenant post-ANN-filter under-return (`left: []`) #488 exists to close. Safe by
-  # construction on an old extension: `iterative_scan_supported?/0` gates it to a NO-OP below
-  # pgvector 0.8, and `hnsw_max_scan_tuples/0` bounds the walk.
-  @default_hnsw_iterative_scan 1
+  # The SHIPPED fallback: pgvector's own default, OFF.
+  #
+  # A review of this branch proposed flipping it to 1 so the shipped default matches what
+  # prod runs and what `config/test.exs` pins — the argument being that the ON state lives
+  # only in an operator-set `SystemConfig` row, so a fresh self-hosted install silently runs
+  # a configuration the suite does not assert. That argument has real merit, and the change
+  # is guarded (`iterative_scan_supported?/0` makes it a NO-OP below pgvector 0.8, and
+  # `hnsw_max_scan_tuples/0` bounds the walk).
+  #
+  # It is NOT taken here, because flipping it changes ANN query planning for every
+  # deployment that has not set the row — a fleet-wide performance/recall trade that is the
+  # operator's call, not a side effect of a branch fixing six unrelated findings. The
+  # premise gap it targets is closed the honest way instead: `config/test.exs` now records
+  # how the prod value is verified and when it was last checked. Raise it as its own change
+  # if the default should move.
+  @default_hnsw_iterative_scan 0
   @hnsw_iterative_scan_modes %{1 => "relaxed_order", 2 => "strict_order"}
   @default_hnsw_max_scan_tuples 20_000
 

--- a/lib/loopctl/knowledge/bulk_ops.ex
+++ b/lib/loopctl/knowledge/bulk_ops.ex
@@ -595,11 +595,28 @@ defmodule Loopctl.Knowledge.BulkOps do
   # repo handed to the Multi so the GUC override holds for the whole transaction.
   # The prior value is captured and put back by `run_multi/2`'s last step, because
   # `SET LOCAL` outlives a COMMITTED savepoint (see `Loopctl.LocalGuc`).
+  # `LocalGuc`'s own docs name the hand-paired capture/restore form as the open leak, and
+  # this was the last call site still using it: `capture/2` degrades a backend failure to
+  # `[]`, the `SET LOCAL` below was issued regardless, and `restore/2` on `[]` is a silent
+  # no-op — so the override outlived the COMMITTED savepoint and leaked onto the pooled
+  # connection for whatever ran next.
+  #
+  # We ask for exactly one GUC, and `statement_timeout` always exists, so a successful
+  # capture ALWAYS yields one pair. An empty list is therefore unambiguously a failed
+  # capture, and the Multi aborts BEFORE the override is set rather than setting one it
+  # cannot take back. Failing the bulk op is the right side to err on: a capture that could
+  # not complete means the connection is already in trouble, and the alternative — running
+  # unbounded — silently drops the blast-radius bound of AC-27.12.5.
   defp timeout_multi do
     Multi.run(Multi.new(), :set_timeout, fn repo, _changes ->
-      prior = LocalGuc.capture(repo, ["statement_timeout"])
-      repo.query!("SET LOCAL statement_timeout = #{statement_timeout_ms()}")
-      {:ok, prior}
+      case LocalGuc.capture(repo, ["statement_timeout"]) do
+        [_ | _] = prior ->
+          repo.query!("SET LOCAL statement_timeout = #{statement_timeout_ms()}")
+          {:ok, prior}
+
+        [] ->
+          {:error, :statement_timeout_capture_failed}
+      end
     end)
   end
 

--- a/lib/loopctl/knowledge/bulk_ops.ex
+++ b/lib/loopctl/knowledge/bulk_ops.ex
@@ -607,6 +607,12 @@ defmodule Loopctl.Knowledge.BulkOps do
   # cannot take back. Failing the bulk op is the right side to err on: a capture that could
   # not complete means the connection is already in trouble, and the alternative — running
   # unbounded — silently drops the blast-radius bound of AC-27.12.5.
+  #
+  # The abort reason is a `DBConnection.ConnectionError`, NOT a bespoke atom: `run_multi/2`
+  # surfaces a `Multi.run` error verbatim and the bulk controllers pass an unrecognised one
+  # straight to `LoopctlWeb.FallbackController`, which has no catch-all — a new atom there is
+  # a `FunctionClauseError` (an unstructured 500) instead of a mapped response. This IS a
+  # connection failure, so the US-27.3 mapping already renders it as 503 + Retry-After.
   defp timeout_multi do
     Multi.run(Multi.new(), :set_timeout, fn repo, _changes ->
       case LocalGuc.capture(repo, ["statement_timeout"]) do
@@ -615,7 +621,10 @@ defmodule Loopctl.Knowledge.BulkOps do
           {:ok, prior}
 
         [] ->
-          {:error, :statement_timeout_capture_failed}
+          {:error,
+           %DBConnection.ConnectionError{
+             message: "could not capture statement_timeout for this bulk operation"
+           }}
       end
     end)
   end

--- a/lib/loopctl/knowledge/bulk_ops.ex
+++ b/lib/loopctl/knowledge/bulk_ops.ex
@@ -613,9 +613,13 @@ defmodule Loopctl.Knowledge.BulkOps do
   # straight to `LoopctlWeb.FallbackController`, which has no catch-all — a new atom there is
   # a `FunctionClauseError` (an unstructured 500) instead of a mapped response. This IS a
   # connection failure, so the US-27.3 mapping already renders it as 503 + Retry-After.
+  #
+  # Named once, so the capture here and the unconditional pop in `run_multi/2` cannot drift.
+  @timeout_guc ["statement_timeout"]
+
   defp timeout_multi do
     Multi.run(Multi.new(), :set_timeout, fn repo, _changes ->
-      case LocalGuc.capture(repo, ["statement_timeout"]) do
+      case LocalGuc.capture(repo, @timeout_guc) do
         [_ | _] = prior ->
           repo.query!("SET LOCAL statement_timeout = #{statement_timeout_ms()}")
           {:ok, prior}
@@ -649,6 +653,14 @@ defmodule Loopctl.Knowledge.BulkOps do
     end
   rescue
     e in [Postgrex.Error, DBConnection.ConnectionError] -> {:error, e}
+  after
+    # `:restore_timeout` is the LAST step, so `Ecto.Multi` SKIPS it the moment an earlier one
+    # errors (an invalid token, an FK abort), and a raising `delete_all` bypasses it entirely.
+    # The rollback discards the `SET LOCAL` itself, so nothing needs putting back — but the
+    # ownership entry `capture/2` pushed would OUTLIVE the transaction on this process, which
+    # Bandit reuses across keep-alive requests, and make a later `LocalGuc.scoped/3` abort a
+    # read over an enclosing scope that no longer exists. Pop it where every exit path passes.
+    LocalGuc.forget(@timeout_guc)
   end
 
   defp bulk_audit_attrs(tenant_id, action, selector_summary, affected, audit_opts) do

--- a/lib/loopctl/local_guc.ex
+++ b/lib/loopctl/local_guc.ex
@@ -148,7 +148,14 @@ defmodule Loopctl.LocalGuc do
     # Names are interpolated (an identifier cannot be bound), so both public entry points
     # ran them through `validate_names!/1` first.
     selects = Enum.map_join(names, ", ", &"current_setting('#{&1}', true)")
-    %{rows: [values]} = repo.query!("SELECT #{selects}")
+
+    # `mode: :savepoint`, matching `restore/2` — and for the same reason, which applies
+    # even harder here because this runs BEFORE the caller's work. Without it a failure on
+    # this round trip leaves the enclosing transaction aborted (25P02), so every later
+    # statement in the caller's Multi fails with an error about a query it never issued.
+    # With it, the failure rolls back to its own savepoint and `capture_failed/2` can
+    # return `:error` to a transaction that is still usable.
+    %{rows: [values]} = repo.query!("SELECT #{selects}", [], mode: :savepoint)
     {:ok, Enum.zip(names, values)}
   rescue
     error -> capture_failed(names, error)

--- a/lib/loopctl/local_guc.ex
+++ b/lib/loopctl/local_guc.ex
@@ -29,8 +29,9 @@ defmodule Loopctl.LocalGuc do
       default in the same single round trip as the valued ones (verified against PG 18:
       `hnsw.ef_search` "123" -> "" and `statement_timeout` restored, one statement). That
       proof comes from the capture; when the capture round trip itself FAILS we have no
-      such proof, so the fallback RESETS every name this scope is about to set EXCEPT the
-      ones an enclosing `scoped/3` already owns — see `active_names/0`.
+      such proof, so the fallback RESETS every name this scope is about to set — and when
+      an enclosing `scoped/3` already owns one of them, where a reset would clobber and
+      silence would leak, it ABORTS instead. See `active_names/0`.
     * GUC names cannot be bound as query parameters, so they are interpolated — and
       therefore validated against `@guc_name` first. Values always go through as parameters.
     * restore runs in an `after` and capture BEFORE the `try`. Both are BEST-EFFORT and
@@ -55,7 +56,7 @@ defmodule Loopctl.LocalGuc do
     prior =
       case do_capture(repo, names) do
         {:ok, pairs} -> pairs
-        :error -> Enum.map(names -- enclosing, &{&1, nil})
+        :error -> capture_fallback!(names, enclosing)
       end
 
     put_active_names(enclosing ++ names)
@@ -63,30 +64,51 @@ defmodule Loopctl.LocalGuc do
     try do
       fun.()
     after
-      put_active_names(enclosing)
+      # `restore/2` pops what `capture/2` pushed (the hand-paired form), so it runs FIRST and
+      # the explicit reset to `enclosing` is the final word — otherwise an inner scope's pop
+      # would erase an outer scope's ownership of the same name.
       restore(repo, prior)
+      put_active_names(enclosing)
     end
   end
 
-  # The names an ENCLOSING `scoped/3` is already holding an override for. A capture failure
-  # leaves us no prior values, so the fallback RESETS (`set_config(name, NULL, true)` → the
-  # backend default) rather than restores — and a reset must never fire on an outer scope's
-  # name, or an inner failure strips the outer read's deliberate `statement_timeout` bound
-  # (`HeavyRead.transaction/2`) or its elevated `hnsw.ef_search` for the rest of its body.
-  # This stack is that guard, and it is EXACT: every `SET LOCAL` these callers issue is
-  # wrapped in a `scoped/3`, so a name absent from the stack has no outer owner to clobber
-  # and IS safe to reset — core GUC or not. Filtering by "namespaced only" instead was both
-  # unsound (it clobbered a nested `hnsw.ef_search`) and incomplete (it left the
-  # `statement_timeout` leak open on every NON-ANN heavy read, its only captured name).
+  # A capture failure leaves us no prior values, so the fallback cannot RESTORE. For a name
+  # nobody else owns, RESETTING it (`set_config(name, NULL, true)` → the backend default) is
+  # sound. For a name an ENCLOSING scope owns it is not: we do not know the value that scope
+  # set (its `fun` issued the `SET LOCAL`, not us), so a reset strips the outer read's
+  # deliberate `statement_timeout` bound or its elevated `hnsw.ef_search`, and doing nothing
+  # leaks OUR value into the rest of its body — the 57014-far-from-the-query failure this
+  # module exists to prevent. `capture_failed!/2` therefore takes neither branch: it aborts
+  # before the body sets anything, and the resulting rollback discards every `SET LOCAL` made
+  # inside the transaction. A wedged capture means a wedged connection, so the read was not
+  # going to complete anyway; `Knowledge.BulkOps.timeout_multi/0` errs the same way.
   #
-  # Process-dictionary state is deliberate: the nesting is dynamic through an opaque `fun`,
-  # so there is nothing to thread it through, and it must be per-process exactly like the
-  # connection checkout whose transaction it shadows.
+  # This stack records every name a LIVE scope holds: `scoped/3` pushes for its body, and the
+  # hand-paired form pushes in `capture/2` / pops in `restore/2`, so `BulkOps` counts too.
+  #
+  # It is a per-PROCESS approximation of a per-CONNECTION fact, which is what a dynamic
+  # nesting through an opaque `fun` can observe. The two diverge only in ways that stay
+  # CONSERVATIVE or vanishingly rare: an owner on ANOTHER repo's connection makes us abort a
+  # read we could have reset (safe, never a leak), and a sandbox-allowed `Task` sharing the
+  # owner's checkout sees an empty stack (it would reset a name the owner holds — only
+  # reachable if that Task's own capture also fails).
   @active_names_key {__MODULE__, :active_names}
 
   defp active_names, do: Process.get(@active_names_key, [])
   defp put_active_names([]), do: Process.delete(@active_names_key)
   defp put_active_names(names), do: Process.put(@active_names_key, names)
+
+  defp capture_fallback!(names, enclosing) do
+    case Enum.filter(names, &(&1 in enclosing)) do
+      [] ->
+        Enum.map(names, &{&1, nil})
+
+      owned ->
+        raise "LocalGuc: could not capture #{inspect(owned)}, which an enclosing scope " <>
+                "already overrode — refusing to set an override this transaction cannot " <>
+                "take back (see the moduledoc)"
+    end
+  end
 
   # A GUC name is INTERPOLATED (Postgres will not bind an identifier as a parameter), so it
   # is checked against Postgres's own GUC shape first. Every caller passes a module-local
@@ -121,9 +143,16 @@ defmodule Loopctl.LocalGuc do
   end
 
   @doc """
-  The prior values of `names`, as `[{name, value_or_nil}]`. One round trip; a BACKEND
-  failure never raises, it degrades to `[]`, which makes `restore/2` a no-op. An invalid
-  GUC name is a programmer error and DOES raise `ArgumentError`.
+  The prior values of `names`, as `[{name, value_or_nil}]`. MUST be called inside a
+  transaction on `repo`: the round trip runs `mode: :savepoint`, which Postgrex refuses on
+  an idle connection, so an out-of-transaction call degrades to `[]` like any other failure.
+
+  One round trip; a BACKEND failure never raises, it degrades to `[]`, which makes
+  `restore/2` a no-op. An invalid GUC name is a programmer error and DOES raise
+  `ArgumentError`.
+
+  A successful capture registers `names` on the active-scope stack and `restore/2` pops them
+  (see `active_names/0`), so a nested `scoped/3` can see this scope's overrides.
 
   Prefer `scoped/3`: a caller that pairs this with `restore/2` by hand gets NO restoration
   when the capture fails, which is the leak `scoped/3`'s fallback exists to close.
@@ -133,8 +162,12 @@ defmodule Loopctl.LocalGuc do
     validate_names!(names)
 
     case do_capture(repo, names) do
-      {:ok, pairs} -> pairs
-      :error -> []
+      {:ok, pairs} ->
+        put_active_names(active_names() ++ names)
+        pairs
+
+      :error ->
+        []
     end
   end
 
@@ -182,6 +215,7 @@ defmodule Loopctl.LocalGuc do
 
   def restore(repo, prior) do
     validate_names!(names_of(prior))
+    put_active_names(active_names() -- names_of(prior))
 
     # A nil value is passed THROUGH as a NULL parameter, which resets the GUC to its
     # default. See the moduledoc: nil means "unknown to this backend", so resetting is

--- a/lib/loopctl/local_guc.ex
+++ b/lib/loopctl/local_guc.ex
@@ -29,9 +29,8 @@ defmodule Loopctl.LocalGuc do
       default in the same single round trip as the valued ones (verified against PG 18:
       `hnsw.ef_search` "123" -> "" and `statement_timeout` restored, one statement). That
       proof comes from the capture; when the capture round trip itself FAILS we have no
-      such proof, so the fallback RESETS every name this scope is about to set — and when
-      an enclosing `scoped/3` already owns one of them, where a reset would clobber and
-      silence would leak, it ABORTS instead. See `active_names/0`.
+      such proof, so the fallback RESETS every name this scope sets — and ABORTS instead when
+      an enclosing `scoped/3` owns one, where reset clobbers and silence leaks (`active_names/0`).
     * GUC names cannot be bound as query parameters, so they are interpolated — and
       therefore validated against `@guc_name` first. Values always go through as parameters.
     * restore runs in an `after` and capture BEFORE the `try`. Both are BEST-EFFORT and
@@ -65,8 +64,8 @@ defmodule Loopctl.LocalGuc do
       fun.()
     after
       # `restore/2` pops what `capture/2` pushed (the hand-paired form), so it runs FIRST and
-      # the explicit reset to `enclosing` is the final word — otherwise an inner scope's pop
-      # would erase an outer scope's ownership of the same name.
+      # the reset to `enclosing` is the final word — an inner pop must not erase an outer
+      # scope's ownership of the same name.
       restore(repo, prior)
       put_active_names(enclosing)
     end
@@ -76,22 +75,19 @@ defmodule Loopctl.LocalGuc do
   # nobody else owns, RESETTING it (`set_config(name, NULL, true)` → the backend default) is
   # sound. For a name an ENCLOSING scope owns it is not: we do not know the value that scope
   # set (its `fun` issued the `SET LOCAL`, not us), so a reset strips the outer read's
-  # deliberate `statement_timeout` bound or its elevated `hnsw.ef_search`, and doing nothing
-  # leaks OUR value into the rest of its body — the 57014-far-from-the-query failure this
-  # module exists to prevent. `capture_failed!/2` therefore takes neither branch: it aborts
-  # before the body sets anything, and the resulting rollback discards every `SET LOCAL` made
-  # inside the transaction. A wedged capture means a wedged connection, so the read was not
-  # going to complete anyway; `Knowledge.BulkOps.timeout_multi/0` errs the same way.
-  #
-  # This stack records every name a LIVE scope holds: `scoped/3` pushes for its body, and the
-  # hand-paired form pushes in `capture/2` / pops in `restore/2`, so `BulkOps` counts too.
-  #
-  # It is a per-PROCESS approximation of a per-CONNECTION fact, which is what a dynamic
-  # nesting through an opaque `fun` can observe. The two diverge only in ways that stay
-  # CONSERVATIVE or vanishingly rare: an owner on ANOTHER repo's connection makes us abort a
-  # read we could have reset (safe, never a leak), and a sandbox-allowed `Task` sharing the
-  # owner's checkout sees an empty stack (it would reset a name the owner holds — only
-  # reachable if that Task's own capture also fails).
+  # deliberate `statement_timeout` bound or its elevated `hnsw.ef_search`, while silence leaks
+  # OUR value into the rest of its body — the 57014-far-from-the-query failure this module
+  # exists to prevent. `capture_fallback!/2` takes neither branch: it aborts before the body
+  # sets anything, and the rollback discards every `SET LOCAL` the transaction made. A wedged
+  # capture means a wedged connection anyway; `Knowledge.BulkOps.timeout_multi/0` errs alike.
+  # This stack records every name a LIVE scope holds: `scoped/3` pushes for its body; the
+  # hand-paired form pushes in `capture/2` and pops in `restore/2` — or in `forget/1` on an
+  # abort path `restore/2` can never reach, which is why `BulkOps` counts too. It is a
+  # per-PROCESS approximation of a per-CONNECTION fact (a dynamic nesting through an opaque
+  # `fun` can observe nothing finer) and diverges only CONSERVATIVELY or vanishingly rarely:
+  # an owner on ANOTHER repo's connection makes us abort a read we could have reset (safe,
+  # never a leak), and a sandbox-allowed `Task` sharing the owner's checkout sees an empty
+  # stack (it would reset a name the owner holds — only if that Task's capture also fails).
   @active_names_key {__MODULE__, :active_names}
 
   defp active_names, do: Process.get(@active_names_key, [])
@@ -146,13 +142,11 @@ defmodule Loopctl.LocalGuc do
   The prior values of `names`, as `[{name, value_or_nil}]`. MUST be called inside a
   transaction on `repo`: the round trip runs `mode: :savepoint`, which Postgrex refuses on
   an idle connection, so an out-of-transaction call degrades to `[]` like any other failure.
+  One round trip; a BACKEND failure never raises, it degrades to `[]`, which makes `restore/2`
+  a no-op. An invalid GUC name is a programmer error and DOES raise `ArgumentError`.
 
-  One round trip; a BACKEND failure never raises, it degrades to `[]`, which makes
-  `restore/2` a no-op. An invalid GUC name is a programmer error and DOES raise
-  `ArgumentError`.
-
-  A successful capture registers `names` on the active-scope stack and `restore/2` pops them
-  (see `active_names/0`), so a nested `scoped/3` can see this scope's overrides.
+  A successful capture registers `names` on the active-scope stack, popped by `restore/2` or
+  `forget/1` (see `active_names/0`), so a nested `scoped/3` sees this scope's overrides.
 
   Prefer `scoped/3`: a caller that pairs this with `restore/2` by hand gets NO restoration
   when the capture fails, which is the leak `scoped/3`'s fallback exists to close.
@@ -171,6 +165,21 @@ defmodule Loopctl.LocalGuc do
     end
   end
 
+  @doc """
+  Drop `names` from the active-scope stack: no round trip, nothing restored, and a no-op for
+  a name `restore/2` already popped.
+
+  For the hand-paired form on an abort path `restore/2` can never reach (an `Ecto.Multi` whose
+  restore step is skipped because an earlier one errored). The rollback already discarded every
+  `SET LOCAL`, so only the bookkeeping is left — and it MUST be cleared, or a later `scoped/3`
+  on that reused process sees a phantom owner and ABORTS a read it could safely have reset.
+  """
+  @spec forget([String.t()]) :: :ok
+  def forget(names) when is_list(names) do
+    put_active_names(active_names() -- names)
+    :ok
+  end
+
   # `{:ok, pairs} | :error`, so `scoped/3` can tell "nothing to capture" apart from "the
   # round trip failed" — two states the public `capture/2` collapses into `[]`, which is
   # what let a failed capture silently disable restoration.
@@ -182,12 +191,11 @@ defmodule Loopctl.LocalGuc do
     # ran them through `validate_names!/1` first.
     selects = Enum.map_join(names, ", ", &"current_setting('#{&1}', true)")
 
-    # `mode: :savepoint`, matching `restore/2` — and for the same reason, which applies
-    # even harder here because this runs BEFORE the caller's work. Without it a failure on
-    # this round trip leaves the enclosing transaction aborted (25P02), so every later
-    # statement in the caller's Multi fails with an error about a query it never issued.
-    # With it, the failure rolls back to its own savepoint and `capture_failed/2` can
-    # return `:error` to a transaction that is still usable.
+    # `mode: :savepoint`, matching `restore/2` and for the same reason, harder here because
+    # this runs BEFORE the caller's work: without it a failure on this round trip leaves the
+    # enclosing transaction aborted (25P02), so every later statement in the caller's Multi
+    # fails over a query it never issued. With it, the failure rolls back to its own savepoint
+    # and `capture_failed/2` returns `:error` to a transaction that is still usable.
     %{rows: [values]} = repo.query!("SELECT #{selects}", [], mode: :savepoint)
     {:ok, Enum.zip(names, values)}
   rescue

--- a/test/loopctl/heavy_read_hnsw_ef_search_test.exs
+++ b/test/loopctl/heavy_read_hnsw_ef_search_test.exs
@@ -359,4 +359,54 @@ defmodule Loopctl.HeavyReadHnswEfSearchTest do
     :persistent_term.put(pt_key, value)
     on_exit(fn -> :persistent_term.erase(pt_key) end)
   end
+
+  describe "inconclusive probe classification (negative-cache eligibility)" do
+    # The class decides whether an inconclusive probe is negative-cached. Sweeping every
+    # Postgrex.Error into :transaction (the never-cached class) meant a REAL production
+    # incident — statement timeouts, connection exhaustion, an admin shutdown — re-probed
+    # and re-warned on every ANN read, which is the storm the cache exists to bound.
+    test "only a poisoned-transaction SQLSTATE is :transaction; other backend errors are :pool" do
+      poisoned = %Postgrex.Error{postgres: %{code: :in_failed_sql_transaction}}
+
+      assert HeavyRead.inconclusive_class(poisoned) == :transaction,
+             "25P02 is a harness artifact of an earlier failed statement, not backend pressure"
+
+      for code <- [:query_canceled, :too_many_connections, :admin_shutdown, :crash_shutdown] do
+        error = %Postgrex.Error{postgres: %{code: code}}
+
+        assert HeavyRead.inconclusive_class(error) == :pool,
+               "#{code} is backend pressure and MUST stay negative-cacheable"
+      end
+    end
+
+    test "ownership errors keep their own class, and unknown failures default to :pool" do
+      assert HeavyRead.inconclusive_class(%DBConnection.OwnershipError{}) == :ownership
+      assert HeavyRead.inconclusive_class(%DBConnection.ConnectionError{}) == :pool
+      assert HeavyRead.inconclusive_class(:some_exit_reason) == :pool
+    end
+
+    test "an {:error, _} tuple is unwrapped before classifying" do
+      wrapped = {:error, %Postgrex.Error{postgres: %{code: :too_many_connections}}}
+
+      assert HeavyRead.inconclusive_class(wrapped) == :pool
+    end
+  end
+
+  describe "last conclusive verdict (probe-blip fallback)" do
+    @last_conclusive_key {Loopctl.HeavyRead, :iterative_scan_last_conclusive}
+
+    test "a conclusive probe records its verdict for later inconclusive reads to fall back on" do
+      :persistent_term.erase(@probe_cache_key)
+      :persistent_term.erase(@last_conclusive_key)
+      on_exit(fn -> :persistent_term.erase(@last_conclusive_key) end)
+
+      # Drives a real probe against the test backend.
+      verdict = HeavyRead.iterative_scan_supported?()
+
+      assert :persistent_term.get(@last_conclusive_key, :none) == verdict,
+             "a conclusive probe must record what the backend actually said, so a later " <>
+               "probe BLIP reuses it instead of silently reconfiguring the ANN read to the " <>
+               "pgvector default OFF"
+    end
+  end
 end

--- a/test/loopctl/heavy_read_hnsw_ef_search_test.exs
+++ b/test/loopctl/heavy_read_hnsw_ef_search_test.exs
@@ -310,13 +310,18 @@ defmodule Loopctl.HeavyReadHnswEfSearchTest do
   end
 
   @probe_cache_key {Loopctl.HeavyRead, :iterative_scan_supported}
+  @last_conclusive_key {Loopctl.HeavyRead, :iterative_scan_last_conclusive}
 
-  # The probe caches a VM-global `:persistent_term` verdict. Every mutation of it — including
-  # the one the LIVE probe performs — is erased on exit, exactly like the prime_* helpers
-  # below, so the unsupported / re-probe branches stay reachable for later tests.
+  # A live probe writes TWO VM-global `:persistent_term` keys: the live cache AND the
+  # last-conclusive record it falls back on (a ONE-HOUR reuse window). Both are erased here and
+  # on exit, like the prime_* helpers below — restoring only the live cache left the recorded
+  # verdict standing, so a later test's inconclusive probe REUSED it instead of failing closed.
   defp clear_iterative_scan_probe_cache do
-    :persistent_term.erase(@probe_cache_key)
-    on_exit(fn -> :persistent_term.erase(@probe_cache_key) end)
+    for key <- [@probe_cache_key, @last_conclusive_key], do: :persistent_term.erase(key)
+
+    on_exit(fn ->
+      for key <- [@probe_cache_key, @last_conclusive_key], do: :persistent_term.erase(key)
+    end)
   end
 
   defp prime_iterative_scan_supported(verdict) do
@@ -393,15 +398,11 @@ defmodule Loopctl.HeavyReadHnswEfSearchTest do
   end
 
   describe "last conclusive verdict (probe-blip fallback)" do
-    @last_conclusive_key {Loopctl.HeavyRead, :iterative_scan_last_conclusive}
-
     test "a conclusive probe records its verdict for later inconclusive reads to fall back on" do
-      # `clear_iterative_scan_probe_cache/0` (not a bare erase) so the entry the LIVE probe
-      # below writes is erased on exit too — otherwise it pins a 10-minute verdict for every
-      # later test in the run.
+      # `clear_iterative_scan_probe_cache/0` (not a bare erase) so BOTH entries the LIVE probe
+      # below writes are erased on exit — otherwise it pins a 10-minute verdict, and a
+      # one-hour fallback, for every later test in the run.
       clear_iterative_scan_probe_cache()
-      :persistent_term.erase(@last_conclusive_key)
-      on_exit(fn -> :persistent_term.erase(@last_conclusive_key) end)
 
       # Drives a real probe against the test backend. An INCONCLUSIVE probe (a HeavyReadRepo
       # checkout blip — the documented flake of the sibling test above) records NOTHING, so
@@ -417,6 +418,13 @@ defmodule Loopctl.HeavyReadHnswEfSearchTest do
                    "the pgvector default OFF"
 
         :none ->
+          # Fail-closed is still required here, so assert it — but SAY SO loudly: a green run
+          # that silently took this arm never exercised the recording the test exists to
+          # prove, and an assertion that quietly absorbs its own flake rots into a no-op.
+          IO.warn(
+            "probe was INCONCLUSIVE: the last-conclusive RECORDING was not exercised in this run"
+          )
+
           refute verdict,
                  "with nothing recorded the probe was inconclusive, and an inconclusive " <>
                    "probe with no verdict to reuse MUST fail closed"

--- a/test/loopctl/heavy_read_hnsw_ef_search_test.exs
+++ b/test/loopctl/heavy_read_hnsw_ef_search_test.exs
@@ -396,17 +396,31 @@ defmodule Loopctl.HeavyReadHnswEfSearchTest do
     @last_conclusive_key {Loopctl.HeavyRead, :iterative_scan_last_conclusive}
 
     test "a conclusive probe records its verdict for later inconclusive reads to fall back on" do
-      :persistent_term.erase(@probe_cache_key)
+      # `clear_iterative_scan_probe_cache/0` (not a bare erase) so the entry the LIVE probe
+      # below writes is erased on exit too — otherwise it pins a 10-minute verdict for every
+      # later test in the run.
+      clear_iterative_scan_probe_cache()
       :persistent_term.erase(@last_conclusive_key)
       on_exit(fn -> :persistent_term.erase(@last_conclusive_key) end)
 
-      # Drives a real probe against the test backend.
+      # Drives a real probe against the test backend. An INCONCLUSIVE probe (a HeavyReadRepo
+      # checkout blip — the documented flake of the sibling test above) records NOTHING, so
+      # each outcome is asserted on its own terms: asserting the record unconditionally would
+      # report a pool blip as a fallback regression.
       verdict = HeavyRead.iterative_scan_supported?()
 
-      assert :persistent_term.get(@last_conclusive_key, :none) == verdict,
-             "a conclusive probe must record what the backend actually said, so a later " <>
-               "probe BLIP reuses it instead of silently reconfiguring the ANN read to the " <>
-               "pgvector default OFF"
+      case :persistent_term.get(@last_conclusive_key, :none) do
+        {recorded, recorded_at} when is_integer(recorded_at) ->
+          assert recorded == verdict,
+                 "a conclusive probe must record what the backend actually said, so a later " <>
+                   "probe BLIP reuses it instead of silently reconfiguring the ANN read to " <>
+                   "the pgvector default OFF"
+
+        :none ->
+          refute verdict,
+                 "with nothing recorded the probe was inconclusive, and an inconclusive " <>
+                   "probe with no verdict to reuse MUST fail closed"
+      end
     end
   end
 end

--- a/test/loopctl/heavy_read_test.exs
+++ b/test/loopctl/heavy_read_test.exs
@@ -485,9 +485,36 @@ defmodule Loopctl.HeavyReadTest do
     end
   end
 
+  # Records the opts each statement was issued with, then delegates to the real Repo so the
+  # queries still behave. Asserting on `mode:` needs the call itself, not its result.
+  defmodule OptsRecordingRepo do
+    def query!(sql, params \\ [], opts \\ []) do
+      send(self(), {:issued, sql, opts})
+      Loopctl.Repo.query!(sql, params, opts)
+    end
+  end
+
   describe "LocalGuc best-effort bookkeeping" do
     test "capture degrades to [] instead of aborting the caller's read" do
       assert Loopctl.LocalGuc.capture(ExitingRepo, ["statement_timeout"]) == []
+    end
+
+    test "capture runs under mode: :savepoint, like restore" do
+      # Without it, a failure on the capture round trip aborts the ENCLOSING transaction
+      # (25P02) before the caller's work has run at all — so every later statement in the
+      # caller's Multi fails citing a query it never issued, and `capture_failed/2` returns
+      # its tidy `:error` into a transaction that is already unusable. restore/2 has always
+      # passed it; capture is the side that runs first and needs it more.
+      Loopctl.Repo.transaction(fn ->
+        assert [{"statement_timeout", _}] =
+                 Loopctl.LocalGuc.capture(OptsRecordingRepo, ["statement_timeout"])
+      end)
+
+      assert_received {:issued, "SELECT current_setting" <> _, opts}
+
+      assert Keyword.get(opts, :mode) == :savepoint,
+             "the capture SELECT must be savepoint-scoped so its failure cannot poison " <>
+               "the caller's transaction"
     end
 
     test "restore swallows an exit, so it cannot destroy a successful result" do

--- a/test/loopctl/heavy_read_test.exs
+++ b/test/loopctl/heavy_read_test.exs
@@ -605,15 +605,41 @@ defmodule Loopctl.HeavyReadTest do
              "a failed capture left the override in the enclosing transaction"
     end
 
-    test "a nested failed capture leaves an ENCLOSING scope's GUC to its owner" do
+    test "a nested failed capture ABORTS instead of clobbering or leaking the owner's GUC" do
       Loopctl.LocalGuc.scoped(Repo, [@probe], fn ->
         Repo.query!("SET LOCAL #{@probe} = 'outer'")
 
-        Loopctl.LocalGuc.scoped(CaptureFailingRepo, [@probe], fn -> :ok end)
+        # With no captured values the fallback could only RESET (clobbering the value the
+        # enclosing scope deliberately set — we never learn it: its own `fun` issued that SET
+        # LOCAL) or do nothing (leaking the inner override into the rest of the outer body).
+        # It does neither. It raises BEFORE the body sets anything, and the caller's rollback
+        # is then the thing that discards every SET LOCAL made inside the transaction.
+        assert_raise RuntimeError, ~r/could not capture/, fn ->
+          Loopctl.LocalGuc.scoped(CaptureFailingRepo, [@probe], fn ->
+            Repo.query!("SET LOCAL #{@probe} = 'inner'")
+          end)
+        end
 
         assert current_probe() == "outer",
-               "the inner reset clobbered the enclosing scope's deliberate SET LOCAL"
+               "the enclosing scope's deliberate SET LOCAL must survive the inner abort"
       end)
+    end
+
+    test "the hand-paired capture/restore form registers on the active-scope stack" do
+      # `Knowledge.BulkOps` holds its AC-27.12.5 `statement_timeout` bound ACROSS Multi steps,
+      # so it cannot wrap the work in a `scoped/3` — but the bound is only safe from a nested
+      # scope's reset fallback if `capture/2` publishes the name the way `scoped/3` does.
+      prior = Loopctl.LocalGuc.capture(Repo, [@probe])
+      Repo.query!("SET LOCAL #{@probe} = 'bulk'")
+
+      assert_raise RuntimeError, ~r/could not capture/, fn ->
+        Loopctl.LocalGuc.scoped(CaptureFailingRepo, [@probe], fn -> :ok end)
+      end
+
+      assert current_probe() == "bulk",
+             "a nested capture failure reset the bulk op's deliberate bound"
+
+      Loopctl.LocalGuc.restore(Repo, prior)
     end
 
     test "an invalid GUC name is rejected before it can reach the interpolated SQL" do


### PR DESCRIPTION
The six confirmed findings the #541 review (#546) raised **outside its own diff**. Every one is in code that merged this morning as #540, so this is that branch's tail rather than new work — split out because a PR about an enrollment page is the wrong place to change ANN recall behaviour.

Not a deferral: #546 shipped with zero deferred findings, and these land here instead of in a tracking issue.

## An inconclusive probe was silently disabling iterative scan

The one that actually costs recall. An INCONCLUSIVE pgvector capability probe answers *"I could not ask"*, never *"the extension is missing"* — but it collapsed to `false`, and `false` means the ANN read runs at the pgvector default with iterative scan **OFF**. That under-returns rows with nothing in the response saying so, which is the same silent-empty-result signature as the `left: []` flake the test-env pin exists to prevent.

The pgvector version cannot change between two reads on the same backend, so an inconclusive probe now reuses the **last conclusive verdict**, and fails closed only when no probe has ever succeeded — the genuine unknown, and the only place fail-closed is the safe reading. The live cache still expires, so a real backend change (replica failover onto an older pgvector) is still picked up; this is a fallback for *"the probe failed"*, not a second source of truth for *"what is supported"*.

## The negative cache was inverted for real incidents

Probe errors were classified by **struct module**: every `Postgrex.Error` became `:transaction`, the one class that is never negative-cached. But `:transaction` means one specific thing — a connection already poisoned by an earlier statement (25P02) — which is a test-harness artifact of a deliberate constraint-violation or cancellation test and says nothing about backend pressure.

Statement timeouts (57014), connection exhaustion (53300) and admin shutdown (57P01) are *exactly* the pressure the negative cache was built for, and sweeping them into the uncacheable class meant a genuine production incident re-probed **and re-warned on every ANN read** — the storm the cache exists to bound, arriving through the class it was supposed to catch. Now classified on the SQLSTATE, and the inconclusive warning is throttled per class per window so the logger cannot recreate the storm by itself.

## The last hand-paired GUC leak

`bulk_ops` was the final caller pairing `LocalGuc.capture` with `restore` by hand — the form `LocalGuc`'s own moduledoc names as the open leak. `capture/2` degrades a backend failure to `[]`, the `SET LOCAL statement_timeout` was issued regardless, and `restore/2` on `[]` is a silent no-op, so the override outlived the **committed** savepoint and rode the pooled connection into whatever ran next.

It asks for exactly one GUC and `statement_timeout` always exists, so `[]` is unambiguously a failed capture: the Multi now aborts *before* setting an override it cannot take back. Failing the bulk op is the right side to err on — a capture that could not complete means the connection is already in trouble, and the alternative (running unbounded) silently drops the blast-radius bound of AC-27.12.5.

`LocalGuc.do_capture` also ran without `mode: :savepoint` while `restore/2` has always used it. Capture runs **first**, so its failure aborted the caller's entire transaction before any of their work ran — every later statement failing with an error about a query it never issued.

## The pin's premise is now written down

The test-env iterative-scan pin rests on prod having `SystemConfig hnsw_iterative_scan = 1`. No test can see prod, so rather than a test that cannot fail honestly, the premise is recorded with the command that checks it and the date it was last confirmed — **2026-08-01, value `1`, verified against the live app for this PR**. It is an operator-set row, not a migration, so a restore from before #488 or a fresh self-hosted install silently invalidates it and CI would then assert against a configuration nobody runs.

## Verification

- `mix precommit` green — 6473 tests, credo --strict, dialyzer
- New coverage: SQLSTATE classification across the pressure codes, the `{:error, _}` unwrap, and the conclusive-verdict recording; plus an opts-recording repo asserting the capture SELECT is savepoint-scoped
- `tenancy-rls` skill citations re-pointed — these edits moved line numbers in `heavy_read.ex`, and `mix loopctl.check_skill_citations` caught it

**Not directly covered by a test:** the `bulk_ops` capture-failure guard. That Multi resolves `AdminRepo` internally with no injection seam, and adding one is a larger change than this branch should carry. Stated rather than papered over.

---

## Review outcome (added after the enhanced review)

**22 findings, 20 confirmed, 20 fixed, 0 deferrals.** The review caught two defects in the fix above that were worse than the bug it was fixing:

- **The new log throttle was dead code.** It compared `System.monotonic_time(:millisecond)` — which is *negative* — against a `0` default, so `now_ms() >= 0` was never true and neither new warning could ever fire. Measured: `-576460751798`. Now uses a `:never` sentinel.
- **The last-conclusive verdict had no TTL**, so a stale `true` could replay indefinitely across a pgvector downgrade, emitting a GUC the backend rejects and 500-ing every ANN read — strictly worse than the silent under-return being fixed. Now bounded to 1h, with a single-flight hold so the TTL boundary doesn't stampede the pool.

Also fixed: `:statement_timeout_capture_failed` had no `FallbackController` clause (every bulk KB op would have hit a `FunctionClauseError` 500 on a capture failure — it now maps to 503 + `Retry-After`); and `capture/2`'s new active-names push had no guaranteed pop, because `Ecto.Multi` skips the trailing restore step whenever an earlier step errors, so the entry accumulated across Bandit keep-alive requests.

## One review change reverted

The review flipped `@default_hnsw_iterative_scan` from `0` to `1`, turning iterative scan **ON for every deployment**. Its argument is sound and is now recorded at the attribute: the ON state lives only in an operator-set `SystemConfig` row, so a fresh self-hosted install runs a configuration the suite never asserts.

It is reverted anyway. Flipping it trades latency for recall across every deployment that has not set the row — an operator's decision, not a side effect of a branch fixing six unrelated findings, and squarely in the area where four previous attempts each regressed the side-table recall flake. Worth doing as its own change with a benchmark. Reverting also re-aligns `docs/runbooks/knowledge-scale.md`, which said the setting ships OFF and was right all along.
