### PR TITLE
Say what enrollment physically asks of you, and let a device be renamed

### DIFF
--- a/assets/js/hooks/authenticator_enroll.js
+++ b/assets/js/hooks/authenticator_enroll.js
@@ -557,7 +557,7 @@ const AuthenticatorEnroll = {
 
   status(message) {
     this.statusEl.textContent = message;
-    this.statusEl.className = "mt-4 font-mono text-xs text-slate-400";
+    this.statusEl.className = "mt-4 font-mono text-sm text-slate-300";
   },
 
   clearResult() {
@@ -599,17 +599,17 @@ const AuthenticatorEnroll = {
     // can confirm the one-way door closed on the tenant they meant.
     const anchored = document.createElement("p");
     anchored.id = "enroll-tenant";
-    anchored.className = "font-mono text-xs text-slate-400";
+    anchored.className = "font-mono text-sm text-slate-300";
     anchored.textContent = `tenant: ${describe(tenant)}`;
     box.appendChild(anchored);
 
     const tier = document.createElement("p");
-    tier.className = "font-mono text-xs text-slate-400";
+    tier.className = "font-mono text-sm text-slate-300";
     tier.textContent = `trust_tier: ${enrolled.trust_tier}`;
     box.appendChild(tier);
 
     const name = document.createElement("p");
-    name.className = "font-mono text-xs text-slate-400";
+    name.className = "font-mono text-sm text-slate-300";
     name.textContent = `authenticator: ${enrolled.authenticator.friendly_name} (${enrolled.authenticator.attestation_format})`;
     box.appendChild(name);
 
@@ -618,7 +618,7 @@ const AuthenticatorEnroll = {
 
     if (names.length > 0) {
       const label = document.createElement("p");
-      label.className = "pt-2 font-display text-xs uppercase tracking-wide text-slate-500";
+      label.className = "pt-2 font-display text-xs uppercase tracking-wide text-slate-400";
       label.textContent = "Surfaces";
       box.appendChild(label);
 
@@ -629,7 +629,7 @@ const AuthenticatorEnroll = {
       names.forEach((surface) => {
         const item = document.createElement("li");
         const allowed = surfaces[surface] === "allowed";
-        item.className = `font-mono text-xs ${allowed ? "text-accent-200" : "text-slate-500"}`;
+        item.className = `font-mono text-sm ${allowed ? "text-accent-200" : "text-slate-400"}`;
         item.textContent = `${allowed ? "✓" : "·"} ${surface}: ${surfaces[surface]}`;
         list.appendChild(item);
       });

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -814,7 +814,9 @@ defmodule Loopctl.ApiSpec.Schemas do
         credential_id: %Schema{type: :string, description: "Base64url credential id"},
         friendly_name: %Schema{
           type: :string,
-          description: "Operator-supplied label (1..120 chars, default \"Authenticator\")"
+          description:
+            "Operator-supplied label (1..120 BYTES — the same unit the schema " <>
+              "validates — default \"Authenticator\")"
         },
         reauth_assertion: WebAuthnAssertion
       }
@@ -911,7 +913,8 @@ defmodule Loopctl.ApiSpec.Schemas do
       title: "AuthenticatorListResponse",
       description:
         "The tenant's enrolled authenticators. Credential material " <>
-          "(credential_id, public_key) is deliberately never returned.",
+          "(credential_id, public_key) is deliberately never returned — only the " <>
+          "non-reversible credential_fingerprint.",
       type: :object,
       required: [:data],
       properties: %{
@@ -922,6 +925,13 @@ defmodule Loopctl.ApiSpec.Schemas do
             properties: %{
               id: %Schema{type: :string, format: :uuid},
               friendly_name: %Schema{type: :string},
+              credential_fingerprint: %Schema{
+                type: :string,
+                description:
+                  "Truncated SHA-256 of the credential id, as recorded in the audit " <>
+                    "chain. Credential-derived and not writable by any endpoint, unlike " <>
+                    "friendly_name — confirm a revocation target against this."
+              },
               attestation_format: %Schema{type: :string},
               inserted_at: %Schema{type: :string, format: :"date-time"},
               last_used_at: %Schema{type: :string, format: :"date-time", nullable: true}
@@ -947,8 +957,9 @@ defmodule Loopctl.ApiSpec.Schemas do
         friendly_name: %Schema{
           type: :string,
           description:
-            "New operator-facing label. Capped at 120 bytes; an over-long value is " <>
-              "rejected with 422 friendly_name_too_long.",
+            "New operator-facing label. Capped at 120 bytes (the same unit the schema " <>
+              "validates); an over-long value is rejected with 422 " <>
+              "friendly_name_too_long, a non-UTF-8 one with 422 friendly_name_invalid.",
           minLength: 1,
           example: "mac-mini Touch ID"
         }

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -903,6 +903,35 @@ defmodule Loopctl.ApiSpec.Schemas do
     })
   end
 
+  defmodule AuthenticatorListResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AuthenticatorListResponse",
+      description:
+        "The tenant's enrolled authenticators. Credential material " <>
+          "(credential_id, public_key) is deliberately never returned.",
+      type: :object,
+      required: [:data],
+      properties: %{
+        data: %Schema{
+          type: :array,
+          items: %Schema{
+            type: :object,
+            properties: %{
+              id: %Schema{type: :string, format: :uuid},
+              friendly_name: %Schema{type: :string},
+              attestation_format: %Schema{type: :string},
+              inserted_at: %Schema{type: :string, format: :"date-time"},
+              last_used_at: %Schema{type: :string, format: :"date-time", nullable: true}
+            }
+          }
+        }
+      }
+    })
+  end
+
   defmodule RenameAuthenticatorRequest do
     @moduledoc false
     require OpenApiSpex

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -903,6 +903,52 @@ defmodule Loopctl.ApiSpec.Schemas do
     })
   end
 
+  defmodule RenameAuthenticatorRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "RenameAuthenticatorRequest",
+      description:
+        "Request body for relabelling an enrolled authenticator. Only the display " <>
+          "label is writable — credential material cannot be changed by this endpoint.",
+      type: :object,
+      required: [:friendly_name],
+      properties: %{
+        friendly_name: %Schema{
+          type: :string,
+          description:
+            "New operator-facing label. Capped at 120 bytes; an over-long value is " <>
+              "rejected with 422 friendly_name_too_long.",
+          minLength: 1,
+          example: "mac-mini Touch ID"
+        }
+      }
+    })
+  end
+
+  defmodule RenameAuthenticatorResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "RenameAuthenticatorResponse",
+      description: "Result of a successful authenticator rename.",
+      type: :object,
+      required: [:data],
+      properties: %{
+        data: %Schema{
+          type: :object,
+          properties: %{
+            tenant_id: %Schema{type: :string, format: :uuid},
+            authenticator_id: %Schema{type: :string, format: :uuid},
+            friendly_name: %Schema{type: :string}
+          }
+        }
+      }
+    })
+  end
+
   # ---------- API Keys ----------
 
   defmodule ApiKeyCreateRequest do

--- a/lib/loopctl/tenants/enrollment.ex
+++ b/lib/loopctl/tenants/enrollment.ex
@@ -111,6 +111,8 @@ defmodule Loopctl.Tenants.Enrollment do
           | {:error, :not_found}
           | {:error, :reauth_required}
           | {:error, :too_many_authenticators}
+          | {:error, :audit_failed}
+          | {:error, :internal_error}
           | {:error, Ecto.Changeset.t()}
   def enroll(tenant_id, attrs, assertion_verified?)
       when is_binary(tenant_id) and is_map(attrs) and is_boolean(assertion_verified?) do
@@ -128,26 +130,37 @@ defmodule Loopctl.Tenants.Enrollment do
       |> Multi.run(:reloaded_tenant, fn repo, _changes -> {:ok, repo.get!(Tenant, tenant_id)} end)
       |> Audit.log_in_multi(:audit, &build_enroll_audit_attrs(tenant_id, &1))
 
-    case AdminRepo.transaction(multi) do
-      {:ok, %{authenticator: auth, reloaded_tenant: tenant, flip_tier: {flipped, _}}} ->
-        on_enroll_success(tenant_id, tenant, auth, flipped)
-
-      {:error, :tenant, :not_found, _changes} ->
-        {:error, :not_found}
-
-      {:error, :assert_gate, :reauth_required, _changes} ->
-        {:error, :reauth_required}
-
-      {:error, :check_cap, :too_many_authenticators, _changes} ->
-        {:error, :too_many_authenticators}
-
-      {:error, :authenticator, %Ecto.Changeset{} = changeset, _changes} ->
-        {:error, changeset}
-
-      {:error, _step, reason, _changes} ->
-        {:error, reason}
-    end
+    multi |> AdminRepo.transaction() |> enroll_result(tenant_id)
   end
+
+  defp enroll_result({:ok, changes}, tenant_id) do
+    %{authenticator: auth, reloaded_tenant: tenant, flip_tier: {flipped, _}} = changes
+    on_enroll_success(tenant_id, tenant, auth, flipped)
+  end
+
+  defp enroll_result({:error, :tenant, :not_found, _changes}, _tenant_id),
+    do: {:error, :not_found}
+
+  defp enroll_result({:error, :assert_gate, :reauth_required, _changes}, _tenant_id),
+    do: {:error, :reauth_required}
+
+  defp enroll_result({:error, :check_cap, :too_many_authenticators, _changes}, _tenant_id),
+    do: {:error, :too_many_authenticators}
+
+  defp enroll_result(
+         {:error, :authenticator, %Ecto.Changeset{} = changeset, _changes},
+         _tenant_id
+       ),
+       do: {:error, changeset}
+
+  # Same split rename/4 makes: an audit-chain append failure is an internal
+  # fault, and returning its changeset would render a 422 blaming the caller's
+  # enrollment payload for it. Everything else is an unmatched Multi failure and
+  # must not be reported as an audit-log fault either.
+  defp enroll_result({:error, :audit, _reason, _changes}, _tenant_id), do: {:error, :audit_failed}
+
+  defp enroll_result({:error, _step, _reason, _changes}, _tenant_id),
+    do: {:error, :internal_error}
 
   # US-33.3: a first-device enrollment flips the tenant to :human_anchored. The
   # api-key cache stores each key WITH its :tenant preloaded (trust_tier is read by
@@ -184,6 +197,8 @@ defmodule Loopctl.Tenants.Enrollment do
           {:ok, RootAuthenticator.t()}
           | {:error, :not_found}
           | {:error, :last_authenticator}
+          | {:error, :audit_failed}
+          | {:error, :internal_error}
   def revoke(tenant_id, authenticator_id)
       when is_binary(tenant_id) and is_binary(authenticator_id) do
     multi =
@@ -227,8 +242,14 @@ defmodule Loopctl.Tenants.Enrollment do
       {:error, :guard_last, :last_authenticator, _changes} ->
         {:error, :last_authenticator}
 
