### PR TITLE
Give the legacy embedding columns a retirement trigger, not a note (#551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Operator-facing changes for deployments outside the hosted instance.
 
 ### Added
 
+- **A retirement trigger for the US-41.1 legacy embedding columns (#551).** New migration
+  (`embedding_retirement_observations`, a global non-tenant table) and a new daily job at
+  03:40 UTC. It records one observation per UTC day — the read flag, which legacy columns
+  survive, and the cumulative `idx_scan` of every index over them — and once retirement is
+  owed it logs at `error` every run and enqueues an operator alert
+  (`embeddings.legacy_retirement_due`) through the existing `SCALE_ALERT_WEBHOOK_URL`
+  channel, which stays a no-op when that is unset.
+
+  **It drops nothing.** Dropping `articles.embedding` / `memories.embedding` remains a
+  deliberate, reviewed migration; this only decides when the system starts asking for one.
+  Two triggers, both requiring the columns to still exist: 30 consecutive clear days
+  (`embedding_side_table_reads = 1`, no movement on any legacy index), or the `review_by`
+  date passing — `2027-01-22`, six months after the cutover. The deadline is what keeps
+  the check honest: a probe that errors forever looks exactly like a probe that keeps
+  finding nothing. Both values are `config :loopctl, :embedding_legacy_retirement` — no
+  new environment variable, and moving the date out is a supported operator decision.
+
 - **`GET /enroll` — a browser page that anchors an EXISTING tenant (#541).** The API
   advertised an `enrollment_upgrade` path out of `agent_rooted`, but nobody could walk it:
   `navigator.credentials.create()` needs a browser, and the only page running a WebAuthn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ Operator-facing changes for deployments outside the hosted instance.
   survive, and the cumulative `idx_scan` of every index over them — and once retirement is
   owed it logs at `error` every run and enqueues an operator alert
   (`embeddings.legacy_retirement_due`) through the existing `SCALE_ALERT_WEBHOOK_URL`
-  channel, which stays a no-op when that is unset.
+  channel, which stays a no-op when that is unset. A passed deadline that a revert in
+  progress is BLOCKING alerts on the same channel under `embeddings.legacy_retirement_blocked`
+  — it names a condition to resolve, not a column to drop.
 
   **It drops nothing.** Dropping `articles.embedding` / `memories.embedding` remains a
   deliberate, reviewed migration; this only decides when the system starts asking for one.

--- a/config/config.exs
+++ b/config/config.exs
@@ -44,6 +44,25 @@ config :loopctl,
   # progress. `0` disables caching entirely (config/test.exs sets 0 so tests observe
   # a disclosure change immediately).
   embedding_disclosure_cache_ms: 5_000,
+  # GH #551: the US-41.1 legacy-column RETIREMENT trigger
+  # (`Loopctl.Embeddings.LegacyRetirement`). Nothing here drops a column — these two
+  # values decide only when the system starts SAYING the drop is owed.
+  #
+  # - required_clear_days: consecutive UTC days that must show `embedding_side_table_reads
+  #   = 1` and zero movement in any legacy index's `idx_scan` before the evidence trigger
+  #   fires. 30 is chosen to span the slowest recurring workload that could still touch
+  #   the legacy path (the weekly MOC fan-out, the monthly-ish scale runs), so a clear
+  #   window means clear, not merely "nothing ran".
+  # - review_by: the date past which retirement is owed REGARDLESS of the evidence. Set
+  #   six months after the 2026-07-22 read-flag flip. This is the part that makes the
+  #   check fail closed: a probe that errors forever, or an `idx_scan` that never settles,
+  #   is indistinguishable from "not due yet", so an evidence-only trigger decays
+  #   silently back into the prose it replaced. Moving this date out is a legitimate
+  #   operator decision — making it moot by accident is not.
+  embedding_legacy_retirement: [
+    required_clear_days: 30,
+    review_by: ~D[2027-01-22]
+  ],
   # US-38.4: EXPLICIT pgvector HNSW build parameters for every `CREATE INDEX ... USING
   # hnsw` (`Loopctl.Repo.HnswIndex`). These EQUAL pgvector's implicit defaults (m=16,
   # ef_construction=64) — a deliberate, documented "keep the defaults" tuning outcome

--- a/config/test.exs
+++ b/config/test.exs
@@ -705,6 +705,23 @@ config :loopctl, :custody_flush_debounce_seconds, 0
 # the real `SystemConfigReadPath`, so every other test keeps production behaviour.
 config :loopctl, :embedding_read_path, Loopctl.MockEmbeddingReadPath
 
+# GH #551: the legacy-column retirement trigger is injected (see
+# `Loopctl.Embeddings.LegacyRetirementBehaviour`) so the worker's fail-closed probe-error
+# branch is reachable from a test — the test database never fails the catalog read that
+# would produce it in production. `Loopctl.DataCase.stub_all_defaults/0` stubs this mock
+# to the real `Loopctl.Embeddings.LegacyRetirement`, so every other test sees production
+# behaviour.
+config :loopctl, :legacy_retirement, Loopctl.MockLegacyRetirement
+
+# GH #551: a SHORT evidence window in tests. The production bar is 30 days; asserting
+# against it would mean fabricating 30 observation rows per test to say something that
+# is true at 3. The window LENGTH is not what the tests are checking — the gate logic
+# over a window of that length is — and `required_clear_days` is threaded through
+# `evaluate/2` opts, so the tests that DO care state their own.
+config :loopctl, :embedding_legacy_retirement,
+  required_clear_days: 3,
+  review_by: ~D[2027-01-22]
+
 # #488 / US-41.1: `hnsw.iterative_scan` is pinned ON for the TEST env only.
 #
 # It is the PRODUCTION remedy for cross-tenant filtered-ANN under-return. THREE values are in

--- a/docs/epic_41_breadcrumb.md
+++ b/docs/epic_41_breadcrumb.md
@@ -1,6 +1,15 @@
-# Epic 41 — Private/Local Knowledge Tier (Draft, Needs Review)
+# Epic 41 — Private/Local Knowledge Tier
 
-**Status:** Draft in PR #410; awaiting enhanced review before implementation
+**Status:** PARTLY SHIPPED — 5 of 7 stories merged. See the story table in
+[`docs/user_stories/epic_41_private_local_tier/README.md`](user_stories/epic_41_private_local_tier/README.md)
+for the per-story state and merge PR; this file records the DESIGN decisions that got
+the epic here and is not re-verified per merge.
+
+Everything below the "Re-scope" heading is the 2026-07-20 draft's reasoning, preserved
+as written. It describes what was TRUE THEN — treat its present tense as historical.
+**Grounded current state** in particular was verified against master 2026-07-20 and has
+since been overtaken by the merges the story table lists.
+
 **Filed:** GH issue #409 (a loopctl user's self-host blocker + privacy concern)
 **Companion:** GH issue #331 (agent-usable KB curation) — SHIPPED. Together the two
 define the real gap: agent-native curation of PRIVATE data.
@@ -56,7 +65,7 @@ repo-coordination-bus epic, and 40 is the coordination-bus v2 epic.
 - `private`/`owner` visibility is a metadata string filtered ONLY for agent-role
   callers (`coordination.ex:1021-1022`); memories have no visibility field at all
 
-## Next Steps
+## Next Steps (as planned on 2026-07-20 — steps 1-2 and most of 3 are DONE)
 1. `/review:enhanced-review-workflow` on PR #410 (README + 7 stories)
 2. Fix confirmed findings — no deferrals
 3. Implement **41.4 first** -> 41.1 -> 41.2 -> 41.3 -> 41.5, then 41.6 / 41.7.

--- a/docs/user_stories/epic_41_private_local_tier/README.md
+++ b/docs/user_stories/epic_41_private_local_tier/README.md
@@ -1,6 +1,19 @@
 # Epic 41 — Private / Local-Only Knowledge & Memory (data sovereignty)
 
-**Status: DRAFT — re-scoped 2026-07-20 from the parked epic 39 draft (2026-07-15).
+**Status: PARTLY SHIPPED. US-41.1, 41.3, 41.4, 41.5 and 41.7 are merged; US-41.2 and
+US-41.6 are not started.** The per-story state and its merge PR live in the Stories
+table below — that table is the single source of truth for what is done, and this
+header is the only place that summarises it. Everything in the prose below (the
+motivation, the audit table, the "Grounded current state" table, the decisions) was
+written against master 2026-07-20 and is the epic's DESIGN record: read its present
+tense as "at design time", not as a claim about master today.
+
+Recording this mattered enough to fix: GH #551 was filed against a stale reading of
+this header and asserted that five stories were open when three of those five had
+already merged. A status line nobody updates is worse than no status line, because it
+gets cited.
+
+**Re-scoped 2026-07-20 from the parked epic 39 draft (2026-07-15).
 Renumbered 39 -> 41 because epic 39 was reused by the shipped repo-coordination-bus
 epic. Every story MUST go through the enhanced-review workflow (against the story
 text AND the diff) before/at implementation.
@@ -172,15 +185,23 @@ requires the `.well-known` capability publication from AC-41.4.10 — so 41.2, 4
 41.1 all depend on 41.4. **Implementation order: 41.4 -> 41.1 -> 41.2 -> 41.3 -> 41.5,
 then 41.6 / 41.7.**
 
-| Story | Title | Axis | Depends |
-|-------|-------|------|---------|
-| US-41.1 | Per-tenant embedding dimension via an `article_embeddings` / `memory_embeddings` side table | B | US-41.4 (`.well-known` capability publication, AC-41.4.10) |
-| US-41.2 | Per-tenant embedding **endpoint** + config-time dimension probe with legible remediation | A | US-41.1, US-41.4 (egress policy module, AC-41.4.9) |
-| US-41.3 | Pluggable extraction/classification/merge endpoint (OpenAI-compatible local chat) | A | US-41.4 (egress policy module, AC-41.4.9) |
-| US-41.4 | **Fail-closed** no-egress guard + `local_only` scope marking + tenant-declared trusted endpoints + `egress_posture` MCP tool + `.well-known` capability publication | A | — |
-| US-41.5 | Extend the egress guard to non-provider egress (webhook delivery) | A | US-41.4 |
-| US-41.6 | Encrypted private-tier bodies at rest + vector-only recall + honest threat model | B | US-41.1, US-41.4 |
-| US-41.7 | Egress posture as a **witnessed custody claim** in the audit chain / STH | A | US-41.4, US-41.5 |
+| Story | Title | Axis | Depends | State |
+|-------|-------|------|---------|-------|
+| US-41.1 | Per-tenant embedding dimension via an `article_embeddings` / `memory_embeddings` side table | B | US-41.4 (`.well-known` capability publication, AC-41.4.10) | SHIPPED (PR #482) |
+| US-41.2 | Per-tenant embedding **endpoint** + config-time dimension probe with legible remediation | A | US-41.1, US-41.4 (egress policy module, AC-41.4.9) | NOT STARTED |
+| US-41.3 | Pluggable extraction/classification/merge endpoint (OpenAI-compatible local chat) | A | US-41.4 (egress policy module, AC-41.4.9) | SHIPPED (PR #472) |
+| US-41.4 | **Fail-closed** no-egress guard + `local_only` scope marking + tenant-declared trusted endpoints + `egress_posture` MCP tool + `.well-known` capability publication | A | — | SHIPPED (PR #457) |
+| US-41.5 | Extend the egress guard to non-provider egress (webhook delivery) | A | US-41.4 | SHIPPED (PR #477) |
+| US-41.6 | Encrypted private-tier bodies at rest + vector-only recall + honest threat model | B | US-41.1, US-41.4 | NOT STARTED |
+| US-41.7 | Egress posture as a **witnessed custody claim** in the audit chain / STH | A | US-41.4, US-41.5 | SHIPPED (PR #481) |
+
+The two open stories are load-bearing on OTHER work and are cheap to re-verify in code
+rather than by trusting this table: US-41.2 is unstarted iff `tenant_llm_settings` has
+no `embedding_base_url` field (`lib/loopctl/llm/tenant_llm_settings.ex`) and
+`EmbeddingClient` still resolves `base_url` from runtime config
+(`lib/loopctl/knowledge/embedding_client.ex`); US-41.6 is unstarted iff
+`Loopctl.Egress` still hardcodes `encrypt_body: false` with a "ships in US-41.6"
+comment (`lib/loopctl/egress.ex`). Both hold as of 2026-08-02.
 
 ## Decisions
 

--- a/lib/loopctl/embeddings/legacy_retirement.ex
+++ b/lib/loopctl/embeddings/legacy_retirement.ex
@@ -1,0 +1,431 @@
+defmodule Loopctl.Embeddings.LegacyRetirement do
+  @moduledoc """
+  The retirement TRIGGER for the US-41.1 legacy embedding columns (GH #551).
+
+  After the side-table cutover flipped `embedding_side_table_reads` to `1`
+  (2026-07-22), `articles.embedding` / `memories.embedding` stayed fully
+  dual-written — correctly, because the column IS the revert
+  (`Loopctl.Embeddings.SystemConfigReadPath`, AC-41.1.8(ii)/(iii)). What was missing
+  was anything that ever ASKS whether the revert is still needed. At ~1.36 GB
+  (HNSW + TOAST) that silence has a monthly price, and "retirement recorded as prose"
+  is not a mechanism.
+
+  This module is the mechanism. It does NOT drop anything — dropping stays a
+  deliberate human migration. It decides, daily and from evidence, whether the drop
+  is now OWED, and hands that verdict to
+  `Loopctl.Workers.LegacyEmbeddingRetirementWorker` to raise.
+
+  ## The two triggers
+
+  A verdict of `:due` fires when the legacy columns still exist AND either:
+
+    * **evidence** — `required_clear_days` consecutive UTC days of observations, all
+      with `side_table_reads == 1` and no change in any legacy index's `idx_scan`
+      counter. This is the "we can prove nothing reads it" path.
+
+    * **deadline** — `review_by` has passed. This is the "we could not prove
+      anything, and that is exactly when a retirement gets forgotten" path.
+
+  The deadline is not a belt-and-braces flourish; it is what makes the whole thing
+  fail closed. Every way the evidence path can go quiet — a probe that errors every
+  run, a monitor nobody redeployed, an `idx_scan` that never settles because some
+  forgotten query still touches the legacy index — looks IDENTICAL to "not due yet"
+  from the outside. Without a date that fires on its own, an evidence-only check
+  degrades silently into the very prose it replaced.
+
+  ## Fail-closed, stated precisely
+
+  "Fail closed" here means an inconclusive reading must never render as *already
+  cleaned up* or *nothing to do*:
+
+    * A probe that cannot read `information_schema` reports NO columns... which would
+      read as retired. So `probe/0` returns `{:error, _}` as a whole rather than a
+      partial map, and the worker treats that as a monitor failure (loud, retried) —
+      never as a verdict.
+    * A gap in the daily observations breaks the streak (`length(rows) == n` over a
+      window of `n` distinct days is exactly the contiguity check, since
+      `observed_on` is unique).
+    * A `pg_stat_reset()` inside the window invalidates it: counters that went to
+      zero are not counters that stayed still.
+    * An index present at the end of the window but absent at its start invalidates
+      it: an index created three days ago cannot testify about thirty.
+
+  The one deliberately vacuous pass: if a legacy column survives with NO index over
+  it, the scan check is trivially satisfied. That is a correct `:due`, not a hole —
+  an unindexed legacy column is already past the expensive half of retirement (the
+  655 MB HNSW is gone; only TOAST remains), and the read flag plus the streak still
+  have to hold.
+
+  ## Why counters need a table
+
+  `pg_stat_user_indexes.idx_scan` is cumulative. "Zero scans over N days" is a delta,
+  and a delta needs a stored earlier reading — hence
+  `Loopctl.Embeddings.RetirementObservation`, one row per UTC day.
+
+  Indexes are discovered BY COLUMN (every index whose key includes the legacy
+  `embedding` attribute of `articles` / `memories`), never by name. The legacy index
+  has already been renamed once in this repo's history
+  (`20260624120000_reconcile_hnsw_index_name.exs`), and `memories` carries a PARTIAL
+  one (`memories_live_embedding_hnsw_idx`) that a name list would have missed.
+  """
+
+  @behaviour Loopctl.Embeddings.LegacyRetirementBehaviour
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Embeddings
+  alias Loopctl.Embeddings.RetirementObservation
+
+  # The tables whose legacy `embedding` column this trigger is about. The side
+  # tables (`article_embeddings` / `memory_embeddings`) are deliberately absent —
+  # they are the REPLACEMENT, not the thing being retired.
+  @legacy_tables ["articles", "memories"]
+  @legacy_column "embedding"
+
+  @default_required_clear_days 30
+
+  # Six months after the read flag flipped to 1 (2026-07-22). Chosen so the question
+  # resurfaces on its own well before the rollback value has decayed to zero but long
+  # after any realistic need to exercise it. Overridable via config for tests and for
+  # an operator who wants to pull it in.
+  @default_review_by ~D[2027-01-22]
+
+  @typedoc """
+  A single live reading of the legacy footprint. Produced whole by `probe/0` — never
+  partially, so a failed sub-query cannot masquerade as an absent column.
+  """
+  @type probe :: %{
+          side_table_reads: integer(),
+          legacy_columns: [String.t()],
+          legacy_index_scans: %{optional(String.t()) => integer()},
+          stats_reset_at: DateTime.t() | nil
+        }
+
+  @type verdict :: %{
+          verdict: :due | :not_due | :retired,
+          trigger: :evidence | :deadline | nil,
+          reasons: [String.t()],
+          legacy_columns: [String.t()],
+          clear_days: non_neg_integer(),
+          required_clear_days: pos_integer(),
+          review_by: Date.t(),
+          deadline_passed?: boolean(),
+          legacy_index_scans: %{optional(String.t()) => integer()}
+        }
+
+  @doc "Consecutive clear days required before the evidence trigger fires."
+  @spec required_clear_days() :: pos_integer()
+  def required_clear_days do
+    config()[:required_clear_days] || @default_required_clear_days
+  end
+
+  @doc "The date past which retirement is owed regardless of what the evidence shows."
+  @spec review_by() :: Date.t()
+  def review_by, do: config()[:review_by] || @default_review_by
+
+  defp config, do: Application.get_env(:loopctl, :embedding_legacy_retirement, [])
+
+  # ---------------------------------------------------------------------------
+  # Probe
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Read the live legacy footprint: the read flag, which legacy columns survive, the
+  cumulative scan counter of every index over them, and the statistics-reset stamp.
+
+  Returns `{:error, reason}` as a WHOLE if any part is unreadable. A partial map is
+  not offered on purpose: the caller's only safe reading of "I could not check" is
+  "I still owe the check", and a map missing its `legacy_columns` key would instead
+  read as a finished retirement.
+  """
+  @impl Loopctl.Embeddings.LegacyRetirementBehaviour
+  @spec probe() :: {:ok, probe()} | {:error, term()}
+  def probe do
+    with {:ok, columns} <- legacy_columns(),
+         {:ok, scans} <- legacy_index_scans(),
+         {:ok, stats_reset_at} <- stats_reset_at() do
+      {:ok,
+       %{
+         # Deliberately the INJECTED read path (`Embeddings.side_table_reads_enabled?/0`),
+         # not a fresh `SystemConfig.get_int/2`: the question is what the request path
+         # is actually doing, and re-deriving it from the underlying row would let the
+         # two disagree at exactly the moment that disagreement matters.
+         side_table_reads: if(Embeddings.side_table_reads_enabled?(), do: 1, else: 0),
+         legacy_columns: columns,
+         legacy_index_scans: scans,
+         stats_reset_at: stats_reset_at
+       }}
+    end
+  rescue
+    error -> {:error, error}
+  end
+
+  defp legacy_columns do
+    sql = """
+    SELECT table_name
+    FROM information_schema.columns
+    WHERE table_schema = current_schema()
+      AND column_name = $1
+      AND table_name = ANY($2)
+    ORDER BY table_name
+    """
+
+    case query(sql, [@legacy_column, @legacy_tables]) do
+      {:ok, %{rows: rows}} -> {:ok, Enum.map(rows, fn [name] -> name end)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # Every index whose key includes the legacy `embedding` attribute of a legacy
+  # table — discovered by COLUMN, not by name (see the moduledoc). `indkey` is an
+  # int2vector of attribute numbers; a `0` entry marks an expression, which cannot
+  # be this plain column and so is correctly never matched.
+  defp legacy_index_scans do
+    sql = """
+    SELECT s.indexrelname, s.idx_scan
+    FROM pg_stat_user_indexes s
+    JOIN pg_index i ON i.indexrelid = s.indexrelid
+    JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+    WHERE s.schemaname = current_schema()
+      AND s.relname = ANY($1)
+      AND a.attname = $2
+    GROUP BY s.indexrelname, s.idx_scan
+    ORDER BY s.indexrelname
+    """
+
+    case query(sql, [@legacy_tables, @legacy_column]) do
+      {:ok, %{rows: rows}} ->
+        {:ok, Map.new(rows, fn [name, scans] -> {name, scans || 0} end)}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp stats_reset_at do
+    sql = "SELECT stats_reset FROM pg_stat_database WHERE datname = current_database()"
+
+    case query(sql, []) do
+      {:ok, %{rows: [[reset]]}} -> {:ok, to_utc(reset)}
+      {:ok, %{rows: _}} -> {:ok, nil}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # A short SET LOCAL statement_timeout keeps these catalog reads from ever pinning
+  # a connection in AdminRepo's small (3-connection) pool — the US-27.11 starvation
+  # class. They are cheap catalog/stat reads, so 5s is generous, not tight.
+  defp query(sql, params) do
+    AdminRepo.transaction(fn ->
+      AdminRepo.query!("SET LOCAL statement_timeout = '5s'", [])
+
+      case AdminRepo.query(sql, params) do
+        {:ok, result} -> result
+        {:error, reason} -> AdminRepo.rollback(reason)
+      end
+    end)
+  end
+
+  defp to_utc(%DateTime{} = dt), do: dt
+  defp to_utc(%NaiveDateTime{} = ndt), do: DateTime.from_naive!(ndt, "Etc/UTC")
+  defp to_utc(_), do: nil
+
+  # ---------------------------------------------------------------------------
+  # Record
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Upsert today's observation from a `t:probe/0`.
+
+  One row per UTC day (`observed_on` is unique), so an Oban retry or a manual run
+  refreshes the day rather than adding a second row for it — the streak is counted
+  in days, and duplicates would let one day stand in for several.
+  """
+  @impl Loopctl.Embeddings.LegacyRetirementBehaviour
+  @spec record(probe(), Keyword.t()) ::
+          {:ok, RetirementObservation.t()} | {:error, Ecto.Changeset.t()}
+  def record(probe, opts \\ []) do
+    now = Keyword.get(opts, :now, DateTime.utc_now())
+    today = Keyword.get(opts, :today, DateTime.to_date(now))
+
+    attrs = %{
+      observed_on: today,
+      observed_at: now,
+      side_table_reads: probe.side_table_reads,
+      legacy_columns_present: probe.legacy_columns,
+      legacy_index_scans: probe.legacy_index_scans,
+      stats_reset_at: probe.stats_reset_at
+    }
+
+    existing = AdminRepo.get_by(RetirementObservation, observed_on: today)
+
+    (existing || %RetirementObservation{})
+    |> RetirementObservation.changeset(attrs)
+    |> AdminRepo.insert_or_update()
+  end
+
+  # ---------------------------------------------------------------------------
+  # Evaluate
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Decide whether the legacy columns are now owed a retirement.
+
+  Takes the CURRENT `t:probe/0` explicitly rather than re-reading it, so the
+  decision logic is exercisable without a live catalog and so one run's verdict is
+  always about the same reading it recorded.
+
+  Verdicts:
+
+    * `:retired` — no legacy column survives. Nothing is owed; the trigger has been
+      satisfied and this worker can be retired along with it.
+    * `:due` — a legacy column survives AND (the evidence window is clear OR
+      `review_by` has passed).
+    * `:not_due` — a legacy column survives and neither trigger has fired.
+  """
+  @impl Loopctl.Embeddings.LegacyRetirementBehaviour
+  @spec evaluate(probe(), Keyword.t()) :: verdict()
+  def evaluate(probe, opts \\ []) do
+    today = Keyword.get(opts, :today, Date.utc_today())
+    required = Keyword.get(opts, :required_clear_days, required_clear_days())
+    review_by = Keyword.get(opts, :review_by, review_by())
+
+    base = %{
+      legacy_columns: probe.legacy_columns,
+      required_clear_days: required,
+      review_by: review_by,
+      legacy_index_scans: probe.legacy_index_scans
+    }
+
+    if probe.legacy_columns == [] do
+      Map.merge(base, %{
+        verdict: :retired,
+        trigger: nil,
+        reasons: ["no legacy embedding column remains"],
+        clear_days: 0,
+        deadline_passed?: false
+      })
+    else
+      decide(base, today, required, review_by)
+    end
+  end
+
+  defp decide(base, today, required, review_by) do
+    {clear_days, evidence_reasons} = clear_streak(today, required)
+    deadline_passed? = Date.compare(today, review_by) != :lt
+    evidence? = clear_days >= required
+
+    {verdict, trigger, reasons} =
+      cond do
+        evidence? ->
+          {:due, :evidence,
+           ["#{clear_days} consecutive clear day(s) at or above the #{required}-day bar"]}
+
+        deadline_passed? ->
+          {:due, :deadline,
+           ["review_by #{Date.to_iso8601(review_by)} has passed" | evidence_reasons]}
+
+        true ->
+          {:not_due, nil, evidence_reasons}
+      end
+
+    Map.merge(base, %{
+      verdict: verdict,
+      trigger: trigger,
+      reasons: reasons,
+      clear_days: clear_days,
+      deadline_passed?: deadline_passed?
+    })
+  end
+
+  # Returns {clear_days, reasons_it_is_not_clear}. `clear_days` is `required` when the
+  # whole window qualifies and 0 otherwise: this is a gate, not a progress bar, and
+  # reporting a partial streak that a later check invalidates would be worse than
+  # reporting none. The reasons are what an operator actually needs — WHY the window
+  # is not clear.
+  defp clear_streak(today, required) do
+    from_day = Date.add(today, -(required - 1))
+
+    rows =
+      RetirementObservation
+      |> where([o], o.observed_on >= ^from_day and o.observed_on <= ^today)
+      |> order_by([o], asc: o.observed_on)
+      |> AdminRepo.all()
+
+    reasons = window_defects(rows, required)
+
+    if reasons == [], do: {required, []}, else: {0, reasons}
+  end
+
+  defp window_defects(rows, required) do
+    # `observed_on` is unique, so "n rows inside an n-day window" IS contiguity.
+    # A missing day is a day we cannot speak for, which is not the same as a quiet one.
+    coverage =
+      if length(rows) < required,
+        do: ["only #{length(rows)} of #{required} day(s) observed"],
+        else: []
+
+    coverage ++ flag_defects(rows) ++ reset_defects(rows) ++ scan_defects(rows)
+  end
+
+  defp flag_defects(rows) do
+    case Enum.filter(rows, &(&1.side_table_reads != 1)) do
+      [] ->
+        []
+
+      off ->
+        ["side_table_reads was not 1 on #{length(off)} day(s) in the window"]
+    end
+  end
+
+  defp reset_defects([]), do: []
+
+  defp reset_defects([first | _] = rows) do
+    if Enum.all?(rows, &same_instant?(&1.stats_reset_at, first.stats_reset_at)) do
+      []
+    else
+      ["pg_stat statistics were reset inside the window; scan deltas are meaningless"]
+    end
+  end
+
+  defp same_instant?(nil, nil), do: true
+  defp same_instant?(nil, _), do: false
+  defp same_instant?(_, nil), do: false
+  defp same_instant?(a, b), do: DateTime.compare(a, b) == :eq
+
+  # Counters only ever increase (a reset is excluded above), so first == last across
+  # the window is exactly "no scan happened in between" — no need to walk the middle.
+  defp scan_defects(rows) when length(rows) < 2, do: []
+
+  defp scan_defects(rows) do
+    first = List.first(rows).legacy_index_scans || %{}
+    last = List.last(rows).legacy_index_scans || %{}
+
+    missing =
+      last |> Map.keys() |> Enum.reject(&Map.has_key?(first, &1)) |> Enum.sort()
+
+    scanned =
+      for {index, last_count} <- last,
+          baseline = Map.get(first, index),
+          is_integer(baseline),
+          last_count != baseline,
+          do: "#{index} (+#{last_count - baseline})"
+
+    missing_reason =
+      if missing == [],
+        do: [],
+        else: ["index(es) absent at the start of the window: #{Enum.join(missing, ", ")}"]
+
+    scanned_reason =
+      if scanned == [],
+        do: [],
+        else: [
+          "legacy index scans inside the window: #{scanned |> Enum.sort() |> Enum.join(", ")}"
+        ]
+
+    missing_reason ++ scanned_reason
+  end
+end

--- a/lib/loopctl/embeddings/legacy_retirement.ex
+++ b/lib/loopctl/embeddings/legacy_retirement.ex
@@ -38,10 +38,15 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
   "Fail closed" here means an inconclusive reading must never render as *already
   cleaned up* or *nothing to do*:
 
-    * A probe that cannot read `information_schema` reports NO columns... which would
-      read as retired. So `probe/0` returns `{:error, _}` as a whole rather than a
-      partial map, and the worker treats that as a monitor failure (loud, retried) —
-      never as a verdict.
+    * A probe that cannot read the catalog reports NO columns... which would read as
+      retired. So `probe/0` returns `{:error, _}` as a whole rather than a partial map,
+      and the worker treats that as a monitor failure (loud, retried) — never as a
+      verdict. It reads `pg_attribute`, not `information_schema.columns`, for the same
+      reason: the latter is privilege-FILTERED, so an under-privileged role gets zero
+      rows and NO error — a silent `:retired` indistinguishable from a real one.
+    * The LIVE `side_table_reads` reading vetoes both triggers while it is 0: the legacy
+      column is then the active read path (the revert in progress), and the deadline
+      degrades to `:deadline_blocked` rather than naming it for deletion.
     * A gap in the daily observations breaks the streak (`length(rows) == n` over a
       window of `n` distinct days is exactly the contiguity check, since
       `observed_on` is unique).
@@ -78,6 +83,7 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
   alias Loopctl.AdminRepo
   alias Loopctl.Embeddings
   alias Loopctl.Embeddings.RetirementObservation
+  alias Loopctl.LocalGuc
 
   # The tables whose legacy `embedding` column this trigger is about. The side
   # tables (`article_embeddings` / `memory_embeddings`) are deliberately absent —
@@ -106,20 +112,37 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
 
   @type verdict :: %{
           verdict: :due | :not_due | :retired,
-          trigger: :evidence | :deadline | nil,
+          trigger: :evidence | :deadline | :deadline_blocked | nil,
           reasons: [String.t()],
           legacy_columns: [String.t()],
           clear_days: non_neg_integer(),
           required_clear_days: pos_integer(),
           review_by: Date.t(),
           deadline_passed?: boolean(),
+          days_past_review_by: integer(),
+          side_table_reads: integer(),
           legacy_index_scans: %{optional(String.t()) => integer()}
         }
 
   @doc "Consecutive clear days required before the evidence trigger fires."
   @spec required_clear_days() :: pos_integer()
-  def required_clear_days do
-    config()[:required_clear_days] || @default_required_clear_days
+  def required_clear_days, do: normalize_required(config()[:required_clear_days])
+
+  # `||` only rejects nil/false, and BOTH degenerate values are truthy: `0` makes the
+  # window empty, so every check passes over no rows and `:due` is asserted from no
+  # evidence at all, and `1` makes `scan_defects/1` (which needs two readings for a
+  # delta) return unconditionally — deleting the core of the evidence path. The
+  # `pos_integer()` spec never enforced either, so the value is validated, not defaulted.
+  defp normalize_required(value) when is_integer(value) and value >= 2, do: value
+  defp normalize_required(nil), do: @default_required_clear_days
+
+  defp normalize_required(value) do
+    Logger.warning(
+      "LegacyRetirement: required_clear_days #{inspect(value)} is not an integer >= 2; " <>
+        "using #{@default_required_clear_days}"
+    )
+
+    @default_required_clear_days
   end
 
   @doc "The date past which retirement is owed regardless of what the evidence shows."
@@ -163,14 +186,27 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
     error -> {:error, error}
   end
 
+  # Read from `pg_attribute`/`pg_class`, NOT `information_schema.columns`: the latter is
+  # privilege-FILTERED by design, so a role without privileges on these tables gets zero
+  # rows and no error — indistinguishable from "the columns are gone", which `evaluate/2`
+  # would turn straight into a silent `:retired`. Scoped to the whole search path
+  # (`current_schemas(false)`) rather than `current_schema()`, for the reason
+  # `ChannelPostRescanWorker`'s probes spell out: `current_schema()` is only the FIRST
+  # entry, so a deployment whose search_path resolves elsewhere probes the wrong schema
+  # and disables the trigger permanently.
   defp legacy_columns do
     sql = """
-    SELECT table_name
-    FROM information_schema.columns
-    WHERE table_schema = current_schema()
-      AND column_name = $1
-      AND table_name = ANY($2)
-    ORDER BY table_name
+    SELECT c.relname
+    FROM pg_attribute a
+    JOIN pg_class c ON c.oid = a.attrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = ANY(current_schemas(false))
+      AND a.attname = $1
+      AND c.relname = ANY($2)
+      AND c.relkind = 'r'
+      AND a.attnum > 0
+      AND NOT a.attisdropped
+    ORDER BY c.relname
     """
 
     case query(sql, [@legacy_column, @legacy_tables]) do
@@ -189,7 +225,7 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
     FROM pg_stat_user_indexes s
     JOIN pg_index i ON i.indexrelid = s.indexrelid
     JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
-    WHERE s.schemaname = current_schema()
+    WHERE s.schemaname = ANY(current_schemas(false))
       AND s.relname = ANY($1)
       AND a.attname = $2
     GROUP BY s.indexrelname, s.idx_scan
@@ -215,13 +251,14 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
     end
   end
 
-  # A short SET LOCAL statement_timeout keeps these catalog reads from ever pinning
-  # a connection in AdminRepo's small (3-connection) pool — the US-27.11 starvation
-  # class. They are cheap catalog/stat reads, so 5s is generous, not tight.
+  # A short statement_timeout keeps these catalog reads from ever pinning a connection in
+  # AdminRepo's small (3-connection) pool — the US-27.11 starvation class. They are cheap
+  # catalog/stat reads, so 5s is generous, not tight. Via `LocalGuc.timed_transaction/4`,
+  # never a raw `SET LOCAL`: `SET LOCAL` is scoped to the TOP-LEVEL transaction, so a
+  # nested one (every call under `Ecto.Adapters.SQL.Sandbox`) merges the 5s deadline into
+  # the enclosing transaction on savepoint commit.
   defp query(sql, params) do
-    AdminRepo.transaction(fn ->
-      AdminRepo.query!("SET LOCAL statement_timeout = '5s'", [])
-
+    LocalGuc.timed_transaction(AdminRepo, 5_000, fn ->
       case AdminRepo.query(sql, params) do
         {:ok, result} -> result
         {:error, reason} -> AdminRepo.rollback(reason)
@@ -290,13 +327,20 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
   @spec evaluate(probe(), Keyword.t()) :: verdict()
   def evaluate(probe, opts \\ []) do
     today = Keyword.get(opts, :today, Date.utc_today())
-    required = Keyword.get(opts, :required_clear_days, required_clear_days())
     review_by = Keyword.get(opts, :review_by, review_by())
+
+    required =
+      case Keyword.fetch(opts, :required_clear_days) do
+        {:ok, value} -> normalize_required(value)
+        :error -> required_clear_days()
+      end
 
     base = %{
       legacy_columns: probe.legacy_columns,
       required_clear_days: required,
       review_by: review_by,
+      days_past_review_by: Date.diff(today, review_by),
+      side_table_reads: probe.side_table_reads,
       legacy_index_scans: probe.legacy_index_scans
     }
 
@@ -313,23 +357,39 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
     end
   end
 
+  @revert_reason "side_table_reads is currently 0 — the legacy column is the ACTIVE read path"
+
+  # The LIVE reading vetoes BOTH triggers. The stored window can only speak for days
+  # already past, so a revert flipped after the last observation is invisible to it — and
+  # a revert is precisely what these columns are kept for. Firing `:due` then would name
+  # the live read path for deletion, so the deadline degrades to `:deadline_blocked`
+  # (still surfaced, never acted on) rather than to silence.
   defp decide(base, today, required, review_by) do
-    {clear_days, evidence_reasons} = clear_streak(today, required)
+    {streak, window_reasons} = clear_streak(today, required)
     deadline_passed? = Date.compare(today, review_by) != :lt
-    evidence? = clear_days >= required
+    reverting? = base.side_table_reads != 1
+    clear_days = if reverting?, do: 0, else: streak
+    reasons = if reverting?, do: [@revert_reason | window_reasons], else: window_reasons
 
     {verdict, trigger, reasons} =
       cond do
-        evidence? ->
+        clear_days >= required ->
           {:due, :evidence,
            ["#{clear_days} consecutive clear day(s) at or above the #{required}-day bar"]}
 
+        deadline_passed? and reverting? ->
+          {:not_due, :deadline_blocked,
+           [
+             "review_by #{Date.to_iso8601(review_by)} has passed, but retirement is " <>
+               "BLOCKED"
+             | reasons
+           ]}
+
         deadline_passed? ->
-          {:due, :deadline,
-           ["review_by #{Date.to_iso8601(review_by)} has passed" | evidence_reasons]}
+          {:due, :deadline, ["review_by #{Date.to_iso8601(review_by)} has passed" | reasons]}
 
         true ->
-          {:not_due, nil, evidence_reasons}
+          {:not_due, nil, reasons}
       end
 
     Map.merge(base, %{
@@ -347,17 +407,27 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
   # reporting none. The reasons are what an operator actually needs — WHY the window
   # is not clear.
   defp clear_streak(today, required) do
-    from_day = Date.add(today, -(required - 1))
+    case observations(Date.add(today, -(required - 1)), today) do
+      {:ok, rows} ->
+        reasons = window_defects(rows, required)
+        if reasons == [], do: {required, []}, else: {0, reasons}
 
-    rows =
-      RetirementObservation
-      |> where([o], o.observed_on >= ^from_day and o.observed_on <= ^today)
-      |> order_by([o], asc: o.observed_on)
-      |> AdminRepo.all()
+      {:error, tag} ->
+        {0, ["the observation log is unreadable (#{tag}); there is no evidence window"]}
+    end
+  end
 
-    reasons = window_defects(rows, required)
-
-    if reasons == [], do: {required, []}, else: {0, reasons}
+  # The log can be genuinely ABSENT — a crontab entry deployed ahead of its migration —
+  # and unreadable must cost the EVIDENCE path without costing the deadline, which is the
+  # one trigger designed to fire with no observations at all.
+  defp observations(from_day, today) do
+    {:ok,
+     RetirementObservation
+     |> where([o], o.observed_on >= ^from_day and o.observed_on <= ^today)
+     |> order_by([o], asc: o.observed_on)
+     |> AdminRepo.all()}
+  rescue
+    error -> {:error, inspect(error.__struct__)}
   end
 
   defp window_defects(rows, required) do
@@ -396,23 +466,26 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
   defp same_instant?(_, nil), do: false
   defp same_instant?(a, b), do: DateTime.compare(a, b) == :eq
 
-  # Counters only ever increase (a reset is excluded above), so first == last across
-  # the window is exactly "no scan happened in between" — no need to walk the middle.
+  # Counters only ever increase (a reset is excluded above), so comparing each index's
+  # window PEAK to its baseline is exactly "no scan happened in between". Every index seen
+  # ANYWHERE in the window counts, not just at its endpoints: one created on day 5,
+  # scanned hard, and dropped on day 25 appears at neither end, and an endpoint-only
+  # comparison never examined it at all.
   defp scan_defects(rows) when length(rows) < 2, do: []
 
   defp scan_defects(rows) do
-    first = List.first(rows).legacy_index_scans || %{}
-    last = List.last(rows).legacy_index_scans || %{}
+    first = scans(List.first(rows))
+    seen = rows |> Enum.flat_map(&Map.keys(scans(&1))) |> Enum.uniq()
 
-    missing =
-      last |> Map.keys() |> Enum.reject(&Map.has_key?(first, &1)) |> Enum.sort()
+    missing = seen |> Enum.reject(&Map.has_key?(first, &1)) |> Enum.sort()
 
     scanned =
-      for {index, last_count} <- last,
+      for index <- seen -- missing,
           baseline = Map.get(first, index),
           is_integer(baseline),
-          last_count != baseline,
-          do: "#{index} (+#{last_count - baseline})"
+          peak = peak_scans(rows, index, baseline),
+          peak != baseline,
+          do: "#{index} (+#{peak - baseline})"
 
     missing_reason =
       if missing == [],
@@ -427,5 +500,14 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
         ]
 
     missing_reason ++ scanned_reason
+  end
+
+  defp scans(row), do: row.legacy_index_scans || %{}
+
+  defp peak_scans(rows, index, baseline) do
+    rows
+    |> Enum.map(&Map.get(scans(&1), index))
+    |> Enum.filter(&is_integer/1)
+    |> Enum.max(fn -> baseline end)
   end
 end

--- a/lib/loopctl/embeddings/legacy_retirement.ex
+++ b/lib/loopctl/embeddings/legacy_retirement.ex
@@ -46,7 +46,10 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
       rows and NO error — a silent `:retired` indistinguishable from a real one.
     * The LIVE `side_table_reads` reading vetoes both triggers while it is 0: the legacy
       column is then the active read path (the revert in progress), and the deadline
-      degrades to `:deadline_blocked` rather than naming it for deletion.
+      degrades to `:deadline_blocked` (still ALERTED, never silent) rather than naming it
+      for deletion. A `0` that is merely UNREADABLE — a cold `:persistent_term` cache,
+      whose default is also 0 — is not a revert and must not veto anything, so `probe/0`
+      resolves it against the stored row and fails whole instead (see `side_table_reads/0`).
     * A gap in the daily observations breaks the streak (`length(rows) == n` over a
       window of `n` distinct days is exactly the contiguity check, since
       `observed_on` is unique).
@@ -167,16 +170,13 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
   @impl Loopctl.Embeddings.LegacyRetirementBehaviour
   @spec probe() :: {:ok, probe()} | {:error, term()}
   def probe do
-    with {:ok, columns} <- legacy_columns(),
+    with {:ok, reads} <- side_table_reads(),
+         {:ok, columns} <- legacy_columns(),
          {:ok, scans} <- legacy_index_scans(),
          {:ok, stats_reset_at} <- stats_reset_at() do
       {:ok,
        %{
-         # Deliberately the INJECTED read path (`Embeddings.side_table_reads_enabled?/0`),
-         # not a fresh `SystemConfig.get_int/2`: the question is what the request path
-         # is actually doing, and re-deriving it from the underlying row would let the
-         # two disagree at exactly the moment that disagreement matters.
-         side_table_reads: if(Embeddings.side_table_reads_enabled?(), do: 1, else: 0),
+         side_table_reads: reads,
          legacy_columns: columns,
          legacy_index_scans: scans,
          stats_reset_at: stats_reset_at
@@ -184,6 +184,28 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
     end
   rescue
     error -> {:error, error}
+  end
+
+  # The reading is the INJECTED read path (`Embeddings.side_table_reads_enabled?/0`), not a
+  # fresh `SystemConfig.get_int/2`: the question is what the request path is actually doing.
+  #
+  # But a `0` from it has TWO causes that must not render alike. One is an operator who
+  # deliberately reverted — a real revert, which correctly vetoes the drop. The other is a
+  # node whose `:persistent_term` cache never primed: `SystemConfig.get_int/2` returns its
+  # default on a MISS and even rescues to it, so an unreadable flag is shaped exactly like a
+  # revert and would veto the DEADLINE — the one trigger that exists to fire when everything
+  # else has gone quiet — silently and forever. So a live `0` is resolved against the STORED
+  # row, and a disagreement is a probe FAILURE (loud, retried), never a verdict.
+  defp side_table_reads do
+    if Embeddings.side_table_reads_enabled?() do
+      {:ok, 1}
+    else
+      case query("SELECT value FROM system_configs WHERE key = $1", [Embeddings.read_flag_key()]) do
+        {:ok, %{rows: [[1]]}} -> {:error, {:read_flag_cache_stale, Embeddings.read_flag_key()}}
+        {:ok, %{rows: _}} -> {:ok, 0}
+        {:error, reason} -> {:error, reason}
+      end
+    end
   end
 
   # Read from `pg_attribute`/`pg_class`, NOT `information_schema.columns`: the latter is
@@ -266,6 +288,29 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
     end)
   end
 
+  @doc """
+  Whether the observation log table exists.
+
+  `{:ok, false}` is a GENUINE absence (a crontab entry deployed ahead of its migration).
+  An unreadable catalog is `{:error, _}` and never folded into `false`: a saturated
+  AdminRepo pool would otherwise answer exactly the way a pending migration does.
+
+  It lives here, behind the same guarded `query/2` as every other catalog read, so both
+  share ONE 5s statement_timeout and one owner — an unbounded probe against AdminRepo's
+  3-connection pool is precisely the starvation that timeout exists to prevent, and this
+  is the read that runs first on every job.
+  """
+  @impl Loopctl.Embeddings.LegacyRetirementBehaviour
+  @spec observations_table_ready?() :: {:ok, boolean()} | {:error, term()}
+  def observations_table_ready? do
+    case query("SELECT to_regclass($1::text)", ["embedding_retirement_observations"]) do
+      {:ok, %{rows: [[nil]]}} -> {:ok, false}
+      {:ok, %{rows: [[_oid]]}} -> {:ok, true}
+      {:ok, %{rows: rows}} -> {:error, {:unexpected_table_probe_result, length(rows)}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   defp to_utc(%DateTime{} = dt), do: dt
   defp to_utc(%NaiveDateTime{} = ndt), do: DateTime.from_naive!(ndt, "Etc/UTC")
   defp to_utc(_), do: nil
@@ -335,23 +380,21 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
         :error -> required_clear_days()
       end
 
+    # `deadline_passed?` is derived ONCE, here, and inherited by every branch: it and
+    # `days_past_review_by` are two readings of one fact, and a branch that hard-coded its
+    # own copy (the `:retired` one did) shipped a verdict map that contradicted itself.
     base = %{
       legacy_columns: probe.legacy_columns,
       required_clear_days: required,
       review_by: review_by,
       days_past_review_by: Date.diff(today, review_by),
+      deadline_passed?: Date.compare(today, review_by) != :lt,
       side_table_reads: probe.side_table_reads,
       legacy_index_scans: probe.legacy_index_scans
     }
 
     if probe.legacy_columns == [] do
-      Map.merge(base, %{
-        verdict: :retired,
-        trigger: nil,
-        reasons: ["no legacy embedding column remains"],
-        clear_days: 0,
-        deadline_passed?: false
-      })
+      retired(base)
     else
       decide(base, today, required, review_by)
     end
@@ -359,15 +402,28 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
 
   @revert_reason "side_table_reads is currently 0 — the legacy column is the ACTIVE read path"
 
+  # `evaluate/2` short-circuits here BEFORE `decide/4`, so the live read-flag veto never
+  # sees this case — and "the column is gone while the read path points back AT it" is a
+  # broken deployment, not a finished retirement. The verdict stays `:retired` (nothing is
+  # droppable), but it carries the contradiction so the worker can log it at :error.
+  defp retired(base) do
+    reasons =
+      if reads_side_table?(base),
+        do: ["no legacy embedding column remains"],
+        else: ["no legacy embedding column remains, yet #{@revert_reason}"]
+
+    Map.merge(base, %{verdict: :retired, trigger: nil, reasons: reasons, clear_days: 0})
+  end
+
   # The LIVE reading vetoes BOTH triggers. The stored window can only speak for days
   # already past, so a revert flipped after the last observation is invisible to it — and
   # a revert is precisely what these columns are kept for. Firing `:due` then would name
   # the live read path for deletion, so the deadline degrades to `:deadline_blocked`
-  # (still surfaced, never acted on) rather than to silence.
+  # (still surfaced and still ALERTED, never acted on) rather than to silence.
   defp decide(base, today, required, review_by) do
     {streak, window_reasons} = clear_streak(today, required)
-    deadline_passed? = Date.compare(today, review_by) != :lt
-    reverting? = base.side_table_reads != 1
+    deadline_passed? = base.deadline_passed?
+    reverting? = not reads_side_table?(base)
     clear_days = if reverting?, do: 0, else: streak
     reasons = if reverting?, do: [@revert_reason | window_reasons], else: window_reasons
 
@@ -396,8 +452,7 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
       verdict: verdict,
       trigger: trigger,
       reasons: reasons,
-      clear_days: clear_days,
-      deadline_passed?: deadline_passed?
+      clear_days: clear_days
     })
   end
 
@@ -418,8 +473,14 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
   end
 
   # The log can be genuinely ABSENT — a crontab entry deployed ahead of its migration —
-  # and unreadable must cost the EVIDENCE path without costing the deadline, which is the
-  # one trigger designed to fire with no observations at all.
+  # and that must cost the EVIDENCE path without costing the deadline, which is the one
+  # trigger designed to fire with no observations at all.
+  #
+  # ONLY that case is rescued. A blanket rescue here folded a saturated pool, a statement
+  # timeout and a permission error into the same routine `:not_due` at :info — a
+  # permanently wedged evidence path rendered as a monitor that keeps finding nothing,
+  # which is the failure this module exists to prevent. Everything else propagates, and
+  # the worker turns it into a probe failure (telemetry, `{:error, _}`, Oban retry).
   defp observations(from_day, today) do
     {:ok,
      RetirementObservation
@@ -427,7 +488,14 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
      |> order_by([o], asc: o.observed_on)
      |> AdminRepo.all()}
   rescue
-    error -> {:error, inspect(error.__struct__)}
+    error in Postgrex.Error ->
+      case error do
+        %Postgrex.Error{postgres: %{code: :undefined_table}} ->
+          {:error, "the table does not exist"}
+
+        _ ->
+          reraise error, __STACKTRACE__
+      end
   end
 
   defp window_defects(rows, required) do
@@ -441,8 +509,13 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
     coverage ++ flag_defects(rows) ++ reset_defects(rows) ++ scan_defects(rows)
   end
 
+  # ONE definition of "the side table is the read path", shared by the stored-row check
+  # below, `decide/4`'s live veto and `retired/1` — so the predicate cannot drift between
+  # the three sites that have to agree on it.
+  defp reads_side_table?(%{side_table_reads: reads}), do: reads == 1
+
   defp flag_defects(rows) do
-    case Enum.filter(rows, &(&1.side_table_reads != 1)) do
+    case Enum.reject(rows, &reads_side_table?/1) do
       [] ->
         []
 
@@ -466,11 +539,17 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
   defp same_instant?(_, nil), do: false
   defp same_instant?(a, b), do: DateTime.compare(a, b) == :eq
 
-  # Counters only ever increase (a reset is excluded above), so comparing each index's
-  # window PEAK to its baseline is exactly "no scan happened in between". Every index seen
-  # ANYWHERE in the window counts, not just at its endpoints: one created on day 5,
-  # scanned hard, and dropped on day 25 appears at neither end, and an endpoint-only
-  # comparison never examined it at all.
+  # Comparing each index's window PEAK to its baseline is exactly "no scan happened in
+  # between". Every index seen ANYWHERE in the window counts, not just at its endpoints:
+  # one created on day 5, scanned hard, and dropped on day 25 appears at neither end, and
+  # an endpoint-only comparison never examined it at all.
+  #
+  # The peak alone cannot see a counter going BACKWARDS, and the baseline is itself in the
+  # window, so the peak can never fall below it. A per-index reset — `REINDEX CONCURRENTLY`,
+  # or a drop and recreate under the same name — zeroes `idx_scan` without touching
+  # `pg_stat_database.stats_reset`, so `reset_defects/1` does not cover it either: a rebuilt
+  # index scanned back to just under its old total would read as perfectly still. Any
+  # reading below its baseline is therefore its own defect.
   defp scan_defects(rows) when length(rows) < 2, do: []
 
   defp scan_defects(rows) do
@@ -479,35 +558,36 @@ defmodule Loopctl.Embeddings.LegacyRetirement do
 
     missing = seen |> Enum.reject(&Map.has_key?(first, &1)) |> Enum.sort()
 
-    scanned =
+    tracked =
       for index <- seen -- missing,
           baseline = Map.get(first, index),
           is_integer(baseline),
-          peak = peak_scans(rows, index, baseline),
-          peak != baseline,
+          do: {index, baseline, window_scans(rows, index)}
+
+    scanned =
+      for {index, baseline, values} <- tracked,
+          peak = Enum.max(values, fn -> baseline end),
+          peak > baseline,
           do: "#{index} (+#{peak - baseline})"
 
-    missing_reason =
-      if missing == [],
-        do: [],
-        else: ["index(es) absent at the start of the window: #{Enum.join(missing, ", ")}"]
+    rebuilt =
+      for {index, baseline, values} <- tracked,
+          Enum.min(values, fn -> baseline end) < baseline,
+          do: index
 
-    scanned_reason =
-      if scanned == [],
-        do: [],
-        else: [
-          "legacy index scans inside the window: #{scanned |> Enum.sort() |> Enum.join(", ")}"
-        ]
-
-    missing_reason ++ scanned_reason
+    reason("index(es) absent at the start of the window", missing) ++
+      reason("index(es) whose scan counter went BACKWARDS inside the window (rebuilt)", rebuilt) ++
+      reason("legacy index scans inside the window", scanned)
   end
+
+  defp reason(_prefix, []), do: []
+  defp reason(prefix, items), do: ["#{prefix}: #{items |> Enum.sort() |> Enum.join(", ")}"]
 
   defp scans(row), do: row.legacy_index_scans || %{}
 
-  defp peak_scans(rows, index, baseline) do
+  defp window_scans(rows, index) do
     rows
     |> Enum.map(&Map.get(scans(&1), index))
     |> Enum.filter(&is_integer/1)
-    |> Enum.max(fn -> baseline end)
   end
 end

--- a/lib/loopctl/embeddings/legacy_retirement_behaviour.ex
+++ b/lib/loopctl/embeddings/legacy_retirement_behaviour.ex
@@ -21,6 +21,9 @@ defmodule Loopctl.Embeddings.LegacyRetirementBehaviour do
   @doc "Read the live legacy-embedding footprint. Whole, or `{:error, _}`."
   @callback probe() :: {:ok, map()} | {:error, term()}
 
+  @doc "Whether the observation log exists. `{:error, _}` for an unreadable catalog."
+  @callback observations_table_ready?() :: {:ok, boolean()} | {:error, term()}
+
   @doc "Upsert today's observation from a probe reading."
   @callback record(probe :: map(), opts :: keyword()) ::
               {:ok, struct()} | {:error, Ecto.Changeset.t()}

--- a/lib/loopctl/embeddings/legacy_retirement_behaviour.ex
+++ b/lib/loopctl/embeddings/legacy_retirement_behaviour.ex
@@ -1,0 +1,30 @@
+defmodule Loopctl.Embeddings.LegacyRetirementBehaviour do
+  @moduledoc """
+  DI seam for the US-41.1 legacy-column retirement trigger (GH #551), between
+  `Loopctl.Workers.LegacyEmbeddingRetirementWorker` and
+  `Loopctl.Embeddings.LegacyRetirement`.
+
+  It exists for ONE branch: the worker's fail-closed handling of a probe that cannot
+  read the catalog. That branch is the whole point of the issue — an unreadable probe
+  must be loud and retried, never quietly rendered as "already cleaned up" — and it is
+  unreachable from a test otherwise, because the test database always answers the
+  catalog query successfully. An untested fail-closed path is indistinguishable from
+  an absent one.
+
+  Sibling of `Loopctl.Embeddings.ReadPathBehaviour`, and injected the same way:
+  `config/test.exs` points `:legacy_retirement` at a Mox mock and
+  `Loopctl.DataCase.stub_all_defaults/0` stubs it back to the real module, so every
+  test sees production behaviour unless it says otherwise — process-scoped, with
+  nothing VM-global written.
+  """
+
+  @doc "Read the live legacy-embedding footprint. Whole, or `{:error, _}`."
+  @callback probe() :: {:ok, map()} | {:error, term()}
+
+  @doc "Upsert today's observation from a probe reading."
+  @callback record(probe :: map(), opts :: keyword()) ::
+              {:ok, struct()} | {:error, Ecto.Changeset.t()}
+
+  @doc "Decide whether retirement is owed, given a probe reading and the stored history."
+  @callback evaluate(probe :: map(), opts :: keyword()) :: map()
+end

--- a/lib/loopctl/embeddings/retirement_observation.ex
+++ b/lib/loopctl/embeddings/retirement_observation.ex
@@ -1,0 +1,58 @@
+defmodule Loopctl.Embeddings.RetirementObservation do
+  @moduledoc """
+  Schema for `embedding_retirement_observations` — one row per UTC day recording
+  what the US-41.1 legacy embedding columns looked like that day (GH #551).
+
+  Global, like `Loopctl.SystemConfig.Setting`: there is no `tenant_id`, because the
+  fact recorded is a property of the deployment's schema and index usage. All access
+  goes through `Loopctl.AdminRepo` (BYPASSRLS).
+
+  See `Loopctl.Embeddings.LegacyRetirement` for what the fields mean and how a run of
+  these rows becomes a retirement verdict.
+  """
+
+  use Loopctl.Schema, tenant_scoped: false
+
+  @type t :: %__MODULE__{}
+
+  schema "embedding_retirement_observations" do
+    field :observed_on, :date
+    field :observed_at, :utc_datetime_usec
+    field :side_table_reads, :integer
+    field :legacy_columns_present, {:array, :string}, default: []
+    field :legacy_index_scans, :map, default: %{}
+    field :stats_reset_at, :utc_datetime_usec
+
+    timestamps()
+  end
+
+  @doc """
+  Changeset for a daily observation. Every field except `stats_reset_at` is
+  required: a row that cannot state the flag value, the surviving columns and the
+  scan counters is not evidence of anything, and admitting it would let a partial
+  reading count toward a clear streak.
+
+  `stats_reset_at` is nullable because `pg_stat_database.stats_reset` is genuinely
+  NULL on a database whose statistics have never been reset.
+  """
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
+  def changeset(observation, attrs) do
+    observation
+    |> cast(attrs, [
+      :observed_on,
+      :observed_at,
+      :side_table_reads,
+      :legacy_columns_present,
+      :legacy_index_scans,
+      :stats_reset_at
+    ])
+    |> validate_required([
+      :observed_on,
+      :observed_at,
+      :side_table_reads,
+      :legacy_columns_present,
+      :legacy_index_scans
+    ])
+    |> unique_constraint(:observed_on)
+  end
+end

--- a/lib/loopctl/embeddings/retirement_observation.ex
+++ b/lib/loopctl/embeddings/retirement_observation.ex
@@ -19,8 +19,13 @@ defmodule Loopctl.Embeddings.RetirementObservation do
     field :observed_on, :date
     field :observed_at, :utc_datetime_usec
     field :side_table_reads, :integer
-    field :legacy_columns_present, {:array, :string}, default: []
-    field :legacy_index_scans, :map, default: %{}
+    # No schema `default:` on either, deliberately: `validate_required/2` reads a struct
+    # default as a STATED value, so defaulting them to `[]`/`%{}` let a writer that never
+    # said which columns survived (or what the counters were) insert a row that then
+    # cleared the scan check trivially. An explicit `[]`/`%{}` still passes — the
+    # requirement is that the reading was taken, not that it found something.
+    field :legacy_columns_present, {:array, :string}
+    field :legacy_index_scans, :map
     field :stats_reset_at, :utc_datetime_usec
 
     timestamps()

--- a/lib/loopctl/oban_config.ex
+++ b/lib/loopctl/oban_config.ex
@@ -492,7 +492,18 @@ defmodule Loopctl.ObanConfig do
          # IEx call. Bounded per run; a backlog drains over successive hourly runs.
          # Keep in sync with the crontab assertion in oban_plugins_config_test.exs.
          {"15 * * * *", Loopctl.Workers.EmbeddingReconciliationWorker,
-          args: %{"mode" => "all_tenants"}}
+          args: %{"mode" => "all_tenants"}},
+         # GH #551: the RETIREMENT trigger for the US-41.1 legacy embedding columns.
+         # Records one observation per UTC day (the `idx_scan` deltas that "zero scans
+         # over N days" is made of) and raises an operator alert once retirement is
+         # owed — by evidence, or by the `review_by` deadline if the evidence never
+         # settles. Never drops anything. DAILY and HARDCODED (no env var), like
+         # IngestionHealthWorker: the interval is a latency knob on a decision measured
+         # in months, so app boot must not gain a dependency on a new env var for it.
+         # 03:40 UTC sits between the 03:00 webhook/token cleanups and the 04:00
+         # knowledge-lint fan-out rather than piling onto either. Keep in sync with the
+         # crontab assertion in oban_plugins_config_test.exs.
+         {"40 3 * * *", Loopctl.Workers.LegacyEmbeddingRetirementWorker}
        ]},
       # Rescue jobs orphaned in :executing when a node dies mid-run (e.g. a deploy).
       # Without Lifeline these rows stay `executing` forever — 110 such orphans (from

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -453,6 +453,26 @@ defmodule Loopctl.TelemetryEvents do
   """
   def channel_post_quarantined, do: [:loopctl, :coordination, :channel_post_quarantined]
 
+  @doc """
+  The US-41.1 legacy-column retirement probe
+  (`Loopctl.Embeddings.LegacyRetirement.probe/0`, GH #551) could NOT read the live
+  legacy embedding footprint.
+
+  Worth its own signal because of what the failure looks like from outside: a probe
+  that errors every run is indistinguishable from a probe that keeps finding nothing
+  to retire. Without this event the monitor's own death is silent, and a silent
+  retirement monitor is the exact failure #551 exists to close.
+
+  ## Payload (bounded tags only)
+
+    * `measurements`: `%{count: 1}` — a pure increment.
+    * `metadata`: `%{error_class}` — the raised exception's MODULE name (e.g.
+      `"Postgrex.Error"`, `"DBConnection.ConnectionError"`) or `"rollback"` for a
+      returned error tuple. A bounded dimension, never the failure's message.
+  """
+  def legacy_retirement_probe_failed,
+    do: [:loopctl, :embeddings, :legacy_retirement_probe_failed]
+
   @doc "Returns all defined event names for attachment"
   def all_events do
     [
@@ -479,7 +499,8 @@ defmodule Loopctl.TelemetryEvents do
       sweep_stall_detection_failed(),
       channel_post_rescanned(),
       channel_post_rescan_failed(),
-      channel_post_quarantined()
+      channel_post_quarantined(),
+      legacy_retirement_probe_failed()
     ]
   end
 end

--- a/lib/loopctl/workers/legacy_embedding_retirement_worker.ex
+++ b/lib/loopctl/workers/legacy_embedding_retirement_worker.ex
@@ -36,7 +36,6 @@ defmodule Loopctl.Workers.LegacyEmbeddingRetirementWorker do
 
   require Logger
 
-  alias Loopctl.AdminRepo
   alias Loopctl.Embeddings.LegacyRetirement
   alias Loopctl.TelemetryEvents
   alias Loopctl.Workers.ScaleAlertDeliveryWorker
@@ -46,10 +45,24 @@ defmodule Loopctl.Workers.LegacyEmbeddingRetirementWorker do
 
   @impl Oban.Worker
   def perform(%Oban.Job{}) do
-    case observations_table_ready?() do
+    case guarded(fn -> retirement().observations_table_ready?() end) do
       {:ok, record?} -> run(record?)
       {:error, reason} -> monitor_failed(reason, "could not probe the observation table")
     end
+  end
+
+  # A raise or an EXIT would otherwise escape `perform/1` without ever reaching
+  # `monitor_failed/2`, so the telemetry this monitor's own death is supposed to be visible
+  # through never fires. Both shapes are live here: a wedged AdminRepo pool EXITs with
+  # `{:timeout, {GenServer, :call, _}}` or `{:noproc, _}`, and an unreadable observation log
+  # raises — which is exactly what `LegacyRetirement.observations/2` now lets propagate
+  # rather than folding into a routine `:not_due`.
+  defp guarded(fun) do
+    fun.()
+  rescue
+    error -> {:error, error}
+  catch
+    :exit, reason -> {:error, reason}
   end
 
   # Injected (`Loopctl.Embeddings.LegacyRetirementBehaviour`) for ONE reason: the
@@ -62,29 +75,36 @@ defmodule Loopctl.Workers.LegacyEmbeddingRetirementWorker do
   # means a run straddling UTC midnight (a manual run, a delayed retry) records day D then
   # evaluates a window ending D+1 — a deficit that never happened.
   defp run(record?) do
-    case retirement().probe() do
+    case guarded(fn -> retirement().probe() end) do
       {:ok, probe} ->
         now = DateTime.utc_now()
         today = DateTime.to_date(now)
 
         maybe_record(record?, probe, now: now, today: today)
-
-        probe
-        |> retirement().evaluate(today: today)
-        |> react()
+        evaluate(probe, today)
 
       {:error, reason} ->
         monitor_failed(reason, "could not read the legacy embedding footprint")
     end
   end
 
+  defp evaluate(probe, today) do
+    case guarded(fn -> {:ok, retirement().evaluate(probe, today: today)} end) do
+      {:ok, verdict} -> react(verdict)
+      {:error, reason} -> monitor_failed(reason, "could not evaluate the evidence window")
+    end
+  end
+
+  # The message carries the BOUNDED `error_class/1` tag, never `inspect(reason)`: a
+  # Postgrex/DBConnection error's message embeds the backend host, database and role
+  # (the reason `LocalGuc.failure_tag/1` exists). The raw reason still rides back to Oban.
   defp monitor_failed(reason, what) do
     :telemetry.execute(TelemetryEvents.legacy_retirement_probe_failed(), %{count: 1}, %{
       error_class: error_class(reason)
     })
 
     Logger.error(
-      "LegacyEmbeddingRetirementWorker: #{what}: #{inspect(reason)}. This is NOT " <>
+      "LegacyEmbeddingRetirementWorker: #{what} (#{error_class(reason)}). This is NOT " <>
         "evidence that the columns are gone — the retirement check did not run."
     )
 
@@ -123,6 +143,17 @@ defmodule Loopctl.Workers.LegacyEmbeddingRetirementWorker do
     end
   end
 
+  # The columns are gone AND the read path points back at them: a broken deployment, not a
+  # satisfied trigger. Nothing is droppable, so the verdict stays `:retired` — but at :error.
+  defp react(%{verdict: :retired, side_table_reads: reads} = verdict) when reads != 1 do
+    Logger.error(
+      "LegacyEmbeddingRetirementWorker: BROKEN read path — " <>
+        reasons(verdict) <> ". The request path cannot serve a column that no longer exists."
+    )
+
+    :ok
+  end
+
   # Logged, not silent: `:retired` is also what a MIS-SCOPED or under-privileged probe
   # produces, and a permanently disabled monitor must not look like a satisfied one.
   defp react(%{verdict: :retired} = verdict) do
@@ -131,13 +162,18 @@ defmodule Loopctl.Workers.LegacyEmbeddingRetirementWorker do
   end
 
   # The deadline DID pass, so louder than a plain :not_due — but deliberately not a :due:
-  # acting on it would drop the column the request path is reading right now.
+  # acting on it would drop the column the request path is reading right now. It still
+  # ALERTS: this condition re-fires every day and is strictly more urgent than a plain
+  # :not_due, so leaving it on the log channel alone was the one branch where a passed
+  # deadline reached no operator. A distinct `alert` name keeps it from reading as a drop
+  # instruction.
   defp react(%{verdict: :not_due, trigger: :deadline_blocked} = verdict) do
     Logger.warning(
       "LegacyEmbeddingRetirementWorker: retirement BLOCKED for legacy embedding " <>
         "column(s) #{inspect(verdict.legacy_columns)} — " <> reasons(verdict)
     )
 
+    enqueue_alert(verdict, "embeddings.legacy_retirement_blocked")
     :ok
   end
 
@@ -177,15 +213,15 @@ defmodule Loopctl.Workers.LegacyEmbeddingRetirementWorker do
   # threshold, window_seconds, at}) so the channel — including ScaleAlertDeliveryWorker's
   # no-URL skip log, which renders metric=value — stays meaningful. Extra context rides
   # alongside; consumers branch on `alert`.
-  defp enqueue_alert(verdict) do
-    {metric, value, threshold} = alert_metric(verdict)
+  defp enqueue_alert(verdict, alert \\ "embeddings.legacy_retirement_due") do
+    {metric, value, threshold, window_seconds} = alert_metric(verdict)
 
     payload = %{
-      "alert" => "embeddings.legacy_retirement_due",
+      "alert" => alert,
       "metric" => metric,
       "value" => value,
       "threshold" => threshold,
-      "window_seconds" => verdict.required_clear_days * 86_400,
+      "window_seconds" => window_seconds,
       "trigger" => to_string(verdict.trigger),
       "side_table_reads" => verdict.side_table_reads,
       "legacy_columns" => verdict.legacy_columns,
@@ -218,25 +254,23 @@ defmodule Loopctl.Workers.LegacyEmbeddingRetirementWorker do
       :ok
   end
 
-  # On the DEADLINE trigger `clear_days` is 0 BY CONSTRUCTION, so shipping it as the breach
+  # The whole breach triple (plus its window) comes from ONE place, so value, threshold and
+  # window_seconds always describe each other.
+  #
+  # On the DEADLINE triggers `clear_days` is 0 BY CONSTRUCTION, so shipping it as the breach
   # pair renders "0 of 30" — which any consumer comparing value to threshold (including the
-  # no-URL skip log) reads as healthy, the exact inversion of what the alert means.
-  defp alert_metric(%{trigger: :deadline} = v),
-    do: {"embeddings.legacy_retirement.days_past_review_by", v.days_past_review_by, 0}
+  # no-URL skip log) reads as healthy, the exact inversion of what the alert means. The
+  # metric counts days AT OR PAST review_by (`diff + 1`), not days past it: on the review
+  # date itself the diff is 0, so "days past" would ship 0 against 0 and read as at-threshold
+  # on the first — and most actionable — day it fires. The window is the DAILY cadence: this
+  # is a point-in-time date breach, not a count measured over the 30-day evidence window.
+  defp alert_metric(%{trigger: trigger} = v) when trigger in [:deadline, :deadline_blocked],
+    do:
+      {"embeddings.legacy_retirement.days_at_or_past_review_by", v.days_past_review_by + 1, 0,
+       86_400}
 
   defp alert_metric(v),
-    do: {"embeddings.legacy_retirement.clear_days", v.clear_days, v.required_clear_days}
-
-  # An error is NOT folded into "absent": a saturated AdminRepo pool (3 connections) would
-  # answer with the same `false` a pending migration does, and returning `:ok` from a run
-  # that measured nothing — under a log naming an untrue cause — is the fail-open this
-  # worker exists to prevent.
-  defp observations_table_ready? do
-    case AdminRepo.query("SELECT to_regclass('embedding_retirement_observations')", []) do
-      {:ok, %{rows: [[nil]]}} -> {:ok, false}
-      {:ok, %{rows: [[_oid]]}} -> {:ok, true}
-      {:ok, %{rows: rows}} -> {:error, {:unexpected_table_probe_result, length(rows)}}
-      {:error, reason} -> {:error, reason}
-    end
-  end
+    do:
+      {"embeddings.legacy_retirement.clear_days", v.clear_days, v.required_clear_days,
+       v.required_clear_days * 86_400}
 end

--- a/lib/loopctl/workers/legacy_embedding_retirement_worker.ex
+++ b/lib/loopctl/workers/legacy_embedding_retirement_worker.ex
@@ -1,0 +1,203 @@
+defmodule Loopctl.Workers.LegacyEmbeddingRetirementWorker do
+  @moduledoc """
+  Daily driver for the US-41.1 legacy-column retirement trigger (GH #551).
+
+  Each run takes one live reading of the legacy `articles.embedding` /
+  `memories.embedding` footprint, records it as that UTC day's observation, and asks
+  `Loopctl.Embeddings.LegacyRetirement` whether retirement is now owed. It never
+  drops anything — the drop stays a deliberate human migration behind a reviewed PR.
+
+  ## What a `:due` verdict raises
+
+  Mirroring `Loopctl.Workers.IngestionHealthWorker`, the signal is deliberately
+  multi-channel so it does not depend on optional configuration:
+
+    * an always-on `Logger.error`, so the condition surfaces in logs/monitoring even
+      with no alert webhook configured (which is the CURRENT prod posture — scale
+      alerting was switched off in #539 until a receiver exists), and
+    * an operator alert enqueued via `Loopctl.Workers.ScaleAlertDeliveryWorker`,
+      which resolves `SCALE_ALERT_WEBHOOK_URL` itself and no-ops when unset.
+
+  It re-fires EVERY day for as long as the condition holds. That is the point rather
+  than an oversight: this is a "the build is red until you deal with it" signal, and
+  the failure mode it exists to prevent is precisely a reminder that stopped arriving.
+  There is no per-run anti-alarm-fatigue suppression here for the same reason — one
+  daily line about a standing 1.36 GB debt is the cheapest possible nag.
+
+  ## Failure is loud, not silent
+
+  A probe that cannot read the catalog returns `{:error, _}` and this worker returns
+  `{:error, _}` too, so Oban retries with backoff and the failure is visible as a job
+  failure rather than being swallowed into "nothing to do". It emits
+  `Loopctl.TelemetryEvents.legacy_retirement_probe_failed/0` on the way out so the
+  monitor's own death is itself observable.
+
+  Even so, a monitor that fails forever LOOKS like a monitor that keeps finding
+  nothing. That is why `LegacyRetirement`'s deadline trigger exists and does not
+  depend on any observation being recorded.
+  """
+
+  use Oban.Worker, queue: :default, max_attempts: 3
+
+  require Logger
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Embeddings.LegacyRetirement
+  alias Loopctl.TelemetryEvents
+  alias Loopctl.Workers.ScaleAlertDeliveryWorker
+
+  @impl Oban.Worker
+  def timeout(_job), do: :timer.seconds(60)
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    if observations_table_ready?() do
+      run()
+    else
+      # Version skew: this worker's crontab entry deployed before its migration ran.
+      # Skip quietly and self-heal next run rather than burning retries — the daily
+      # cadence means at most one day of evidence is lost, and the deadline trigger
+      # does not depend on the table at all.
+      Logger.warning(
+        "LegacyEmbeddingRetirementWorker: embedding_retirement_observations table " <>
+          "is absent (migration pending); skipping this run"
+      )
+
+      :ok
+    end
+  end
+
+  # Injected (`Loopctl.Embeddings.LegacyRetirementBehaviour`) for ONE reason: the
+  # `{:error, _}` branch below is the fail-closed guarantee this worker exists to
+  # provide, and the test database always answers the catalog query successfully, so
+  # without a seam that branch could never be exercised. Production resolves to the
+  # real module.
+  defp retirement do
+    Application.get_env(:loopctl, :legacy_retirement, LegacyRetirement)
+  end
+
+  defp run do
+    case retirement().probe() do
+      {:ok, probe} ->
+        record(probe)
+
+        probe
+        |> retirement().evaluate([])
+        |> react()
+
+      {:error, reason} ->
+        :telemetry.execute(TelemetryEvents.legacy_retirement_probe_failed(), %{count: 1}, %{
+          error_class: error_class(reason)
+        })
+
+        Logger.error(
+          "LegacyEmbeddingRetirementWorker: could not read the legacy embedding " <>
+            "footprint: #{inspect(reason)}. This is NOT evidence that the columns " <>
+            "are gone — the retirement check did not run."
+        )
+
+        {:error, reason}
+    end
+  end
+
+  # Recording is best-effort relative to REACTING: a day whose row failed to persist
+  # costs one day of evidence, but suppressing the verdict over it would turn a
+  # storage hiccup into silence about a condition we just successfully measured.
+  defp record(probe) do
+    case retirement().record(probe, []) do
+      {:ok, _observation} ->
+        :ok
+
+      {:error, changeset} ->
+        Logger.warning(
+          "LegacyEmbeddingRetirementWorker: failed to record today's observation: " <>
+            inspect(changeset.errors)
+        )
+
+        :ok
+    end
+  end
+
+  defp react(%{verdict: :retired}), do: :ok
+
+  defp react(%{verdict: :not_due} = verdict) do
+    Logger.info(
+      "LegacyEmbeddingRetirementWorker: legacy embedding columns " <>
+        "#{inspect(verdict.legacy_columns)} not yet retirable — " <>
+        reasons(verdict)
+    )
+
+    :ok
+  end
+
+  defp react(%{verdict: :due} = verdict) do
+    Logger.error(
+      "LegacyEmbeddingRetirementWorker: RETIREMENT DUE (#{verdict.trigger}) for legacy " <>
+        "embedding column(s) #{inspect(verdict.legacy_columns)} — " <>
+        reasons(verdict) <>
+        ". Drop them in a reviewed migration (see GH #551), or move review_by out " <>
+        "deliberately if the rollback is still wanted."
+    )
+
+    enqueue_alert(verdict)
+    :ok
+  end
+
+  # Keeps the telemetry dimension BOUNDED: a module name, never a message that could
+  # carry a query fragment or a connection string.
+  defp error_class(%{__struct__: module}), do: inspect(module)
+  defp error_class(_), do: "rollback"
+
+  defp reasons(%{reasons: []}), do: "no reason recorded"
+  defp reasons(%{reasons: reasons}), do: Enum.join(reasons, "; ")
+
+  # Conforms to the shared ScaleAlert operator-alert contract (%{alert, metric, value,
+  # threshold, window_seconds, at}) so the channel — including
+  # ScaleAlertDeliveryWorker's no-URL skip log, which renders metric=value — stays
+  # meaningful. Extra context rides alongside; consumers branch on `alert`.
+  defp enqueue_alert(verdict) do
+    payload = %{
+      "alert" => "embeddings.legacy_retirement_due",
+      "metric" => "embeddings.legacy_retirement.clear_days",
+      "value" => verdict.clear_days,
+      "threshold" => verdict.required_clear_days,
+      "window_seconds" => verdict.required_clear_days * 86_400,
+      "trigger" => to_string(verdict.trigger),
+      "legacy_columns" => verdict.legacy_columns,
+      "legacy_index_scans" => verdict.legacy_index_scans,
+      "review_by" => Date.to_iso8601(verdict.review_by),
+      "reasons" => verdict.reasons,
+      "at" => DateTime.utc_now() |> DateTime.to_iso8601()
+    }
+
+    case %{payload: payload} |> ScaleAlertDeliveryWorker.new() |> Oban.insert() do
+      {:ok, _job} ->
+        :ok
+
+      {:error, reason} ->
+        # Already logged at :error above, so a lost webhook does not lose the signal.
+        Logger.warning(
+          "LegacyEmbeddingRetirementWorker: failed to enqueue operator alert: " <>
+            inspect(reason)
+        )
+
+        :ok
+    end
+  rescue
+    error ->
+      Logger.warning(
+        "LegacyEmbeddingRetirementWorker: failed to enqueue operator alert " <>
+          "(#{inspect(error.__struct__)}): #{Exception.message(error)}"
+      )
+
+      :ok
+  end
+
+  defp observations_table_ready? do
+    case AdminRepo.query("SELECT to_regclass('embedding_retirement_observations')", []) do
+      {:ok, %{rows: [[nil]]}} -> false
+      {:ok, %{rows: [[_oid]]}} -> true
+      _ -> false
+    end
+  end
+end

--- a/lib/loopctl/workers/legacy_embedding_retirement_worker.ex
+++ b/lib/loopctl/workers/legacy_embedding_retirement_worker.ex
@@ -2,39 +2,34 @@ defmodule Loopctl.Workers.LegacyEmbeddingRetirementWorker do
   @moduledoc """
   Daily driver for the US-41.1 legacy-column retirement trigger (GH #551).
 
-  Each run takes one live reading of the legacy `articles.embedding` /
-  `memories.embedding` footprint, records it as that UTC day's observation, and asks
-  `Loopctl.Embeddings.LegacyRetirement` whether retirement is now owed. It never
-  drops anything — the drop stays a deliberate human migration behind a reviewed PR.
+  Each run takes one live reading of the legacy `articles.embedding` / `memories.embedding`
+  footprint, records it as that UTC day's observation, and asks
+  `Loopctl.Embeddings.LegacyRetirement` whether retirement is now owed. It never drops
+  anything — the drop stays a deliberate human migration behind a reviewed PR.
 
   ## What a `:due` verdict raises
 
-  Mirroring `Loopctl.Workers.IngestionHealthWorker`, the signal is deliberately
-  multi-channel so it does not depend on optional configuration:
+  Mirroring `Loopctl.Workers.IngestionHealthWorker`, the signal is multi-channel so it does
+  not depend on optional configuration:
 
-    * an always-on `Logger.error`, so the condition surfaces in logs/monitoring even
-      with no alert webhook configured (which is the CURRENT prod posture — scale
-      alerting was switched off in #539 until a receiver exists), and
-    * an operator alert enqueued via `Loopctl.Workers.ScaleAlertDeliveryWorker`,
-      which resolves `SCALE_ALERT_WEBHOOK_URL` itself and no-ops when unset.
+    * an always-on `Logger.error`, so the condition surfaces in logs even with no alert
+      webhook configured (the CURRENT prod posture — scale alerting was switched off in
+      #539 until a receiver exists), and
+    * an operator alert enqueued via `Loopctl.Workers.ScaleAlertDeliveryWorker`, which
+      resolves `SCALE_ALERT_WEBHOOK_URL` itself and no-ops when unset.
 
-  It re-fires EVERY day for as long as the condition holds. That is the point rather
-  than an oversight: this is a "the build is red until you deal with it" signal, and
-  the failure mode it exists to prevent is precisely a reminder that stopped arriving.
-  There is no per-run anti-alarm-fatigue suppression here for the same reason — one
-  daily line about a standing 1.36 GB debt is the cheapest possible nag.
+  It re-fires EVERY day while the condition holds, with no anti-alarm-fatigue suppression:
+  the failure mode it prevents is a reminder that stopped arriving.
 
   ## Failure is loud, not silent
 
-  A probe that cannot read the catalog returns `{:error, _}` and this worker returns
-  `{:error, _}` too, so Oban retries with backoff and the failure is visible as a job
-  failure rather than being swallowed into "nothing to do". It emits
-  `Loopctl.TelemetryEvents.legacy_retirement_probe_failed/0` on the way out so the
-  monitor's own death is itself observable.
-
-  Even so, a monitor that fails forever LOOKS like a monitor that keeps finding
-  nothing. That is why `LegacyRetirement`'s deadline trigger exists and does not
-  depend on any observation being recorded.
+  Anything this worker cannot READ — the catalog probe, or the observation table's own
+  existence check — returns `{:error, _}` from `perform/1`, so Oban retries with backoff,
+  `Loopctl.TelemetryEvents.legacy_retirement_probe_failed/0` fires, and the failure shows up
+  as a failed job instead of being swallowed into "nothing to do". A table that is genuinely
+  ABSENT is the one quiet skip, and even then the run still EVALUATES — the deadline trigger
+  needs no observation, which stops a monitor that fails forever from looking like one that
+  keeps finding nothing.
   """
 
   use Oban.Worker, queue: :default, max_attempts: 3
@@ -51,60 +46,70 @@ defmodule Loopctl.Workers.LegacyEmbeddingRetirementWorker do
 
   @impl Oban.Worker
   def perform(%Oban.Job{}) do
-    if observations_table_ready?() do
-      run()
-    else
-      # Version skew: this worker's crontab entry deployed before its migration ran.
-      # Skip quietly and self-heal next run rather than burning retries — the daily
-      # cadence means at most one day of evidence is lost, and the deadline trigger
-      # does not depend on the table at all.
-      Logger.warning(
-        "LegacyEmbeddingRetirementWorker: embedding_retirement_observations table " <>
-          "is absent (migration pending); skipping this run"
-      )
-
-      :ok
+    case observations_table_ready?() do
+      {:ok, record?} -> run(record?)
+      {:error, reason} -> monitor_failed(reason, "could not probe the observation table")
     end
   end
 
   # Injected (`Loopctl.Embeddings.LegacyRetirementBehaviour`) for ONE reason: the
-  # `{:error, _}` branch below is the fail-closed guarantee this worker exists to
-  # provide, and the test database always answers the catalog query successfully, so
-  # without a seam that branch could never be exercised. Production resolves to the
-  # real module.
-  defp retirement do
-    Application.get_env(:loopctl, :legacy_retirement, LegacyRetirement)
-  end
+  # `{:error, _}` branch below is this worker's fail-closed guarantee, and the test database
+  # always answers the catalog query successfully, so without a seam it could never be
+  # exercised. Production resolves to the real module.
+  defp retirement, do: Application.get_env(:loopctl, :legacy_retirement, LegacyRetirement)
 
-  defp run do
+  # `now`/`today` are resolved ONCE and threaded into both calls: letting each derive its own
+  # means a run straddling UTC midnight (a manual run, a delayed retry) records day D then
+  # evaluates a window ending D+1 — a deficit that never happened.
+  defp run(record?) do
     case retirement().probe() do
       {:ok, probe} ->
-        record(probe)
+        now = DateTime.utc_now()
+        today = DateTime.to_date(now)
+
+        maybe_record(record?, probe, now: now, today: today)
 
         probe
-        |> retirement().evaluate([])
+        |> retirement().evaluate(today: today)
         |> react()
 
       {:error, reason} ->
-        :telemetry.execute(TelemetryEvents.legacy_retirement_probe_failed(), %{count: 1}, %{
-          error_class: error_class(reason)
-        })
-
-        Logger.error(
-          "LegacyEmbeddingRetirementWorker: could not read the legacy embedding " <>
-            "footprint: #{inspect(reason)}. This is NOT evidence that the columns " <>
-            "are gone — the retirement check did not run."
-        )
-
-        {:error, reason}
+        monitor_failed(reason, "could not read the legacy embedding footprint")
     end
   end
 
-  # Recording is best-effort relative to REACTING: a day whose row failed to persist
-  # costs one day of evidence, but suppressing the verdict over it would turn a
-  # storage hiccup into silence about a condition we just successfully measured.
-  defp record(probe) do
-    case retirement().record(probe, []) do
+  defp monitor_failed(reason, what) do
+    :telemetry.execute(TelemetryEvents.legacy_retirement_probe_failed(), %{count: 1}, %{
+      error_class: error_class(reason)
+    })
+
+    Logger.error(
+      "LegacyEmbeddingRetirementWorker: #{what}: #{inspect(reason)}. This is NOT " <>
+        "evidence that the columns are gone — the retirement check did not run."
+    )
+
+    {:error, reason}
+  end
+
+  defp maybe_record(true, probe, opts), do: record(probe, opts)
+
+  # Version skew: the crontab entry deployed ahead of the migration. Only the EVIDENCE path
+  # needs the table, so the run still probes, evaluates and reacts — returning early here
+  # silenced the deadline in exactly the deployment where evidence is impossible.
+  defp maybe_record(false, _probe, _opts) do
+    Logger.warning(
+      "LegacyEmbeddingRetirementWorker: embedding_retirement_observations table is " <>
+        "absent (migration pending); evaluating without today's observation"
+    )
+
+    :ok
+  end
+
+  # Recording is best-effort relative to REACTING: a day whose row failed to persist costs
+  # one day of evidence, but suppressing the verdict over it turns a storage hiccup into
+  # silence about a condition we just measured.
+  defp record(probe, opts) do
+    case retirement().record(probe, opts) do
       {:ok, _observation} ->
         :ok
 
@@ -118,13 +123,28 @@ defmodule Loopctl.Workers.LegacyEmbeddingRetirementWorker do
     end
   end
 
-  defp react(%{verdict: :retired}), do: :ok
+  # Logged, not silent: `:retired` is also what a MIS-SCOPED or under-privileged probe
+  # produces, and a permanently disabled monitor must not look like a satisfied one.
+  defp react(%{verdict: :retired} = verdict) do
+    Logger.info("LegacyEmbeddingRetirementWorker: #{reasons(verdict)} — trigger satisfied")
+    :ok
+  end
+
+  # The deadline DID pass, so louder than a plain :not_due — but deliberately not a :due:
+  # acting on it would drop the column the request path is reading right now.
+  defp react(%{verdict: :not_due, trigger: :deadline_blocked} = verdict) do
+    Logger.warning(
+      "LegacyEmbeddingRetirementWorker: retirement BLOCKED for legacy embedding " <>
+        "column(s) #{inspect(verdict.legacy_columns)} — " <> reasons(verdict)
+    )
+
+    :ok
+  end
 
   defp react(%{verdict: :not_due} = verdict) do
     Logger.info(
       "LegacyEmbeddingRetirementWorker: legacy embedding columns " <>
-        "#{inspect(verdict.legacy_columns)} not yet retirable — " <>
-        reasons(verdict)
+        "#{inspect(verdict.legacy_columns)} not yet retirable — " <> reasons(verdict)
     )
 
     :ok
@@ -143,26 +163,31 @@ defmodule Loopctl.Workers.LegacyEmbeddingRetirementWorker do
     :ok
   end
 
-  # Keeps the telemetry dimension BOUNDED: a module name, never a message that could
-  # carry a query fragment or a connection string.
+  # Keeps the telemetry dimension BOUNDED: a module name or a stable exit tag, never a
+  # message that could carry a query fragment or a connection string. DBConnection/Postgrex
+  # EXIT with a TUPLE (`{:timeout, _}`, `{:noproc, _}`) — mirrors `LocalGuc.failure_tag/1`.
   defp error_class(%{__struct__: module}), do: inspect(module)
+  defp error_class({tag, _details}) when is_atom(tag), do: to_string(tag)
   defp error_class(_), do: "rollback"
 
   defp reasons(%{reasons: []}), do: "no reason recorded"
   defp reasons(%{reasons: reasons}), do: Enum.join(reasons, "; ")
 
   # Conforms to the shared ScaleAlert operator-alert contract (%{alert, metric, value,
-  # threshold, window_seconds, at}) so the channel — including
-  # ScaleAlertDeliveryWorker's no-URL skip log, which renders metric=value — stays
-  # meaningful. Extra context rides alongside; consumers branch on `alert`.
+  # threshold, window_seconds, at}) so the channel — including ScaleAlertDeliveryWorker's
+  # no-URL skip log, which renders metric=value — stays meaningful. Extra context rides
+  # alongside; consumers branch on `alert`.
   defp enqueue_alert(verdict) do
+    {metric, value, threshold} = alert_metric(verdict)
+
     payload = %{
       "alert" => "embeddings.legacy_retirement_due",
-      "metric" => "embeddings.legacy_retirement.clear_days",
-      "value" => verdict.clear_days,
-      "threshold" => verdict.required_clear_days,
+      "metric" => metric,
+      "value" => value,
+      "threshold" => threshold,
       "window_seconds" => verdict.required_clear_days * 86_400,
       "trigger" => to_string(verdict.trigger),
+      "side_table_reads" => verdict.side_table_reads,
       "legacy_columns" => verdict.legacy_columns,
       "legacy_index_scans" => verdict.legacy_index_scans,
       "review_by" => Date.to_iso8601(verdict.review_by),
@@ -193,11 +218,25 @@ defmodule Loopctl.Workers.LegacyEmbeddingRetirementWorker do
       :ok
   end
 
+  # On the DEADLINE trigger `clear_days` is 0 BY CONSTRUCTION, so shipping it as the breach
+  # pair renders "0 of 30" — which any consumer comparing value to threshold (including the
+  # no-URL skip log) reads as healthy, the exact inversion of what the alert means.
+  defp alert_metric(%{trigger: :deadline} = v),
+    do: {"embeddings.legacy_retirement.days_past_review_by", v.days_past_review_by, 0}
+
+  defp alert_metric(v),
+    do: {"embeddings.legacy_retirement.clear_days", v.clear_days, v.required_clear_days}
+
+  # An error is NOT folded into "absent": a saturated AdminRepo pool (3 connections) would
+  # answer with the same `false` a pending migration does, and returning `:ok` from a run
+  # that measured nothing — under a log naming an untrue cause — is the fail-open this
+  # worker exists to prevent.
   defp observations_table_ready? do
     case AdminRepo.query("SELECT to_regclass('embedding_retirement_observations')", []) do
-      {:ok, %{rows: [[nil]]}} -> false
-      {:ok, %{rows: [[_oid]]}} -> true
-      _ -> false
+      {:ok, %{rows: [[nil]]}} -> {:ok, false}
+      {:ok, %{rows: [[_oid]]}} -> {:ok, true}
+      {:ok, %{rows: rows}} -> {:error, {:unexpected_table_probe_result, length(rows)}}
+      {:error, reason} -> {:error, reason}
     end
   end
 end

--- a/priv/repo/migrations/20260802120000_create_embedding_retirement_observations.exs
+++ b/priv/repo/migrations/20260802120000_create_embedding_retirement_observations.exs
@@ -1,0 +1,60 @@
+defmodule Loopctl.Repo.Migrations.CreateEmbeddingRetirementObservations do
+  use Ecto.Migration
+
+  # GH #551: the daily evidence trail behind the US-41.1 legacy-column retirement
+  # trigger (`Loopctl.Embeddings.LegacyRetirement`). GLOBAL (non-tenant) like
+  # `system_configs`: what it records is a property of the DEPLOYMENT's schema and
+  # index usage, not of any tenant.
+  #
+  # Per CLAUDE.md rule 4 we ENABLE (never FORCE) Row Level Security, with no
+  # tenant_isolation policy: there is no tenant_id to scope by, and all access goes
+  # through `Loopctl.AdminRepo` (BYPASSRLS in prod, table owner in dev/test). RLS
+  # therefore simply denies the low-privilege `Loopctl.Repo` role, which never
+  # touches this table.
+  #
+  # Why a table at all, rather than reading `pg_stat_user_indexes` once at decision
+  # time: `idx_scan` is a CUMULATIVE counter. "Zero scans over the last N days" is a
+  # DELTA, and a delta needs a stored earlier reading. `stats_reset_at` is captured
+  # alongside it so a `pg_stat_reset()` (which zeroes the counters and would
+  # otherwise read as a suspiciously quiet window) invalidates the window instead of
+  # fabricating evidence.
+  #
+  # `observed_on` is UNIQUE: exactly one observation per UTC day, so a re-run of the
+  # daily cron (Oban retry, redeploy, manual invocation) UPSERTS rather than
+  # inflating the record count. The streak is counted in DAYS, and duplicate rows for
+  # a single day would let one day masquerade as a long quiet stretch.
+
+  def change do
+    create table(:embedding_retirement_observations, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :observed_on, :date, null: false
+      add :observed_at, :utc_datetime_usec, null: false
+
+      # The value the READ PATH sees (`SystemConfig` "embedding_side_table_reads"),
+      # not a re-derivation of it: 1 = side table, 0 = legacy column.
+      add :side_table_reads, :integer, null: false
+
+      # WHICH legacy columns still exist, e.g. ["articles", "memories"]. A list
+      # rather than a boolean so a half-completed retirement is legible.
+      add :legacy_columns_present, {:array, :string}, null: false, default: []
+
+      # index_name => cumulative idx_scan, for every index over a legacy `embedding`
+      # column. Discovered BY COLUMN, never by name, so a renamed or newly added
+      # legacy index cannot slip out of the window unnoticed.
+      add :legacy_index_scans, :map, null: false, default: %{}
+
+      # pg_stat_database.stats_reset at observation time. A change across the window
+      # makes every counter delta in it meaningless.
+      add :stats_reset_at, :utc_datetime_usec
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:embedding_retirement_observations, [:observed_on])
+
+    execute(
+      "ALTER TABLE embedding_retirement_observations ENABLE ROW LEVEL SECURITY",
+      "ALTER TABLE embedding_retirement_observations DISABLE ROW LEVEL SECURITY"
+    )
+  end
+end

--- a/test/loopctl/embeddings/legacy_retirement_test.exs
+++ b/test/loopctl/embeddings/legacy_retirement_test.exs
@@ -111,6 +111,21 @@ defmodule Loopctl.Embeddings.LegacyRetirementTest do
       stub(Loopctl.MockEmbeddingReadPath, :side_table_reads_enabled?, fn -> false end)
       assert {:ok, %{side_table_reads: 0}} = LegacyRetirement.probe()
     end
+
+    test "a live 0 that the STORED row contradicts fails the probe instead of reading as a revert" do
+      # `SystemConfig.get_int/2` returns its default (0) on a `:persistent_term` MISS and
+      # even rescues to it, so an unprimed node is shaped exactly like a deliberate revert
+      # — and a revert vetoes the DEADLINE, the one trigger that fires when everything else
+      # has gone quiet. Silently, forever. It must be a loud, retried probe failure.
+      AdminRepo.insert!(%Loopctl.SystemConfig.Setting{
+        key: Loopctl.Embeddings.read_flag_key(),
+        value: 1
+      })
+
+      stub(Loopctl.MockEmbeddingReadPath, :side_table_reads_enabled?, fn -> false end)
+
+      assert {:error, {:read_flag_cache_stale, _key}} = LegacyRetirement.probe()
+    end
   end
 
   describe "record/2" do
@@ -161,6 +176,25 @@ defmodule Loopctl.Embeddings.LegacyRetirementTest do
 
       assert verdict.verdict == :retired
       assert verdict.trigger == nil
+    end
+
+    test "a dropped column the read path was reverted TO carries the contradiction" do
+      # `:retired` short-circuits `decide/4`, so the live read-flag veto never sees this
+      # case — and a request path pointing at a column that no longer exists is a broken
+      # deployment, not a finished retirement.
+      verdict = evaluate(probe(%{legacy_columns: [], side_table_reads: 0}))
+
+      assert verdict.verdict == :retired
+      assert Enum.any?(verdict.reasons, &(&1 =~ "ACTIVE read path"))
+    end
+
+    test "deadline_passed? agrees with days_past_review_by on EVERY branch" do
+      # Two readings of one fact in one map: the `:retired` branch hard-coded its own
+      # `false` while inheriting a positive `days_past_review_by`.
+      verdict = evaluate(probe(%{legacy_columns: []}), review_by: Date.add(@today, -1))
+
+      assert verdict.days_past_review_by > 0
+      assert verdict.deadline_passed?
     end
   end
 
@@ -280,6 +314,25 @@ defmodule Loopctl.Embeddings.LegacyRetirementTest do
 
       assert verdict.verdict == :not_due
       assert Enum.any?(verdict.reasons, &(&1 =~ "articles_embedding_hnsw_idx (+16)"))
+    end
+
+    test "a counter that went BACKWARDS is a rebuilt index, not a quiet one" do
+      clear_window()
+
+      # REINDEX CONCURRENTLY (or a drop and recreate under the same name) restarts
+      # `idx_scan` at 0 WITHOUT touching `pg_stat_database.stats_reset`, so neither the
+      # reset check nor a peak-only comparison can see it: the baseline is itself in the
+      # window, so the peak never falls below it and a rebuilt-then-scanned index reads
+      # as perfectly still.
+      AdminRepo.update_all(
+        from(o in RetirementObservation, where: o.observed_on == ^@today),
+        set: [legacy_index_scans: %{"articles_embedding_hnsw_idx" => 12}]
+      )
+
+      verdict = evaluate(probe())
+
+      assert verdict.verdict == :not_due
+      assert Enum.any?(verdict.reasons, &(&1 =~ "went BACKWARDS"))
     end
 
     test "a degenerate required_clear_days falls back rather than clearing vacuously" do

--- a/test/loopctl/embeddings/legacy_retirement_test.exs
+++ b/test/loopctl/embeddings/legacy_retirement_test.exs
@@ -1,0 +1,308 @@
+defmodule Loopctl.Embeddings.LegacyRetirementTest do
+  @moduledoc """
+  GH #551 — the US-41.1 legacy-column retirement TRIGGER.
+
+  The thing under test is a gate, so most of these are negative: each asserts that one
+  specific way of NOT knowing keeps the verdict at `:not_due`. That is the property the
+  issue actually asked for — "an expired token or an API error must not read as already
+  cleaned up" — and every one of them would pass vacuously against a gate that simply
+  never fires, so the positive cases (`due_via_evidence`, `due_via_deadline`) are what
+  keep the negatives honest.
+  """
+
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Embeddings.LegacyRetirement
+  alias Loopctl.Embeddings.RetirementObservation
+
+  setup :verify_on_exit!
+
+  @today ~D[2026-08-02]
+  @required 3
+
+  # A window that WOULD pass: `@required` contiguous days, flag on, counters frozen.
+  defp clear_window(opts \\ []) do
+    scans = Keyword.get(opts, :scans, %{"articles_embedding_hnsw_idx" => 674})
+    reset = Keyword.get(opts, :stats_reset_at, ~U[2026-01-01 00:00:00.000000Z])
+
+    for offset <- (@required - 1)..0//-1 do
+      insert_observation(
+        observed_on: Date.add(@today, -offset),
+        side_table_reads: 1,
+        legacy_index_scans: scans,
+        stats_reset_at: reset
+      )
+    end
+  end
+
+  defp insert_observation(attrs) do
+    attrs = Map.new(attrs)
+
+    %RetirementObservation{}
+    |> RetirementObservation.changeset(
+      Map.merge(
+        %{
+          observed_at: DateTime.utc_now(),
+          side_table_reads: 1,
+          legacy_columns_present: ["articles", "memories"],
+          legacy_index_scans: %{},
+          stats_reset_at: nil
+        },
+        attrs
+      )
+    )
+    |> AdminRepo.insert!()
+  end
+
+  defp probe(overrides \\ %{}) do
+    Map.merge(
+      %{
+        side_table_reads: 1,
+        legacy_columns: ["articles", "memories"],
+        legacy_index_scans: %{"articles_embedding_hnsw_idx" => 674},
+        stats_reset_at: ~U[2026-01-01 00:00:00.000000Z]
+      },
+      overrides
+    )
+  end
+
+  defp evaluate(probe, opts \\ []) do
+    LegacyRetirement.evaluate(
+      probe,
+      Keyword.merge(
+        [today: @today, required_clear_days: @required, review_by: ~D[2027-01-22]],
+        opts
+      )
+    )
+  end
+
+  describe "probe/0 against the live schema" do
+    test "reports the legacy columns that actually exist" do
+      assert {:ok, result} = LegacyRetirement.probe()
+
+      assert "articles" in result.legacy_columns
+      assert "memories" in result.legacy_columns
+    end
+
+    test "discovers legacy indexes BY COLUMN, and finds a non-empty set" do
+      assert {:ok, result} = LegacyRetirement.probe()
+
+      # The non-emptiness assertion is the load-bearing one. A `pg_index`/`pg_attribute`
+      # join that silently matches NOTHING would make every "zero scans" window pass
+      # vacuously forever, and the resulting `:due` would look identical to a real one.
+      refute result.legacy_index_scans == %{},
+             "expected at least one index over a legacy `embedding` column; an empty " <>
+               "set makes the scan check vacuous"
+
+      assert Enum.all?(result.legacy_index_scans, fn {name, scans} ->
+               is_binary(name) and is_integer(scans)
+             end)
+
+      # Discovery is by column, so it must catch the canonical articles index WITHOUT
+      # that name appearing anywhere in the query.
+      assert Map.has_key?(result.legacy_index_scans, "articles_embedding_hnsw_idx")
+    end
+
+    test "reports the read flag the request path is actually using" do
+      stub(Loopctl.MockEmbeddingReadPath, :side_table_reads_enabled?, fn -> true end)
+      assert {:ok, %{side_table_reads: 1}} = LegacyRetirement.probe()
+
+      stub(Loopctl.MockEmbeddingReadPath, :side_table_reads_enabled?, fn -> false end)
+      assert {:ok, %{side_table_reads: 0}} = LegacyRetirement.probe()
+    end
+  end
+
+  describe "record/2" do
+    test "writes one row per UTC day" do
+      assert {:ok, first} = LegacyRetirement.record(probe(), today: @today)
+      assert first.observed_on == @today
+      assert first.side_table_reads == 1
+      assert first.legacy_columns_present == ["articles", "memories"]
+    end
+
+    test "a same-day re-run UPDATES rather than adding a second row for the day" do
+      {:ok, first} = LegacyRetirement.record(probe(), today: @today)
+
+      {:ok, second} =
+        LegacyRetirement.record(
+          probe(%{legacy_index_scans: %{"articles_embedding_hnsw_idx" => 700}}),
+          today: @today
+        )
+
+      assert second.id == first.id
+      assert second.legacy_index_scans == %{"articles_embedding_hnsw_idx" => 700}
+
+      # A duplicate row for one day would let a single day stand in for a whole streak.
+      assert AdminRepo.aggregate(
+               from(o in RetirementObservation, where: o.observed_on == ^@today),
+               :count
+             ) == 1
+    end
+  end
+
+  describe "evaluate/2 — the retired terminus" do
+    test "no surviving legacy column is :retired, not :due" do
+      verdict = evaluate(probe(%{legacy_columns: []}))
+
+      assert verdict.verdict == :retired
+      assert verdict.trigger == nil
+    end
+  end
+
+  describe "evaluate/2 — the evidence trigger" do
+    test "a full clear window is :due via evidence" do
+      clear_window()
+
+      verdict = evaluate(probe())
+
+      assert verdict.verdict == :due
+      assert verdict.trigger == :evidence
+      assert verdict.clear_days == @required
+    end
+
+    test "no observations at all is :not_due, and says which days are missing" do
+      verdict = evaluate(probe())
+
+      assert verdict.verdict == :not_due
+      assert verdict.clear_days == 0
+      assert Enum.any?(verdict.reasons, &(&1 =~ "only 0 of #{@required} day(s) observed"))
+    end
+
+    test "a GAP in the window is :not_due — a day we cannot speak for is not a quiet one" do
+      # Two of three days, the missing one strictly inside the window.
+      insert_observation(observed_on: Date.add(@today, -2), side_table_reads: 1)
+      insert_observation(observed_on: @today, side_table_reads: 1)
+
+      verdict = evaluate(probe())
+
+      assert verdict.verdict == :not_due
+      assert Enum.any?(verdict.reasons, &(&1 =~ "only 2 of #{@required} day(s) observed"))
+    end
+
+    test "the read flag being OFF on any day in the window is :not_due" do
+      clear_window()
+
+      AdminRepo.update_all(
+        from(o in RetirementObservation, where: o.observed_on == ^Date.add(@today, -1)),
+        set: [side_table_reads: 0]
+      )
+
+      verdict = evaluate(probe())
+
+      assert verdict.verdict == :not_due
+      assert Enum.any?(verdict.reasons, &(&1 =~ "side_table_reads was not 1 on 1 day(s)"))
+    end
+
+    test "a legacy index scan inside the window is :not_due, and names the index" do
+      clear_window()
+
+      AdminRepo.update_all(
+        from(o in RetirementObservation, where: o.observed_on == ^@today),
+        set: [legacy_index_scans: %{"articles_embedding_hnsw_idx" => 700}]
+      )
+
+      verdict = evaluate(probe())
+
+      assert verdict.verdict == :not_due
+
+      assert Enum.any?(
+               verdict.reasons,
+               &(&1 =~ "legacy index scans inside the window: articles_embedding_hnsw_idx (+26)")
+             )
+    end
+
+    test "a pg_stat reset inside the window invalidates it" do
+      clear_window()
+
+      # A reset zeroes idx_scan. Without this check the frozen-looking counters that
+      # follow would read as proof of quiet — the precise inversion of the truth.
+      AdminRepo.update_all(
+        from(o in RetirementObservation, where: o.observed_on == ^@today),
+        set: [
+          stats_reset_at: ~U[2026-08-02 03:00:00.000000Z],
+          legacy_index_scans: %{"articles_embedding_hnsw_idx" => 0}
+        ]
+      )
+
+      verdict = evaluate(probe())
+
+      assert verdict.verdict == :not_due
+      assert Enum.any?(verdict.reasons, &(&1 =~ "statistics were reset inside the window"))
+    end
+
+    test "an index absent at the START of the window is :not_due" do
+      clear_window()
+
+      # An index created two days ago cannot testify about three.
+      AdminRepo.update_all(
+        from(o in RetirementObservation, where: o.observed_on == ^Date.add(@today, -2)),
+        set: [legacy_index_scans: %{}]
+      )
+
+      verdict = evaluate(probe())
+
+      assert verdict.verdict == :not_due
+
+      assert Enum.any?(
+               verdict.reasons,
+               &(&1 =~ "absent at the start of the window: articles_embedding_hnsw_idx")
+             )
+    end
+
+    test "a surviving column with NO index over it still clears — deliberately" do
+      # Documented as a correct vacuous pass, not a hole: an unindexed legacy column is
+      # already past the expensive half of retirement. The flag and the full window
+      # still have to hold, which is what makes it a decision rather than a default.
+      clear_window(scans: %{})
+
+      verdict = evaluate(probe(%{legacy_index_scans: %{}}))
+
+      assert verdict.verdict == :due
+      assert verdict.trigger == :evidence
+    end
+  end
+
+  describe "evaluate/2 — the deadline trigger" do
+    test "a passed review_by is :due even with no evidence whatsoever" do
+      # This is the case that makes the whole check fail closed. With no observations,
+      # an evidence-only trigger is silent forever and indistinguishable from healthy.
+      verdict = evaluate(probe(), review_by: Date.add(@today, -1))
+
+      assert verdict.verdict == :due
+      assert verdict.trigger == :deadline
+      assert verdict.deadline_passed?
+      assert Enum.any?(verdict.reasons, &(&1 =~ "has passed"))
+    end
+
+    test "review_by exactly today has passed" do
+      verdict = evaluate(probe(), review_by: @today)
+
+      assert verdict.verdict == :due
+      assert verdict.trigger == :deadline
+    end
+
+    test "a future review_by does not fire on its own" do
+      verdict = evaluate(probe(), review_by: Date.add(@today, 1))
+
+      assert verdict.verdict == :not_due
+      refute verdict.deadline_passed?
+    end
+
+    test "the deadline NEVER fires once the columns are gone" do
+      verdict = evaluate(probe(%{legacy_columns: []}), review_by: Date.add(@today, -1))
+
+      assert verdict.verdict == :retired
+    end
+  end
+
+  describe "the shipped defaults" do
+    test "review_by is a real future-dated deadline, not an unset placeholder" do
+      # A deadline defaulted to nil or to the epoch is the same as having none: the
+      # first quietly never fires, the second fires on day one and gets muted.
+      assert %Date{} = LegacyRetirement.review_by()
+      assert Date.compare(LegacyRetirement.review_by(), ~D[2026-08-02]) == :gt
+      assert LegacyRetirement.required_clear_days() > 0
+    end
+  end
+end

--- a/test/loopctl/embeddings/legacy_retirement_test.exs
+++ b/test/loopctl/embeddings/legacy_retirement_test.exs
@@ -121,6 +121,20 @@ defmodule Loopctl.Embeddings.LegacyRetirementTest do
       assert first.legacy_columns_present == ["articles", "memories"]
     end
 
+    test "an observation that never states the columns or the counters is rejected" do
+      # A schema `default:` reads as a stated value to `validate_required/2`, so an
+      # OMITTED field inserted cleanly and then cleared the scan check trivially.
+      changeset =
+        RetirementObservation.changeset(%RetirementObservation{}, %{
+          observed_on: @today,
+          observed_at: DateTime.utc_now(),
+          side_table_reads: 1
+        })
+
+      refute changeset.valid?
+      assert %{legacy_columns_present: _, legacy_index_scans: _} = errors_on(changeset)
+    end
+
     test "a same-day re-run UPDATES rather than adding a second row for the day" do
       {:ok, first} = LegacyRetirement.record(probe(), today: @today)
 
@@ -250,6 +264,33 @@ defmodule Loopctl.Embeddings.LegacyRetirementTest do
              )
     end
 
+    test "an index scanned only in the MIDDLE of the window is :not_due" do
+      clear_window()
+
+      # Created, scanned and dropped strictly inside the window: it appears at neither
+      # endpoint, so an endpoint-only comparison never examined it at all.
+      AdminRepo.update_all(
+        from(o in RetirementObservation, where: o.observed_on == ^Date.add(@today, -1)),
+        set: [
+          legacy_index_scans: %{"articles_embedding_hnsw_idx" => 690}
+        ]
+      )
+
+      verdict = evaluate(probe())
+
+      assert verdict.verdict == :not_due
+      assert Enum.any?(verdict.reasons, &(&1 =~ "articles_embedding_hnsw_idx (+16)"))
+    end
+
+    test "a degenerate required_clear_days falls back rather than clearing vacuously" do
+      # 0 is truthy, so `||` never rejected it: the window became empty, every check
+      # passed over no rows, and `:due` was asserted from literally no evidence.
+      verdict = evaluate(probe(), required_clear_days: 0)
+
+      assert verdict.verdict == :not_due
+      assert verdict.required_clear_days == 30
+    end
+
     test "a surviving column with NO index over it still clears — deliberately" do
       # Documented as a correct vacuous pass, not a hole: an unindexed legacy column is
       # already past the expensive half of retirement. The flag and the full window
@@ -287,6 +328,18 @@ defmodule Loopctl.Embeddings.LegacyRetirementTest do
 
       assert verdict.verdict == :not_due
       refute verdict.deadline_passed?
+    end
+
+    test "a LIVE read-flag revert blocks the deadline instead of naming the read path" do
+      # The columns exist FOR this rollback. A `:due` here tells an operator to drop the
+      # column the request path is reading from right now.
+      verdict =
+        evaluate(probe(%{side_table_reads: 0}), review_by: Date.add(@today, -1))
+
+      assert verdict.verdict == :not_due
+      assert verdict.trigger == :deadline_blocked
+      assert verdict.side_table_reads == 0
+      assert Enum.any?(verdict.reasons, &(&1 =~ "ACTIVE read path"))
     end
 
     test "the deadline NEVER fires once the columns are gone" do

--- a/test/loopctl/oban_plugins_config_test.exs
+++ b/test/loopctl/oban_plugins_config_test.exs
@@ -225,6 +225,36 @@ defmodule Loopctl.ObanPluginsConfigTest do
     end
   end
 
+  describe "#551: LegacyEmbeddingRetirementWorker crontab entry" do
+    setup do
+      plugins = Application.get_env(:loopctl, Oban)[:plugins]
+
+      {Oban.Plugins.Cron, cron_opts} =
+        Enum.find(plugins, &match?({Oban.Plugins.Cron, _}, &1))
+
+      entry =
+        Enum.find(cron_opts[:crontab], fn
+          {_schedule, Loopctl.Workers.LegacyEmbeddingRetirementWorker} -> true
+          {_schedule, Loopctl.Workers.LegacyEmbeddingRetirementWorker, _opts} -> true
+          _ -> false
+        end)
+
+      %{entry: entry}
+    end
+
+    test "the LegacyEmbeddingRetirementWorker entry exists in the crontab", %{entry: entry} do
+      assert entry,
+             "expected a LegacyEmbeddingRetirementWorker crontab entry — without a SCHEDULE " <>
+               "the US-41.1 legacy-column retirement has no trigger at all, which is exactly " <>
+               "the #551 defect"
+    end
+
+    test "its schedule is the daily off-peak observation", %{entry: entry} do
+      schedule = elem(entry, 0)
+      assert schedule == "40 3 * * *"
+    end
+  end
+
   describe "US-35.3: sth_sweep_cron/0 (config-based DI, runtime-tunable)" do
     test "defaults to a 5-minute sweep when STH_SWEEP_CRON is unset" do
       # STH_SWEEP_CRON is not set in the test environment, so the default applies.

--- a/test/loopctl/workers/legacy_embedding_retirement_worker_test.exs
+++ b/test/loopctl/workers/legacy_embedding_retirement_worker_test.exs
@@ -149,16 +149,16 @@ defmodule Loopctl.Workers.LegacyEmbeddingRetirementWorkerTest do
       assert payload["legacy_index_scans"] == %{"articles_embedding_hnsw_idx" => 674}
     end
 
-    test "the DEADLINE alert reports a metric that crosses its threshold upward" do
-      # `clear_days` is 0 by construction on the deadline path, so shipping it as the
-      # breach pair renders "0 of 30" — which any consumer comparing value to threshold
-      # reads as healthy, for the one trigger that exists to be un-ignorable.
+    test "the DEADLINE alert breaches its threshold on the review_by day ITSELF" do
+      # `clear_days` is 0 by construction here, so shipping it renders "0 of 30" — healthy
+      # to a consumer comparing value to threshold. So is "0 past review_by" on the day the
+      # deadline FIRST fires: hence days AT OR past it, over a window describing a date check.
       stub(Loopctl.MockLegacyRetirement, :evaluate, fn _probe, _opts ->
         verdict(%{
           verdict: :due,
           trigger: :deadline,
           deadline_passed?: true,
-          days_past_review_by: 4
+          days_past_review_by: 0
         })
       end)
 
@@ -167,14 +167,58 @@ defmodule Loopctl.Workers.LegacyEmbeddingRetirementWorkerTest do
       assert [job] = all_enqueued(worker: ScaleAlertDeliveryWorker)
       payload = job.args["payload"]
 
-      assert payload["metric"] == "embeddings.legacy_retirement.days_past_review_by"
-      assert payload["value"] == 4
+      assert payload["metric"] == "embeddings.legacy_retirement.days_at_or_past_review_by"
+      assert payload["value"] == 1
       assert payload["threshold"] == 0
-      assert payload["side_table_reads"] == 1
+      assert payload["window_seconds"] == 86_400
     end
   end
 
   describe "fail closed" do
+    test "a BLOCKED deadline alerts too, under its own name" do
+      # More urgent than a plain :not_due (the deadline DID pass) and it re-fires daily, so
+      # the log channel alone was the one passed deadline that reached no operator. The
+      # distinct name keeps it from reading as a drop instruction.
+      stub(Loopctl.MockLegacyRetirement, :evaluate, fn _probe, _opts ->
+        verdict(%{trigger: :deadline_blocked, deadline_passed?: true, days_past_review_by: 0})
+      end)
+
+      capture_log(fn -> assert :ok = run_job() end)
+
+      assert [job] = all_enqueued(worker: ScaleAlertDeliveryWorker)
+      assert job.args["payload"]["alert"] == "embeddings.legacy_retirement_blocked"
+      assert job.args["payload"]["value"] > job.args["payload"]["threshold"]
+    end
+
+    test "a dropped column the read path still points AT logs at :error, not :info" do
+      # `:retired` short-circuits the live read-flag veto, so this contradiction reaches
+      # the worker as a satisfied trigger unless the worker itself says otherwise.
+      stub(Loopctl.MockLegacyRetirement, :evaluate, fn _probe, _opts ->
+        verdict(%{verdict: :retired, legacy_columns: [], side_table_reads: 0})
+      end)
+
+      log = capture_log(fn -> assert :ok = run_job() end)
+
+      assert log =~ "[error]"
+      assert log =~ "BROKEN read path"
+    end
+
+    test "an evidence window that RAISES is a monitor failure, not a quiet :not_due" do
+      # An unreadable observation log (saturated pool, statement timeout, permission) must
+      # not render as the routine ":not_due" a genuinely empty log does — and the log line
+      # must carry the bounded class, never a message embedding host/database/role.
+      stub(Loopctl.MockLegacyRetirement, :evaluate, fn _probe, _opts ->
+        raise %Postgrex.Error{message: "connection not available"}
+      end)
+
+      log = capture_log(fn -> assert {:error, _} = run_job() end)
+
+      refute_enqueued(worker: ScaleAlertDeliveryWorker)
+      assert log =~ "could not evaluate the evidence window"
+      assert log =~ "Postgrex.Error"
+      refute log =~ "connection not available"
+    end
+
     test "a probe error returns {:error, _} and enqueues NOTHING" do
       error = %Postgrex.Error{message: "permission denied for view pg_stat_user_indexes"}
 
@@ -236,7 +280,12 @@ defmodule Loopctl.Workers.LegacyEmbeddingRetirementWorkerTest do
       end)
 
       stub(Loopctl.MockLegacyRetirement, :evaluate, fn _probe, _opts ->
-        verdict(%{verdict: :due, trigger: :deadline, deadline_passed?: true})
+        verdict(%{
+          verdict: :due,
+          trigger: :deadline,
+          deadline_passed?: true,
+          days_past_review_by: 0
+        })
       end)
 
       capture_log(fn ->

--- a/test/loopctl/workers/legacy_embedding_retirement_worker_test.exs
+++ b/test/loopctl/workers/legacy_embedding_retirement_worker_test.exs
@@ -1,0 +1,241 @@
+defmodule Loopctl.Workers.LegacyEmbeddingRetirementWorkerTest do
+  @moduledoc """
+  GH #551 — the daily driver for the legacy-column retirement trigger.
+
+  The load-bearing test here is `probe error`: an unreadable catalog must surface as a
+  failed job and must NOT enqueue anything, because "I could not check" rendering as
+  "nothing to do" is the exact defect the issue describes. It is reachable only through
+  the injected `Loopctl.Embeddings.LegacyRetirementBehaviour` — the test database always
+  answers that query successfully.
+  """
+
+  use Loopctl.DataCase, async: true
+  use Oban.Testing, repo: Loopctl.Repo
+
+  import ExUnit.CaptureLog
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Embeddings.LegacyRetirement
+  alias Loopctl.Embeddings.RetirementObservation
+  alias Loopctl.Workers.LegacyEmbeddingRetirementWorker
+  alias Loopctl.Workers.ScaleAlertDeliveryWorker
+
+  setup :verify_on_exit!
+
+  defp probe(overrides \\ %{}) do
+    Map.merge(
+      %{
+        side_table_reads: 1,
+        legacy_columns: ["articles", "memories"],
+        legacy_index_scans: %{"articles_embedding_hnsw_idx" => 674},
+        stats_reset_at: nil
+      },
+      overrides
+    )
+  end
+
+  defp verdict(overrides) do
+    Map.merge(
+      %{
+        verdict: :not_due,
+        trigger: nil,
+        reasons: ["only 0 of 30 day(s) observed"],
+        legacy_columns: ["articles", "memories"],
+        clear_days: 0,
+        required_clear_days: 30,
+        review_by: ~D[2027-01-22],
+        deadline_passed?: false,
+        legacy_index_scans: %{"articles_embedding_hnsw_idx" => 674}
+      },
+      overrides
+    )
+  end
+
+  # `config/test.exs` runs Oban `testing: :inline`, which EXECUTES an inserted job
+  # instead of storing it — so an enqueue assertion needs `:manual` for the duration of
+  # the call, exactly as the sibling `ChannelPostRescanWorker` tests do.
+  defp run_job do
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      LegacyEmbeddingRetirementWorker.perform(%Oban.Job{args: %{}})
+    end)
+  end
+
+  describe "a healthy run" do
+    test "records today's observation from the live probe" do
+      assert :ok = run_job()
+
+      observation = AdminRepo.get_by(RetirementObservation, observed_on: Date.utc_today())
+
+      assert observation
+      assert "articles" in observation.legacy_columns_present
+      refute observation.legacy_index_scans == %{}
+    end
+
+    test "a :not_due verdict enqueues no operator alert" do
+      stub(Loopctl.MockLegacyRetirement, :probe, fn -> {:ok, probe()} end)
+      stub(Loopctl.MockLegacyRetirement, :evaluate, fn _probe, _opts -> verdict(%{}) end)
+
+      assert :ok = run_job()
+      refute_enqueued(worker: ScaleAlertDeliveryWorker)
+    end
+
+    test "a :retired verdict enqueues nothing and stays quiet" do
+      stub(Loopctl.MockLegacyRetirement, :probe, fn ->
+        {:ok, probe(%{legacy_columns: []})}
+      end)
+
+      stub(Loopctl.MockLegacyRetirement, :evaluate, fn _probe, _opts ->
+        verdict(%{verdict: :retired, legacy_columns: []})
+      end)
+
+      log =
+        capture_log(fn ->
+          assert :ok = run_job()
+        end)
+
+      refute_enqueued(worker: ScaleAlertDeliveryWorker)
+      refute log =~ "RETIREMENT DUE"
+    end
+  end
+
+  describe "a :due verdict" do
+    setup do
+      stub(Loopctl.MockLegacyRetirement, :probe, fn -> {:ok, probe()} end)
+
+      stub(Loopctl.MockLegacyRetirement, :evaluate, fn _probe, _opts ->
+        verdict(%{
+          verdict: :due,
+          trigger: :evidence,
+          reasons: ["30 consecutive clear day(s) at or above the 30-day bar"],
+          clear_days: 30
+        })
+      end)
+
+      :ok
+    end
+
+    test "logs at :error, so the condition surfaces with no alert channel configured" do
+      # Scale alerting is OFF in prod (#539) until a receiver exists, so the log is the
+      # channel that actually works today. A signal that only exists on an unconfigured
+      # webhook is the same silence the issue is about.
+      log =
+        capture_log(fn ->
+          assert :ok = run_job()
+        end)
+
+      assert log =~ "RETIREMENT DUE"
+      assert log =~ "evidence"
+      assert log =~ "articles"
+    end
+
+    test "enqueues an operator alert carrying the trigger and the deadline" do
+      capture_log(fn ->
+        assert :ok = run_job()
+        assert_enqueued(worker: ScaleAlertDeliveryWorker)
+      end)
+
+      assert [job] = all_enqueued(worker: ScaleAlertDeliveryWorker)
+      payload = job.args["payload"]
+
+      assert payload["alert"] == "embeddings.legacy_retirement_due"
+      assert payload["metric"] == "embeddings.legacy_retirement.clear_days"
+      assert payload["value"] == 30
+      assert payload["threshold"] == 30
+      assert payload["trigger"] == "evidence"
+      assert payload["legacy_columns"] == ["articles", "memories"]
+      assert payload["review_by"] == "2027-01-22"
+      assert payload["legacy_index_scans"] == %{"articles_embedding_hnsw_idx" => 674}
+    end
+  end
+
+  describe "fail closed" do
+    test "a probe error returns {:error, _} and enqueues NOTHING" do
+      error = %Postgrex.Error{message: "permission denied for view pg_stat_user_indexes"}
+
+      stub(Loopctl.MockLegacyRetirement, :probe, fn -> {:error, error} end)
+
+      # `evaluate/2` must never be consulted: there is no reading to evaluate, and a
+      # verdict derived from an absent probe is worse than no verdict.
+      stub(Loopctl.MockLegacyRetirement, :evaluate, fn _probe, _opts ->
+        flunk("evaluate/2 must not run when the probe failed")
+      end)
+
+      log =
+        capture_log(fn ->
+          assert {:error, ^error} = run_job()
+        end)
+
+      refute_enqueued(worker: ScaleAlertDeliveryWorker)
+      assert log =~ "could not read the legacy embedding footprint"
+
+      # The wording matters as much as the branch: an operator reading this line must
+      # not take it for a clean bill of health.
+      assert log =~ "NOT evidence that the columns are gone"
+    end
+
+    test "a probe error emits the probe-failed telemetry with a BOUNDED error class" do
+      event = Loopctl.TelemetryEvents.legacy_retirement_probe_failed()
+      handler = "test-#{System.unique_integer([:positive])}"
+      parent = self()
+
+      :telemetry.attach(
+        handler,
+        event,
+        fn _e, measurements, metadata, _ ->
+          send(parent, {:probe_failed, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+
+      stub(Loopctl.MockLegacyRetirement, :probe, fn ->
+        {:error, %Postgrex.Error{message: "a message that must never become a tag"}}
+      end)
+
+      capture_log(fn -> run_job() end)
+
+      assert_received {:probe_failed, %{count: 1}, metadata}
+      assert metadata.error_class == "Postgrex.Error"
+      refute metadata.error_class =~ "must never become a tag"
+    end
+
+    test "a failed observation write does not suppress a :due verdict" do
+      # A storage hiccup costs one day of evidence. Letting it also swallow a verdict we
+      # just successfully measured would trade a small loss for the total one.
+      stub(Loopctl.MockLegacyRetirement, :probe, fn -> {:ok, probe()} end)
+
+      stub(Loopctl.MockLegacyRetirement, :record, fn _probe, _opts ->
+        {:error, %{errors: [observed_on: {"boom", []}]}}
+      end)
+
+      stub(Loopctl.MockLegacyRetirement, :evaluate, fn _probe, _opts ->
+        verdict(%{verdict: :due, trigger: :deadline, deadline_passed?: true})
+      end)
+
+      capture_log(fn ->
+        assert :ok = run_job()
+        assert_enqueued(worker: ScaleAlertDeliveryWorker)
+      end)
+    end
+  end
+
+  describe "the real trigger, end to end" do
+    test "a clear window recorded day by day ends in a :due verdict" do
+      today = Date.utc_today()
+      required = LegacyRetirement.required_clear_days()
+      scans = %{"articles_embedding_hnsw_idx" => 674}
+
+      for offset <- (required - 1)..0//-1 do
+        {:ok, _} =
+          LegacyRetirement.record(
+            probe(%{legacy_index_scans: scans}),
+            today: Date.add(today, -offset)
+          )
+      end
+
+      assert %{verdict: :due, trigger: :evidence} =
+               LegacyRetirement.evaluate(probe(%{legacy_index_scans: scans}), today: today)
+    end
+  end
+end

--- a/test/loopctl/workers/legacy_embedding_retirement_worker_test.exs
+++ b/test/loopctl/workers/legacy_embedding_retirement_worker_test.exs
@@ -45,6 +45,8 @@ defmodule Loopctl.Workers.LegacyEmbeddingRetirementWorkerTest do
         required_clear_days: 30,
         review_by: ~D[2027-01-22],
         deadline_passed?: false,
+        days_past_review_by: -173,
+        side_table_reads: 1,
         legacy_index_scans: %{"articles_embedding_hnsw_idx" => 674}
       },
       overrides
@@ -145,6 +147,30 @@ defmodule Loopctl.Workers.LegacyEmbeddingRetirementWorkerTest do
       assert payload["legacy_columns"] == ["articles", "memories"]
       assert payload["review_by"] == "2027-01-22"
       assert payload["legacy_index_scans"] == %{"articles_embedding_hnsw_idx" => 674}
+    end
+
+    test "the DEADLINE alert reports a metric that crosses its threshold upward" do
+      # `clear_days` is 0 by construction on the deadline path, so shipping it as the
+      # breach pair renders "0 of 30" — which any consumer comparing value to threshold
+      # reads as healthy, for the one trigger that exists to be un-ignorable.
+      stub(Loopctl.MockLegacyRetirement, :evaluate, fn _probe, _opts ->
+        verdict(%{
+          verdict: :due,
+          trigger: :deadline,
+          deadline_passed?: true,
+          days_past_review_by: 4
+        })
+      end)
+
+      capture_log(fn -> assert :ok = run_job() end)
+
+      assert [job] = all_enqueued(worker: ScaleAlertDeliveryWorker)
+      payload = job.args["payload"]
+
+      assert payload["metric"] == "embeddings.legacy_retirement.days_past_review_by"
+      assert payload["value"] == 4
+      assert payload["threshold"] == 0
+      assert payload["side_table_reads"] == 1
     end
   end
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -19,6 +19,7 @@ defmodule Loopctl.DataCase do
   alias Ecto.Adapters.SQL.Sandbox
   alias Loopctl.Custody.Coverage
   alias Loopctl.Egress.Scope, as: EgressScope
+  alias Loopctl.Embeddings.LegacyRetirement
   alias Loopctl.Embeddings.SystemConfigReadPath
   alias Loopctl.Knowledge.StreamingExport.NoopBodyProbe
   alias Loopctl.Oban.FairShare
@@ -100,6 +101,13 @@ defmodule Loopctl.DataCase do
     end)
 
     stub_embedding_read_path()
+
+    # GH #551: production behaviour by default — the retirement trigger really probes,
+    # records and evaluates. Only the worker's fail-closed test overrides `probe/0` to
+    # return an error, which is the one shape the test database cannot produce.
+    Mox.stub(Loopctl.MockLegacyRetirement, :probe, fn -> LegacyRetirement.probe() end)
+    Mox.stub(Loopctl.MockLegacyRetirement, :record, &LegacyRetirement.record/2)
+    Mox.stub(Loopctl.MockLegacyRetirement, :evaluate, &LegacyRetirement.evaluate/2)
 
     # US-27.16: default to PRODUCTION behaviour — the streaming-export producer observes
     # (and therefore retains) nothing. Only the bounded-memory scale gate overrides this,

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -106,6 +106,11 @@ defmodule Loopctl.DataCase do
     # records and evaluates. Only the worker's fail-closed test overrides `probe/0` to
     # return an error, which is the one shape the test database cannot produce.
     Mox.stub(Loopctl.MockLegacyRetirement, :probe, fn -> LegacyRetirement.probe() end)
+
+    Mox.stub(Loopctl.MockLegacyRetirement, :observations_table_ready?, fn ->
+      LegacyRetirement.observations_table_ready?()
+    end)
+
     Mox.stub(Loopctl.MockLegacyRetirement, :record, &LegacyRetirement.record/2)
     Mox.stub(Loopctl.MockLegacyRetirement, :evaluate, &LegacyRetirement.evaluate/2)
 

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -106,6 +106,14 @@ Mox.defmock(Loopctl.MockCustodyCoverage, for: Loopctl.Custody.CoverageBehaviour)
 # `Mox.stub/3`, which is scoped to the calling process.
 Mox.defmock(Loopctl.MockEmbeddingReadPath, for: Loopctl.Embeddings.ReadPathBehaviour)
 
+# GH #551: DI seam for the US-41.1 legacy-column retirement trigger. It exists for one
+# branch — `LegacyEmbeddingRetirementWorker`'s fail-closed handling of a probe that
+# cannot read the catalog — which is unreachable otherwise, because the test database
+# always answers that query. An untested fail-closed path is indistinguishable from an
+# absent one, and the absent one is exactly the #551 defect. The DataCase default stub
+# delegates to the real `Loopctl.Embeddings.LegacyRetirement`.
+Mox.defmock(Loopctl.MockLegacyRetirement, for: Loopctl.Embeddings.LegacyRetirementBehaviour)
+
 # US-27.16: DI seam for the streaming-export producer's per-body observation point. The
 # bounded-memory scale gate must prove its metric is LOAD-BEARING by turning the streaming
 # producer into a MATERIALIZING one, which needs a seam in the production emit path.


### PR DESCRIPTION
Closes #551.

## What this does

Gives the US-41.1 legacy embedding columns a retirement **trigger**. It drops nothing — dropping `articles.embedding` / `memories.embedding` stays a deliberate, reviewed migration. This only decides, daily and from evidence, when the drop is *owed*.

- **New table** `embedding_retirement_observations` (global, non-tenant, RLS enabled with no policy, AdminRepo-only) — one row per UTC day: the read flag, which legacy columns survive, the cumulative `idx_scan` of every index over them, and `pg_stat_database.stats_reset`.
- **New daily job** at 03:40 UTC (`LegacyEmbeddingRetirementWorker`) — observe, evaluate, raise.
- **New config** `:embedding_legacy_retirement` — `required_clear_days: 30`, `review_by: ~D[2027-01-22]`. No new environment variable.

## The two triggers

Both require the columns to still exist:

1. **Evidence** — 30 consecutive clear days: `embedding_side_table_reads = 1` and no movement on any legacy index counter.
2. **Deadline** — `review_by` passes (2027-01-22, six months after the 2026-07-22 flip).

The deadline is not belt-and-braces; it is what makes the check fail closed. A probe that errors every run, a monitor nobody redeployed, an `idx_scan` that never settles — all of them look *identical to "not due yet"* from outside. Without a date that fires on its own, an evidence-only check decays silently back into the prose it replaced.

## Fail-closed, concretely

Every way of not knowing keeps the verdict at `:not_due`, and an unreadable probe is never a verdict at all:

- `probe/0` returns `{:error, _}` **as a whole** rather than a partial map. A map missing its column list would read as a *finished* retirement — the exact inversion the issue warns about ("an expired token or an API error must not read as already cleaned up"). The worker surfaces it as a failed Oban job plus a `Logger.error` that says in words it is not evidence the columns are gone, and consults no verdict.
- A gap in the daily rows breaks the streak (`length(rows) == n` over an n-day window *is* the contiguity check, since `observed_on` is unique).
- A `pg_stat_reset()` inside the window invalidates it — counters that went to zero are not counters that stayed still.
- An index present at the end of the window but absent at its start invalidates it — an index created three days ago cannot testify about thirty.

One pass is deliberately vacuous and documented as such: a surviving column with **no** index over it clears the scan check trivially. That is a correct `:due` — such a column is already past the expensive half of retirement (the HNSW is gone, only TOAST remains) — and the flag plus the full window still have to hold.

## Why a table, and why by column

`idx_scan` is cumulative, so "zero scans over N days" is a delta, and a delta needs a stored earlier reading.

Indexes are discovered **by column** (every index whose key includes the legacy `embedding` attribute), never by name. The articles index has already been renamed once in this repo's history (`20260624120000_reconcile_hnsw_index_name.exs`), and `memories` carries a partial one (`memories_live_embedding_hnsw_idx`) that a name list would have missed. A test asserts the discovered set is **non-empty** and contains `articles_embedding_hnsw_idx` — an empty set would make every window pass vacuously forever, and the resulting `:due` would look identical to a real one.

## Surfacing

An always-on `Logger.error` plus an operator alert (`embeddings.legacy_retirement_due`) through the existing `ScaleAlertDeliveryWorker` channel, which no-ops when `SCALE_ALERT_WEBHOOK_URL` is unset — the current prod posture since #539. The log is the channel that actually works today.

It re-fires every day for as long as the condition holds, with no anti-alarm-fatigue suppression. That is deliberate: the failure being prevented is a reminder that stopped arriving.

## The DI seam

`LegacyRetirementBehaviour` exists for exactly one branch — the worker's fail-closed handling of an unreadable probe, which the test database cannot produce because it always answers the catalog query. An untested fail-closed path is indistinguishable from an absent one, and the absent one is the defect. Config-based DI + Mox, stubbed back to the real module in `stub_all_defaults/0`, matching the sibling `ReadPathBehaviour`.

## Epic 41 status correction

#551 asserted that US-41.2, 41.3, 41.5, 41.6 and 41.7 were open. Three of those five had already merged: **41.3** (#472), **41.5** (#477), **41.7** (#481), alongside **41.1** (#482) and **41.4** (#457). Only **41.2** and **41.6** are unstarted.

The premise came from the epic README's header, which still read `Status: DRAFT`. Both it and `docs/epic_41_breadcrumb.md` are corrected: the story table now carries per-story state with its merge PR, and names the code check that re-verifies each open story (`embedding_base_url` absent from `tenant_llm_settings`; `encrypt_body: false` hardcoded in `Loopctl.Egress`) so the next reader does not have to trust the table. The breadcrumb is marked as a design record whose present tense is historical.

## Verification

- `mix precommit` green — compile clean, format, credo --strict (no issues), dialyzer clean, 6540 tests / 0 failures.
- `SCALE_TESTS=true mix test --only scale` — 26 tests / 0 failures (this PR touches `DataCase.stub_all_defaults/0`, which the bare-`ExUnit.Case` scale modules call, and `:scale` is excluded from precommit).
- **All eight new guards mutation-verified**: each one removed makes a test fail (coverage/gap, read flag, stats reset, absent index, scan delta, deadline trigger, retired short-circuit, worker probe-error branch).
