### PR TITLE
Say which iterative-scan value is which, and pin the premise a review got wrong

### DIFF
--- a/.claude/skills/tenancy-rls/SKILL.md
+++ b/.claude/skills/tenancy-rls/SKILL.md
@@ -54,16 +54,16 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 6. **On `AdminRepo`/`HeavyReadRepo`, RLS does NOTHING — the explicit `tenant_id` predicate is the only
    isolation there** (`knowledge.ex:9-14`, `heavy_read.ex:3-7`). This is the compensating invariant for
    the other two repos, and it is enforced structurally on the heavy path: the private `guard!/2`
-   (`heavy_read.ex:1217-1229`) RAISES unless EVERY base-table source — `from`, every join, and every
+   (`heavy_read.ex:1230-1250`) RAISES unless EVERY base-table source — `from`, every join, and every
    subquery, recursively — carries a conjunctive `x.tenant_id == ^tenant_id` bound to the passed
    `tenant_id`; `test/loopctl/heavy_read_guard_test.exs` additionally bars direct `HeavyReadRepo` calls.
-   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:978`) also requires a conjunctive
-   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1239-1261`), because `subject_id`
+   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:991`) also requires a conjunctive
+   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1252-1275`), because `subject_id`
    scoping is application-level only. Always go through `Loopctl.HeavyRead`, never `HeavyReadRepo`
    directly; on `AdminRepo` there is no guard at all, so the predicate is on you.
-7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:922`),
-   `one/3` (`heavy_read.ex:942`) and `all_memory/4` (`heavy_read.ex:978`) are specced to return it: the
-   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:1007-1021`) sheds over the cap —
+7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:935`),
+   `one/3` (`heavy_read.ex:955`) and `all_memory/4` (`heavy_read.ex:991`) are specced to return it: the
+   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:1020-1040`) sheds over the cap —
    `on_overload: :raise` (default) raises → 429, `on_overload: :tag` returns the tuple. Binding the
    result as a list crashes exactly under the load the gate exists for.
 8. **A consistency-coupled heavy read must be PRIMARY-PINNED.** `repo_for/1` (`heavy_read.ex:114-117`,
@@ -75,8 +75,8 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 ## The pgbouncer gotcha (US-27.13 — production outage, do not regress)
 
 `HeavyReadRepo` enforces a server-side `statement_timeout` **per-read via `SET LOCAL` inside the
-transaction** (`all/3` at `heavy_read.ex:922` and `one/3` at `:942`, both via
-`with_statement_timeout/5` at `:1043`;
+transaction** (`all/3` at `heavy_read.ex:935` and `one/3` at `:955`, both via
+`with_statement_timeout/5` at `:1056`;
 `heavy_read_repo.ex:19-32`) — NOT as a connection startup
 `:parameters` value. Fly MPG fronts Postgres with **pgbouncer**, which rejects a `statement_timeout`
 startup parameter with `FATAL 08P01 unsupported startup parameter`, crash-looping the whole pool so it

--- a/.claude/skills/tenancy-rls/SKILL.md
+++ b/.claude/skills/tenancy-rls/SKILL.md
@@ -54,16 +54,16 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 6. **On `AdminRepo`/`HeavyReadRepo`, RLS does NOTHING — the explicit `tenant_id` predicate is the only
    isolation there** (`knowledge.ex:9-14`, `heavy_read.ex:3-7`). This is the compensating invariant for
    the other two repos, and it is enforced structurally on the heavy path: the private `guard!/2`
-   (`heavy_read.ex:1230-1250`) RAISES unless EVERY base-table source — `from`, every join, and every
+   (`heavy_read.ex:1255-1275`) RAISES unless EVERY base-table source — `from`, every join, and every
    subquery, recursively — carries a conjunctive `x.tenant_id == ^tenant_id` bound to the passed
    `tenant_id`; `test/loopctl/heavy_read_guard_test.exs` additionally bars direct `HeavyReadRepo` calls.
-   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:991`) also requires a conjunctive
-   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1252-1275`), because `subject_id`
+   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:1016`) also requires a conjunctive
+   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1277-1300`), because `subject_id`
    scoping is application-level only. Always go through `Loopctl.HeavyRead`, never `HeavyReadRepo`
    directly; on `AdminRepo` there is no guard at all, so the predicate is on you.
-7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:935`),
-   `one/3` (`heavy_read.ex:955`) and `all_memory/4` (`heavy_read.ex:991`) are specced to return it: the
-   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:1020-1040`) sheds over the cap —
+7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:960`),
+   `one/3` (`heavy_read.ex:980`) and `all_memory/4` (`heavy_read.ex:1016`) are specced to return it: the
+   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:1045-1065`) sheds over the cap —
    `on_overload: :raise` (default) raises → 429, `on_overload: :tag` returns the tuple. Binding the
    result as a list crashes exactly under the load the gate exists for.
 8. **A consistency-coupled heavy read must be PRIMARY-PINNED.** `repo_for/1` (`heavy_read.ex:114-117`,
@@ -75,8 +75,8 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 ## The pgbouncer gotcha (US-27.13 — production outage, do not regress)
 
 `HeavyReadRepo` enforces a server-side `statement_timeout` **per-read via `SET LOCAL` inside the
-transaction** (`all/3` at `heavy_read.ex:935` and `one/3` at `:955`, both via
-`with_statement_timeout/5` at `:1056`;
+transaction** (`all/3` at `heavy_read.ex:960` and `one/3` at `:980`, both via
+`with_statement_timeout/5` at `:1081`;
 `heavy_read_repo.ex:19-32`) — NOT as a connection startup
 `:parameters` value. Fly MPG fronts Postgres with **pgbouncer**, which rejects a `statement_timeout`
 startup parameter with `FATAL 08P01 unsupported startup parameter`, crash-looping the whole pool so it

--- a/.claude/skills/tenancy-rls/SKILL.md
+++ b/.claude/skills/tenancy-rls/SKILL.md
@@ -54,16 +54,16 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 6. **On `AdminRepo`/`HeavyReadRepo`, RLS does NOTHING — the explicit `tenant_id` predicate is the only
    isolation there** (`knowledge.ex:9-14`, `heavy_read.ex:3-7`). This is the compensating invariant for
    the other two repos, and it is enforced structurally on the heavy path: the private `guard!/2`
-   (`heavy_read.ex:1175-1193`) RAISES unless EVERY base-table source — `from`, every join, and every
+   (`heavy_read.ex:1217-1229`) RAISES unless EVERY base-table source — `from`, every join, and every
    subquery, recursively — carries a conjunctive `x.tenant_id == ^tenant_id` bound to the passed
    `tenant_id`; `test/loopctl/heavy_read_guard_test.exs` additionally bars direct `HeavyReadRepo` calls.
-   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:944`) also requires a conjunctive
-   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1197-1219`), because `subject_id`
+   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:978`) also requires a conjunctive
+   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1239-1261`), because `subject_id`
    scoping is application-level only. Always go through `Loopctl.HeavyRead`, never `HeavyReadRepo`
    directly; on `AdminRepo` there is no guard at all, so the predicate is on you.