-      {:error, _step, reason, _changes} ->
-        {:error, reason}
+      {:error, :audit, _reason, _changes} ->
+        {:error, :audit_failed}
+
+      # Never leak an unmatched Multi reason to the caller: `do_revoke/4` has no
+      # clause for a changeset, so returning one crashed with a CaseClauseError
+      # instead of a structured 500.
+      {:error, _step, _reason, _changes} ->
+        {:error, :internal_error}
     end
   end
 
@@ -263,6 +284,7 @@ defmodule Loopctl.Tenants.Enrollment do
           {:ok, RootAuthenticator.t()}
           | {:error, :not_found}
           | {:error, :audit_failed}
+          | {:error, :internal_error}
           | {:error, Ecto.Changeset.t()}
   def rename(tenant_id, authenticator_id, friendly_name, opts \\ [])
       when is_binary(tenant_id) and is_binary(authenticator_id) and is_binary(friendly_name) do
@@ -276,8 +298,16 @@ defmodule Loopctl.Tenants.Enrollment do
         # this UPDATE. Ecto RAISES Ecto.StaleEntryError on a zero-row update
         # rather than returning an error tuple, which would escape the
         # transaction as a 500 instead of the 404 the endpoint documents.
+        #
+        # `force: true` is load-bearing: renaming a label to its CURRENT value
+        # yields a changeset with no changes, and Ecto then returns {:ok, struct}
+        # WITHOUT issuing any SQL — so the row is never touched, StaleEntryError
+        # can never fire, and a rename racing a revoke would 200 (and audit) a
+        # row that no longer exists. Forcing the UPDATE makes every rename hit
+        # the row, so the stale case is always detected.
         try do
-          repo.update(RootAuthenticator.rename_changeset(auth, %{friendly_name: friendly_name}))
+          RootAuthenticator.rename_changeset(auth, %{friendly_name: friendly_name})
+          |> repo.update(force: true)
         rescue
           Ecto.StaleEntryError -> {:error, :not_found}
         end
@@ -309,11 +339,16 @@ defmodule Loopctl.Tenants.Enrollment do
       {:error, :renamed, %Ecto.Changeset{} = changeset, _changes} ->
         {:error, changeset}
 
-      # Anything left is the :audit step — an INTERNAL fault, not a caller
-      # mistake. Returning its changeset here would render the operator a 422
-      # blaming their friendly_name for an audit-chain append failure.
-      {:error, _step, _reason, _changes} ->
+      # The :audit step is an INTERNAL fault, not a caller mistake. Returning its
+      # changeset here would render the operator a 422 blaming their
+      # friendly_name for an audit-chain append failure. Matched BY STEP NAME: a
+      # Postgrex fault on the :renamed UPDATE is not an audit-log failure, and
+      # reporting it as one points whoever triages it at the wrong subsystem.
+      {:error, :audit, _reason, _changes} ->
         {:error, :audit_failed}
+
+      {:error, _step, _reason, _changes} ->
+        {:error, :internal_error}
     end
   end
 

--- a/lib/loopctl/tenants/enrollment.ex
+++ b/lib/loopctl/tenants/enrollment.ex
@@ -232,6 +232,69 @@ defmodule Loopctl.Tenants.Enrollment do
     end
   end
 
+  @doc """
+  Renames an enrolled authenticator's operator-facing label.
+
+  Deliberately does NOT take the tenant `FOR UPDATE` lock that `enroll/3` and
+  `revoke/2` share. That lock exists to serialize mutations that can violate an
+  invariant — the per-tenant authenticator cap, the trust-tier flip, and the
+  last-authenticator guard. A rename touches none of them: it cannot change how
+  many authenticators a tenant has, nor its tier, so the worst outcome of two
+  concurrent renames is last-write-wins on a display string. Taking the tenant
+  lock anyway would let a label edit block an in-flight enrollment ceremony.
+
+  No reauth assertion is required either, unlike `revoke/2`. A rename is
+  reversible, destroys nothing, and is already bounded by the `user` role gate
+  and the human-anchor tier gate; demanding a touch would price a typo fix at
+  the same cost as destroying a root-of-trust credential. The change is still
+  recorded in the append-only audit chain with both the old and new label.
+  """
+  @spec rename(Ecto.UUID.t(), Ecto.UUID.t(), String.t()) ::
+          {:ok, RootAuthenticator.t()}
+          | {:error, :not_found}
+          | {:error, Ecto.Changeset.t()}
+  def rename(tenant_id, authenticator_id, friendly_name)
+      when is_binary(tenant_id) and is_binary(authenticator_id) and is_binary(friendly_name) do
+    multi =
+      Multi.new()
+      |> Multi.run(:target, fn repo, _changes ->
+        find_authenticator(repo, tenant_id, authenticator_id)
+      end)
+      |> Multi.update(:renamed, fn %{target: auth} ->
+        RootAuthenticator.rename_changeset(auth, %{friendly_name: friendly_name})
+      end)
+      |> Audit.log_in_multi(:audit, fn %{target: old, renamed: auth} ->
+        %{
+          tenant_id: tenant_id,
+          entity_type: "tenant",
+          entity_id: tenant_id,
+          action: "authenticator_renamed",
+          actor_type: "human",
+          actor_id: nil,
+          actor_label: "human:api",
+          old_state: %{
+            "authenticator_fingerprint" => Tenants.fingerprint(old.credential_id),
+            "friendly_name" => old.friendly_name
+          },
+          new_state: %{"friendly_name" => auth.friendly_name}
+        }
+      end)
+
+    case AdminRepo.transaction(multi) do
+      {:ok, %{renamed: auth}} ->
+        {:ok, auth}
+
+      {:error, :target, :not_found, _changes} ->
+        {:error, :not_found}
+
+      {:error, :renamed, %Ecto.Changeset{} = changeset, _changes} ->
+        {:error, changeset}
+
+      {:error, _step, reason, _changes} ->
+        {:error, reason}
+    end
+  end
+
   # Locks the tenant row for the duration of the enclosing transaction —
   # the single mechanism serializing every authenticator mutation
   # (enroll AND revoke) for this tenant, including the zero-row first-enroll

--- a/lib/loopctl/tenants/enrollment.ex
+++ b/lib/loopctl/tenants/enrollment.ex
@@ -244,24 +244,43 @@ defmodule Loopctl.Tenants.Enrollment do
   lock anyway would let a label edit block an in-flight enrollment ceremony.
 
   No reauth assertion is required either, unlike `revoke/2`. A rename is
-  reversible, destroys nothing, and is already bounded by the `user` role gate
-  and the human-anchor tier gate; demanding a touch would price a typo fix at
-  the same cost as destroying a root-of-trust credential. The change is still
-  recorded in the append-only audit chain with both the old and new label.
+  reversible, destroys nothing, and is bounded by the `user` role gate plus
+  `owns_tenant?/2` and the tenant-scoped lookup below — NOT by the human-anchor
+  tier gate, which `LoopctlWeb.TenantAuthenticatorController` deliberately does
+  not mount (the route is an explicit exemption in
+  `test/loopctl_web/require_human_anchor_default_deny_test.exs`, sound only
+  because an agent-rooted tenant owns zero authenticators by construction and
+  there is no downgrade path). Demanding a touch would price a typo fix at the
+  same cost as destroying a root-of-trust credential.
+
+  Because possession of a device is therefore NEVER proved here, after-the-fact
+  attribution is the compensating control: `opts` carries the calling key's
+  `:actor_id`/`:actor_label`, and the entry is stamped `actor_type: "api_key"`
+  (matching every other bearer-key-driven mutation) rather than claiming a human
+  presence nothing verified. The old and new label are both recorded.
   """
-  @spec rename(Ecto.UUID.t(), Ecto.UUID.t(), String.t()) ::
+  @spec rename(Ecto.UUID.t(), Ecto.UUID.t(), String.t(), keyword()) ::
           {:ok, RootAuthenticator.t()}
           | {:error, :not_found}
+          | {:error, :audit_failed}
           | {:error, Ecto.Changeset.t()}
-  def rename(tenant_id, authenticator_id, friendly_name)
+  def rename(tenant_id, authenticator_id, friendly_name, opts \\ [])
       when is_binary(tenant_id) and is_binary(authenticator_id) and is_binary(friendly_name) do
     multi =
       Multi.new()
       |> Multi.run(:target, fn repo, _changes ->
         find_authenticator(repo, tenant_id, authenticator_id)
       end)
-      |> Multi.update(:renamed, fn %{target: auth} ->
-        RootAuthenticator.rename_changeset(auth, %{friendly_name: friendly_name})
+      |> Multi.run(:renamed, fn repo, %{target: auth} ->
+        # A concurrent revoke can delete the row between the :target read and
+        # this UPDATE. Ecto RAISES Ecto.StaleEntryError on a zero-row update
+        # rather than returning an error tuple, which would escape the
+        # transaction as a 500 instead of the 404 the endpoint documents.
+        try do
+          repo.update(RootAuthenticator.rename_changeset(auth, %{friendly_name: friendly_name}))
+        rescue
+          Ecto.StaleEntryError -> {:error, :not_found}
+        end
       end)
       |> Audit.log_in_multi(:audit, fn %{target: old, renamed: auth} ->
         %{
@@ -269,9 +288,9 @@ defmodule Loopctl.Tenants.Enrollment do
           entity_type: "tenant",
           entity_id: tenant_id,
           action: "authenticator_renamed",
-          actor_type: "human",
-          actor_id: nil,
-          actor_label: "human:api",
+          actor_type: "api_key",
+          actor_id: Keyword.get(opts, :actor_id),
+          actor_label: Keyword.get(opts, :actor_label),
           old_state: %{
             "authenticator_fingerprint" => Tenants.fingerprint(old.credential_id),
             "friendly_name" => old.friendly_name
@@ -284,14 +303,17 @@ defmodule Loopctl.Tenants.Enrollment do
       {:ok, %{renamed: auth}} ->
         {:ok, auth}
 
-      {:error, :target, :not_found, _changes} ->
+      {:error, step, :not_found, _changes} when step in [:target, :renamed] ->
         {:error, :not_found}
 
       {:error, :renamed, %Ecto.Changeset{} = changeset, _changes} ->
         {:error, changeset}
 
-      {:error, _step, reason, _changes} ->
-        {:error, reason}
+      # Anything left is the :audit step — an INTERNAL fault, not a caller
+      # mistake. Returning its changeset here would render the operator a 422
+      # blaming their friendly_name for an audit-chain append failure.
+      {:error, _step, _reason, _changes} ->
+        {:error, :audit_failed}
     end
   end
 
@@ -322,14 +344,21 @@ defmodule Loopctl.Tenants.Enrollment do
     from(t in Tenant, where: t.id == ^tenant_id and t.trust_tier == :agent_rooted)
   end
 
+  # A malformed id must 404, not 500: binding a non-UUID to the :binary_id
+  # column raises Ecto.Query.CastError, which carries no plug_status (same
+  # guard as projects.ex:108 / agents.ex:120).
   defp find_authenticator(repo, tenant_id, authenticator_id) do
-    query =
-      from a in RootAuthenticator,
-        where: a.tenant_id == ^tenant_id and a.id == ^authenticator_id
+    case Ecto.UUID.cast(authenticator_id) do
+      :error ->
+        {:error, :not_found}
 
-    case repo.one(query) do
-      nil -> {:error, :not_found}
-      authenticator -> {:ok, authenticator}
+      {:ok, id} ->
+        query = from a in RootAuthenticator, where: a.tenant_id == ^tenant_id and a.id == ^id
+
+        case repo.one(query) do
+          nil -> {:error, :not_found}
+          authenticator -> {:ok, authenticator}
+        end
     end
   end
 

--- a/lib/loopctl/tenants/root_authenticator.ex
+++ b/lib/loopctl/tenants/root_authenticator.ex
@@ -67,6 +67,24 @@ defmodule Loopctl.Tenants.RootAuthenticator do
   end
 
   @doc """
