### PR TITLE
Stop swallowing LocalGuc's refusal, and stop popping someone else's GUC ownership

### DIFF
--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -44,9 +44,9 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:499-505`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:461-463`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8328`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8337`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
-   (`absolute_score/1`, `:8402-8407`) clears a scale-matched threshold AND beats the best retrieved
+   (`absolute_score/1`, `:8464-8469`) clears a scale-matched threshold AND beats the best retrieved
    candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:8453-8463`; the pure decision is
    `resolve_provenance/4`, `:8508-8518`) AND is authoritative (not superseded/conflicted — the caller
    passes only `list_curated_sources/2`-filtered scores). Otherwise `:retrieved`. Both branches return identical `results`/`meta`

--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -47,8 +47,8 @@ never pass `tenant_id`/`subject_id`.
 2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8337`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
    (`absolute_score/1`, `:8464-8469`) clears a scale-matched threshold AND beats the best retrieved
-   candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:8453-8463`; the pure decision is
-   `resolve_provenance/4`, `:8508-8518`) AND is authoritative (not superseded/conflicted — the caller
+   candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:8515-8525`; the pure decision is
+   `resolve_provenance/4`, `:8568-8580`) AND is authoritative (not superseded/conflicted — the caller
    passes only `list_curated_sources/2`-filtered scores). Otherwise `:retrieved`. Both branches return identical `results`/`meta`
    key sets — callers branch on `meta.provenance` alone. A sparse pool must never let a near-but-wrong
    curated doc win.

--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -44,11 +44,11 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:499-505`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:461-463`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8337`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8357`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
-   (`absolute_score/1`, `:8464-8469`) clears a scale-matched threshold AND beats the best retrieved
-   candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:8515-8525`; the pure decision is
-   `resolve_provenance/4`, `:8568-8580`) AND is authoritative (not superseded/conflicted — the caller
+   (`absolute_score/1`, `:8484-8489`) clears a scale-matched threshold AND beats the best retrieved
+   candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:8535-8545`; the pure decision is
+   `resolve_provenance/4`, `:8588-8600`) AND is authoritative (not superseded/conflicted — the caller
    passes only `list_curated_sources/2`-filtered scores). Otherwise `:retrieved`. Both branches return identical `results`/`meta`
    key sets — callers branch on `meta.provenance` alone. A sparse pool must never let a near-but-wrong
    curated doc win.

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -5134,34 +5134,54 @@ defmodule Loopctl.Knowledge do
     e in DBConnection.ConnectionError ->
       # `LocalGuc`'s capture ABORT shares this struct with a transient pool fault and is a
       # different animal — a deliberate refusal to override a GUC an enclosing scope owns —
-      # so it is NAMED distinctly in the log. It still degrades: this probe runs only after
-      # the suggestions are already in hand and produces telemetry alone, so re-raising would
+      # so it is NAMED distinctly. It still degrades: this probe runs only after the
+      # suggestions are already in hand and feeds a diagnostic signal, so re-raising would
       # trade a valid response for a 503 over a diagnostic read, which is precisely what the
       # AREA-5 fail-soft contract at `maybe_signal_under_fill/8` forbids.
-      tag = if LocalGuc.capture_abort?(e), do: "guc_capture_abort", else: "connection"
-
-      Logger.warning(
-        "knowledge.vector_search under_fill probe degraded (#{tag}); suggestions returned: " <>
-          Exception.message(e)
-      )
-
-      :error
+      under_fill_probe_degraded(tenant_id, e)
 
     e in Postgrex.Error ->
       # Degrade ONLY on a server-side cancel (statement_timeout); re-raise anything else
       # (e.g. a malformed query) so genuine bugs surface in tests instead of silently
       # becoming a missing signal.
       if match?(%{postgres: %{code: :query_canceled}}, e) do
-        Logger.warning(
-          "knowledge.vector_search under_fill probe degraded (timeout); suggestions returned: " <>
-            Exception.message(e)
-        )
-
-        :error
+        under_fill_probe_degraded(tenant_id, e)
       else
         reraise(e, __STACKTRACE__)
       end
   end
+
+  @doc false
+  # The probe's ONE fail-soft exit. A degraded probe used to be a 503; it is now a 200 whose
+  # truncation signal is silently absent, so the refusal must stay ALERTABLE — a log line
+  # alone is invisible to a dashboard. Emits the bounded counter
+  # (`TelemetryEvents.vector_search_under_fill_probe_degraded/0`) and logs the CLASS TAG only:
+  # `Exception.message/1` on a Postgrex/DBConnection struct names the backend host, database
+  # and role. Public-but-`@doc false` so the degradation contract is testable through the real
+  # path (see `heavy_read_opts/1` for the same precedent).
+  def under_fill_probe_degraded(tenant_id, error) do
+    error_class = probe_error_class(error)
+
+    :telemetry.execute(
+      Loopctl.TelemetryEvents.vector_search_under_fill_probe_degraded(),
+      %{count: 1},
+      %{tenant_id: tenant_id, endpoint: :suggested_links, error_class: error_class}
+    )
+
+    Logger.warning(
+      "knowledge.vector_search under_fill probe degraded (#{error_class}) " <>
+        "tenant_id=#{tenant_id}; suggestions returned"
+    )
+
+    :error
+  end
+
+  defp probe_error_class(%DBConnection.ConnectionError{} = e) do
+    if LocalGuc.capture_abort?(e), do: "guc_capture_abort", else: "connection"
+  end
+
+  # Only reachable for 57014 — the caller re-raises every other SQLSTATE.
+  defp probe_error_class(%Postgrex.Error{}), do: "timeout"
 
   @doc false
   # Per-read options for a heavy endpoint (US-27.4). Delegates to the single source of

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -65,6 +65,7 @@ defmodule Loopctl.Knowledge do
   alias Loopctl.Knowledge.RankingPriors
   alias Loopctl.Knowledge.VectorSearch
   alias Loopctl.Llm.ProviderError
+  alias Loopctl.LocalGuc
   alias Loopctl.Projects.Project
   alias Loopctl.Provider.RetryAfter
   alias Loopctl.Search.Regconfig
@@ -5131,6 +5132,14 @@ defmodule Loopctl.Knowledge do
     end
   rescue
     e in DBConnection.ConnectionError ->
+      # `LocalGuc`'s capture ABORT shares this struct with the transient pool faults this
+      # clause degrades on, but it is a deliberate refusal to override a GUC an enclosing
+      # scope owns — not a degraded dependency. Degrading on it would turn a connection
+      # already known to be mis-scoped into a silently missing signal, which is the same
+      # mistake as the `query_canceled` narrowing directly below. Re-raise; the US-27.3
+      # backstop maps it to a 503.
+      if LocalGuc.capture_abort?(e), do: reraise(e, __STACKTRACE__)
+
       Logger.warning(
         "knowledge.vector_search under_fill probe degraded (connection); suggestions returned: " <>
           Exception.message(e)

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -5132,16 +5132,16 @@ defmodule Loopctl.Knowledge do
     end
   rescue
     e in DBConnection.ConnectionError ->
-      # `LocalGuc`'s capture ABORT shares this struct with the transient pool faults this
-      # clause degrades on, but it is a deliberate refusal to override a GUC an enclosing
-      # scope owns — not a degraded dependency. Degrading on it would turn a connection
-      # already known to be mis-scoped into a silently missing signal, which is the same
-      # mistake as the `query_canceled` narrowing directly below. Re-raise; the US-27.3
-      # backstop maps it to a 503.
-      if LocalGuc.capture_abort?(e), do: reraise(e, __STACKTRACE__)
+      # `LocalGuc`'s capture ABORT shares this struct with a transient pool fault and is a
+      # different animal — a deliberate refusal to override a GUC an enclosing scope owns —
+      # so it is NAMED distinctly in the log. It still degrades: this probe runs only after
+      # the suggestions are already in hand and produces telemetry alone, so re-raising would
+      # trade a valid response for a 503 over a diagnostic read, which is precisely what the
+      # AREA-5 fail-soft contract at `maybe_signal_under_fill/8` forbids.
+      tag = if LocalGuc.capture_abort?(e), do: "guc_capture_abort", else: "connection"
 
       Logger.warning(
-        "knowledge.vector_search under_fill probe degraded (connection); suggestions returned: " <>
+        "knowledge.vector_search under_fill probe degraded (#{tag}); suggestions returned: " <>
           Exception.message(e)
       )
 

--- a/lib/loopctl/knowledge/bulk_ops.ex
+++ b/lib/loopctl/knowledge/bulk_ops.ex
@@ -644,24 +644,52 @@ defmodule Loopctl.Knowledge.BulkOps do
         {:ok, LocalGuc.restore(repo, prior)}
       end)
 