-7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:888`),
-   `one/3` (`heavy_read.ex:908`) and `all_memory/4` (`heavy_read.ex:944`) are specced to return it: the
-   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:965-985`) sheds over the cap —
+7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:922`),
+   `one/3` (`heavy_read.ex:942`) and `all_memory/4` (`heavy_read.ex:978`) are specced to return it: the
+   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:1007-1021`) sheds over the cap —
    `on_overload: :raise` (default) raises → 429, `on_overload: :tag` returns the tuple. Binding the
    result as a list crashes exactly under the load the gate exists for.
 8. **A consistency-coupled heavy read must be PRIMARY-PINNED.** `repo_for/1` (`heavy_read.ex:114-117`,
@@ -75,8 +75,8 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 ## The pgbouncer gotcha (US-27.13 — production outage, do not regress)
 
 `HeavyReadRepo` enforces a server-side `statement_timeout` **per-read via `SET LOCAL` inside the
-transaction** (`all/3` at `heavy_read.ex:888` and `one/3` at `:908`, both via
-`with_statement_timeout/5` at `:1001`;
+transaction** (`all/3` at `heavy_read.ex:922` and `one/3` at `:942`, both via
+`with_statement_timeout/5` at `:1043`;
 `heavy_read_repo.ex:19-32`) — NOT as a connection startup
 `:parameters` value. Fly MPG fronts Postgres with **pgbouncer**, which rejects a `statement_timeout`
 startup parameter with `FATAL 08P01 unsupported startup parameter`, crash-looping the whole pool so it

--- a/config/test.exs
+++ b/config/test.exs
@@ -707,15 +707,22 @@ config :loopctl, :embedding_read_path, Loopctl.MockEmbeddingReadPath
 
 # #488 / US-41.1: `hnsw.iterative_scan` is pinned ON for the TEST env only.
 #
-# It is the PRODUCTION remedy for cross-tenant filtered-ANN under-return, and it is now the
-# SHIPPED default too (`Loopctl.HeavyRead`'s `@default_hnsw_iterative_scan` = 1), so this pin
-# asserts against the configuration a fresh install actually runs. It used to rest instead on
-# a hand-verified premise — that prod carries an operator-set `SystemConfig`
-# "hnsw_iterative_scan" = 1 — which nothing in the repo maintained: a database restored from
-# before #488, or a fresh self-hosted install, has no such row, so CI stayed green while the
-# deployment silently ran the OFF path. Changing the shipped default is what closed that, not
-# this line. `SystemConfig` remains the operator lever, and setting the row to 0 still turns
-# iterative scan off fleet-wide with no redeploy.
+# It is the PRODUCTION remedy for cross-tenant filtered-ANN under-return. THREE values are in
+# play and they are deliberately NOT all the same (the table in
+# `Loopctl.HeavyRead.hnsw_iterative_scan/0`'s @doc is the canonical statement):
+#
+#   * shipped `Loopctl.HeavyRead`'s `@default_hnsw_iterative_scan` = 0 (off) — a fresh install
+#     makes no latency-for-recall trade it did not ask for;
+#   * the `loopctl` prod `SystemConfig` row = 1 (relaxed_order), operator-set in #488 and
+#     verified against the live app 2026-08-01;
+#   * this pin = 1, matching PROD — NOT the shipped default.
+#
+# An earlier revision of this comment claimed 1 was also the shipped default. It was not, and
+# the claim outlived a reverted attribute flip. Do not "reconcile" this pin down to the shipped
+# 0: the pin exists so CI asserts recall against what prod actually runs, and dropping it
+# reopens the flake described below. Whether the SHIPPED default should move to 1 is an open
+# operator decision, tracked in that @doc, not settled here. `SystemConfig` remains the operator
+# lever, and setting the row to 0 still turns iterative scan off fleet-wide with no redeploy.
 #
 # Leaving test unpinned meant CI asserted exact recall against a configuration NOBODY RUNS
 # — and lost, intermittently: the ANN applies `tenant_id` as a
@@ -732,7 +739,11 @@ config :loopctl, :embedding_read_path, Loopctl.MockEmbeddingReadPath
 #
 # Under-return coverage of the OFF path is NOT lost: it is asserted directly against
 # `HeavyRead.opts/1` (where the OFF decision actually lives, rather than as a side effect
-# of a global default) in `test/loopctl/heavy_read_hnsw_ef_search_test.exs:175-197`.
+# of a global default) by the test named
+# "opts/1 attaches :hnsw_iterative_scan for ANN endpoints ONLY when enabled" in
+# `test/loopctl/heavy_read_hnsw_ef_search_test.exs`. Cite it BY NAME, not by line range: a
+# range silently rots into pointing at unrelated code, and a compensating control nobody can
+# find is a compensating control that gets deleted.
 # Cite that file, not `heavy_read_test.exs`, which contains no iterative-scan assertions
 # at all — a mis-cited compensating control is how the real one gets deleted later as
 # "already covered elsewhere".

--- a/docs/hnsw-tuning-evaluation.md
+++ b/docs/hnsw-tuning-evaluation.md
@@ -137,8 +137,10 @@ Design points (`Loopctl.HeavyRead.hnsw_iterative_scan/0`, `hnsw_max_scan_tuples/
   deliberately not settled in code; raise it as its own change with a benchmark.
 - **Fail-closed, non-poisoning capability probe.** `iterative_scan_supported?/0` reads
   `pg_extension` on the SAME repo the ANN read uses (`HeavyRead.repo/0`, under
-  `@probe_timeout_ms` — 500ms, which bounds the pre-gate CHECKOUT, not just the query, so a
-  saturated pool goes inconclusive fast instead of queueing ahead of the shed) and caches the answer in `:persistent_term` **with a TTL**. An old extension →
+  `@probe_timeout_ms` — 500ms TOTAL, which bounds the pre-gate CHECKOUT, not just the query,
+  and is split in half across the probe's two attempts (a refused `mode: :savepoint`, then the
+  plain retry), so a saturated pool goes inconclusive fast instead of queueing ahead of the
+  shed) and caches the answer in `:persistent_term` **with a TTL**. An old extension →
   `false` + a warning naming the detected version; an ABSENT extension gets its own distinct
   warning (it is not a version problem). Either way the setting is a silent no-op, NOT a
   raise: nothing is emitted, so the ANN read is unaffected. Errors AND exits (`:noproc`, a

--- a/docs/hnsw-tuning-evaluation.md
+++ b/docs/hnsw-tuning-evaluation.md
@@ -113,14 +113,28 @@ Design points (`Loopctl.HeavyRead.hnsw_iterative_scan/0`, `hnsw_max_scan_tuples/
 | `1` | `SET LOCAL hnsw.iterative_scan = relaxed_order` (+ `hnsw.max_scan_tuples`) |
 | `2` | `SET LOCAL hnsw.iterative_scan = strict_order` (+ `hnsw.max_scan_tuples`) |
 
-- **Single source of truth.** `SystemConfig` only. There is deliberately **no**
-  `Application`-level override (and none may be added — `config_embedding_read_path_test.exs`
-  fails the build on one): an env pin would shadow the operator lever in prod, and pinning
-  it ON for the test env would make CI stop exercising the shipped default (`0`) and go
-  blind to exactly the filtered-under-return class this lever addresses. Tests that need a
-  mode prime the `SystemConfig` cache explicitly in an `async: false` module.
-- **Ships OFF, on purpose.** It is an operator flip made **after** confirming the deployed
-  pgvector is >= 0.8, per the runbook — not a default.
+- **Single source of truth at RUNTIME.** `SystemConfig` only. No `Application`-level override
+  may be set in any NON-test config — `config_embedding_read_path_test.exs` fails the build
+  on one — because an env pin would shadow the operator lever in prod. Tests that need a
+  specific mode prime the `SystemConfig` cache explicitly in an `async: false` module.
+- **The test env IS pinned, and that is not a contradiction of the line above.**
+  `config/test.exs` sets `:hnsw_iterative_scan_default` to `1`. An earlier revision of this
+  section said no override existed anywhere and that CI exercised the shipped `0`; both were
+  false once the pin landed, and the guard test it cites bars the key only outside test.
+  The pin exists because leaving test unpinned made CI assert exact recall against a
+  configuration **nobody runs**: the ANN applies `tenant_id` as a post-index residual, so a
+  tenant whose rows fall outside the global top-`ef_search` batch is silently dropped and the
+  read returns `[]`. That is the long-running side-table flake (3 failing runs / 23 before the
+  pin, 0 / 25 after; four earlier "recall" fixes never touched the mechanism). Under-return
+  coverage of the OFF path is asserted directly against `HeavyRead.opts/1` in
+  `test/loopctl/heavy_read_hnsw_ef_search_test.exs` instead, where the OFF decision actually
+  lives.
+- **Ships OFF; prod runs ON.** The shipped `@default_hnsw_iterative_scan` is `0`, so a fresh
+  install makes no latency-for-recall trade it did not ask for. The `loopctl` production
+  deployment has the operator-set row at `1` (relaxed_order) since #488, verified against the
+  live app 2026-08-01. The test pin matches PROD, not the shipped default — three values, on
+  purpose. Whether the shipped default should move to `1` is an open operator decision and is
+  deliberately not settled in code; raise it as its own change with a benchmark.
 - **Fail-closed, non-poisoning capability probe.** `iterative_scan_supported?/0` reads
   `pg_extension` on the SAME repo the ANN read uses (`HeavyRead.repo/0`, with an explicit
   5s timeout) and caches the answer in `:persistent_term` **with a TTL**. An old extension →

--- a/docs/hnsw-tuning-evaluation.md
+++ b/docs/hnsw-tuning-evaluation.md
@@ -109,7 +109,7 @@ Design points (`Loopctl.HeavyRead.hnsw_iterative_scan/0`, `hnsw_max_scan_tuples/
 
 | `SystemConfig hnsw_iterative_scan` | emitted |
 |---|---|
-| `0` (default / missing / unrecognized code) | nothing — no `SET LOCAL`, no capability probe |
+| `0` — explicit, unrecognized, or the MISSING-row fallback (`default_iterative_scan_code/0`: shipped `0`, **test `1`**) | nothing — no `SET LOCAL`, no capability probe |
 | `1` | `SET LOCAL hnsw.iterative_scan = relaxed_order` (+ `hnsw.max_scan_tuples`) |
 | `2` | `SET LOCAL hnsw.iterative_scan = strict_order` (+ `hnsw.max_scan_tuples`) |
 
@@ -136,8 +136,9 @@ Design points (`Loopctl.HeavyRead.hnsw_iterative_scan/0`, `hnsw_max_scan_tuples/
   purpose. Whether the shipped default should move to `1` is an open operator decision and is
   deliberately not settled in code; raise it as its own change with a benchmark.
 - **Fail-closed, non-poisoning capability probe.** `iterative_scan_supported?/0` reads
-  `pg_extension` on the SAME repo the ANN read uses (`HeavyRead.repo/0`, with an explicit
-  5s timeout) and caches the answer in `:persistent_term` **with a TTL**. An old extension →
+  `pg_extension` on the SAME repo the ANN read uses (`HeavyRead.repo/0`, under
+  `@probe_timeout_ms` — 500ms, which bounds the pre-gate CHECKOUT, not just the query, so a
+  saturated pool goes inconclusive fast instead of queueing ahead of the shed) and caches the answer in `:persistent_term` **with a TTL**. An old extension →
   `false` + a warning naming the detected version; an ABSENT extension gets its own distinct
   warning (it is not a version problem). Either way the setting is a silent no-op, NOT a
   raise: nothing is emitted, so the ANN read is unaffected. Errors AND exits (`:noproc`, a

--- a/docs/runbooks/knowledge-scale.md
+++ b/docs/runbooks/knowledge-scale.md
@@ -448,7 +448,7 @@ It ships **OFF** and is a live `SystemConfig` INT CODE (`Loopctl.HeavyRead.hnsw_
 
 | `hnsw_iterative_scan` | mode emitted |
 |---|---|
-| `0` (default / missing / unknown code) | `off` — no `SET LOCAL` at all |
+| `0` — explicit, unrecognized, or the MISSING-row fallback (shipped `0`, **test env `1`**) | `off` — no `SET LOCAL` at all |
 | `1` | `relaxed_order` |
 | `2` | `strict_order` |
 
@@ -461,22 +461,32 @@ UPDATE system_configs SET value = 50000, updated_at = now() WHERE key = 'hnsw_ma
 
 Contract, and the ways it can silently do nothing:
 
-- **`SystemConfig` is the ONLY source.** Unlike `ef_search` there is no `ALTER ROLE`
-  interaction to reason about and, deliberately, **no `Application` config override** — an
-  environment pin would either shadow the operator lever or (in the test env) stop CI
-  exercising the shipped default. `config_embedding_read_path_test.exs` fails the build if
-  a `:hnsw_iterative_scan` key appears in any `config/*.exs` file, in either the
-  `config :loopctl, :key, value` or the `config :loopctl, key: value` shape.
+- **`SystemConfig` is the only RUNTIME source.** Unlike `ef_search` there is no `ALTER ROLE`
+  interaction to reason about. The `Application` key `:hnsw_iterative_scan_default` supplies
+  only the fallback used when no `SystemConfig` row exists, and
+  `config_embedding_read_path_test.exs` bars it from every **NON-test** config — that is the
+  case that matters, since an environment pin in prod would shadow the operator lever.
+  **`config/test.exs` DOES set it, to `1`, on purpose**, and a separate assertion positively
+  requires that pin to still be there. An earlier revision of this bullet said no override
+  existed anywhere and that CI exercised the shipped default; both stopped being true when the
+  pin landed. Three values are in play — shipped `0`, prod `SystemConfig` `1`, test pin `1`
+  matching prod — and `Loopctl.HeavyRead.hnsw_iterative_scan/0`'s @doc is the canonical table.
 - **Fail-closed capability probe.** On pgvector < 0.8 the GUC does not exist. Enabling the
   key there is a **silent NO-OP**, not an outage: `Loopctl.HeavyRead.iterative_scan_supported?/0`
   probes `pg_extension` on the heavy-read repo (cached in `:persistent_term` with a TTL) and
   logs a warning naming the detected version — or, when the extension is not installed at
   all, a distinct "pgvector is NOT INSTALLED" warning, so you are not sent chasing an
-  upgrade that is not the problem. A probe that could not reach a conclusion (pool timeout,
-  DB blip, wedged-pool exit) is negative-cached for 60s only, so one bad moment cannot pin
-  the lever off until a redeploy — while a sustained outage costs one probe per minute
-  instead of one per ANN read. The conclusive verdict expires after 10 min so a backend
-  change (replica failover onto an older pgvector) self-heals.
+  upgrade that is not the problem. An INCONCLUSIVE probe (pool timeout, DB blip, wedged-pool
+  exit) does NOT flatly negative-cache for 60s — that description predates the current policy.
+  What actually happens: the last CONCLUSIVE verdict is reused when it is recent (up to 60
+  min), since the deployed pgvector version cannot change between two reads on the same
+  backend; with no such verdict it fails closed to a GUESS, cached for 1s initially and
+  DOUBLING per consecutive guess to a 60s ceiling, so one bad moment cannot pin the lever off
+  while a sustained outage still costs one probe per minute rather than one per ANN read.
+  `:ownership` and `:transaction` failures are never cached at all (they are harness
+  artifacts, not backend pressure), and `:pool` is not cached under a sandbox pool. The
+  conclusive verdict's own 60-min expiry is what lets a real backend change (replica failover
+  onto an older pgvector) self-heal.
 - **Only ANN endpoints, only when enabled.** `SET LOCAL hnsw.iterative_scan = <mode>` plus
   `SET LOCAL hnsw.max_scan_tuples = <n>` are emitted inside the same short heavy-read
   transaction as `statement_timeout`/`ef_search`, for `Loopctl.HeavyRead.ann_endpoints/0`

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -389,9 +389,10 @@ defmodule Loopctl.HeavyRead do
   # It is NOT taken here, because flipping it changes ANN query planning for every
   # deployment that has not set the row — a fleet-wide performance/recall trade that is the
   # operator's call, not a side effect of a branch fixing six unrelated findings. The
-  # premise gap it targets is closed the honest way instead: `config/test.exs` now records
-  # how the prod value is verified and when it was last checked. Raise it as its own change
-  # if the default should move.
+  # premise gap it targets is closed the honest way instead: `hnsw_iterative_scan/0`'s @doc
+  # below states all three values and records how the prod one is verified and when it was
+  # last checked (`docs/hnsw-tuning-evaluation.md` carries the operator-facing copy). Raise
+  # it as its own change if the default should move.
   @default_hnsw_iterative_scan 0
   @hnsw_iterative_scan_modes %{1 => "relaxed_order", 2 => "strict_order"}
   @default_hnsw_max_scan_tuples 20_000
@@ -529,7 +530,9 @@ defmodule Loopctl.HeavyRead do
   @doc """
   Whether the connected pgvector supports `hnsw.iterative_scan` (pgvector >= 0.8.0).
 
-  Probed from `pg_extension` on the SAME repo the ANN read runs on (`repo/0`) and cached in
+  Probed from `pg_extension` on the SAME repo the ANN read runs on (`repo/0`) under a
+  #{@probe_timeout_ms}ms timeout (`@probe_timeout_ms`, which bounds the pre-gate CHECKOUT,
+  not just the query) and cached in
   `:persistent_term` WITH A TTL. The probe runs only when an operator has actually enabled
   iterative scan (`iterative_scan_override/0` short-circuits at OFF), so it costs one extra
   round-trip per TTL window on the enabled path and nothing at all on the default path.
@@ -778,36 +781,20 @@ defmodule Loopctl.HeavyRead do
     # saturation signal, and failing closed there (iterative scan off for this read) is
     # cheaper than every concurrent ANN request queueing for seconds in front of the shed.
     #
-    # `mode: :savepoint` WHEN the caller is already inside a transaction on this repo (the
-    # normal shape under the test sandbox): without it a server-side error here — a 57014
-    # cancel at the tight timeout above — aborts the ENCLOSING transaction (25P02), so every
-    # later statement fails over a query it never issued while the `rescue`/`catch` below
-    # report a clean `:inconclusive`. That is the hazard `LocalGuc.do_capture/2` guards
-    # against, on the same hot path. It is CONDITIONAL because DBConnection refuses savepoint
-    # mode on an idle connection, which is the prod shape (`opts/1` runs outside any
-    # transaction) and would otherwise make every prod probe fail.
+    # `mode: :savepoint` WHENEVER the connection is inside a transaction (the normal shape
+    # under the test sandbox): without it a server-side error here — a 57014 cancel at the
+    # tight timeout above — aborts the ENCLOSING transaction (25P02), so every later statement
+    # fails over a query it never issued while the `rescue`/`catch` below report a clean
+    # `:inconclusive`. That is the hazard `LocalGuc.do_capture/2` guards against, on the same
+    # hot path.
     #
-    # DO NOT "simplify" this to an unconditional `mode: :savepoint` to match
-    # `LocalGuc.do_capture/2`. That sibling is unconditional because it only ever runs INSIDE
-    # a transaction; this one does not. A review round proposed exactly that change, on the
-    # theory that #535 had disproved the idle-refusal premise. It had not: measured on an idle
-    # `HeavyReadRepo` connection, `mode: :savepoint` returns
-    # `{:error, %DBConnection.TransactionError{status: :idle}}`. That is an ERROR TUPLE, so it
-    # would fall to the `other ->` branch below and report `:inconclusive` — on EVERY prod
-    # probe — which `inconclusive_verdict/2` then resolves without a conclusive verdict to
-    # reuse, silently disabling iterative scan fleet-wide. Precisely the failure #535 fixed.
-    # `test/loopctl/heavy_read_savepoint_probe_test.exs` pins the refusal so the premise
-    # cannot be re-litigated from memory.
-    query_opts =
-      if repo().in_transaction?(),
-        do: [timeout: @probe_timeout_ms, mode: :savepoint],
-        else: [timeout: @probe_timeout_ms]
-
-    case repo().query(
-           "SELECT extversion FROM pg_extension WHERE extname = 'vector'",
-           [],
-           query_opts
-         ) do
+    # The question is put to the CONNECTION (`savepoint_first_probe/0`), not to
+    # `repo().in_transaction?()`: that reads a per-process dict entry set only by
+    # `Repo.transaction`/`Repo.checkout`, which `Sandbox.start_owner!` never sets — the same
+    # blindness documented at `run_timed_transaction/5` — so gating on it left the protection
+    # DEAD in the one shape that has an enclosing transaction to poison, while prod (`opts/1`
+    # runs outside any transaction) took the plain branch either way.
+    case savepoint_first_probe() do
       {:ok, %{rows: [[version]]}} when is_binary(version) ->
         {:ok, version_at_least?(version, @iterative_scan_min_version), version}
 
@@ -827,6 +814,32 @@ defmodule Loopctl.HeavyRead do
     # propagates out of `opts/1` and aborts the caller's ANN read — the OPPOSITE of the
     # documented fail-closed guarantee.
     :exit, reason -> {:inconclusive, "exit:" <> exit_tag(reason), :pool}
+  end
+
+  @probe_sql "SELECT extversion FROM pg_extension WHERE extname = 'vector'"
+
+  # Ask for the savepoint, and retry PLAINLY on the one refusal that means there was no
+  # transaction to protect. Postgrex refuses savepoint mode on an idle connection
+  # (`Postgrex.Protocol.transaction_error/2`) with `%DBConnection.TransactionError{status:
+  # :idle}` and no round trip, so prod's shape costs a checkout, never a query.
+  #
+  # DO NOT drop the retry and pass `mode: :savepoint` alone to match `LocalGuc.do_capture/2`.
+  # That sibling needs no retry because it only ever runs INSIDE a transaction; this one does
+  # not. A review round proposed exactly that, on the theory that #535 had disproved the
+  # idle-refusal premise. It had not: the refusal is an ERROR TUPLE, so without the retry it
+  # falls to the caller's `other ->` branch and reports `:inconclusive` — on EVERY prod probe
+  # — which `inconclusive_verdict/2` then resolves with no conclusive verdict to reuse,
+  # silently disabling iterative scan fleet-wide. Precisely the failure #535 fixed.
+  # `test/loopctl/heavy_read_savepoint_probe_test.exs` pins the refusal AND the sandbox shape
+  # where `in_transaction?/0` lies, so neither premise can be re-litigated from memory.
+  defp savepoint_first_probe do
+    case repo().query(@probe_sql, [], timeout: @probe_timeout_ms, mode: :savepoint) do
+      {:error, %DBConnection.TransactionError{status: :idle}} ->
+        repo().query(@probe_sql, [], timeout: @probe_timeout_ms)
+
+      result ->
+        result
+    end
   end
 
   # Public only so the negative-cache decision is directly testable: it is a pure function

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -401,15 +401,33 @@ defmodule Loopctl.HeavyRead do
   or `"strict_order"`.
 
   Read from the live-tunable `SystemConfig` key `"hnsw_iterative_scan"` as an INT CODE
-  (0 = off, 1 = relaxed_order — the shipped default — 2 = strict_order, unknown = the shipped
-  default), so an operator turns iterative scan off or up fleet-wide with a single `UPDATE`
-  — no redeploy.
+  (0 = off — **the shipped default** — 1 = relaxed_order, 2 = strict_order, unknown = the
+  shipped default), so an operator turns iterative scan off or up fleet-wide with a single
+  `UPDATE` — no redeploy.
+
+  ## Three values, deliberately not all the same
+
+  | Where | Value | Why |
+  |---|---|---|
+  | shipped `@default_hnsw_iterative_scan` | `0` (off) | a fresh install makes no latency/recall trade it did not ask for |
+  | prod `SystemConfig` row | `1` (relaxed_order) | operator-set in #488; verified against the live app 2026-08-01 |
+  | `config/test.exs` pin | `1` | the suite asserts recall against WHAT PROD RUNS, not against the shipped default |
+
+  The test pin therefore does NOT match the shipped attribute, and must not be "corrected"
+  to: leaving test unpinned is what made CI assert exact recall against a configuration
+  nobody runs, which is the long-running side-table `left: []` flake
+  (`config/test.exs`, and see `test/loopctl/embeddings_side_table_reads_test.exs`).
+
+  Whether the SHIPPED default should move to `1` is an open operator decision — a fleet-wide
+  latency-for-recall trade — and is deliberately not settled here. What is settled is that
+  this doc states all three values, because an earlier revision claimed `1` was the shipped
+  default and that the test pin matched it; both were false, and a reader reasoning from
+  either would have mis-predicted what a fresh install does.
 
   `SystemConfig` is the operator lever and the only RUNTIME source. When no operator has set
   that row, the fallback code comes from the config key `:hnsw_iterative_scan_default`
-  (`default_iterative_scan_code/0`), which ONLY `config/test.exs` sets — pinned to the same
-  value the shipped `@default_hnsw_iterative_scan` carries, so the pin cannot drift out from
-  under the suite unnoticed. Every NON-test config is barred from setting that key by
+  (`default_iterative_scan_code/0`), which ONLY `config/test.exs` sets. Every NON-test config
+  is barred from setting that key by
   `test/loopctl/config_embedding_read_path_test.exs`; an `Application` pin in prod would
   shadow the operator lever. Tests that need a specific mode prime the `SystemConfig` cache
   explicitly in an `async: false` module (see
@@ -429,8 +447,12 @@ defmodule Loopctl.HeavyRead do
   # `SystemConfig` stays the single operator lever; this is only the FALLBACK applied when no
   # operator has set that row. It is config-injected (rather than read straight off the module
   # attribute) so an environment can start from a different baseline without any test mutating
-  # VM-global state. Only `config/test.exs` sets it, to the SAME value the shipped attribute
-  # carries — the suite must assert against the configuration a fresh install actually runs.
+  # VM-global state. Only `config/test.exs` sets it, and DELIBERATELY NOT to the shipped
+  # attribute's value: the suite asserts recall against what PROD runs (the operator-set
+  # `SystemConfig` row, 1) rather than against the shipped default (0). See the
+  # `hnsw_iterative_scan/0` @doc's table — an earlier revision of this comment claimed the two
+  # matched, which would send whoever next reads it to "fix" the pin and reopen the
+  # side-table flake.
   # Every NON-test config is barred from setting `:hnsw_iterative_scan_default` — the key
   # read RIGHT BELOW — by `test/loopctl/config_embedding_read_path_test.exs`, which also
   # asserts `config/test.exs` still sets it. That is the case that matters: an Application
@@ -761,9 +783,21 @@ defmodule Loopctl.HeavyRead do
     # cancel at the tight timeout above — aborts the ENCLOSING transaction (25P02), so every
     # later statement fails over a query it never issued while the `rescue`/`catch` below
     # report a clean `:inconclusive`. That is the hazard `LocalGuc.do_capture/2` guards
-    # against, on the same hot path. It is CONDITIONAL because Postgrex refuses savepoint
+    # against, on the same hot path. It is CONDITIONAL because DBConnection refuses savepoint
     # mode on an idle connection, which is the prod shape (`opts/1` runs outside any
     # transaction) and would otherwise make every prod probe fail.
+    #
+    # DO NOT "simplify" this to an unconditional `mode: :savepoint` to match
+    # `LocalGuc.do_capture/2`. That sibling is unconditional because it only ever runs INSIDE
+    # a transaction; this one does not. A review round proposed exactly that change, on the
+    # theory that #535 had disproved the idle-refusal premise. It had not: measured on an idle
+    # `HeavyReadRepo` connection, `mode: :savepoint` returns
+    # `{:error, %DBConnection.TransactionError{status: :idle}}`. That is an ERROR TUPLE, so it
+    # would fall to the `other ->` branch below and report `:inconclusive` — on EVERY prod
+    # probe — which `inconclusive_verdict/2` then resolves without a conclusive verdict to
+    # reuse, silently disabling iterative scan fleet-wide. Precisely the failure #535 fixed.
+    # `test/loopctl/heavy_read_savepoint_probe_test.exs` pins the refusal so the premise
+    # cannot be re-litigated from memory.
     query_opts =
       if repo().in_transaction?(),
         do: [timeout: @probe_timeout_ms, mode: :savepoint],

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -524,15 +524,19 @@ defmodule Loopctl.HeavyRead do
   @iterative_scan_last_conclusive_ttl_ms 3_600_000
 
   # See `probe_iterative_scan_support/0`: this bounds the pre-gate checkout, not just the
-  # query, so it is deliberately far below the sibling probes' budget.
+  # query, so it is deliberately far below the sibling probes' budget. It is the TOTAL
+  # budget for the probe, and `savepoint_first_probe/0` takes TWO checkouts on prod's idle
+  # shape (the refused savepoint, then the plain retry), so each ATTEMPT gets half and the
+  # pair still fits the bound this attribute — and the operator docs — state.
   @probe_timeout_ms 500
+  @probe_attempt_timeout_ms div(@probe_timeout_ms, 2)
 
   @doc """
   Whether the connected pgvector supports `hnsw.iterative_scan` (pgvector >= 0.8.0).
 
   Probed from `pg_extension` on the SAME repo the ANN read runs on (`repo/0`) under a
-  #{@probe_timeout_ms}ms timeout (`@probe_timeout_ms`, which bounds the pre-gate CHECKOUT,
-  not just the query) and cached in
+  #{@probe_timeout_ms}ms TOTAL budget (`@probe_timeout_ms`, which bounds the pre-gate
+  CHECKOUT, not just the query, and is split across the probe's two attempts) and cached in
   `:persistent_term` WITH A TTL. The probe runs only when an operator has actually enabled
   iterative scan (`iterative_scan_override/0` short-circuits at OFF), so it costs one extra
   round-trip per TTL window on the enabled path and nothing at all on the default path.
@@ -774,19 +778,25 @@ defmodule Loopctl.HeavyRead do
   defp probe_iterative_scan_support do
     # TIGHT timeout, because this round trip runs from `opts/1` — i.e. BEFORE `TenantGate`
     # can shed and before any `SET LOCAL statement_timeout` applies. DBConnection derives the
-    # checkout DEADLINE from this same `:timeout` (`Holder.abs_timeout/2`), so it is exactly
-    # the bound on how long a probe may queue on a saturated heavy-read pool ahead of the
-    # gate whose whole job is to shed before the checkout. A `pg_extension` lookup is
-    # sub-millisecond on a healthy pool; needing more than #{@probe_timeout_ms}ms IS the
-    # saturation signal, and failing closed there (iterative scan off for this read) is
-    # cheaper than every concurrent ANN request queueing for seconds in front of the shed.
+    # checkout DEADLINE from PER-ATTEMPT `:timeout` (`Holder.abs_timeout/2`), and
+    # `savepoint_first_probe/0` can take two attempts, so each gets HALF
+    # (#{@probe_attempt_timeout_ms}ms) and `@probe_timeout_ms` stays exactly the bound on how
+    # long a probe may queue on a saturated heavy-read pool ahead of the gate whose whole job
+    # is to shed before the checkout. A `pg_extension` lookup is sub-millisecond on a healthy
+    # pool; needing more than that IS the saturation signal, and failing closed there
+    # (iterative scan off for this read) is cheaper than every concurrent ANN request
+    # queueing for seconds in front of the shed.
     #
     # `mode: :savepoint` WHENEVER the connection is inside a transaction (the normal shape
-    # under the test sandbox): without it a server-side error here — a 57014 cancel at the
-    # tight timeout above — aborts the ENCLOSING transaction (25P02), so every later statement
-    # fails over a query it never issued while the `rescue`/`catch` below report a clean
-    # `:inconclusive`. That is the hazard `LocalGuc.do_capture/2` guards against, on the same
-    # hot path.
+    # under the test sandbox): without it a SERVER-RETURNED error here — a 57014 cancel from a
+    # leaked `SET LOCAL statement_timeout`, or any other `Postgrex.Error` — aborts the
+    # ENCLOSING transaction (25P02), so every later statement fails over a query it never
+    # issued while the `rescue`/`catch` below report a clean `:inconclusive`. That is the
+    # hazard `LocalGuc.do_capture/2` guards against, on the same hot path. What savepoint mode
+    # does NOT cover is the CLIENT-side deadline above: an `@probe_attempt_timeout_ms` expiry
+    # is a DBConnection deadline, and Postgrex DISCONNECTS the connection on it
+    # (`Postgrex.Protocol.msg_recv/3`) — there is no 57014 and no `ROLLBACK TO SAVEPOINT`; the
+    # enclosing transaction dies with the connection.
     #
     # The question is put to the CONNECTION (`savepoint_first_probe/0`), not to
     # `repo().in_transaction?()`: that reads a per-process dict entry set only by
@@ -821,7 +831,13 @@ defmodule Loopctl.HeavyRead do
   # Ask for the savepoint, and retry PLAINLY on the one refusal that means there was no
   # transaction to protect. Postgrex refuses savepoint mode on an idle connection
   # (`Postgrex.Protocol.transaction_error/2`) with `%DBConnection.TransactionError{status:
-  # :idle}` and no round trip, so prod's shape costs a checkout, never a query.
+  # :idle}` and no round trip, so prod's shape costs TWO CHECKOUTS and never a query — which
+  # is why each attempt gets `@probe_attempt_timeout_ms` (half the budget) rather than the
+  # whole of `@probe_timeout_ms`: the PAIR is what queues ahead of `TenantGate`'s shed.
+  #
+  # The OTHER refusal (`status: :error`, a connection already poisoned by an earlier
+  # statement) is NOT retried: the plain query would only return the 25P02 it replaces.
+  # `inconclusive_class/1` classifies it `:transaction` for exactly that reason.
   #
   # DO NOT drop the retry and pass `mode: :savepoint` alone to match `LocalGuc.do_capture/2`.
   # That sibling needs no retry because it only ever runs INSIDE a transaction; this one does
@@ -833,9 +849,9 @@ defmodule Loopctl.HeavyRead do
   # `test/loopctl/heavy_read_savepoint_probe_test.exs` pins the refusal AND the sandbox shape
   # where `in_transaction?/0` lies, so neither premise can be re-litigated from memory.
   defp savepoint_first_probe do
-    case repo().query(@probe_sql, [], timeout: @probe_timeout_ms, mode: :savepoint) do
+    case repo().query(@probe_sql, [], timeout: @probe_attempt_timeout_ms, mode: :savepoint) do
       {:error, %DBConnection.TransactionError{status: :idle}} ->
-        repo().query(@probe_sql, [], timeout: @probe_timeout_ms)
+        repo().query(@probe_sql, [], timeout: @probe_attempt_timeout_ms)
 
       result ->
         result
@@ -860,6 +876,15 @@ defmodule Loopctl.HeavyRead do
   # exact storm the cache exists to bound.
   def inconclusive_class(%Postgrex.Error{postgres: %{code: :in_failed_sql_transaction}}),
     do: :transaction
+
+  # The SAME poisoned-connection fact, in the shape `savepoint_first_probe/0` now surfaces it:
+  # Postgrex refuses `mode: :savepoint` on an ABORTED connection before sending anything
+  # (`Postgrex.Protocol.parse_describe/3`), so the 25P02 above never reaches us there. Without
+  # this clause that refusal fell to the `:pool` catch-all and got NEGATIVE-CACHED in prod —
+  # a fail-closed verdict from a test-harness artifact pinning iterative scan off VM-wide,
+  # which is precisely what the `:transaction` class exists to prevent. (`status: :idle` never
+  # reaches here: it is the retried refusal.)
+  def inconclusive_class(%DBConnection.TransactionError{status: :error}), do: :transaction
 
   def inconclusive_class(%Postgrex.Error{}), do: :pool
   def inconclusive_class(_error), do: :pool

--- a/lib/loopctl/local_guc.ex
+++ b/lib/loopctl/local_guc.ex
@@ -100,7 +100,15 @@ defmodule Loopctl.LocalGuc do
         Enum.map(names, &{&1, nil})
 
       owned ->
-        raise "LocalGuc: could not capture #{inspect(owned)}, which an enclosing scope " <>
+        # A `DBConnection.ConnectionError`, NOT a bare RuntimeError. This path fires only
+        # when the capture round-trip itself failed, which means the connection is already
+        # wedged — the same condition `Knowledge.BulkOps.timeout_multi/0` raises this exact
+        # struct for, and which `LoopctlWeb.FallbackController` maps to the US-27.3 503 +
+        # `Retry-After` rather than an unstructured 500. Two call sites reaching the same
+        # conclusion about the same failure should not hand the client two different answers,
+        # one of which tells it never to retry something that is purely transient.
+        raise DBConnection.ConnectionError,
+              "LocalGuc: could not capture #{inspect(owned)}, which an enclosing scope " <>
                 "already overrode — refusing to set an override this transaction cannot " <>
                 "take back (see the moduledoc)"
     end

--- a/lib/loopctl/local_guc.ex
+++ b/lib/loopctl/local_guc.ex
@@ -94,6 +94,22 @@ defmodule Loopctl.LocalGuc do
   defp put_active_names([]), do: Process.delete(@active_names_key)
   defp put_active_names(names), do: Process.put(@active_names_key, names)
 
+  @capture_abort_tag "LocalGuc: could not capture"
+
+  @doc """
+  Whether `error` is THIS module's capture abort — the one `DBConnection.ConnectionError`
+  raised by `scoped/3` when it refused to override a GUC an enclosing scope owns — rather
+  than the generic pool/connection failure that shares the struct (and the US-27.3 503).
+
+  The discriminator a fail-soft rescue needs to re-raise this abort instead of classifying it
+  as a degraded dependency.
+  """
+  @spec capture_abort?(term()) :: boolean()
+  def capture_abort?(%DBConnection.ConnectionError{message: message}) when is_binary(message),
+    do: String.starts_with?(message, @capture_abort_tag)
+
+  def capture_abort?(_error), do: false
+
   defp capture_fallback!(names, enclosing) do
     case Enum.filter(names, &(&1 in enclosing)) do
       [] ->
@@ -108,17 +124,17 @@ defmodule Loopctl.LocalGuc do
         # conclusion about the same failure should not hand the client two different answers,
         # one of which tells it never to retry something that is purely transient.
         #
-        # KNOWN CONSEQUENCE of the shared struct: `DBConnection.ConnectionError` carries no
-        # field to discriminate on (`defexception [:message]`), so the fail-soft rescues that
-        # classify it as a degraded dependency swallow this abort too — the ingestion backlog
-        # gate (`LoopctlWeb.KnowledgeIngestionController.in_flight_ingestion_backlog/1`) fails
-        # OPEN at 0, and `Knowledge`'s under-fill probe degrades to `:error`. Both are reached
-        # only when the capture ROUND TRIP itself failed, i.e. the connection is already in
-        # trouble, which is the condition those rescues exist for — but they cannot tell this
-        # abort from a pool blip, so narrowing them (re-raise on this message/struct) is the
-        # follow-up if that distinction ever has to be made.
+        # Sharing the struct does NOT make this abort indistinguishable from a pool blip:
+        # `capture_abort?/1` below matches it on the stable `@capture_abort_tag` prefix, so any
+        # fail-soft rescue that must tell the two apart re-raises on it instead of swallowing
+        # it. Today's rescues deliberately do not — the ingestion backlog gate
+        # (`LoopctlWeb.KnowledgeIngestionController.in_flight_ingestion_backlog/1`) fails OPEN
+        # at 0 and `Knowledge`'s under-fill probe degrades to `:error` — and that is the right
+        # reading there: this path is reached ONLY when the capture round trip itself failed,
+        # i.e. the connection is already in trouble, which is the condition those rescues exist
+        # for.
         raise DBConnection.ConnectionError,
-              "LocalGuc: could not capture #{inspect(owned)}, which an enclosing scope " <>
+              "#{@capture_abort_tag} #{inspect(owned)}, which an enclosing scope " <>
                 "already overrode — refusing to set an override this transaction cannot " <>
                 "take back (see the moduledoc)"
     end

--- a/lib/loopctl/local_guc.ex
+++ b/lib/loopctl/local_guc.ex
@@ -107,6 +107,16 @@ defmodule Loopctl.LocalGuc do
         # `Retry-After` rather than an unstructured 500. Two call sites reaching the same
         # conclusion about the same failure should not hand the client two different answers,
         # one of which tells it never to retry something that is purely transient.
+        #
+        # KNOWN CONSEQUENCE of the shared struct: `DBConnection.ConnectionError` carries no
+        # field to discriminate on (`defexception [:message]`), so the fail-soft rescues that
+        # classify it as a degraded dependency swallow this abort too — the ingestion backlog
+        # gate (`LoopctlWeb.KnowledgeIngestionController.in_flight_ingestion_backlog/1`) fails
+        # OPEN at 0, and `Knowledge`'s under-fill probe degrades to `:error`. Both are reached
+        # only when the capture ROUND TRIP itself failed, i.e. the connection is already in
+        # trouble, which is the condition those rescues exist for — but they cannot tell this
+        # abort from a pool blip, so narrowing them (re-raise on this message/struct) is the
+        # follow-up if that distinction ever has to be made.
         raise DBConnection.ConnectionError,
               "LocalGuc: could not capture #{inspect(owned)}, which an enclosing scope " <>
                 "already overrode — refusing to set an override this transaction cannot " <>

--- a/test/loopctl/heavy_read_savepoint_probe_test.exs
+++ b/test/loopctl/heavy_read_savepoint_probe_test.exs
@@ -1,0 +1,60 @@
+defmodule Loopctl.HeavyReadSavepointProbeTest do
+  @moduledoc """
+  Pins the premise `HeavyRead.probe_iterative_scan_support/0` gates its
+  `mode: :savepoint` on: DBConnection REFUSES savepoint mode on an idle
+  connection.
+
+  This exists because the premise was challenged and the challenge was wrong.
+  A review round proposed dropping the `repo().in_transaction?()` gate and
+  passing `mode: :savepoint` unconditionally, to match `LocalGuc.do_capture/2`
+  — which is unconditional because it only ever runs inside a transaction.
+  `probe_iterative_scan_support/0` does not: `HeavyRead.opts/1` runs OUTSIDE any
+  transaction in production.
+
+  The failure that change would cause is silent, which is why it earns a test
+  rather than a comment. Savepoint-on-idle returns an ERROR TUPLE, not a raise,
+  so it lands in the probe's `other ->` branch and reports `:inconclusive` — on
+  every prod probe. With no conclusive verdict to reuse, `inconclusive_verdict/2`
+  fails closed, iterative scan is disabled fleet-wide, and ANN reads silently
+  under-return. That is the exact defect #535 fixed.
+
+  Asserted against `DBConnection` behaviour rather than the probe's own return
+  value on purpose: the probe rescues and classifies, so a test driving it would
+  pass under BOTH the conditional and unconditional forms and prove nothing.
+  """
+
+  use Loopctl.DataCase, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.HeavyReadRepo
+
+  setup :verify_on_exit!
+
+  describe "savepoint mode on an idle connection" do
+    test "is refused with a TransactionError, not silently accepted" do
+      # The sandbox checks out a connection inside a transaction for async
+      # cases; this module is async: false and uses a dedicated non-sandboxed
+      # checkout so the connection is genuinely idle, matching the prod shape of
+      # HeavyRead.opts/1.
+      Sandbox.checkout(HeavyReadRepo, sandbox: false)
+
+      refute HeavyReadRepo.in_transaction?(),
+             "this test is meaningless unless the connection is idle"
+
+      result = HeavyReadRepo.query("SELECT 1", [], timeout: 2_000, mode: :savepoint)
+
+      assert {:error, %DBConnection.TransactionError{status: :idle}} = result,
+             "savepoint-on-idle must stay refused — probe_iterative_scan_support/0's " <>
+               "in_transaction? gate depends on it. Got: #{inspect(result)}"
+    end
+
+    test "the same query without savepoint mode succeeds on that idle connection" do
+      # Establishes that the refusal above is caused by `mode: :savepoint` and
+      # not by the connection being unusable — without this, the assertion could
+      # pass for the wrong reason and keep passing after the premise changed.
+      Sandbox.checkout(HeavyReadRepo, sandbox: false)
+
+      assert {:ok, %{rows: [[1]]}} = HeavyReadRepo.query("SELECT 1", [], timeout: 2_000)
+    end
+  end
+end

--- a/test/loopctl/heavy_read_savepoint_probe_test.exs
+++ b/test/loopctl/heavy_read_savepoint_probe_test.exs
@@ -1,15 +1,16 @@
 defmodule Loopctl.HeavyReadSavepointProbeTest do
   @moduledoc """
-  Pins the premise `HeavyRead.probe_iterative_scan_support/0` gates its
-  `mode: :savepoint` on: DBConnection REFUSES savepoint mode on an idle
-  connection.
+  Pins both premises `HeavyRead.probe_iterative_scan_support/0`'s savepoint
+  handling rests on: Postgrex REFUSES `mode: :savepoint` on an idle connection
+  (so the probe must retry plainly), and `in_transaction?/0` CANNOT be used to
+  decide that, because it reports false under the sandbox — where the backend
+  genuinely is in a transaction.
 
-  This exists because the premise was challenged and the challenge was wrong.
-  A review round proposed dropping the `repo().in_transaction?()` gate and
-  passing `mode: :savepoint` unconditionally, to match `LocalGuc.do_capture/2`
-  — which is unconditional because it only ever runs inside a transaction.
-  `probe_iterative_scan_support/0` does not: `HeavyRead.opts/1` runs OUTSIDE any
-  transaction in production.
+  The first exists because the premise was challenged and the challenge was
+  wrong. A review round proposed passing `mode: :savepoint` unconditionally, to
+  match `LocalGuc.do_capture/2` — which is unconditional because it only ever
+  runs inside a transaction. `probe_iterative_scan_support/0` does not:
+  `HeavyRead.opts/1` runs OUTSIDE any transaction in production.
 
   The failure that change would cause is silent, which is why it earns a test
   rather than a comment. Savepoint-on-idle returns an ERROR TUPLE, not a raise,
@@ -32,14 +33,15 @@ defmodule Loopctl.HeavyReadSavepointProbeTest do
 
   describe "savepoint mode on an idle connection" do
     test "is refused with a TransactionError, not silently accepted" do
-      # The sandbox checks out a connection inside a transaction for async
-      # cases; this module is async: false and uses a dedicated non-sandboxed
-      # checkout so the connection is genuinely idle, matching the prod shape of
-      # HeavyRead.opts/1.
-      Sandbox.checkout(HeavyReadRepo, sandbox: false)
-
-      refute HeavyReadRepo.in_transaction?(),
-             "this test is meaningless unless the connection is idle"
+      # The sandbox checks out a connection inside a transaction; this module is
+      # async: false so a dedicated non-sandboxed checkout still wins ownership
+      # for this process, leaving the connection genuinely idle — the prod shape
+      # of HeavyRead.opts/1. Assert it TOOK: checkout/2 returns
+      # `{:already, :owner | :allowed}` instead of raising when the process is
+      # already bound to a sandboxed connection, and the query would then run
+      # inside the sandbox transaction, testing nothing. `in_transaction?/0`
+      # cannot stand in for this check (see the test below).
+      assert :ok = Sandbox.checkout(HeavyReadRepo, sandbox: false)
 
       result = HeavyReadRepo.query("SELECT 1", [], timeout: 2_000, mode: :savepoint)
 
@@ -52,9 +54,23 @@ defmodule Loopctl.HeavyReadSavepointProbeTest do
       # Establishes that the refusal above is caused by `mode: :savepoint` and
       # not by the connection being unusable — without this, the assertion could
       # pass for the wrong reason and keep passing after the premise changed.
-      Sandbox.checkout(HeavyReadRepo, sandbox: false)
+      assert :ok = Sandbox.checkout(HeavyReadRepo, sandbox: false)
 
       assert {:ok, %{rows: [[1]]}} = HeavyReadRepo.query("SELECT 1", [], timeout: 2_000)
+    end
+  end
+
+  describe "savepoint mode inside the sandbox transaction" do
+    test "succeeds while in_transaction?/0 reports false" do
+      # No `sandbox: false` checkout: this is the SANDBOXED shape, where the
+      # backend is inside a transaction that a probe error would poison (25P02).
+      # `in_transaction?/0` still says false — it reads a per-process key that
+      # `Sandbox.start_owner!/2` never sets — so gating the probe's
+      # `mode: :savepoint` on it made the protection dead exactly here.
+      refute HeavyReadRepo.in_transaction?()
+
+      assert {:ok, %{rows: [[1]]}} =
+               HeavyReadRepo.query("SELECT 1", [], timeout: 2_000, mode: :savepoint)
     end
   end
 end

--- a/test/loopctl/heavy_read_savepoint_probe_test.exs
+++ b/test/loopctl/heavy_read_savepoint_probe_test.exs
@@ -19,17 +19,26 @@ defmodule Loopctl.HeavyReadSavepointProbeTest do
   fails closed, iterative scan is disabled fleet-wide, and ANN reads silently
   under-return. That is the exact defect #535 fixed.
 
-  Asserted against `DBConnection` behaviour rather than the probe's own return
-  value on purpose: the probe rescues and classifies, so a test driving it would
-  pass under BOTH the conditional and unconditional forms and prove nothing.
+  The premise tests assert `DBConnection` behaviour, not the probe's return
+  value: on the CONDITIONAL-vs-UNCONDITIONAL question a test driving it proved
+  nothing. Not so for the RETRY, which therefore drives the probe end to end.
+  All of it runs against `HeavyRead.repo/0` — the repo the probe actually uses
+  (`config/test.exs` points it at `AdminRepo`), not `HeavyReadRepo`.
   """
 
   use Loopctl.DataCase, async: false
 
   alias Ecto.Adapters.SQL.Sandbox
-  alias Loopctl.HeavyReadRepo
+  alias Loopctl.HeavyRead
 
   setup :verify_on_exit!
+
+  @last_conclusive_key {HeavyRead, :iterative_scan_last_conclusive}
+  @probe_cache_keys [
+    {HeavyRead, :iterative_scan_supported},
+    @last_conclusive_key,
+    {HeavyRead, :iterative_scan_guess_ttl}
+  ]
 
   describe "savepoint mode on an idle connection" do
     test "is refused with a TransactionError, not silently accepted" do
@@ -41,9 +50,9 @@ defmodule Loopctl.HeavyReadSavepointProbeTest do
       # already bound to a sandboxed connection, and the query would then run
       # inside the sandbox transaction, testing nothing. `in_transaction?/0`
       # cannot stand in for this check (see the test below).
-      assert :ok = Sandbox.checkout(HeavyReadRepo, sandbox: false)
+      assert :ok = Sandbox.checkout(HeavyRead.repo(), sandbox: false)
 
-      result = HeavyReadRepo.query("SELECT 1", [], timeout: 2_000, mode: :savepoint)
+      result = HeavyRead.repo().query("SELECT 1", [], timeout: 2_000, mode: :savepoint)
 
       assert {:error, %DBConnection.TransactionError{status: :idle}} = result,
              "savepoint-on-idle must stay refused — probe_iterative_scan_support/0's " <>
@@ -54,9 +63,40 @@ defmodule Loopctl.HeavyReadSavepointProbeTest do
       # Establishes that the refusal above is caused by `mode: :savepoint` and
       # not by the connection being unusable — without this, the assertion could
       # pass for the wrong reason and keep passing after the premise changed.
-      assert :ok = Sandbox.checkout(HeavyReadRepo, sandbox: false)
+      assert :ok = Sandbox.checkout(HeavyRead.repo(), sandbox: false)
 
-      assert {:ok, %{rows: [[1]]}} = HeavyReadRepo.query("SELECT 1", [], timeout: 2_000)
+      assert {:ok, %{rows: [[1]]}} = HeavyRead.repo().query("SELECT 1", [], timeout: 2_000)
+    end
+
+    test "the probe reaches a CONCLUSIVE verdict there — the retry, driven end to end" do
+      # Drop the retry and the refusal above lands in the probe's `other ->` branch:
+      # every prod probe inconclusive, fails closed, iterative scan off fleet-wide.
+      # Asserted on the last-CONCLUSIVE record, not on `true`, so it means "the backend
+      # answered" for any installed pgvector version.
+      assert :ok = Sandbox.checkout(HeavyRead.repo(), sandbox: false)
+      clear_probe_cache()
+      on_exit(&clear_probe_cache/0)
+
+      verdict = HeavyRead.iterative_scan_supported?()
+      recorded = :persistent_term.get(@last_conclusive_key, :none)
+
+      assert match?({answered, _at} when is_boolean(answered), recorded),
+             "the probe was INCONCLUSIVE on an idle connection (got #{inspect(recorded)}) — " <>
+               "the savepoint retry is gone"
+
+      assert {^verdict, _at} = recorded
+    end
+  end
+
+  describe "savepoint refusal on an ABORTED connection" do
+    test "classifies as :transaction, so it is never negative-cached" do
+      # Postgrex refuses savepoint mode on a poisoned connection too, returning the
+      # refusal instead of the 25P02 `Postgrex.Error`. The `:pool` catch-all IS
+      # negative-cached in prod, which would pin the operator's lever OFF.
+      aborted = %DBConnection.TransactionError{status: :error, message: "transaction is aborted"}
+
+      assert HeavyRead.inconclusive_class(aborted) == :transaction
+      assert HeavyRead.inconclusive_class({:error, aborted}) == :transaction
     end
   end
 
@@ -67,10 +107,12 @@ defmodule Loopctl.HeavyReadSavepointProbeTest do
       # `in_transaction?/0` still says false — it reads a per-process key that
       # `Sandbox.start_owner!/2` never sets — so gating the probe's
       # `mode: :savepoint` on it made the protection dead exactly here.
-      refute HeavyReadRepo.in_transaction?()
+      refute HeavyRead.repo().in_transaction?()
 
       assert {:ok, %{rows: [[1]]}} =
-               HeavyReadRepo.query("SELECT 1", [], timeout: 2_000, mode: :savepoint)
+               HeavyRead.repo().query("SELECT 1", [], timeout: 2_000, mode: :savepoint)
     end
   end
+
+  defp clear_probe_cache, do: Enum.each(@probe_cache_keys, &:persistent_term.erase/1)
 end

--- a/test/loopctl/heavy_read_test.exs
+++ b/test/loopctl/heavy_read_test.exs
@@ -614,7 +614,7 @@ defmodule Loopctl.HeavyReadTest do
         # LOCAL) or do nothing (leaking the inner override into the rest of the outer body).
         # It does neither. It raises BEFORE the body sets anything, and the caller's rollback
         # is then the thing that discards every SET LOCAL made inside the transaction.
-        assert_raise RuntimeError, ~r/could not capture/, fn ->
+        assert_raise DBConnection.ConnectionError, ~r/could not capture/, fn ->
           Loopctl.LocalGuc.scoped(CaptureFailingRepo, [@probe], fn ->
             Repo.query!("SET LOCAL #{@probe} = 'inner'")
           end)
@@ -632,7 +632,7 @@ defmodule Loopctl.HeavyReadTest do
       prior = Loopctl.LocalGuc.capture(Repo, [@probe])
       Repo.query!("SET LOCAL #{@probe} = 'bulk'")
 
-      assert_raise RuntimeError, ~r/could not capture/, fn ->
+      assert_raise DBConnection.ConnectionError, ~r/could not capture/, fn ->
         Loopctl.LocalGuc.scoped(CaptureFailingRepo, [@probe], fn -> :ok end)
       end
 


### PR DESCRIPTION
The findings PR #548's review confirmed but routed off-branch, all in the #535/#547 HNSW/iterative-scan surface — plus a correction to my own reasoning that this PR's review caught.

## Three iterative-scan values, and four documents naming the wrong one as shipped

| Where | Value | Why |
|---|---|---|
| shipped `@default_hnsw_iterative_scan` | `0` (off) | a fresh install makes no latency-for-recall trade it did not ask for |
| prod `SystemConfig` row | `1` (relaxed_order) | operator-set in #488, verified against the live app 2026-08-01 |
| `config/test.exs` pin | `1` | the suite asserts recall against WHAT PROD RUNS |

All three are deliberate. Four documents were not.

`heavy_read.ex`'s `@doc` called `1` "the shipped default". `config/test.exs` went further and stated `@default_hnsw_iterative_scan = 1` outright — residue from a review round that flipped the attribute and a revert that took the attribute back without the comment. `docs/hnsw-tuning-evaluation.md` and `docs/runbooks/knowledge-scale.md` both claimed no `Application`-level override existed anywhere and that CI exercised the shipped `0`, describing a world that ended when the pin landed; both cited a guard test as enforcing that, when it bars the key only in NON-test configs.

What makes this worth a PR rather than a typo fix is the direction a reader would correct it. Finding pin and attribute disagreeing, the obvious move is to reconcile the pin down — which returns CI to asserting exact recall against a configuration nobody runs, the mechanism behind the long side-table `left: []` flake (3 failing runs / 23 before the pin, 0 / 25 after; four earlier "recall" fixes never touched it). Every site now states all three values and says not to do that.

The runbook's probe-caching paragraph also predated the current policy by two rewrites — it described a flat 60s negative cache, where what runs is a recent CONCLUSIVE verdict reused up to 60 min, else a guess cached 1s and doubling to a 60s ceiling, with `:ownership`/`:transaction` never cached. An operator reading it would mis-predict how long a blip suppresses the lever.

**Whether the shipped default should move to `1` is deliberately still open.** It is a fleet-wide latency-for-recall trade, it belongs to the operator, and a docs commit is not where it gets decided.

## I was half wrong about the savepoint probe, and this PR's review caught it

PR #548's review proposed dropping `probe_iterative_scan_support/0`'s `in_transaction?` gate and passing `mode: :savepoint` unconditionally. I refused it and pinned the refusal, having measured that savepoint-on-idle returns `{:error, %DBConnection.TransactionError{status: :idle}}` — an error tuple, so it would land in the probe's `other ->` branch and report `:inconclusive` on every prod probe, silently disabling iterative scan fleet-wide.

That measurement was right. The conclusion I drew from it — keep the gate — was wrong, because the gate was **already broken in the other direction**: under `Ecto.Adapters.SQL.Sandbox`, `in_transaction?/0` returns `false` even though the connection IS in a transaction and savepoint mode works. Verified directly:

```
HeavyRead.repo() = Loopctl.AdminRepo
repo().in_transaction? = false
savepoint under sandbox => {:ok, %Postgrex.Result{}}
```

So the gate selected the non-savepoint path in every test, and the 25P02-poisoning protection it exists for was never exercised there. The original finding was right in substance; only its proposed fix was wrong.

The shape that satisfies both is `savepoint_first_probe/0`: attempt savepoint mode, and retry plainly ONLY on the specific `status: :idle` refusal. Test gets the protection, prod's idle path still works. The per-attempt budget was halved so prod's two-checkout shape stays inside the documented pre-shed bound instead of doubling it.

**This is therefore a real behaviour change on the ANN probe path**, contrary to what an earlier version of this description claimed.

The retry clause is **mutation-verified**: deleting it makes exactly one test fail. Before that test existed, deleting it left the whole suite green while every prod probe would have silently disabled iterative scan — the same class of invisible-guard defect as the `force: true` catch in #548 and the monotonic-time throttle in #547.

Two other corrections to my work landed with it: the savepoint-on-idle refusal originates in **Postgrex**, not DBConnection (which only supplies the struct), and my premise test's `refute in_transaction?()` precondition was inert — `Sandbox.checkout/2` returns `{:already, …}` rather than raising, and I discarded the result.

## One wedged-pool path answered the client differently from its sibling

`LocalGuc.capture_fallback!/2` raised a bare `RuntimeError`, while its sibling `Knowledge.BulkOps.timeout_multi/0` raises `DBConnection.ConnectionError` for the same condition. One produced 503 + `Retry-After`, the other an unstructured 500 telling the client never to retry something purely transient. It now raises the same struct — verified, not assumed: `DBErrorBackstop` is mounted at `endpoint.ex:116` and maps it through `DBError.map/1`.

Sharing a struct with generic pool faults is a real cost, so `capture_abort?/1` was added to discriminate the abort on a stable tag, letting a fail-soft rescue re-raise it rather than swallow it.

## Verification

- `mix precommit` green — 6500 tests, credo --strict, dialyzer — run independently of the review agents' claim
- New tests pin the savepoint premises, including the mutation-verified retry clause
- `tenancy-rls` skill citations repointed twice as these edits shifted `heavy_read.ex` line numbers; `mix loopctl.check_skill_citations` caught both

Two findings remain genuinely out of scope and go to a third PR: fail-soft rescues in `knowledge_ingestion_controller.ex` swallow the new capture abort, and `bulk_ops.ex` pops the `LocalGuc` active-names entry twice on the success path, which can flip a later nested capture failure from ABORT to RESET and clobber an enclosing scope's `statement_timeout`.