+  Changeset for relabelling an enrolled authenticator.
+
+  Casts ONLY `friendly_name`. The credential material (`credential_id`,
+  `public_key`, `attestation_format`) and the clone-detection counter are
+  deliberately outside this changeset: a rename is a display-label edit, and
+  routing it through `create_changeset/2` would put a live rename endpoint one
+  forgotten `Map.take/2` away from letting a caller swap the credential a
+  tenant's root of trust hangs on.
+  """
+  @spec rename_changeset(t(), map()) :: Ecto.Changeset.t()
+  def rename_changeset(%__MODULE__{} = authenticator, attrs) do
+    authenticator
+    |> cast(attrs, [:friendly_name])
+    |> validate_required([:friendly_name])
+    |> validate_length(:friendly_name, min: 1, max: 120)
+  end
+
+  @doc """
   Changeset for bumping the sign counter after a successful assertion.
   """
   @spec touch_changeset(t(), non_neg_integer()) :: Ecto.Changeset.t()

--- a/lib/loopctl/tenants/root_authenticator.ex
+++ b/lib/loopctl/tenants/root_authenticator.ex
@@ -58,7 +58,12 @@ defmodule Loopctl.Tenants.RootAuthenticator do
       :attestation_format,
       :friendly_name
     ])
-    |> validate_length(:friendly_name, min: 1, max: 120)
+    # count: :bytes, NOT the default grapheme count — the write paths
+    # (TenantAuthenticatorController, signup_live) cap the label with
+    # byte_size/1, and a grapheme-counting schema is looser than they are for
+    # every non-ASCII label, so the two layers would disagree on what "120"
+    # means. One unit, stated in bytes everywhere including the OpenAPI spec.
+    |> validate_length(:friendly_name, min: 1, max: 120, count: :bytes)
     |> validate_length(:attestation_format, min: 1, max: 32)
     |> validate_number(:sign_count, greater_than_or_equal_to: 0)
     |> unique_constraint(:credential_id,
@@ -81,7 +86,7 @@ defmodule Loopctl.Tenants.RootAuthenticator do
     authenticator
     |> cast(attrs, [:friendly_name])
     |> validate_required([:friendly_name])
-    |> validate_length(:friendly_name, min: 1, max: 120)
+    |> validate_length(:friendly_name, min: 1, max: 120, count: :bytes)
   end
 
   @doc """

--- a/lib/loopctl_web/controllers/tenant_authenticator_controller.ex
+++ b/lib/loopctl_web/controllers/tenant_authenticator_controller.ex
@@ -75,7 +75,7 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
   # Authenticator enrollment/revocation requires user role — agents must not
   # perform trust-tier operations.
   plug LoopctlWeb.Plugs.RequireRole,
-       [role: :user] when action in [:challenge, :create, :revoke_challenge, :delete]
+       [role: :user] when action in [:challenge, :create, :revoke_challenge, :delete, :rename]
 
   tags(["Tenants"])
 
@@ -526,6 +526,78 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
 
       {:error, _reason} ->
         unauthorized(conn, "webauthn_failed", "WebAuthn assertion verification failed")
+    end
+  end
+
+  operation(:rename,
+    summary: "Rename an enrolled authenticator",
+    description:
+      "Updates the operator-facing display label of an enrolled authenticator. " <>
+        "Requires user role and tenant ownership. Unlike revocation this needs NO " <>
+        "WebAuthn assertion: a rename is reversible, destroys nothing, and changes " <>
+        "no credential material — only `friendly_name` is writable. The change is " <>
+        "recorded in the append-only audit chain with the old and new label. " <>
+        "`friendly_name` is capped at #{@max_friendly_name_bytes} bytes.",
+    parameters: [
+      id: [in: :path, type: :string, description: "Tenant UUID"],
+      auth_id: [in: :path, type: :string, description: "Authenticator UUID"]
+    ],
+    request_body:
+      {"Rename request", "application/json", Schemas.RenameAuthenticatorRequest, required: true},
+    responses: %{
+      200 => {"Authenticator renamed", "application/json", Schemas.RenameAuthenticatorResponse},
+      400 => {"Bad request", "application/json", Schemas.ErrorResponse},
+      403 => {"Forbidden", "application/json", Schemas.ErrorResponse},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      422 => {"Validation failed", "application/json", Schemas.ErrorResponse}
+    }
+  )
+
+  @doc """
+  PATCH /api/v1/tenants/:id/authenticators/:auth_id
+
+  Relabels an enrolled authenticator. Deliberately NOT behind the
+  `@max_enroll_actions_per_window` budget that the ceremony endpoints share:
+  that budget bounds CPU-bound WebAuthn verification, and spending one of a
+  tenant's 30 hourly enroll actions on a label edit could 429 an operator out
+  of their own enrollment ceremony. The blanket `RateLimiter` plug still applies.
+  """
+  def rename(conn, %{"id" => tenant_id, "auth_id" => auth_id} = params) do
+    friendly_name = Map.get(params, "friendly_name")
+
+    cond do
+      not owns_tenant?(conn, tenant_id) ->
+        forbidden(conn)
+
+      not is_binary(friendly_name) ->
+        bad_request(conn, "friendly_name is required and must be a string")
+
+      byte_size(friendly_name) > @max_friendly_name_bytes ->
+        friendly_name_too_long(conn)
+
+      true ->
+        do_rename(conn, tenant_id, auth_id, friendly_name)
+    end
+  end
+
+  defp do_rename(conn, tenant_id, auth_id, friendly_name) do
+    case Enrollment.rename(tenant_id, auth_id, friendly_name) do
+      {:ok, auth} ->
+        conn
+        |> put_status(:ok)
+        |> json(%{
+          data: %{
+            tenant_id: tenant_id,
+            authenticator_id: auth.id,
+            friendly_name: auth.friendly_name
+          }
+        })
+
+      {:error, :not_found} ->
+        not_found(conn)
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        changeset_error(conn, changeset)
     end
   end
 

--- a/lib/loopctl_web/controllers/tenant_authenticator_controller.ex
+++ b/lib/loopctl_web/controllers/tenant_authenticator_controller.ex
@@ -3,9 +3,14 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
   US-26.7.2 — opt-in WebAuthn trust-tier upgrade ceremony
   (agent_rooted -> human_anchored) and authenticator revocation.
 
-  Four endpoints, mirroring `LoopctlWeb.TenantAuditKeyController`'s
+  Endpoints, mirroring `LoopctlWeb.TenantAuditKeyController`'s
   challenge/act shape:
 
+    0. `GET /tenants/:id/authenticators` — lists the tenant's enrolled
+       authenticators (id, label, format, timestamps — never credential
+       material). The row id is the handle the rename and revoke endpoints key
+       on, and a browser ceremony discards the 201 body, so without this index
+       an operator has no way to discover it.
     1. `POST /tenants/:id/authenticators/challenge` — issues a registration
        challenge (AC-26.7.2.1/.2). If the tenant is already `human_anchored`,
        ALSO issues a fresh-assertion (reauth) challenge for an existing
@@ -34,7 +39,7 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
   audience for the FIRST enrollment. `revoke-challenge`/`delete` and any
   SUBSEQUENT enrollment are protected by fresh, per-operation WebAuthn
   assertions (`Loopctl.WebAuthn.Reauth`), a STRONGER control than the tier
-  gate. All four require `role: :user` + tenant ownership
+  gate. All of them require `role: :user` + tenant ownership
   (`owns_tenant?/2`, mirroring `TenantAuditKeyController`).
   """
 
@@ -44,6 +49,7 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Tenants
   alias Loopctl.Tenants.Enrollment
+  alias Loopctl.Tenants.RootAuthenticators
   alias Loopctl.Tenants.TierCapabilities
   alias Loopctl.WebAuthn
   alias Loopctl.WebAuthn.Enrollment, as: RegistrationChallenges
@@ -67,6 +73,12 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
   @enroll_rate_window_ms 60_000 * 60
   @max_enroll_actions_per_window 30
 
+  # Rename does no crypto, so it gets its own far looser bucket rather than
+  # spending the ceremony budget. It still needs a per-tenant ceiling: each
+  # rename appends to the hash-chained audit log, and that append serializes
+  # per tenant against genuine custody writes.
+  @max_rename_actions_per_window 300
+
   @pub_key_cred_params [
     %{type: "public-key", alg: -7},
     %{type: "public-key", alg: -257}
@@ -75,9 +87,48 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
   # Authenticator enrollment/revocation requires user role — agents must not
   # perform trust-tier operations.
   plug LoopctlWeb.Plugs.RequireRole,
-       [role: :user] when action in [:challenge, :create, :revoke_challenge, :delete, :rename]
+       [role: :user]
+       when action in [:index, :challenge, :create, :revoke_challenge, :delete, :rename]
 
   tags(["Tenants"])
+
+  operation(:index,
+    summary: "List a tenant's enrolled authenticators",
+    description:
+      "Returns the enrolled authenticators' ids and display labels — the handle " <>
+        "the rename (PATCH) and revoke (DELETE) endpoints key on. NO credential " <>
+        "material (credential_id, public_key) is ever returned. Requires user role " <>
+        "and tenant ownership.",
+    parameters: [id: [in: :path, type: :string, description: "Tenant UUID"]],
+    responses: %{
+      200 => {"Enrolled authenticators", "application/json", Schemas.AuthenticatorListResponse},
+      403 => {"Forbidden", "application/json", Schemas.ErrorResponse}
+    }
+  )
+
+  @doc """
+  GET /api/v1/tenants/:id/authenticators
+  """
+  def index(conn, %{"id" => tenant_id}) do
+    if owns_tenant?(conn, tenant_id) do
+      data =
+        tenant_id
+        |> RootAuthenticators.list_by_tenant()
+        |> Enum.map(
+          &%{
+            id: &1.id,
+            friendly_name: &1.friendly_name,
+            attestation_format: &1.attestation_format,
+            inserted_at: &1.inserted_at,
+            last_used_at: &1.last_used_at
+          }
+        )
+
+      conn |> put_status(:ok) |> json(%{data: data})
+    else
+      forbidden(conn)
+    end
+  end
 
   operation(:challenge,
     summary: "Issue a WebAuthn enrollment registration challenge",
@@ -536,8 +587,10 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
         "Requires user role and tenant ownership. Unlike revocation this needs NO " <>
         "WebAuthn assertion: a rename is reversible, destroys nothing, and changes " <>
         "no credential material — only `friendly_name` is writable. The change is " <>
-        "recorded in the append-only audit chain with the old and new label. " <>
-        "`friendly_name` is capped at #{@max_friendly_name_bytes} bytes.",
+        "recorded in the append-only audit chain, stamped with the CALLING KEY " <>
+        "(actor_type api_key) and the old and new label. `friendly_name` is " <>
+        "trimmed, must be non-blank (422 friendly_name_blank) and is capped at " <>
+        "#{@max_friendly_name_bytes} bytes (422 friendly_name_too_long).",
     parameters: [
       id: [in: :path, type: :string, description: "Tenant UUID"],
       auth_id: [in: :path, type: :string, description: "Authenticator UUID"]
@@ -549,7 +602,8 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
       400 => {"Bad request", "application/json", Schemas.ErrorResponse},
       403 => {"Forbidden", "application/json", Schemas.ErrorResponse},
       404 => {"Not found", "application/json", Schemas.ErrorResponse},
-      422 => {"Validation failed", "application/json", Schemas.ErrorResponse}
+      422 => {"Validation failed", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limited", "application/json", Schemas.ErrorResponse}
     }
   )
 
@@ -560,10 +614,17 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
   `@max_enroll_actions_per_window` budget that the ceremony endpoints share:
   that budget bounds CPU-bound WebAuthn verification, and spending one of a
   tenant's 30 hourly enroll actions on a label edit could 429 an operator out
-  of their own enrollment ceremony. The blanket `RateLimiter` plug still applies.
+  of their own enrollment ceremony. It gets its own, far looser per-tenant
+  bucket instead — every rename appends to the hash-chained audit log, whose
+  per-tenant append serializes against genuine custody writes, so "no
+  tenant-scoped ceiling at all" is not an option either.
+
+  `friendly_name` is TRIMMED before validation, mirroring the enroll path's
+  `friendly_name/1`, so the two write paths agree on what a label is.
   """
   def rename(conn, %{"id" => tenant_id, "auth_id" => auth_id} = params) do