-    case AdminRepo.transaction(multi, timeout: transaction_timeout_ms()) do
-      {:ok, %{articles: {affected, _}}} ->
-        {:ok, %{affected: affected, resolved_count: resolved_count || affected}}
+    outcome =
+      try do
+        {:completed, AdminRepo.transaction(multi, timeout: transaction_timeout_ms())}
+      rescue
+        e in [Postgrex.Error, DBConnection.ConnectionError] -> {:raised, e}
+      end
 
-      {:error, _step, reason, _changes} ->
-        {:error, reason}
-    end
-  rescue
-    e in [Postgrex.Error, DBConnection.ConnectionError] -> {:error, e}
-  after
     # `:restore_timeout` is the LAST step, so `Ecto.Multi` SKIPS it the moment an earlier one
     # errors (an invalid token, an FK abort), and a raising `delete_all` bypasses it entirely.
     # The rollback discards the `SET LOCAL` itself, so nothing needs putting back — but the
     # ownership entry `capture/2` pushed would OUTLIVE the transaction on this process, which
     # Bandit reuses across keep-alive requests, and make a later `LocalGuc.scoped/3` abort a
-    # read over an enclosing scope that no longer exists. Pop it where every exit path passes.
-    LocalGuc.forget(@timeout_guc)
+    # read over an enclosing scope that no longer exists.
+    #
+    # CONDITIONAL, not unconditional. `restore/2` and `forget/1` both pop via `list -- names`,
+    # which removes ONE occurrence — so popping again after `:restore_timeout` already ran
+    # takes an ENCLOSING scope's entry instead. That scope then looks unowned, and a later
+    # nested capture failure takes `capture_fallback!/2`'s RESET branch rather than its ABORT
+    # branch: it clobbers the outer read's deliberate `statement_timeout` instead of refusing,
+    # which is the exact leak `LocalGuc` exists to prevent. The `:set_timeout` failure path is
+    # the mirror image — `capture/2` pushes ONLY on success, so a `[]` capture pushed nothing
+    # and popping there would steal an enclosing entry too.
+    if pop_timeout_ownership?(outcome), do: LocalGuc.forget(@timeout_guc)
+
+    case outcome do
+      {:completed, {:ok, %{articles: {affected, _}}}} ->
+        {:ok, %{affected: affected, resolved_count: resolved_count || affected}}
+
+      {:completed, {:error, _step, reason, _changes}} ->
+        {:error, reason}
+
+      {:raised, e} ->
+        {:error, e}
+    end
   end