-    friendly_name = Map.get(params, "friendly_name")
+    raw = Map.get(params, "friendly_name")
+    friendly_name = if is_binary(raw), do: String.trim(raw), else: raw
 
     cond do
       not owns_tenant?(conn, tenant_id) ->
@@ -571,6 +632,9 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
 
       not is_binary(friendly_name) ->
         bad_request(conn, "friendly_name is required and must be a string")
+
+      friendly_name == "" ->
+        friendly_name_blank(conn)
 
       byte_size(friendly_name) > @max_friendly_name_bytes ->
         friendly_name_too_long(conn)
@@ -581,7 +645,14 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
   end
 
   defp do_rename(conn, tenant_id, auth_id, friendly_name) do
-    case Enrollment.rename(tenant_id, auth_id, friendly_name) do
+    case check_rename_rate_limit(tenant_id) do
+      :ok -> complete_rename(conn, tenant_id, auth_id, friendly_name)
+      {:error, :rate_limited} -> rate_limited(conn)
+    end
+  end
+
+  defp complete_rename(conn, tenant_id, auth_id, friendly_name) do
+    case Enrollment.rename(tenant_id, auth_id, friendly_name, audit_actor(conn)) do
       {:ok, auth} ->
         conn
         |> put_status(:ok)
@@ -596,6 +667,9 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
       {:error, :not_found} ->
         not_found(conn)
 
+      {:error, :audit_failed} ->
+        internal_error(conn, "Failed to record the rename in the audit log")
+
       {:error, %Ecto.Changeset{} = changeset} ->
         changeset_error(conn, changeset)
     end
@@ -604,19 +678,33 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
   # --- Shared helpers ---
 
   defp check_rate_limit(tenant_id) do
-    bucket = "enroll:actions:#{tenant_id}"
+    gate("enroll:actions:#{tenant_id}", @max_enroll_actions_per_window)
+  end
 
+  defp check_rename_rate_limit(tenant_id) do
+    gate("rename:actions:#{tenant_id}", @max_rename_actions_per_window)
+  end
+
+  defp gate(bucket, max) do
     # FAIL-CLOSED anti-abuse gate (WebAuthn enroll/revoke is CPU-bound): on a
     # limiter fault deny rather than unlock the throttle. `gate_ok?/3` also
     # absorbs the behaviour's `{:error, _}` shape so a soft-error can't raise.
-    if Loopctl.RateLimiter.gate_ok?(
-         bucket,
-         @enroll_rate_window_ms,
-         @max_enroll_actions_per_window
-       ) do
+    if Loopctl.RateLimiter.gate_ok?(bucket, @enroll_rate_window_ms, max) do
       :ok
     else
       {:error, :rate_limited}
+    end
+  end
+
+  # Rename proves no device possession, so the acting key IS the evidence.
+  # Mirrors egress_controller.ex:420's audit-actor shape.
+  defp audit_actor(conn) do
+    case conn.assigns do
+      %{current_api_key: %{id: id, role: role, name: name}} ->
+        [actor_id: id, actor_label: "#{role}:#{name}"]
+
+      _ ->
+        []
     end
   end
 
@@ -688,6 +776,18 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
         status: 422,
         code: "friendly_name_too_long",
         message: "friendly_name must be at most #{@max_friendly_name_bytes} bytes"
+      }
+    })
+  end
+
+  defp friendly_name_blank(conn) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: %{
+        status: 422,
+        code: "friendly_name_blank",
+        message: "friendly_name must not be blank"
       }
     })
   end

--- a/lib/loopctl_web/controllers/tenant_authenticator_controller.ex
+++ b/lib/loopctl_web/controllers/tenant_authenticator_controller.ex
@@ -7,10 +7,13 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
   challenge/act shape:
 
     0. `GET /tenants/:id/authenticators` — lists the tenant's enrolled
-       authenticators (id, label, format, timestamps — never credential
-       material). The row id is the handle the rename and revoke endpoints key
-       on, and a browser ceremony discards the 201 body, so without this index
-       an operator has no way to discover it.
+       authenticators (id, label, credential FINGERPRINT, format, timestamps —
+       never credential material). The row id is the handle the rename and
+       revoke endpoints key on, and a browser ceremony discards the 201 body, so
+       without this index an operator has no way to discover it. The fingerprint
+       is what a revoke should be confirmed against: it is credential-derived
+       and no endpoint can write it, whereas `friendly_name` is rewritable by
+       any user-role bearer key (see `rename/2`).
     1. `POST /tenants/:id/authenticators/challenge` — issues a registration
        challenge (AC-26.7.2.1/.2). If the tenant is already `human_anchored`,
        ALSO issues a fresh-assertion (reauth) challenge for an existing
@@ -64,7 +67,10 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
   # under 8 KB.
   @max_attestation_field_bytes 8 * 1024
 
-  # Matches RootAuthenticator's `validate_length(:friendly_name, max: 120)`.
+  # Matches RootAuthenticator's
+  # `validate_length(:friendly_name, max: 120, count: :bytes)` — same unit on
+  # both layers, so a multi-byte label can never be accepted by one and refused
+  # by the other.
   @max_friendly_name_bytes 120
 
   # WebAuthn verification (and, for revoke, the assertion verify) is
@@ -97,8 +103,11 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
     description:
       "Returns the enrolled authenticators' ids and display labels — the handle " <>
         "the rename (PATCH) and revoke (DELETE) endpoints key on. NO credential " <>
-        "material (credential_id, public_key) is ever returned. Requires user role " <>
-        "and tenant ownership.",
+        "material (credential_id, public_key) is ever returned; " <>
+        "`credential_fingerprint` is a truncated SHA-256 of the credential id, the " <>
+        "SAME value the audit chain records, and is the identifier to confirm " <>
+        "before revoking — `friendly_name` is rewritable by any bearer key with " <>
+        "user role, the fingerprint is not. Requires user role and tenant ownership.",
     parameters: [id: [in: :path, type: :string, description: "Tenant UUID"]],
     responses: %{
       200 => {"Enrolled authenticators", "application/json", Schemas.AuthenticatorListResponse},
@@ -118,6 +127,13 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
           &%{
             id: &1.id,
             friendly_name: &1.friendly_name,
+            # An enumerable id plus an assertion-free rename means a stolen
+            # user-role key can relabel every device a tenant owns, and the label
+            # is what an operator steers a WebAuthn-gated revoke by. The
+            # fingerprint is derived from the credential and cannot be edited by
+            # any endpoint, so it — not the label — is the stable identity, and
+            # it matches the audit chain's enroll/rename/revoke entries.
+            credential_fingerprint: Tenants.fingerprint(&1.credential_id),
             attestation_format: &1.attestation_format,
             inserted_at: &1.inserted_at,
             last_used_at: &1.last_used_at
@@ -281,6 +297,9 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
       {:error, :friendly_name_too_long} ->
         friendly_name_too_long(conn)
 
+      {:error, :friendly_name_invalid} ->
+        friendly_name_invalid(conn)
+
       {:error, :not_found} ->
         not_found(conn)
 
@@ -398,6 +417,7 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
 
         cond do
           trimmed == "" -> {:ok, "Authenticator"}
+          not String.valid?(trimmed) -> {:error, :friendly_name_invalid}
           byte_size(trimmed) > @max_friendly_name_bytes -> {:error, :friendly_name_too_long}
           true -> {:ok, trimmed}
         end
@@ -451,6 +471,12 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
 
       {:error, :too_many_authenticators} ->
         too_many_authenticators(conn)
+
+      {:error, :audit_failed} ->
+        internal_error(conn, "Failed to record the enrollment in the audit log")
+
+      {:error, :internal_error} ->
+        internal_error(conn, "Failed to enroll the authenticator")
 
       {:error, %Ecto.Changeset{} = changeset} ->
         changeset_error(conn, changeset)
@@ -573,6 +599,12 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
 
           {:error, :last_authenticator} ->
             last_authenticator(conn)
+
+          {:error, :audit_failed} ->
+            internal_error(conn, "Failed to record the revocation in the audit log")
+
+          {:error, :internal_error} ->
+            internal_error(conn, "Failed to revoke the authenticator")
         end
 
       {:error, _reason} ->
@@ -589,8 +621,11 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
         "no credential material — only `friendly_name` is writable. The change is " <>
         "recorded in the append-only audit chain, stamped with the CALLING KEY " <>
         "(actor_type api_key) and the old and new label. `friendly_name` is " <>
-        "trimmed, must be non-blank (422 friendly_name_blank) and is capped at " <>
-        "#{@max_friendly_name_bytes} bytes (422 friendly_name_too_long).",
+        "trimmed, must be non-blank (422 friendly_name_blank), must be valid UTF-8 " <>
+        "(422 friendly_name_invalid) and is capped at #{@max_friendly_name_bytes} " <>
+        "bytes (422 friendly_name_too_long) — the same byte unit the schema " <>
+        "validates, so a multi-byte label is never accepted by one layer and " <>
+        "refused by the other.",
     parameters: [
       id: [in: :path, type: :string, description: "Tenant UUID"],
       auth_id: [in: :path, type: :string, description: "Authenticator UUID"]
@@ -636,6 +671,12 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
       friendly_name == "" ->
         friendly_name_blank(conn)
 
+      # A urlencoded body can carry bytes that are not valid UTF-8 (the JSON
+      # parser rejects them first, that parser does not). Without this they reach
+      # the UPDATE, Postgres refuses the encoding, and hostile input gets a 500.
+      not String.valid?(friendly_name) ->
+        friendly_name_invalid(conn)
+
       byte_size(friendly_name) > @max_friendly_name_bytes ->
         friendly_name_too_long(conn)
 
@@ -646,8 +687,14 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
 
   defp do_rename(conn, tenant_id, auth_id, friendly_name) do
     case check_rename_rate_limit(tenant_id) do
-      :ok -> complete_rename(conn, tenant_id, auth_id, friendly_name)
-      {:error, :rate_limited} -> rate_limited(conn)
+      :ok ->
+        complete_rename(conn, tenant_id, auth_id, friendly_name)
+
+      # Names the RENAME bucket, not the ceremony one: rename has its own,
+      # far looser budget, so telling an operator their enrollment actions are
+      # spent would send them away from a ceremony that is still available.
+      {:error, :rate_limited} ->
+        rate_limited(conn, "Too many authenticator rename actions. Please try again later.")
     end
   end
 
@@ -669,6 +716,9 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
 
       {:error, :audit_failed} ->
         internal_error(conn, "Failed to record the rename in the audit log")
+
+      {:error, :internal_error} ->
+        internal_error(conn, "Failed to rename the authenticator")
 
       {:error, %Ecto.Changeset{} = changeset} ->
         changeset_error(conn, changeset)
@@ -725,16 +775,13 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
     conn |> put_status(:not_found) |> json(%{error: %{status: 404, message: "Not found"}})
   end
 
-  defp rate_limited(conn) do
+  defp rate_limited(
+         conn,
+         message \\ "Too many authenticator enrollment actions. Please try again later."
+       ) do
     conn
     |> put_status(:too_many_requests)
-    |> json(%{
-      error: %{
-        status: 429,
-        code: "rate_limited",
-        message: "Too many authenticator enrollment actions. Please try again later."
-      }
-    })
+    |> json(%{error: %{status: 429, code: "rate_limited", message: message}})
   end
 
   defp challenge_invalid(conn) do
@@ -776,6 +823,18 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
         status: 422,
         code: "friendly_name_too_long",
         message: "friendly_name must be at most #{@max_friendly_name_bytes} bytes"
+      }
+    })
+  end
+
+  defp friendly_name_invalid(conn) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: %{
+        status: 422,
+        code: "friendly_name_invalid",
+        message: "friendly_name must be valid UTF-8"
       }
     })
   end

--- a/lib/loopctl_web/live/enroll_live.ex
+++ b/lib/loopctl_web/live/enroll_live.ex
@@ -78,8 +78,13 @@ defmodule LoopctlWeb.EnrollLive do
           <h1 class="font-display text-2xl font-semibold text-slate-100">
             Enroll an authenticator
           </h1>
-          <p class="mt-1 text-sm text-slate-400">
-            Anchor an existing tenant to hardware. This upgrades its trust tier from
+          <p class="mt-1 text-sm text-slate-300">
+            Prove a human controls this tenant by registering a device you can unlock —
+            a fingerprint or face sensor, your phone, or a plug-in security key. It takes
+            one touch.
+          </p>
+          <p class="mt-2 text-sm text-slate-400">
+            Doing so upgrades the tenant's trust tier from
             <span class="font-mono text-slate-300">agent_rooted</span>
             to <span class="font-mono text-slate-300">human_anchored</span>, which unlocks the
             chain-of-custody, work-breakdown, dispatch, and token-budget surfaces.
@@ -98,7 +103,7 @@ defmodule LoopctlWeb.EnrollLive do
             <h2 class="font-display text-sm uppercase tracking-wide text-slate-400">
               Authorize
             </h2>
-            <p class="mt-1 text-xs text-slate-500">
+            <p class="mt-2 text-sm text-slate-300">
               Paste a <span class="font-mono">user</span>-role API key for the tenant you are
               anchoring. It is sent straight to the loopctl API as a bearer token from your
               browser — this page never transmits it over its own connection, never stores it,
@@ -110,7 +115,7 @@ defmodule LoopctlWeb.EnrollLive do
           <div>
             <label
               for="enroll-api-key"
-              class="block font-mono text-xs uppercase tracking-wide text-slate-500"
+              class="block font-mono text-xs uppercase tracking-wide text-slate-400"
             >
               User-role API key
             </label>
@@ -135,14 +140,19 @@ defmodule LoopctlWeb.EnrollLive do
           <div>
             <label
               for="enroll-friendly-name"
-              class="block font-mono text-xs uppercase tracking-wide text-slate-500"
+              class="block font-mono text-xs uppercase tracking-wide text-slate-400"
             >
               Authenticator name
             </label>
+            <p class="mt-1 text-sm text-slate-400">
+              Name it after the DEVICE, not yourself — this label is what you pick from when
+              revoking one later, and a wrong name there means revoking the wrong device.
+              Good: "mac-mini Touch ID", "iPhone passkey", "backup YubiKey".
+            </p>
             <input
               id="enroll-friendly-name"
               type="text"
-              placeholder="Primary YubiKey"
+              placeholder="mac-mini Touch ID"
               class="mt-2 block w-full rounded-md border border-slate-800 bg-slate-900 px-3 py-2 font-mono text-sm text-slate-100 placeholder:text-slate-600 focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500"
             />
           </div>
@@ -155,21 +165,55 @@ defmodule LoopctlWeb.EnrollLive do
             <.icon name="hero-key" class="h-4 w-4" /> Enroll authenticator
           </button>
 
-          <p id="enroll-status" role="status" class="mt-4 font-mono text-xs text-slate-400"></p>
+          <p id="enroll-status" role="status" class="mt-4 font-mono text-sm text-slate-300"></p>
         </div>
 
         <div id="enroll-result"></div>
 
-        <div class="rounded-md border border-slate-800 bg-slate-900/40 p-6 text-xs text-slate-500">
+        <div class="rounded-md border border-slate-800 bg-slate-900/40 p-6 text-sm text-slate-300">
+          <p class="font-display uppercase tracking-wide text-slate-400">
+            What happens when you click Enroll
+          </p>
+          <p class="mt-3">
+            Your browser — not this page — asks you to confirm with a device. What it offers
+            depends on the machine you are on:
+          </p>
+          <ul class="mt-3 space-y-2">
+            <li>
+              <span class="font-mono text-slate-100">Built-in sensor</span>
+              — Touch ID on a Mac, Windows Hello on a PC. You confirm with your fingerprint
+              or face. This is the usual case on a laptop or an iMac.
+            </li>
+            <li>
+              <span class="font-mono text-slate-100">Your phone</span>
+              — choose "Use a phone or tablet" and the browser shows a QR code. Scan it with
+              your phone's camera and confirm there. Both devices need Bluetooth switched on.
+              This is the option to pick on a desktop with no built-in sensor, and the
+              passkey syncs, so it survives losing any one machine.
+            </li>
+            <li>
+              <span class="font-mono text-slate-100">Security key</span>
+              — plug in a USB key such as a YubiKey and press the metal disc on it. That
+              press is all "touch" means: proof a person is physically present.
+            </li>
+          </ul>
+          <p class="mt-4">
+            Nothing secret leaves your device. The key pair is generated inside the
+            authenticator and only its public half is sent to loopctl, so there is no
+            shared secret and no code to copy anywhere.
+          </p>
+        </div>
+
+        <div class="rounded-md border border-slate-800 bg-slate-900/40 p-6 text-sm text-slate-300">
           <p class="font-display uppercase tracking-wide text-slate-400">Before you start</p>
           <ul class="mt-3 space-y-2">
             <li>
-              The key must be <span class="font-mono text-slate-400">user</span>
+              The key must be <span class="font-mono text-slate-100">user</span>
               role and belong to the tenant being anchored. Agent and orchestrator keys are
               refused — trust-tier operations are not delegable.
             </li>
             <li>
-              Enrolling on an <span class="font-mono text-slate-400">agent_rooted</span>
+              Enrolling on an <span class="font-mono text-slate-100">agent_rooted</span>
               tenant needs only the key and a touch. Adding a SECOND authenticator to an
               already-anchored tenant additionally requires a touch from one that is already
               enrolled, so keep the existing device to hand.

--- a/lib/loopctl_web/live/enroll_live.ex
+++ b/lib/loopctl_web/live/enroll_live.ex
@@ -28,8 +28,10 @@ defmodule LoopctlWeb.EnrollLive do
     * **The operator's API key never reaches this process.** It is sent only as
       an `Authorization: Bearer` header on same-origin `fetch` calls from the
       hook. It is never a `handle_event` parameter, so it cannot land in socket
-      assigns, Phoenix's event logging, a crash dump, or telemetry. There is
-      deliberately no `handle_event/3` clause on this module at all.
+      assigns, Phoenix's event logging, a crash dump, or telemetry. The only
+      `handle_event/3` clause is a terminal no-op: this LiveView consumes no
+      client events, but `/enroll` is public, so a crafted event frame would
+      otherwise raise and kill the channel (mirrors `SignupLive`).
 
     * **There is exactly one enrollment implementation.** Re-implementing the
       ceremony behind the LiveView socket would have duplicated the reauth gate
@@ -67,6 +69,13 @@ defmodule LoopctlWeb.EnrollLive do
      |> assign(:page_title, "Enroll an authenticator")
      |> assign(:docs_url, @docs_url)}
   end
+
+  # Catch-all for malformed / unknown client events on this public LiveView.
+  # This module consumes no events, so it is also the ONLY clause — without it
+  # LiveView raises on any pushed frame and kills the channel process (mirrors
+  # `SignupLive`'s terminal clause).
+  @impl true
+  def handle_event(_event, _params, socket), do: {:noreply, socket}
 
   @impl true
   def render(assigns) do

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -293,6 +293,10 @@ defmodule LoopctlWeb.Router do
     # + authenticator revocation. Not tier-gated (enroll IS the upgrade path;
     # revoke + subsequent-enroll are protected by fresh WebAuthn assertions instead —
     # see require_human_anchor_default_deny_test.exs).
+    # The index is what makes :auth_id discoverable — a browser ceremony
+    # discards the 201 body, so without it an operator holds no handle to
+    # rename or revoke with.
+    get "/tenants/:id/authenticators", TenantAuthenticatorController, :index
     post "/tenants/:id/authenticators/challenge", TenantAuthenticatorController, :challenge
     post "/tenants/:id/authenticators", TenantAuthenticatorController, :create
 

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -301,6 +301,7 @@ defmodule LoopctlWeb.Router do
          :revoke_challenge
 
     delete "/tenants/:id/authenticators/:auth_id", TenantAuthenticatorController, :delete