+
+  # Own the pop only when THIS call pushed and did not already pop:
+  #   * success -> `:restore_timeout` ran and popped -> do NOT pop again
+  #   * `:set_timeout` errored -> `capture/2` returned `[]` and pushed nothing -> do NOT pop
+  #   * any other step errored, or the transaction raised -> pushed, never popped -> POP
+  defp pop_timeout_ownership?({:completed, {:ok, changes}}),
+    do: not Map.has_key?(changes, :restore_timeout)
+
+  defp pop_timeout_ownership?({:completed, {:error, :set_timeout, _reason, _changes}}), do: false
+  defp pop_timeout_ownership?({:completed, {:error, _step, _reason, _changes}}), do: true
+  defp pop_timeout_ownership?({:raised, _e}), do: true
 
   defp bulk_audit_attrs(tenant_id, action, selector_summary, affected, audit_opts) do
     %{

--- a/lib/loopctl/knowledge/bulk_ops.ex
+++ b/lib/loopctl/knowledge/bulk_ops.ex
@@ -617,18 +617,27 @@ defmodule Loopctl.Knowledge.BulkOps do
   # Named once, so the capture here and the pop in `run_multi/2` cannot drift.
   @timeout_guc ["statement_timeout"]
 
-  # Whether THIS call pushed an ownership entry that nothing has popped yet. Set here (where
-  # `capture/2` pushes, and ONLY on success) and cleared by `:restore_timeout` (whose
-  # `restore/2` pops), so `run_multi/2` decides from OBSERVED state rather than from the
-  # outcome shape — a raise can land BEFORE the push (pool checkout, BEGIN) or AFTER the pop
-  # (COMMIT), and popping in either case takes an ENCLOSING scope's entry.
-  @timeout_pushed_key {__MODULE__, :timeout_guc_pushed}
+  # How many ownership entries bulk ops have pushed on THIS process and not yet popped.
+  # Incremented here (where `capture/2` pushes, and ONLY on success) and decremented by
+  # `:restore_timeout` (whose `restore/2` pops), so `run_multi/2` decides from OBSERVED state
+  # rather than from the outcome shape — a raise can land BEFORE the push (pool checkout,
+  # BEGIN) or AFTER the pop (COMMIT), and popping in either case takes an ENCLOSING scope's
+  # entry. A DEPTH, not a boolean: a boolean cannot represent nesting, so a bulk op running
+  # inside another's Multi on the same process would have its inner cleanup consume the flag
+  # and leave the outer's entry alive forever. `run_multi/2` compares against the depth it
+  # observed on entry, so each call pops exactly its own.
+  @timeout_pushed_key {__MODULE__, :timeout_guc_depth}
+
+  defp pushed_depth, do: Process.get(@timeout_pushed_key, 0)
+
+  defp put_pushed_depth(depth) when depth <= 0, do: Process.delete(@timeout_pushed_key)
+  defp put_pushed_depth(depth), do: Process.put(@timeout_pushed_key, depth)
 
   defp timeout_multi do
     Multi.run(Multi.new(), :set_timeout, fn repo, _changes ->
       case LocalGuc.capture(repo, @timeout_guc) do
         [_ | _] = prior ->
-          Process.put(@timeout_pushed_key, true)
+          put_pushed_depth(pushed_depth() + 1)
           repo.query!("SET LOCAL statement_timeout = #{statement_timeout_ms()}")
           {:ok, prior}
 
@@ -650,9 +659,11 @@ defmodule Loopctl.Knowledge.BulkOps do
     multi =
       Multi.run(multi, :restore_timeout, fn repo, %{set_timeout: prior} ->
         restored = LocalGuc.restore(repo, prior)
-        Process.delete(@timeout_pushed_key)
+        put_pushed_depth(pushed_depth() - 1)
         {:ok, restored}
       end)
+
+    depth_before = pushed_depth()
 
     try do
       case AdminRepo.transaction(multi, timeout: transaction_timeout_ms()) do
@@ -676,16 +687,21 @@ defmodule Loopctl.Knowledge.BulkOps do
       # them (a changeset raise in the audit step, a `MatchError` in a `Multi.run` body), a
       # Postgrex EXIT from a wedged pool, a throw.
       #
-      # `Process.delete/1` reads AND clears the marker, so the pop happens exactly once and
-      # only when this call pushed. Both "pushed nothing" (a `[]` capture; a raise at checkout
-      # or BEGIN, before `:set_timeout` ran) and "already popped" (`:restore_timeout` ran —
-      # including when the COMMIT itself then failed) read as nil. Popping in either case
-      # would take an ENCLOSING scope's entry, since `restore/2` and `forget/1` both pop via
-      # `list -- names`, one occurrence. That scope would then look unowned, and a later
-      # nested capture failure would take `capture_fallback!/2`'s RESET branch rather than its
-      # ABORT branch — clobbering the outer read's deliberate `statement_timeout` instead of
-      # refusing, the exact leak `LocalGuc` exists to prevent.
-      if Process.delete(@timeout_pushed_key), do: LocalGuc.forget(@timeout_guc)
+      # The depth is compared against `depth_before` (read on entry), so the pop happens
+      # exactly once and only when THIS call's push is still outstanding — correct whether or
+      # not another bulk op encloses this one. Both "pushed nothing" (a `[]` capture; a raise
+      # at checkout or BEGIN, before `:set_timeout` ran) and "already popped"
+      # (`:restore_timeout` ran — including when the COMMIT itself then failed) leave the depth
+      # back at `depth_before`. Popping in either case would take an ENCLOSING scope's entry,
+      # since `restore/2` and `forget/1` both pop via `list -- names`, one occurrence. That
+      # scope would then look unowned, and a later nested capture failure would take
+      # `capture_fallback!/2`'s RESET branch rather than its ABORT branch — clobbering the
+      # outer read's deliberate `statement_timeout` instead of refusing, the exact leak
+      # `LocalGuc` exists to prevent.
+      if pushed_depth() > depth_before do
+        LocalGuc.forget(@timeout_guc)
+        put_pushed_depth(depth_before)
+      end
     end
   end
 

--- a/lib/loopctl/knowledge/bulk_ops.ex
+++ b/lib/loopctl/knowledge/bulk_ops.ex
@@ -614,13 +614,21 @@ defmodule Loopctl.Knowledge.BulkOps do
   # a `FunctionClauseError` (an unstructured 500) instead of a mapped response. This IS a
   # connection failure, so the US-27.3 mapping already renders it as 503 + Retry-After.
   #
-  # Named once, so the capture here and the unconditional pop in `run_multi/2` cannot drift.
+  # Named once, so the capture here and the pop in `run_multi/2` cannot drift.
   @timeout_guc ["statement_timeout"]
+
+  # Whether THIS call pushed an ownership entry that nothing has popped yet. Set here (where
+  # `capture/2` pushes, and ONLY on success) and cleared by `:restore_timeout` (whose
+  # `restore/2` pops), so `run_multi/2` decides from OBSERVED state rather than from the
+  # outcome shape — a raise can land BEFORE the push (pool checkout, BEGIN) or AFTER the pop
+  # (COMMIT), and popping in either case takes an ENCLOSING scope's entry.
+  @timeout_pushed_key {__MODULE__, :timeout_guc_pushed}
 
   defp timeout_multi do
     Multi.run(Multi.new(), :set_timeout, fn repo, _changes ->
       case LocalGuc.capture(repo, @timeout_guc) do
         [_ | _] = prior ->
+          Process.put(@timeout_pushed_key, true)
           repo.query!("SET LOCAL statement_timeout = #{statement_timeout_ms()}")
           {:ok, prior}
 
@@ -641,55 +649,45 @@ defmodule Loopctl.Knowledge.BulkOps do
   defp run_multi(multi, resolved_count \\ nil) do
     multi =
       Multi.run(multi, :restore_timeout, fn repo, %{set_timeout: prior} ->
-        {:ok, LocalGuc.restore(repo, prior)}
+        restored = LocalGuc.restore(repo, prior)
+        Process.delete(@timeout_pushed_key)
+        {:ok, restored}
       end)
 
-    outcome =
-      try do
-        {:completed, AdminRepo.transaction(multi, timeout: transaction_timeout_ms())}
-      rescue
-        e in [Postgrex.Error, DBConnection.ConnectionError] -> {:raised, e}
+    try do
+      case AdminRepo.transaction(multi, timeout: transaction_timeout_ms()) do
+        {:ok, %{articles: {affected, _}}} ->
+          {:ok, %{affected: affected, resolved_count: resolved_count || affected}}
+
+        {:error, _step, reason, _changes} ->
+          {:error, reason}
       end
-
-    # `:restore_timeout` is the LAST step, so `Ecto.Multi` SKIPS it the moment an earlier one
-    # errors (an invalid token, an FK abort), and a raising `delete_all` bypasses it entirely.
-    # The rollback discards the `SET LOCAL` itself, so nothing needs putting back — but the
-    # ownership entry `capture/2` pushed would OUTLIVE the transaction on this process, which
-    # Bandit reuses across keep-alive requests, and make a later `LocalGuc.scoped/3` abort a
-    # read over an enclosing scope that no longer exists.
-    #
-    # CONDITIONAL, not unconditional. `restore/2` and `forget/1` both pop via `list -- names`,
-    # which removes ONE occurrence — so popping again after `:restore_timeout` already ran
-    # takes an ENCLOSING scope's entry instead. That scope then looks unowned, and a later
-    # nested capture failure takes `capture_fallback!/2`'s RESET branch rather than its ABORT
-    # branch: it clobbers the outer read's deliberate `statement_timeout` instead of refusing,
-    # which is the exact leak `LocalGuc` exists to prevent. The `:set_timeout` failure path is
-    # the mirror image — `capture/2` pushes ONLY on success, so a `[]` capture pushed nothing
-    # and popping there would steal an enclosing entry too.
-    if pop_timeout_ownership?(outcome), do: LocalGuc.forget(@timeout_guc)
-
-    case outcome do
-      {:completed, {:ok, %{articles: {affected, _}}}} ->
-        {:ok, %{affected: affected, resolved_count: resolved_count || affected}}
-
-      {:completed, {:error, _step, reason, _changes}} ->
-        {:error, reason}
-
-      {:raised, e} ->
-        {:error, e}
+    rescue
+      e in [Postgrex.Error, DBConnection.ConnectionError] -> {:error, e}
+    after
+      # `:restore_timeout` is the LAST step, so `Ecto.Multi` SKIPS it the moment an earlier one
+      # errors (an invalid token, an FK abort), and a raising `delete_all` bypasses it entirely.
+      # The rollback discards the `SET LOCAL` itself, so nothing needs putting back — but the
+      # ownership entry `capture/2` pushed would OUTLIVE the transaction on this process, which
+      # Bandit reuses across keep-alive requests, and make a later `LocalGuc.scoped/3` abort a
+      # read over an enclosing scope that no longer exists.
+      #
+      # In an `after`, so EVERY exit path passes: the two rescued structs, an exception outside
+      # them (a changeset raise in the audit step, a `MatchError` in a `Multi.run` body), a
+      # Postgrex EXIT from a wedged pool, a throw.
+      #
+      # `Process.delete/1` reads AND clears the marker, so the pop happens exactly once and
+      # only when this call pushed. Both "pushed nothing" (a `[]` capture; a raise at checkout
+      # or BEGIN, before `:set_timeout` ran) and "already popped" (`:restore_timeout` ran —
+      # including when the COMMIT itself then failed) read as nil. Popping in either case
+      # would take an ENCLOSING scope's entry, since `restore/2` and `forget/1` both pop via
+      # `list -- names`, one occurrence. That scope would then look unowned, and a later
+      # nested capture failure would take `capture_fallback!/2`'s RESET branch rather than its
+      # ABORT branch — clobbering the outer read's deliberate `statement_timeout` instead of
+      # refusing, the exact leak `LocalGuc` exists to prevent.
+      if Process.delete(@timeout_pushed_key), do: LocalGuc.forget(@timeout_guc)
     end
   end
-
-  # Own the pop only when THIS call pushed and did not already pop:
-  #   * success -> `:restore_timeout` ran and popped -> do NOT pop again
-  #   * `:set_timeout` errored -> `capture/2` returned `[]` and pushed nothing -> do NOT pop
-  #   * any other step errored, or the transaction raised -> pushed, never popped -> POP
-  defp pop_timeout_ownership?({:completed, {:ok, changes}}),
-    do: not Map.has_key?(changes, :restore_timeout)
-
-  defp pop_timeout_ownership?({:completed, {:error, :set_timeout, _reason, _changes}}), do: false
-  defp pop_timeout_ownership?({:completed, {:error, _step, _reason, _changes}}), do: true
-  defp pop_timeout_ownership?({:raised, _e}), do: true
 
   defp bulk_audit_attrs(tenant_id, action, selector_summary, affected, audit_opts) do
     %{

--- a/lib/loopctl/local_guc.ex
+++ b/lib/loopctl/local_guc.ex
@@ -101,8 +101,21 @@ defmodule Loopctl.LocalGuc do
   raised by `scoped/3` when it refused to override a GUC an enclosing scope owns — rather
   than the generic pool/connection failure that shares the struct (and the US-27.3 503).
 
-  The discriminator a fail-soft rescue needs to re-raise this abort instead of classifying it
-  as a degraded dependency.
+  The discriminator a fail-soft rescue needs to NAME the refusal — its own `error_class` tag
+  on the telemetry it already emits, its own log tag — while STILL degrading. It is not a
+  signal to re-raise.
+
+  That distinction was settled the expensive way. An abort here means one read refused to set
+  an override it could not take back; it does not mean the caller's own work is unsound, and
+  `capture_fallback!/2` raises BEFORE setting anything, so the rollback leaves nothing behind.
+  Re-raising it out of a fail-soft path therefore converts "this diagnostic could not be
+  measured" into a failed request — which is exactly what those paths exist to prevent. The
+  ingestion backlog gate must admit an innocent, under-threshold tenant when the count is
+  unmeasurable, and an abort IS unmeasurable; the vector-search under-fill probe must not
+  destroy an already-computed suggestions response.
+
+  Call sites: `LoopctlWeb.KnowledgeIngestionController`'s backlog gate and
+  `Loopctl.Knowledge`'s under-fill probe, both tagging `guc_capture_abort` and failing soft.
   """
   @spec capture_abort?(term()) :: boolean()
   def capture_abort?(%DBConnection.ConnectionError{message: message}) when is_binary(message),

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -230,9 +230,12 @@ defmodule Loopctl.TelemetryEvents do
   ## Payload (id/atom only — never a query, key, or PG message body)
 
     * `measurements`: `%{count: 1}` — a pure increment.
-    * `metadata`: `%{tenant_id, error_class}` where `error_class` is a BOUNDED 2-value
-      tag (`"timeout"` for the `Postgrex.Error` statement_timeout, `"connection"` for the
-      `DBConnection.ConnectionError` pool-checkout timeout). `tenant_id` is an id, and is
+    * `metadata`: `%{tenant_id, error_class}` where `error_class` is a BOUNDED 4-value
+      tag: `"timeout"` (57014 query_canceled — the count's own statement_timeout),
+      `"db_error"` (any OTHER `Postgrex.Error` SQLSTATE — a query bug in the count path,
+      NOT a timeout), `"connection"` (`DBConnection.ConnectionError` pool-checkout
+      timeout), `"guc_capture_abort"` (`Loopctl.LocalGuc` REFUSED to override a GUC an
+      enclosing scope owns — deliberate, not a blip). `tenant_id` is an id, and is
       cap-gated to a sentinel in the metric's `tag_values` so label cardinality stays
       bounded (same convention as the other scale counters).
 

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -76,6 +76,23 @@ defmodule Loopctl.TelemetryEvents do
   def vector_search_under_fill, do: [:loopctl, :knowledge, :vector_search, :under_fill]
 
   @doc """
+  The bounded under-fill PROBE (`Loopctl.Knowledge.under_fill_probe_degraded/2`) failed its
+  read and degraded to "no truncation signal" rather than sinking a request whose suggestions
+  were already in hand. The response is a valid 200, so without this counter the refusal is
+  invisible to a dashboard and `under_fill/0` just silently stops firing.
+
+  ## Payload (bounded tags only — NEVER the query, the vector, or a PG message body)
+
+    * `measurements`: `%{count: 1}` — a pure increment.
+    * `metadata`: `%{tenant_id, endpoint, error_class}` where `error_class` is a BOUNDED tag:
+      `"guc_capture_abort"` (`Loopctl.LocalGuc` REFUSED to override a GUC an enclosing scope
+      owns — deliberate, not a blip) | `"connection"` (pool/connection fault) | `"timeout"`
+      (57014 server-side cancel).
+  """
+  def vector_search_under_fill_probe_degraded,
+    do: [:loopctl, :knowledge, :vector_search, :under_fill_probe_degraded]
+
+  @doc """
   A mapped DB error was surfaced to a client (US-27.15). Emitted by
   `LoopctlWeb.DBErrorLogger.log/3` after it logs the sanitized structured line, so
   EVERY controller (both the FallbackController rescue path and the uncaught
@@ -445,6 +462,7 @@ defmodule Loopctl.TelemetryEvents do
       webhook_delivery_exception(),
       audit_log_write(),
       vector_search_under_fill(),
+      vector_search_under_fill_probe_degraded(),
       db_error(),
       knowledge_semantic_fallback(),
       knowledge_hybrid_provenance(),

--- a/lib/loopctl/workers/article_linking_worker.ex
+++ b/lib/loopctl/workers/article_linking_worker.ex
@@ -317,9 +317,18 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
       # pre-US-36.4 count, which had no statement_timeout and so never crashed the job).
       # Rescue here — mirroring `ScaleMetrics`' poll rescues — so a slow/failed count degrades
       # only the optional corpus-size signal while the linking it merely observes proceeds.
+      # `LocalGuc`'s capture ABORT arrives here as a `DBConnection.ConnectionError` like any
+      # wedged-pool fault, but it is a deliberate refusal to override a GUC an enclosing scope
+      # owns. It gets its own tag so it stays greppable/alertable rather than hiding inside a
+      # generic count failure — and, like the ingestion backlog gate and the under-fill probe,
+      # it still degrades SOFTLY. Re-raising here would abort a linking job over an
+      # observational signal, which is the precise regression this rescue exists to prevent.
+      tag = if LocalGuc.capture_abort?(e), do: "guc_capture_abort", else: "count_failed"
+
       Logger.warning(
-        "Article linking: corpus-size count failed (#{inspect(e.__struct__)}) for article " <>
-          "#{article.id}; skipping the observational corpus_size signal — linking proceeds"
+        "Article linking: corpus-size count failed (#{tag}: #{inspect(e.__struct__)}) for " <>
+          "article #{article.id}; skipping the observational corpus_size signal — " <>
+          "linking proceeds"
       )
 
       :ok

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -300,10 +300,11 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # because the count path is momentarily degraded). The count runs under a 2s
   # `SET LOCAL statement_timeout`; a raised statement_timeout surfaces as `Postgrex.Error`
   # (57014 query_canceled) and a pool-checkout timeout as `DBConnection.ConnectionError`,
-  # so we rescue ONLY those two classes — NOT a bare `rescue e ->`. A programming error
-  # in the count path (e.g. a bad query change) must therefore propagate and 500, LOUD,
-  # rather than be silently swallowed into a fleet-wide disabling of backpressure that
-  # looks healthy. On the fail-open path we ALSO emit a telemetry counter
+  # so we rescue ONLY those two classes — NOT a bare `rescue e ->`. A NON-DB programming
+  # error in the count path therefore propagates and 500s, LOUD, rather than being silently
+  # swallowed into a fleet-wide disabling of backpressure that looks healthy; a SQL-level one
+  # (a bad query change) is still rescued, and gets its own `db_error` class so it is not
+  # mistaken for a timeout. On the fail-open path we ALSO emit a telemetry counter
   # (`[:loopctl, :ingestion, :backlog_gate, :failed_open]`) so "the backpressure valve is
   # currently admitting because it can't measure" is an alertable signal, not just a
   # warning-log line, and a sustained per-request timeout under a real flood is visible on
@@ -325,25 +326,33 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   end
 
   defp fail_open(tenant_id, e) do
-    Logger.warning(
-      "ingestion backlog gate failed open for tenant=#{tenant_id}: " <>
-        Exception.message(e)
-    )
+    error_class = fail_open_class(e)
+
+    # The bounded CLASS tag only, never `Exception.message/1`: a `Postgrex.Error` /
+    # `DBConnection.ConnectionError` message names the backend host, database and role
+    # ("tcp connect (host:port): ..."), and this line is reachable from any wedged-pool
+    # moment on an ordinary ingest. Same policy as `Loopctl.LocalGuc`'s own failure log.
+    Logger.warning("ingestion backlog gate failed open for tenant=#{tenant_id} (#{error_class})")
 
     :telemetry.execute(
       TelemetryEvents.ingestion_backlog_gate_failed_open(),
       %{count: 1},
-      %{tenant_id: tenant_id, error_class: fail_open_class(e)}
+      %{tenant_id: tenant_id, error_class: error_class}
     )
 
     0
   end
 
+  # BOUNDED, and every value must be TRUE. The rescue above catches EVERY `Postgrex.Error`,
+  # not just 57014 query_canceled, so a flat "timeout" would report a query bug in the count
+  # path (e.g. 42703 undefined_column after a `FairShare` change) as a timeout — sending a
+  # triaging operator after the pool instead of the query that broke.
   defp fail_open_class(%DBConnection.ConnectionError{} = e) do
     if LocalGuc.capture_abort?(e), do: "guc_capture_abort", else: "connection"
   end
 
-  defp fail_open_class(%Postgrex.Error{}), do: "timeout"
+  defp fail_open_class(%Postgrex.Error{postgres: %{code: :query_canceled}}), do: "timeout"
+  defp fail_open_class(%Postgrex.Error{}), do: "db_error"
 
   defp backlog_counter do
     Application.get_env(:loopctl, :ingestion_backlog_counter, FairShare)

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -16,6 +16,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   alias Loopctl.Ingestion.ContentEnvelope
   alias Loopctl.Knowledge.ContentChunker
   alias Loopctl.Llm
+  alias Loopctl.LocalGuc
   alias Loopctl.Net.UrlGuard
   alias Loopctl.Oban.FairShare
   alias Loopctl.ObanConfig
@@ -312,19 +313,34 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   defp in_flight_ingestion_backlog(tenant_id) do
     backlog_counter().in_flight_ingestion_backlog(tenant_id)
   rescue
-    e in [DBConnection.ConnectionError, Postgrex.Error] ->
-      Logger.warning(
-        "ingestion backlog gate failed open for tenant=#{tenant_id}: " <>
-          Exception.message(e)
-      )
+    # `LocalGuc`'s capture ABORT shares `DBConnection.ConnectionError` with the transient
+    # pool faults this clause is for, but it is not one: it is raised DELIBERATELY, after
+    # `LocalGuc` decided it could not safely override a GUC an enclosing scope owns. Failing
+    # open on it would swallow a refusal whose entire purpose is to be noticed, and would do
+    # so on exactly the request whose connection is already mis-scoped. Re-raise it — the
+    # US-27.3 backstop maps it to a 503 with `Retry-After`, which is the honest answer. See
+    # `Loopctl.LocalGuc.capture_abort?/1`.
+    e in DBConnection.ConnectionError ->
+      if LocalGuc.capture_abort?(e), do: reraise(e, __STACKTRACE__)
+      fail_open(tenant_id, e)
 
-      :telemetry.execute(
-        TelemetryEvents.ingestion_backlog_gate_failed_open(),
-        %{count: 1},
-        %{tenant_id: tenant_id, error_class: fail_open_class(e)}
-      )
+    e in Postgrex.Error ->
+      fail_open(tenant_id, e)
+  end
 
-      0
+  defp fail_open(tenant_id, e) do
+    Logger.warning(
+      "ingestion backlog gate failed open for tenant=#{tenant_id}: " <>
+        Exception.message(e)
+    )
+
+    :telemetry.execute(
+      TelemetryEvents.ingestion_backlog_gate_failed_open(),
+      %{count: 1},
+      %{tenant_id: tenant_id, error_class: fail_open_class(e)}
+    )
+
+    0
   end
 
   defp fail_open_class(%DBConnection.ConnectionError{}), do: "connection"

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -314,17 +314,13 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     backlog_counter().in_flight_ingestion_backlog(tenant_id)
   rescue
     # `LocalGuc`'s capture ABORT shares `DBConnection.ConnectionError` with the transient
-    # pool faults this clause is for, but it is not one: it is raised DELIBERATELY, after
-    # `LocalGuc` decided it could not safely override a GUC an enclosing scope owns. Failing
-    # open on it would swallow a refusal whose entire purpose is to be noticed, and would do
-    # so on exactly the request whose connection is already mis-scoped. Re-raise it — the
-    # US-27.3 backstop maps it to a 503 with `Retry-After`, which is the honest answer. See
+    # pool faults this clause is for. It is raised DELIBERATELY, so it gets its OWN
+    # `error_class` (`fail_open_class/1`) rather than hiding inside "connection" — a refusal
+    # whose purpose is to be noticed stays alertable. It still fails OPEN: an abort IS an
+    # unmeasurable count, and this gate exists so an innocent, under-threshold tenant never
+    # eats an error because the count path is momentarily degraded. See
     # `Loopctl.LocalGuc.capture_abort?/1`.
-    e in DBConnection.ConnectionError ->
-      if LocalGuc.capture_abort?(e), do: reraise(e, __STACKTRACE__)
-      fail_open(tenant_id, e)
-
-    e in Postgrex.Error ->
+    e in [DBConnection.ConnectionError, Postgrex.Error] ->
       fail_open(tenant_id, e)
   end
 
@@ -343,7 +339,10 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     0
   end
 
-  defp fail_open_class(%DBConnection.ConnectionError{}), do: "connection"
+  defp fail_open_class(%DBConnection.ConnectionError{} = e) do
+    if LocalGuc.capture_abort?(e), do: "guc_capture_abort", else: "connection"
+  end
+
   defp fail_open_class(%Postgrex.Error{}), do: "timeout"
 
   defp backlog_counter do

--- a/test/loopctl/knowledge/bulk_ops_test.exs
+++ b/test/loopctl/knowledge/bulk_ops_test.exs
@@ -11,6 +11,7 @@ defmodule Loopctl.Knowledge.BulkOpsTest do
   alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Knowledge.BulkDeleteToken
   alias Loopctl.Knowledge.BulkOps
+  alias Loopctl.LocalGuc
 
   defp audit_opts do
     [actor_type: "api_key", actor_id: Ecto.UUID.generate(), actor_label: "user:tester"]
@@ -48,6 +49,20 @@ defmodule Loopctl.Knowledge.BulkOpsTest do
       :ok
     end
 
+    test "the key above is the one LocalGuc actually pushes to" do
+      # `@active_names_key` duplicates a PRIVATE `LocalGuc` detail, which is how a guard test
+      # goes vacuous: seed and read one unrelated key and every assertion below holds
+      # trivially while the accounting it guards goes unverified. Bind the literal to the
+      # real thing — a real capture must land under it — so a rename fails HERE, loudly,
+      # instead of quietly neutering the two tests that follow.
+      AdminRepo.transaction(fn ->
+        prior = LocalGuc.capture(AdminRepo, ["statement_timeout"])
+        assert owned_names() == ["statement_timeout"]
+        LocalGuc.restore(AdminRepo, prior)
+        assert owned_names() == []
+      end)
+    end
+
     test "a SUCCEEDING bulk op leaves an enclosing scope's ownership intact" do
       tenant = fixture(:tenant)
       fixture(:article, tenant_id: tenant.id, tags: ["ownership"], status: :published)
@@ -76,6 +91,24 @@ defmodule Loopctl.Knowledge.BulkOpsTest do
 
       assert owned_names() == ["statement_timeout"],
              "a failed bulk op must release exactly its own entry, no more and no fewer"
+    end
+
+    test "a bulk op that RAISES outside the rescued DB structs still releases its own entry" do
+      tenant = fixture(:tenant)
+      fixture(:article, tenant_id: tenant.id, tags: ["ownership"], status: :published)
+
+      enclosing_owner(["statement_timeout"])
+
+      # A non-keyword `audit_opts` raises `FunctionClauseError` inside the audit step's
+      # changeset fun — an exception neither `rescue` clause names, so it unwinds straight
+      # out of `run_multi/2`. Only an `after` runs on that path; a try/rescue over two DB
+      # structs leaves this call's entry behind for whatever the process serves next.
+      assert_raise FunctionClauseError, fn ->
+        BulkOps.archive(tenant.id, {:tag, "ownership"}, %{actor_type: "api_key"})
+      end
+
+      assert owned_names() == ["statement_timeout"],
+             "a raising bulk op leaked its LocalGuc ownership entry onto this process"
     end
   end
 

--- a/test/loopctl/knowledge/bulk_ops_test.exs
+++ b/test/loopctl/knowledge/bulk_ops_test.exs
@@ -25,6 +25,60 @@ defmodule Loopctl.Knowledge.BulkOpsTest do
     |> AdminRepo.all()
   end
 
+  # --- LocalGuc ownership accounting (PR #549 review follow-up) ---
+
+  describe "LocalGuc active-names ownership across a bulk op" do
+    # `LocalGuc` tracks which GUC names a LIVE scope owns in the process dictionary, and
+    # `capture_fallback!/2` reads it to decide whether a FAILED capture may reset a name
+    # (nobody owns it) or must abort (an enclosing scope does). Both `restore/2` and
+    # `forget/1` pop with `list -- names`, which removes ONE occurrence — so a bulk op that
+    # pops twice silently steals an ENCLOSING scope's entry. That scope then looks unowned,
+    # and the next nested capture failure clobbers its deliberate `statement_timeout`
+    # instead of refusing: the exact leak LocalGuc exists to prevent.
+    #
+    # Asserted on the tracking state itself because there is no other observable: the
+    # damage only materialises on a LATER, unrelated read whose capture happens to fail.
+    @active_names_key {Loopctl.LocalGuc, :active_names}
+
+    defp enclosing_owner(names), do: Process.put(@active_names_key, names)
+    defp owned_names, do: Process.get(@active_names_key, [])
+
+    setup do
+      on_exit(fn -> Process.delete(@active_names_key) end)
+      :ok
+    end
+
+    test "a SUCCEEDING bulk op leaves an enclosing scope's ownership intact" do
+      tenant = fixture(:tenant)
+      fixture(:article, tenant_id: tenant.id, tags: ["ownership"], status: :published)
+
+      enclosing_owner(["statement_timeout"])
+
+      assert {:ok, %{affected: 1}} =
+               BulkOps.archive(tenant.id, {:tag, "ownership"}, audit_opts())
+
+      # Before the fix this was [] — :restore_timeout popped the bulk op's own entry and the
+      # unconditional `after` pop then took the enclosing scope's.
+      assert owned_names() == ["statement_timeout"],
+             "the bulk op popped an enclosing scope's LocalGuc ownership entry"
+    end
+
+    test "a FAILING bulk op still releases its own ownership entry" do
+      tenant = fixture(:tenant)
+
+      enclosing_owner(["statement_timeout"])
+
+      # An invalid delete token errors a step AFTER :set_timeout, so :restore_timeout is
+      # skipped and the entry this call pushed is never popped by it — the case the
+      # `after` cleanup exists for. It must still not over-pop.
+      assert {:error, :invalid_token} =
+               BulkOps.delete_with_token(tenant.id, Ecto.UUID.generate(), audit_opts())
+
+      assert owned_names() == ["statement_timeout"],
+             "a failed bulk op must release exactly its own entry, no more and no fewer"
+    end
+  end
+
   # --- TC-27.12.1: archive by tag is set-based and tenant-scoped ---
 
   describe "archive/3 by tag (TC-27.12.1, AC-27.12.1/.6/.8)" do

--- a/test/loopctl/knowledge/under_fill_probe_degraded_test.exs
+++ b/test/loopctl/knowledge/under_fill_probe_degraded_test.exs
@@ -1,0 +1,94 @@
+defmodule Loopctl.Knowledge.UnderFillProbeDegradedTest do
+  @moduledoc """
+  The under-fill probe's fail-soft exit (`Loopctl.Knowledge.under_fill_probe_degraded/2`).
+
+  The probe is ADVISORY — it runs only once the suggestions are already in hand — so a DB
+  fault on it degrades to "no truncation signal" and the request still returns 200. That
+  makes the refusal INVISIBLE unless it carries a signal of its own, which is why the
+  degradation emits a bounded counter rather than only a log line. A future change that
+  reinstated the old `reraise` would trade a valid 200 for a 503 over a diagnostic read,
+  the exact AREA-5 fail-soft violation this path exists to avoid.
+
+  `LocalGuc`'s capture ABORT shares `DBConnection.ConnectionError` with a transient pool
+  fault and is deliberate, so it must stay separable on a dashboard.
+  """
+  use Loopctl.DataCase, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Loopctl.Knowledge
+  alias Loopctl.LocalGuc
+  alias Loopctl.TelemetryEvents
+
+  setup :verify_on_exit!
+
+  # Forward the degraded-probe counter for THIS tenant to the test process (the handler is
+  # process-GLOBAL and the suite is async), with guaranteed detach.
+  defp attach_degraded(tenant_id) do
+    test_pid = self()
+    handler_id = "probe-degraded-#{System.unique_integer([:positive])}"
+    event = TelemetryEvents.vector_search_under_fill_probe_degraded()
+
+    :telemetry.attach(
+      handler_id,
+      event,
+      fn ^event, measurements, metadata, _ ->
+        if metadata.tenant_id == tenant_id,
+          do: send(test_pid, {:probe_degraded, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
+  # Built by hand, then BOUND to the real discriminator: if `LocalGuc`'s abort tag ever
+  # changes, `capture_abort?/1` stops matching and this fails HERE, loudly, instead of
+  # quietly turning the assertion below into "connection" == "connection".
+  defp capture_abort_error do
+    e = %DBConnection.ConnectionError{
+      message:
+        ~s(LocalGuc: could not capture ["statement_timeout"], which an enclosing scope ) <>
+          "already overrode"
+    }
+
+    assert LocalGuc.capture_abort?(e)
+    e
+  end
+
+  test "a LocalGuc capture abort degrades (never raises) under its OWN error_class" do
+    tenant_id = Ecto.UUID.generate()
+    attach_degraded(tenant_id)
+
+    assert :error = Knowledge.under_fill_probe_degraded(tenant_id, capture_abort_error())
+
+    assert_receive {:probe_degraded, %{count: 1}, metadata}
+    assert metadata.endpoint == :suggested_links
+    # Not "connection": a deliberate refusal must be distinguishable from a pool blip.
+    assert metadata.error_class == "guc_capture_abort"
+  end
+
+  test "a transient pool fault and a 57014 cancel each degrade under their own class" do
+    tenant_id = Ecto.UUID.generate()
+    attach_degraded(tenant_id)
+
+    pool_fault = %DBConnection.ConnectionError{message: "tcp connect (db.internal:5432): timeout"}
+    cancel = %Postgrex.Error{postgres: %{code: :query_canceled, message: "canceling statement"}}
+
+    assert :error = Knowledge.under_fill_probe_degraded(tenant_id, pool_fault)
+    assert_receive {:probe_degraded, %{count: 1}, %{error_class: "connection"}}
+
+    assert :error = Knowledge.under_fill_probe_degraded(tenant_id, cancel)
+    assert_receive {:probe_degraded, %{count: 1}, %{error_class: "timeout"}}
+  end
+
+  test "the log carries the class tag, never the backend host from the exception message" do
+    tenant_id = Ecto.UUID.generate()
+    pool_fault = %DBConnection.ConnectionError{message: "tcp connect (db.internal:5432): timeout"}
+
+    log = capture_log(fn -> Knowledge.under_fill_probe_degraded(tenant_id, pool_fault) end)
+
+    assert log =~ "under_fill probe degraded (connection)"
+    refute log =~ "db.internal"
+  end
+end

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -824,6 +824,26 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
   # --- US-36.3: batch-ingest backlog backpressure (429) ---
 
+  # Forward the fail-open counter for THIS tenant to the test process, with guaranteed
+  # detach. Scoped by tenant because the handler is process-GLOBAL and the suite is async.
+  defp attach_failed_open(tenant_id) do
+    test_pid = self()
+    handler_id = "backlog-failopen-#{System.unique_integer([:positive])}"
+    event = [:loopctl, :ingestion, :backlog_gate, :failed_open]
+
+    :telemetry.attach(
+      handler_id,
+      event,
+      fn ^event, measurements, metadata, _ ->
+        if metadata.tenant_id == tenant_id,
+          do: send(test_pid, {:backlog_failed_open, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
   describe "POST /api/v1/knowledge/ingest/batch backlog backpressure (US-36.3)" do
     test "TC-36.3.1: tenant over threshold -> 429 + Retry-After + coded error; ZERO jobs enqueued",
          %{conn: conn} do
@@ -952,21 +972,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
       # The fail-open path emits an alertable telemetry counter so "the valve is currently
       # admitting because it can't measure" is observable, not just a warning log.
-      test_pid = self()
-      handler_id = "backlog-failopen-#{System.unique_integer([:positive])}"
-      event = [:loopctl, :ingestion, :backlog_gate, :failed_open]
-
-      :telemetry.attach(
-        handler_id,
-        event,
-        fn ^event, measurements, metadata, _ ->
-          if metadata.tenant_id == tenant.id,
-            do: send(test_pid, {:backlog_failed_open, measurements, metadata})
-        end,
-        nil
-      )
-
-      on_exit(fn -> :telemetry.detach(handler_id) end)
+      attach_failed_open(tenant.id)
 
       # Simulate a statement_timeout / transient DB error from the backlog count via the
       # DI seam (overrides the DataCase default that delegates to the real count). The
@@ -1003,21 +1009,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
-      test_pid = self()
-      handler_id = "backlog-abort-#{System.unique_integer([:positive])}"
-      event = [:loopctl, :ingestion, :backlog_gate, :failed_open]
-
-      :telemetry.attach(
-        handler_id,
-        event,
-        fn ^event, measurements, metadata, _ ->
-          if metadata.tenant_id == tenant.id,
-            do: send(test_pid, {:backlog_failed_open, measurements, metadata})
-        end,
-        nil
-      )
-
-      on_exit(fn -> :telemetry.detach(handler_id) end)
+      attach_failed_open(tenant.id)
 
       # Raised with the real module's own message prefix, so the test binds to
       # `LocalGuc.capture_abort?/1`'s actual discriminator rather than a copy of it.
@@ -1039,6 +1031,60 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       # Not "connection": an abort must be distinguishable from a pool blip on the dashboard.
       assert_receive {:backlog_failed_open, %{count: 1}, metadata}
       assert metadata.error_class == "guc_capture_abort"
+    end
+
+    test "a NON-timeout SQLSTATE is not reported as a timeout", %{conn: conn} do
+      # The rescue catches EVERY `Postgrex.Error`, not only 57014, so a query bug in the
+      # count path (a column renamed out from under `FairShare`) also fails open. It must
+      # say so: labelling it "timeout" sends a triaging operator after the pool instead of
+      # the query that broke.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        raise %Postgrex.Error{
+          postgres: %{code: :undefined_column, message: "column j.args does not exist"}
+        }
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Query-bug batch item", source_type: "newsletter"}]
+        })
+
+      assert length(json_response(conn, 200)["data"]) == 1
+
+      assert_receive {:backlog_failed_open, %{count: 1}, metadata}
+      assert metadata.error_class == "db_error"
+    end
+
+    test "a 57014 cancel IS reported as a timeout", %{conn: conn} do
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        raise %Postgrex.Error{
+          postgres: %{code: :query_canceled, message: "canceling statement due to timeout"}
+        }
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Timeout batch item", source_type: "newsletter"}]
+        })
+
+      assert length(json_response(conn, 200)["data"]) == 1
+
+      assert_receive {:backlog_failed_open, %{count: 1}, metadata}
+      assert metadata.error_class == "timeout"
     end
 
     test "TC-36.3.7: a NON-DB error in the backlog count propagates (500), not fail-open",

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -993,6 +993,57 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert metadata.error_class == "connection"
     end
 
+    test "a LocalGuc capture ABORT propagates as 503 — it is not a transient pool fault",
+         %{conn: conn} do
+      # `LocalGuc`'s capture abort shares `DBConnection.ConnectionError` with the transient
+      # pool faults the clause above deliberately fails open on — but it is raised on
+      # PURPOSE, after LocalGuc refused to override a GUC an enclosing scope owns. Failing
+      # open on it would admit the batch on a connection already known to be mis-scoped and
+      # swallow a refusal whose whole point is to be noticed. It must reach the US-27.3 503
+      # instead, and it must NOT emit the fail-open telemetry.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      test_pid = self()
+      handler_id = "backlog-abort-#{System.unique_integer([:positive])}"
+      event = [:loopctl, :ingestion, :backlog_gate, :failed_open]
+
+      :telemetry.attach(
+        handler_id,
+        event,
+        fn ^event, _m, metadata, _ ->
+          if metadata.tenant_id == tenant.id, do: send(test_pid, :wrongly_failed_open)
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      # Raised with the real module's own message prefix, so the test binds to
+      # `LocalGuc.capture_abort?/1`'s actual discriminator rather than a copy of it.
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        raise DBConnection.ConnectionError,
+              ~s(LocalGuc: could not capture ["statement_timeout"], which an enclosing ) <>
+                "scope already overrode"
+      end)
+
+      # DBErrorBackstop logs the sanitized structured line and RE-RAISES a
+      # `SanitizedDBError` (so the web server's crash log can never echo the raw query);
+      # `Plug.Exception` is what turns that into the response status, which is why this
+      # asserts the raised exception's status rather than a rendered body.
+      error =
+        assert_raise LoopctlWeb.SanitizedDBError, fn ->
+          conn
+          |> auth_conn(raw_key)
+          |> post(~p"/api/v1/knowledge/ingest/batch", %{
+            items: [%{content: "Capture abort item", source_type: "newsletter"}]
+          })
+        end
+
+      assert Plug.Exception.status(error) == 503
+      refute_receive :wrongly_failed_open, 100
+    end
+
     test "TC-36.3.7: a NON-DB error in the backlog count propagates (500), not fail-open",
          %{conn: conn} do
       # A programming error in the count path must NOT be silently swallowed into a

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -993,14 +993,13 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert metadata.error_class == "connection"
     end
 
-    test "a LocalGuc capture ABORT propagates as 503 — it is not a transient pool fault",
+    test "a LocalGuc capture ABORT fails open too, under its OWN error_class",
          %{conn: conn} do
       # `LocalGuc`'s capture abort shares `DBConnection.ConnectionError` with the transient
-      # pool faults the clause above deliberately fails open on — but it is raised on
-      # PURPOSE, after LocalGuc refused to override a GUC an enclosing scope owns. Failing
-      # open on it would admit the batch on a connection already known to be mis-scoped and
-      # swallow a refusal whose whole point is to be noticed. It must reach the US-27.3 503
-      # instead, and it must NOT emit the fail-open telemetry.
+      # pool faults the clause above fails open on, and is raised on PURPOSE — but it is
+      # still an UNMEASURABLE count, and this gate exists so that never blocks an innocent,
+      # under-threshold tenant. It therefore admits, and stays alertable through a distinct
+      # `error_class` rather than through a 503 the tenant did nothing to earn.
       tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
@@ -1011,8 +1010,9 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       :telemetry.attach(
         handler_id,
         event,
-        fn ^event, _m, metadata, _ ->
-          if metadata.tenant_id == tenant.id, do: send(test_pid, :wrongly_failed_open)
+        fn ^event, measurements, metadata, _ ->
+          if metadata.tenant_id == tenant.id,
+            do: send(test_pid, {:backlog_failed_open, measurements, metadata})
         end,
         nil
       )
@@ -1027,21 +1027,18 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
                 "scope already overrode"
       end)
 
-      # DBErrorBackstop logs the sanitized structured line and RE-RAISES a
-      # `SanitizedDBError` (so the web server's crash log can never echo the raw query);
-      # `Plug.Exception` is what turns that into the response status, which is why this
-      # asserts the raised exception's status rather than a rendered body.
-      error =
-        assert_raise LoopctlWeb.SanitizedDBError, fn ->
-          conn
-          |> auth_conn(raw_key)
-          |> post(~p"/api/v1/knowledge/ingest/batch", %{
-            items: [%{content: "Capture abort item", source_type: "newsletter"}]
-          })
-        end
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Capture abort item", source_type: "newsletter"}]
+        })
 
-      assert Plug.Exception.status(error) == 503
-      refute_receive :wrongly_failed_open, 100
+      assert length(json_response(conn, 200)["data"]) == 1
+
+      # Not "connection": an abort must be distinguishable from a pool blip on the dashboard.
+      assert_receive {:backlog_failed_open, %{count: 1}, metadata}
+      assert metadata.error_class == "guc_capture_abort"
     end
 
     test "TC-36.3.7: a NON-DB error in the backlog count propagates (500), not fail-open",


### PR DESCRIPTION
The last two findings from PR #549's review. Both are about the same thing: `LocalGuc`'s ownership bookkeeping only works if callers account honestly, and two of them did not.

## A capture abort is not a degraded dependency

PR #549 made `LocalGuc.capture_fallback!/2` raise `DBConnection.ConnectionError` so a wedged-capture reaches the US-27.3 503 instead of an unstructured 500. That put it in the same struct as the transient pool faults two fail-soft paths deliberately swallow — the ingestion backlog gate admits at `0`, and the vector-search under-fill probe returns `:error`.

So #549 handed both of them a new way to fail quietly. A capture abort is not a blip: it is raised **on purpose**, after `LocalGuc` decided it could not safely override a GUC an enclosing scope owns. Failing open on it swallows a refusal whose entire point is to be noticed, and does so on a request whose connection is already known to be mis-scoped.

Both now consult `LocalGuc.capture_abort?/1` and re-raise. Narrowing the `ConnectionError` rescue this way exactly mirrors what the under-fill probe already did one clause down for `Postgrex.Error`, where only `query_canceled` degrades and everything else propagates.

## Bulk ops popped the ownership entry twice

On the success path, `Multi.run(:restore_timeout)` pops via `LocalGuc.restore/2` and the `after` block then popped again via `LocalGuc.forget/1`. Both pop with `list -- names`, which removes ONE occurrence — so the second pop took an **enclosing** scope's entry rather than its own.

The consequence is remote from the cause, which is why it survived review twice. The outer scope now looks unowned, so the NEXT nested capture failure takes `capture_fallback!/2`'s RESET branch instead of its ABORT branch, and clobbers that scope's deliberate `statement_timeout` — the 57014-far-from-the-query leak the module exists to prevent, reintroduced by the bookkeeping meant to prevent it.

The `:set_timeout` failure path is the mirror image: `capture/2` pushes ONLY on success, so a `[]` capture pushed nothing and popping there steals an enclosing entry too.

The pop is now conditional on this call having pushed and not yet popped, enumerated per outcome rather than inferred:

| Outcome | Pop? |
|---|---|
| success — `:restore_timeout` ran and popped | no |
| `:set_timeout` errored — `capture/2` pushed nothing | no |
| a later step errored, or the transaction raised | yes |

## Both fixes are mutation-verified

- Removing the conditional pop → the enclosing-ownership test fails (`the bulk op popped an enclosing scope's LocalGuc ownership entry`)
- Removing the re-raise → the 503 test fails (`Expected exception LoopctlWeb.SanitizedDBError but nothing was raised`)

That check is deliberate rather than ceremonial. Today produced three defects in a row where a guard was present in the source and never fired, none of which failed a test: a throttle comparing against negative `System.monotonic_time` (#547), a rename that issued no SQL so its `StaleEntryError` rescue was unreachable (#548), and a savepoint gate dead under the sandbox (#549). A new guard that has not been mutation-tested is a guard with no evidence it does anything.

The backlog test also asserts the fail-open telemetry does NOT fire, so the abort cannot be counted as an admitted-because-unmeasurable event on a dashboard.

## Verification

- `mix precommit` green — 6503 tests, credo --strict, dialyzer
- 3 new tests, all three mutation-verified against their own fix
- `knowledge-wiki` skill citations repointed — these edits shifted line numbers in `knowledge.ex`; `mix loopctl.check_skill_citations` caught the qualified one and I corrected the bare `absolute_score/1` range it does not check

Closes the review chain started by #548.