+    patch "/tenants/:id/authenticators/:auth_id", TenantAuthenticatorController, :rename
 
     # US-26.2.1 — Dispatch lineage
     # LCP-1 §9.1.1 — transparency read of enrolled agent keys (before :show so it

--- a/test/loopctl_web/controllers/tenant_authenticator_controller_test.exs
+++ b/test/loopctl_web/controllers/tenant_authenticator_controller_test.exs
@@ -622,8 +622,52 @@ defmodule LoopctlWeb.TenantAuthenticatorControllerTest do
     end
   end
 
-  # review #1 regression — the residual double-first-enroll race: two concurrent
-  # first-enrollments on an agent_rooted tenant must result in EXACTLY ONE 201
+  describe "GET /api/v1/tenants/:id/authenticators — index" do
+    test "lists ids and labels, and never credential material", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+
+      auth =
+        fixture(:root_authenticator, tenant_id: tenant.id, friendly_name: "mac-mini Touch ID")
+
+      [row] =
+        conn
+        |> authed(raw_key)
+        |> get(~p"/api/v1/tenants/#{tenant.id}/authenticators")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      # The id is the ONLY handle rename/revoke key on, and a browser ceremony
+      # discards the 201 body — this endpoint is how an operator gets it back.
+      assert row["id"] == auth.id
+      assert row["friendly_name"] == "mac-mini Touch ID"
+      refute Map.has_key?(row, "credential_id")
+      refute Map.has_key?(row, "public_key")
+    end
+
+    test "403s a caller addressing a tenant it does not own", %{conn: conn} do
+      tenant_a = fixture(:tenant, %{trust_tier: :human_anchored})
+      tenant_b = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant_a.id, role: :user)
+      fixture(:root_authenticator, tenant_id: tenant_b.id)
+
+      assert conn
+             |> authed(raw_key)
+             |> get(~p"/api/v1/tenants/#{tenant_b.id}/authenticators")
+             |> json_response(403)
+    end
+
+    test "403s an agent-role key", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :agent)
+
+      assert conn
+             |> authed(raw_key)
+             |> get(~p"/api/v1/tenants/#{tenant.id}/authenticators")
+             |> json_response(403)
+    end
+  end
+
   describe "PATCH /api/v1/tenants/:id/authenticators/:auth_id — rename" do
     test "renames an enrolled authenticator and leaves credential material untouched", %{
       conn: conn
@@ -677,9 +721,9 @@ defmodule LoopctlWeb.TenantAuthenticatorControllerTest do
       assert reloaded.sign_count == auth.sign_count
     end
 
-    test "records the rename in the audit log with the old and new label", %{conn: conn} do
+    test "records the rename in the audit log with the acting key and both labels", %{conn: conn} do
       tenant = fixture(:tenant, %{trust_tier: :human_anchored})
-      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      {raw_key, key} = fixture(:api_key, tenant_id: tenant.id, role: :user)
       auth = fixture(:root_authenticator, tenant_id: tenant.id, friendly_name: "old label")
 
       conn
@@ -695,6 +739,14 @@ defmodule LoopctlWeb.TenantAuthenticatorControllerTest do
       assert entry, "expected an authenticator_renamed audit event"
       assert entry.old_state["friendly_name"] == "old label"
       assert entry.new_state["friendly_name"] == "new label"
+
+      # Rename proves NO device possession (unlike enroll/revoke), so the acting
+      # key is the only evidence there is — stamping it "human" with a nil
+      # actor_id would assert a presence nothing verified and leave every
+      # relabel indistinguishable from every other.
+      assert entry.actor_type == "api_key"
+      assert entry.actor_id == key.id
+      assert entry.actor_label == "user:#{key.name}"
     end
 
     test "rejects a friendly_name over the byte cap with 422", %{conn: conn} do
@@ -731,19 +783,47 @@ defmodule LoopctlWeb.TenantAuthenticatorControllerTest do
              |> json_response(400)
     end
 
-    test "rejects a blank friendly_name with 422", %{conn: conn} do
+    test "trims the label, and rejects a blank or whitespace-only one with 422", %{conn: conn} do
       tenant = fixture(:tenant, %{trust_tier: :human_anchored})
       {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
       auth = fixture(:root_authenticator, tenant_id: tenant.id, friendly_name: "keep me")
+      client = authed(conn, raw_key)
 
-      conn
-      |> authed(raw_key)
-      |> patch(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{auth.id}", %{
-        "friendly_name" => ""
-      })
-      |> json_response(422)
+      # Whitespace-only clears validate_length(min: 1) on byte count alone, so
+      # without the trim it persists a blank-LOOKING label — and the label is
+      # the only thing distinguishing devices at revoke time.
+      for blank <- ["", "   ", "\n\n"] do
+        assert client
+               |> patch(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{auth.id}", %{
+                 "friendly_name" => blank
+               })
+               |> json_response(422)
+      end
 
       assert AdminRepo.get!(Loopctl.Tenants.RootAuthenticator, auth.id).friendly_name == "keep me"
+
+      # Matching the enroll path's friendly_name/1, padding is stripped rather
+      # than persisted verbatim.
+      client
+      |> patch(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{auth.id}", %{
+        "friendly_name" => "  mac-mini  "
+      })
+      |> json_response(200)
+
+      assert AdminRepo.get!(Loopctl.Tenants.RootAuthenticator, auth.id).friendly_name ==
+               "mac-mini"
+    end
+
+    test "404s a malformed auth_id instead of raising Ecto.Query.CastError", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+
+      assert conn
+             |> authed(raw_key)
+             |> patch(~p"/api/v1/tenants/#{tenant.id}/authenticators/not-a-uuid", %{
+               "friendly_name" => "x"
+             })
+             |> json_response(404)
     end
 
     test "404s an authenticator id that does not exist", %{conn: conn} do
@@ -852,6 +932,8 @@ defmodule LoopctlWeb.TenantAuthenticatorControllerTest do
     end
   end
 
+  # review #1 regression — the residual double-first-enroll race: two concurrent
+  # first-enrollments on an agent_rooted tenant must result in EXACTLY ONE 201
   # (flip to human_anchored + enroll) with the loser rejected :reauth_required by
   # the under-lock gate, never a second possession-unproven device grafted on.
   #

--- a/test/loopctl_web/controllers/tenant_authenticator_controller_test.exs
+++ b/test/loopctl_web/controllers/tenant_authenticator_controller_test.exs
@@ -624,6 +624,234 @@ defmodule LoopctlWeb.TenantAuthenticatorControllerTest do
 
   # review #1 regression — the residual double-first-enroll race: two concurrent
   # first-enrollments on an agent_rooted tenant must result in EXACTLY ONE 201
+  describe "PATCH /api/v1/tenants/:id/authenticators/:auth_id — rename" do
+    test "renames an enrolled authenticator and leaves credential material untouched", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, friendly_name: "Mark's phone")
+
+      body =
+        conn
+        |> authed(raw_key)
+        |> patch(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{auth.id}", %{
+          "friendly_name" => "mac-mini Touch ID"
+        })
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert body["friendly_name"] == "mac-mini Touch ID"
+      assert body["authenticator_id"] == auth.id
+
+      reloaded = AdminRepo.get!(Loopctl.Tenants.RootAuthenticator, auth.id)
+      assert reloaded.friendly_name == "mac-mini Touch ID"
+
+      # The whole point of a dedicated rename_changeset: a rename must not be a
+      # vector for swapping the credential the root of trust hangs on.
+      assert reloaded.credential_id == auth.credential_id
+      assert reloaded.public_key == auth.public_key
+      assert reloaded.attestation_format == auth.attestation_format
+      assert reloaded.sign_count == auth.sign_count
+    end
+
+    test "ignores credential fields even when a caller supplies them", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id)
+
+      conn
+      |> authed(raw_key)
+      |> patch(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{auth.id}", %{
+        "friendly_name" => "renamed",
+        "credential_id" => Base.url_encode64("attacker-credential", padding: false),
+        "public_key" => Base.url_encode64("attacker-key", padding: false),
+        "sign_count" => 999_999
+      })
+      |> json_response(200)
+
+      reloaded = AdminRepo.get!(Loopctl.Tenants.RootAuthenticator, auth.id)
+      assert reloaded.friendly_name == "renamed"
+      assert reloaded.credential_id == auth.credential_id
+      assert reloaded.public_key == auth.public_key
+      assert reloaded.sign_count == auth.sign_count
+    end
+
+    test "records the rename in the audit log with the old and new label", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, friendly_name: "old label")
+
+      conn
+      |> authed(raw_key)
+      |> patch(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{auth.id}", %{
+        "friendly_name" => "new label"
+      })
+      |> json_response(200)
+
+      {:ok, %{data: events}} = Audit.list_entries(tenant.id, entity_type: "tenant")
+      entry = Enum.find(events, &(&1.action == "authenticator_renamed"))
+
+      assert entry, "expected an authenticator_renamed audit event"
+      assert entry.old_state["friendly_name"] == "old label"
+      assert entry.new_state["friendly_name"] == "new label"
+    end
+
+    test "rejects a friendly_name over the byte cap with 422", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, friendly_name: "keep me")
+
+      response =
+        conn
+        |> authed(raw_key)
+        |> patch(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{auth.id}", %{
+          "friendly_name" => String.duplicate("x", 121)
+        })
+        |> json_response(422)
+
+      assert response["error"]["code"] == "friendly_name_too_long"
+      assert AdminRepo.get!(Loopctl.Tenants.RootAuthenticator, auth.id).friendly_name == "keep me"
+    end
+
+    test "rejects a missing or non-string friendly_name with 400", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id)
+      client = authed(conn, raw_key)
+
+      assert client
+             |> patch(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{auth.id}", %{})
+             |> json_response(400)
+
+      assert client
+             |> patch(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{auth.id}", %{
+               "friendly_name" => 42
+             })
+             |> json_response(400)
+    end
+
+    test "rejects a blank friendly_name with 422", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, friendly_name: "keep me")
+
+      conn
+      |> authed(raw_key)
+      |> patch(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{auth.id}", %{
+        "friendly_name" => ""
+      })
+      |> json_response(422)
+
+      assert AdminRepo.get!(Loopctl.Tenants.RootAuthenticator, auth.id).friendly_name == "keep me"
+    end
+
+    test "404s an authenticator id that does not exist", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+
+      conn
+      |> authed(raw_key)
+      |> patch(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{Ecto.UUID.generate()}", %{
+        "friendly_name" => "nope"
+      })
+      |> json_response(404)
+    end
+
+    test "cannot rename another tenant's authenticator", %{conn: conn} do
+      tenant_a = fixture(:tenant, %{trust_tier: :human_anchored})
+      tenant_b = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant_a.id, role: :user)
+      victim = fixture(:root_authenticator, tenant_id: tenant_b.id, friendly_name: "b device")
+
+      # Addressed under tenant A's own path, so owns_tenant? passes and the
+      # tenant-scoped lookup is what has to refuse it.
+      conn
+      |> authed(raw_key)
+      |> patch(~p"/api/v1/tenants/#{tenant_a.id}/authenticators/#{victim.id}", %{
+        "friendly_name" => "hijacked"
+      })
+      |> json_response(404)
+
+      assert AdminRepo.get!(Loopctl.Tenants.RootAuthenticator, victim.id).friendly_name ==
+               "b device"
+    end
+
+    test "403s a caller addressing a tenant it does not own", %{conn: conn} do
+      tenant_a = fixture(:tenant, %{trust_tier: :human_anchored})
+      tenant_b = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant_a.id, role: :user)
+      victim = fixture(:root_authenticator, tenant_id: tenant_b.id, friendly_name: "b device")
+
+      conn
+      |> authed(raw_key)
+      |> patch(~p"/api/v1/tenants/#{tenant_b.id}/authenticators/#{victim.id}", %{
+        "friendly_name" => "hijacked"
+      })
+      |> json_response(403)
+
+      assert AdminRepo.get!(Loopctl.Tenants.RootAuthenticator, victim.id).friendly_name ==
+               "b device"
+    end
+
+    test "403s an agent-role key — trust-tier operations are not delegable", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :agent)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, friendly_name: "keep me")
+
+      conn
+      |> authed(raw_key)
+      |> patch(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{auth.id}", %{
+        "friendly_name" => "agent rename"
+      })
+      |> json_response(403)
+
+      assert AdminRepo.get!(Loopctl.Tenants.RootAuthenticator, auth.id).friendly_name == "keep me"
+    end
+
+    test "is unreachable for an agent-rooted tenant — the human-anchor exemption's premise",
+         %{conn: conn} do
+      # require_human_anchor_default_deny_test.exs exempts this route from the
+      # tier gate on the grounds that an agent-rooted tenant has ZERO
+      # authenticators by construction, so there is nothing for it to rename.
+      # Guard that premise behaviourally: if a downgrade path is ever added,
+      # this fails and the exemption has to be revisited rather than silently
+      # becoming a hole.
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+
+      assert RootAuthenticators.count_by_tenant(tenant.id) == 0
+
+      conn
+      |> authed(raw_key)
+      |> patch(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{Ecto.UUID.generate()}", %{
+        "friendly_name" => "nothing to rename"
+      })
+      |> json_response(404)
+    end
+
+    test "needs NO WebAuthn assertion, unlike revoke", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id)
+
+      # DELETE on the same resource demands an assertion; PATCH deliberately
+      # does not. Assert the contrast so a future change that adds a reauth gate
+      # to rename (or drops it from revoke) has to come here and say so.
+      assert conn
+             |> authed(raw_key)
+             |> delete(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{auth.id}")
+             |> json_response(401)
+
+      assert conn
+             |> authed(raw_key)
+             |> patch(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{auth.id}", %{
+               "friendly_name" => "no touch needed"
+             })
+             |> json_response(200)
+    end
+  end
+
   # (flip to human_anchored + enroll) with the loser rejected :reauth_required by
   # the under-lock gate, never a second possession-unproven device grafted on.
   #

--- a/test/loopctl_web/controllers/tenant_authenticator_controller_test.exs
+++ b/test/loopctl_web/controllers/tenant_authenticator_controller_test.exs
@@ -643,6 +643,13 @@ defmodule LoopctlWeb.TenantAuthenticatorControllerTest do
       assert row["friendly_name"] == "mac-mini Touch ID"
       refute Map.has_key?(row, "credential_id")
       refute Map.has_key?(row, "public_key")
+
+      # Enumerable ids + an assertion-free rename mean a stolen user-role key can
+      # relabel every device a tenant owns, and the label is what an operator
+      # steers a WebAuthn-gated revoke by. The fingerprint is credential-derived,
+      # no endpoint writes it, and it is the same value the audit chain records —
+      # so a mislabel cannot make the wrong credential look like the right one.
+      assert row["credential_fingerprint"] == Tenants.fingerprint(auth.credential_id)
     end
 
     test "403s a caller addressing a tenant it does not own", %{conn: conn} do
@@ -812,6 +819,78 @@ defmodule LoopctlWeb.TenantAuthenticatorControllerTest do
 
       assert AdminRepo.get!(Loopctl.Tenants.RootAuthenticator, auth.id).friendly_name ==
                "mac-mini"
+    end
+
+    test "rejects a non-UTF-8 friendly_name with 422 instead of 500ing on the UPDATE",
+         %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, friendly_name: "keep me")
+
+      # A urlencoded body can carry bytes the JSON parser would have refused.
+      # Without the validity check these reach Postgres, which rejects the
+      # encoding — hostile input then gets an unstructured 500.
+      response =
+        conn
+        |> authed(raw_key)
+        |> patch(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{auth.id}", %{
+          "friendly_name" => <<0xFF, 0xFE>>
+        })
+        |> json_response(422)
+
+      assert response["error"]["code"] == "friendly_name_invalid"
+      assert AdminRepo.get!(Loopctl.Tenants.RootAuthenticator, auth.id).friendly_name == "keep me"
+    end
+
+    test "renaming to the CURRENT label still touches the row", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, friendly_name: "same label")
+
+      conn
+      |> authed(raw_key)
+      |> patch(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{auth.id}", %{
+        "friendly_name" => "same label"
+      })
+      |> json_response(200)
+
+      # A no-change changeset makes Ecto skip the UPDATE entirely and return
+      # {:ok, struct} — so Ecto.StaleEntryError could never fire, and a rename
+      # racing a revoke would 200 (and append an audit entry) for a row that no
+      # longer exists. `force: true` is what keeps that guard live; a bumped
+      # updated_at is the observable proof the statement was issued.
+      assert DateTime.compare(
+               AdminRepo.get!(Loopctl.Tenants.RootAuthenticator, auth.id).updated_at,
+               auth.updated_at
+             ) == :gt
+    end
+
+    test "429s with the RENAME bucket named, not the enrollment budget", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id)
+
+      # Deny ONLY the controller's own rename bucket, so the inbound RPM plug
+      # still lets the request through to the action under test.
+      Mox.stub(Loopctl.MockRateLimiter, :check_rate, fn
+        "rename:actions:" <> _tenant, _window, _limit -> {:deny, 0}
+        _bucket, _window, _limit -> {:allow, 1}
+      end)
+
+      response =
+        conn
+        |> authed(raw_key)
+        |> patch(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{auth.id}", %{
+          "friendly_name" => "throttled"
+        })
+        |> json_response(429)
+
+      assert response["error"]["code"] == "rate_limited"
+
+      # Rename has its own far looser budget; reporting the ceremony budget as
+      # spent would send an operator away from an enrollment still available.
+      assert response["error"]["message"] =~ "rename"
+      refute response["error"]["message"] =~ "enrollment"
     end
 
     test "404s a malformed auth_id instead of raising Ecto.Query.CastError", %{conn: conn} do

--- a/test/loopctl_web/live/enroll_live_test.exs
+++ b/test/loopctl_web/live/enroll_live_test.exs
@@ -43,6 +43,42 @@ defmodule LoopctlWeb.EnrollLiveTest do
       assert html =~ ~s(id="enroll-result")
     end
 
+    test "explains the PHYSICAL action, naming all three authenticator kinds", %{conn: conn} do
+      # The first version of this page described the trust-tier semantics and
+      # never said what the operator would be asked to DO, which sent a real
+      # operator looking for a QR code that loopctl does not issue. Each of the
+      # three device classes behaves differently enough that omitting one
+      # strands whoever is on that hardware.
+      {:ok, _view, html} = live(conn, ~p"/enroll")
+
+      assert html =~ "Touch ID"
+      assert html =~ "Windows Hello"
+      assert html =~ "QR code"
+      assert html =~ "YubiKey"
+
+      # The QR path silently fails without Bluetooth on both ends, and that is
+      # invisible in the browser's own dialog.
+      assert html =~ "Bluetooth"
+
+      # Name-the-device guidance: a label naming the PERSON becomes a
+      # revoke-the-wrong-device trap once a backup is enrolled.
+      assert html =~ "Name it after the DEVICE"
+    end
+
+    test "body copy is not rendered at the failing slate-500 contrast", %{conn: conn} do
+      # slate-500 on this page's near-black panels measures ~4.3:1, under the
+      # 4.5:1 WCAG AA floor, and it was previously paired with text-xs for the
+      # whole instructions block. Placeholder text is exempt (it is not content).
+      {:ok, _view, html} = live(conn, ~p"/enroll")
+
+      offenders =
+        html
+        |> String.split(~r/\s+/)
+        |> Enum.filter(&(&1 =~ "slate-500" and not (&1 =~ "placeholder:")))
+
+      assert offenders == [], "low-contrast slate-500 body text on /enroll: #{inspect(offenders)}"
+    end
+
     test "mounts the AuthenticatorEnroll hook and lets it own its DOM", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/enroll")
 

--- a/test/loopctl_web/live/enroll_live_test.exs
+++ b/test/loopctl_web/live/enroll_live_test.exs
@@ -28,8 +28,18 @@ defmodule LoopctlWeb.EnrollLiveTest do
 
   @hook_path "assets/js/hooks/authenticator_enroll.js"
   @app_js_path "assets/js/app.js"
+  @live_path "lib/loopctl_web/live/enroll_live.ex"
 
   setup :verify_on_exit!
+
+  # `:__changed__` is render bookkeeping, not retained state.
+  defp socket_assigns(view) do
+    view.pid
+    |> :sys.get_state()
+    |> Map.fetch!(:socket)
+    |> Map.fetch!(:assigns)
+    |> Map.delete(:__changed__)
+  end
 
   describe "GET /enroll" do
     test "renders unauthenticated, with the ceremony controls", %{conn: conn} do
@@ -128,6 +138,7 @@ defmodule LoopctlWeb.EnrollLiveTest do
       # any pushed frame and a visitor can kill the channel process at will
       # (the same hardening SignupLive already carries).
       {:ok, view, _html} = live(conn, ~p"/enroll")
+      assigns_before = socket_assigns(view)
 
       # Survives the frame (no FunctionClauseError killing the channel)...
       assert render_hook(view, "junk", %{"api_key" => "lc_user_leaked_secret"}) =~
@@ -135,8 +146,23 @@ defmodule LoopctlWeb.EnrollLiveTest do
 
       assert Process.alive?(view.pid)
 
-      # ...and retained nothing from it.
-      refute render(view) =~ "lc_user_leaked_secret"
+      # ...and retained nothing from it. Asserted on the ASSIGNS, not the
+      # rendered HTML: assigns are what reaches a crash dump and telemetry, and
+      # a handler that stashes the key without rendering it leaks just as badly.
+      assert socket_assigns(view) == assigns_before
+
+      # A pushed frame can only exercise the event names it names. The property
+      # the page's security argument actually rests on — the one the deleted
+      # `refute function_exported?(EnrollLive, :handle_event, 3)` guard covered —
+      # is that there is EXACTLY ONE clause and it binds nothing. A future
+      # `handle_event("submit", params, socket)` added above the catch-all would
+      # pass every runtime assertion here.
+      source = File.read!(@live_path)
+
+      assert length(Regex.scan(~r/^\s*def handle_event\(/m, source)) == 1,
+             "EnrollLive must have exactly one handle_event/3 clause: the terminal no-op"
+
+      assert source =~ "def handle_event(_event, _params, socket), do: {:noreply, socket}"
     end
 
     test "the hook never pushes anything over the LiveView socket" do

--- a/test/loopctl_web/live/enroll_live_test.exs
+++ b/test/loopctl_web/live/enroll_live_test.exs
@@ -87,6 +87,23 @@ defmodule LoopctlWeb.EnrollLiveTest do
         |> Enum.filter(&(&1 =~ "slate-500" and not (&1 =~ "placeholder:")))
 
       assert offenders == [], "low-contrast slate-500 body text on /enroll: #{inspect(offenders)}"
+
+      # The rendered HTML is only HALF the page. Everything the operator reads
+      # DURING and AFTER the ceremony — the status line, the result panel, the
+      # per-surface capability rows — is written by the hook at runtime and
+      # never passes through this render, so a scan of `html` alone would
+      # report a clean page while the ceremony's own output stayed unreadable.
+      # That is exactly the state this test shipped in until the review caught
+      # it. Scan the hook source too.
+      hook_offenders =
+        @hook_path
+        |> File.read!()
+        |> String.split(~r/\s+/)
+        |> Enum.filter(&(&1 =~ "slate-500"))
+
+      assert hook_offenders == [],
+             "low-contrast slate-500 injected at runtime by #{@hook_path}: " <>
+               inspect(hook_offenders)
     end
 
     test "mounts the AuthenticatorEnroll hook and lets it own its DOM", %{conn: conn} do

--- a/test/loopctl_web/live/enroll_live_test.exs
+++ b/test/loopctl_web/live/enroll_live_test.exs
@@ -8,8 +8,8 @@ defmodule LoopctlWeb.EnrollLiveTest do
   for, is the set of structural properties that make that split safe:
 
     * the page reaches an unauthenticated visitor at all;
-    * it cannot receive the operator's API key, because it handles no
-      events;
+    * it cannot receive the operator's API key, because its only event
+      handler is a terminal no-op;
     * it cannot leak the key into a URL, because it has no form;
     * the hook that does the work is actually wired into the bundle; and
     * the hook takes the WebAuthn user handle from the server rather than
@@ -117,16 +117,26 @@ defmodule LoopctlWeb.EnrollLiveTest do
   end
 
   describe "the LiveView cannot receive the API key" do
-    test "EnrollLive defines no handle_event/3 at all" do
-      Code.ensure_loaded!(LoopctlWeb.EnrollLive)
-
+    test "its only handle_event/3 is a terminal no-op that stores nothing", %{conn: conn} do
       # This is the whole security argument for the page's shape, expressed as
-      # a property rather than a comment: with no event handler, there is no
-      # path by which a pasted credential reaches socket assigns, Phoenix's
-      # event parameter logging, a crash dump, or telemetry. If a future change
-      # adds an event handler, this test fails and that argument has to be
-      # re-made deliberately rather than eroded by accident.
-      refute function_exported?(LoopctlWeb.EnrollLive, :handle_event, 3)
+      # a property rather than a comment: no event handler RETAINS anything, so
+      # there is no path by which a pasted credential reaches socket assigns,
+      # Phoenix's event parameter logging, a crash dump, or telemetry.
+      #
+      # It is a no-op rather than ABSENT because /enroll is public and outside
+      # any authenticated pipeline: with no clause at all, LiveView raises on
+      # any pushed frame and a visitor can kill the channel process at will
+      # (the same hardening SignupLive already carries).
+      {:ok, view, _html} = live(conn, ~p"/enroll")
+
+      # Survives the frame (no FunctionClauseError killing the channel)...
+      assert render_hook(view, "junk", %{"api_key" => "lc_user_leaked_secret"}) =~
+               ~s(id="enroll-page")
+
+      assert Process.alive?(view.pid)
+
+      # ...and retained nothing from it.
+      refute render(view) =~ "lc_user_leaked_secret"
     end
 
     test "the hook never pushes anything over the LiveView socket" do

--- a/test/loopctl_web/require_human_anchor_default_deny_test.exs
+++ b/test/loopctl_web/require_human_anchor_default_deny_test.exs
@@ -83,6 +83,19 @@ defmodule LoopctlWeb.RequireHumanAnchorDefaultDenyTest do
                {:post, "/api/v1/tenants/:id/authenticators"},
                {:post, "/api/v1/tenants/:id/authenticators/revoke-challenge"},
                {:delete, "/api/v1/tenants/:id/authenticators/:auth_id"},
+               # PATCH (rename) is UNREACHABLE for an agent-rooted tenant rather
+               # than under-gated: such a tenant has ZERO authenticators BY
+               # CONSTRUCTION, so the tenant-scoped lookup 404s and there is no
+               # state for the tier gate to protect. The only production writes
+               # to `trust_tier` are the one-way `agent_rooted -> human_anchored`
+               # flip inside the enroll transaction (`Enrollment.enroll/3`, via
+               # `flip_query/1`) and the `:agent_rooted` default stamped at
+               # self-signup (`Tenant.self_signup_changeset/2`) — there is no
+               # downgrade path, and `revoke/2` refuses the last authenticator on
+               # a human_anchored tenant rather than auto-downgrading. If a
+               # downgrade is ever introduced, this exemption stops being sound
+               # and the route must move behind the tier gate.
+               {:patch, "/api/v1/tenants/:id/authenticators/:auth_id"},
 
                # /api_keys management — explicitly excluded (AC-26.7.1.7).
                {:post, "/api/v1/api_keys"},


### PR DESCRIPTION
Follow-ups from walking the /enroll flow end to end while anchoring a real tenant (#541, then #521). Both are defects the page's author could not see and only a first-time user hits.

## The page never said what you physically do

It opened with "Anchor an existing tenant to hardware", explained the trust-tier semantics — the part you can look up — and never described the action it was about to ask for. A real operator read it, found nothing about the physical step, and went looking for a QR code loopctl does not issue.

It now leads with the action and names all three authenticator kinds: **built-in sensor** (Touch ID, Windows Hello), **phone** via the browser's own QR — with the warning that this silently needs Bluetooth on BOTH ends, which is invisible in the browser's dialog — and **security key**, where pressing the metal disc is stated to be all that "touch" means. It also says plainly that no secret leaves the device, since "scan this QR" primes people to expect a shared secret and there isn't one.

## The instructions were below the AA contrast floor, on both halves of the page

The "Before you start" block and the key-field explanation were text-xs in slate-500 — roughly 4.3:1 on those near-black panels, under the 4.5:1 floor, at the smallest size on the page.

Fixing the render alone would have been a half-fix that read as a whole one. Everything the operator sees DURING and AFTER the ceremony — status line, result panel, per-surface capability rows — is written by the hook at runtime and never passes through the LiveView render, so a guard scanning only the rendered HTML reports a clean page while the ceremony's own output, the part read while something is going wrong, stays unreadable. Both halves are now text-sm at slate-300/400, and the test scans the hook source as well as the render.

## Renaming an authenticator was impossible, and listing them was too

The surface was challenge, create, revoke-challenge, delete. A wrong label could only be fixed by enrolling a second device, revoking the first and re-enrolling it — three WebAuthn ceremonies to correct a string. That matters because the label is what an operator picks from when revoking, so a device named after the person rather than the hardware becomes a revoke-the-wrong-device trap the moment a backup exists.

**PATCH /api/v1/tenants/:id/authenticators/:auth_id** takes only friendly_name, through a dedicated rename_changeset. Reusing create_changeset would have left a live rename endpoint one forgotten Map.take away from letting a caller swap the credential the root of trust hangs on; a test supplies credential_id, public_key and sign_count anyway and asserts they are ignored. The name is trimmed, must be non-blank and valid UTF-8, and is capped in the same unit at both layers so a multi-byte label cannot be accepted by one and refused by the other.

**GET /api/v1/tenants/:id/authenticators** had to come with it. The browser ceremony discards the 201 body and nothing else returns the row id, so without an index the rename endpoint was keyed on an identifier no operator could obtain. It returns no credential material; it does return credential_fingerprint — the same truncated SHA-256 the audit chain records, writable by no endpoint — and both the moduledoc and the OpenAPI description name that as what to confirm a revocation against, because friendly_name is rewritable by any user-role bearer key.

**No WebAuthn assertion, unlike revoke.** A rename is reversible and destroys nothing, and demanding a touch would price a typo fix at the cost of destroying a root-of-trust credential. A test asserts the contrast against DELETE on the same resource so a future change to either side has to come here and say so. Because possession is therefore never proved, after-the-fact attribution is the compensating control: the entry is stamped actor_type api_key with the calling key's id, not the actor_type "human" that enroll and revoke earn with a verified assertion.

**No tenant FOR UPDATE lock.** That lock serializes what can break an invariant — the authenticator cap, the tier flip, the last-authenticator guard — and a rename touches none of them, so taking it would let a label edit block an in-flight ceremony. The race it does have is a concurrent revoke, and the guard for it is load-bearing in a non-obvious way: renaming a label to its current value produces a changeset with no changes, so Ecto issues no SQL at all, StaleEntryError can never fire, and the rename would 200 and audit a deleted row. The update is forced so every rename touches the row.

**Its own rate-limit bucket**, not the 30/hr ceremony budget — spending one of those on a label edit could 429 an operator out of their own enrollment — and not nothing either, since every rename appends to the hash-chained audit log.

## Incidental fixes on the same surface

- EnrollLive had no handle_event/3 clause at all, so any crafted frame on this public socket killed the channel. It now has exactly one terminal no-op that binds nothing, guarded by a source scan asserting that count.
- A malformed auth_id reached a :binary_id bind instead of returning the documented 404.
- An audit-chain append failure returned its changeset to the caller — a 422 blaming their payload for an internal fault — on rename, enroll and revoke alike; revoke additionally raised CaseClauseError on it. All three now return a structured internal error.

## The default-deny tier test caught the new routes, correctly

They are exempted rather than gated, on a premise now written down and guarded: an agent-rooted tenant has zero authenticators by construction. The only production writes to trust_tier are the one-way flip inside the enroll transaction and the agent_rooted default at self-signup; revoke refuses the last authenticator rather than downgrading. A behavioural test asserts an agent-rooted tenant gets 404 here, so a future downgrade path fails loudly instead of quietly opening a hole.

## Verification

- mix precommit green — 6495 tests, credo --strict, dialyzer — run independently of the review agents' own claim
- Enhanced review: 23 raw findings, 21 confirmed, 15 fixed here, zero deferrals
- Five confirmed findings land in the #535/#547 HNSW surface this PR does not touch and go to a follow-up branch, including a real documented-vs-actual divergence: config/test.exs pins hnsw_iterative_scan ON while the shipped default is OFF, and heavy_read.ex's @doc plus docs/hnsw-tuning-evaluation.md describe the default the module does not have

Tail of #541.
