### PR TITLE
Stop a wedged pool killing a linking job, and un-hide a GUC refusal in two places

### DIFF
--- a/lib/loopctl/exit_tag.ex
+++ b/lib/loopctl/exit_tag.ex
@@ -1,0 +1,27 @@
+defmodule Loopctl.ExitTag do
+  @moduledoc """
+  ONE bounded classification of a non-local exit / throw reason, for fail-soft guards.
+
+  The rule ("log a stable, low-cardinality tag, NEVER the raw reason") had grown four
+  private copies with two different behaviours, so the same wedged pool read as
+  `RuntimeError` through one guard and `unknown`/`other` through another. Extracted so a
+  guard gains a class by CALLING this, not by re-deriving the clause list.
+
+  Why each clause is load-bearing:
+
+    * `{reason, call}` — DBConnection reports a wedged or unstarted pool as
+      `{:noproc, {DBConnection, :execute, []}}`, NOT as a bare `:noproc`, so an
+      atom-only tagger degrades every REAL production exit.
+    * `{{exception_or_atom, stacktrace}, call}` — crash PROPAGATION, when the called
+      process dies of an exception rather than being absent. At least as common as
+      `:noproc` for a supervised pool. Bounded either way: an atom, or the exception
+      MODULE name — never its message, which carries host/database/role and query args.
+  """
+
+  @spec tag(term()) :: String.t()
+  def tag(reason) when is_atom(reason), do: to_string(reason)
+  def tag({reason, _call}) when is_atom(reason), do: to_string(reason)
+  def tag({{%module{}, _stack}, _call}), do: inspect(module)
+  def tag({{reason, _stack}, _call}) when is_atom(reason), do: to_string(reason)
+  def tag(_reason), do: "unknown"
+end

--- a/lib/loopctl/local_guc.ex
+++ b/lib/loopctl/local_guc.ex
@@ -43,6 +43,8 @@ defmodule Loopctl.LocalGuc do
 
   require Logger
 
+  alias Loopctl.ExitTag
+
   @doc """
   Capture `names`, run `fun`, then restore the captured values. MUST be called inside a
   transaction on `repo`; `fun` issues its own `SET LOCAL`s.
@@ -346,11 +348,11 @@ defmodule Loopctl.LocalGuc do
   defp failure_tag(%DBConnection.ConnectionError{}), do: "connection_error"
   defp failure_tag(%DBConnection.OwnershipError{}), do: "ownership_error"
   defp failure_tag(%{__exception__: true} = e), do: "exception_#{inspect(e.__struct__)}"
-  defp failure_tag(reason) when is_atom(reason), do: to_string(reason)
-  # DBConnection/Postgrex EXIT with a TUPLE — `{:timeout, {GenServer, :call, _}}` when the
-  # pool is wedged, `{:noproc, _}` when it is not started — which IS the wedged-pool moment
-  # this tag exists for. Without these the real shapes all degraded to "unknown". Mirrors
-  # `HeavyRead.exit_tag/1`.
-  defp failure_tag({reason, _details}) when is_atom(reason), do: to_string(reason)
-  defp failure_tag(_reason), do: "unknown"
+  # Everything else is an EXIT reason, classified by the ONE shared tagger: DBConnection
+  # exits with a TUPLE — `{:timeout, {GenServer, :call, _}}` when the pool is wedged,
+  # `{:noproc, _}` when it is not started, `{{exception, stack}, call}` when the pool process
+  # dies of a crash — and this module's own clause list handled only two of those three, so
+  # crash propagation degraded to "unknown" here while the same shape tagged correctly
+  # elsewhere.
+  defp failure_tag(reason), do: ExitTag.tag(reason)
 end

--- a/lib/loopctl/local_guc.ex
+++ b/lib/loopctl/local_guc.ex
@@ -147,10 +147,14 @@ defmodule Loopctl.LocalGuc do
         # Specifically: recognising the tag is NOT a signal to re-raise. `capture_abort?/1`'s
         # @doc settles that (it was settled the expensive way, in #550) — re-raising out of a
         # fail-soft path converts "this diagnostic could not be measured" into a failed
-        # request, which is the thing those paths exist to prevent. So the ingestion backlog
+        # request, which is the thing those paths exist to prevent. So ON THIS ABORT — which
+        # is a RAISE, and therefore exactly what a `rescue` clause sees — the ingestion backlog
         # gate (`LoopctlWeb.KnowledgeIngestionController`) fails OPEN at 0, `Knowledge`'s
         # under-fill probe degrades to `:error`, and `ArticleLinkingWorker` skips its
-        # observational count — all tagging, none re-raising. An earlier revision of this
+        # observational count — all tagging, none re-raising. That is a claim about the abort,
+        # NOT about the separate EXIT shape of a wedged pool checkout: only
+        # `ArticleLinkingWorker` and the `ScaleMetrics` pollers catch that today; the first two
+        # still let an exit escape their class-restricted rescue. An earlier revision of this
         # comment said such rescues "re-raise ... Today's rescues deliberately do not", which
         # read as an aspiration the call sites had not caught up with. They had; the sentence
         # was wrong, and it contradicted the @doc twenty lines above it.

--- a/lib/loopctl/local_guc.ex
+++ b/lib/loopctl/local_guc.ex
@@ -138,14 +138,22 @@ defmodule Loopctl.LocalGuc do
         # one of which tells it never to retry something that is purely transient.
         #
         # Sharing the struct does NOT make this abort indistinguishable from a pool blip:
-        # `capture_abort?/1` below matches it on the stable `@capture_abort_tag` prefix, so any
-        # fail-soft rescue that must tell the two apart re-raises on it instead of swallowing
-        # it. Today's rescues deliberately do not — the ingestion backlog gate
-        # (`LoopctlWeb.KnowledgeIngestionController.in_flight_ingestion_backlog/1`) fails OPEN
-        # at 0 and `Knowledge`'s under-fill probe degrades to `:error` — and that is the right
-        # reading there: this path is reached ONLY when the capture round trip itself failed,
-        # i.e. the connection is already in trouble, which is the condition those rescues exist
-        # for.
+        # `capture_abort?/1` above matches it on the stable `@capture_abort_tag` prefix, so a
+        # fail-soft rescue that must tell the two apart TAGS it — `guc_capture_abort` rather
+        # than a generic connection failure — and then degrades exactly as it would for any
+        # other unmeasurable diagnostic. Telling them apart is a LOGGING distinction, never a
+        # control-flow one.
+        #
+        # Specifically: recognising the tag is NOT a signal to re-raise. `capture_abort?/1`'s
+        # @doc settles that (it was settled the expensive way, in #550) — re-raising out of a
+        # fail-soft path converts "this diagnostic could not be measured" into a failed
+        # request, which is the thing those paths exist to prevent. So the ingestion backlog
+        # gate (`LoopctlWeb.KnowledgeIngestionController`) fails OPEN at 0, `Knowledge`'s
+        # under-fill probe degrades to `:error`, and `ArticleLinkingWorker` skips its
+        # observational count — all tagging, none re-raising. An earlier revision of this
+        # comment said such rescues "re-raise ... Today's rescues deliberately do not", which
+        # read as an aspiration the call sites had not caught up with. They had; the sentence
+        # was wrong, and it contradicted the @doc twenty lines above it.
         raise DBConnection.ConnectionError,
               "#{@capture_abort_tag} #{inspect(owned)}, which an enclosing scope " <>
                 "already overrode — refusing to set an override this transaction cannot " <>

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -1322,7 +1322,21 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   end
 
   defp oban_poll_error_class(%Postgrex.Error{}), do: "db_error"
-  defp oban_poll_error_class(%DBConnection.ConnectionError{}), do: "db_error"
+
+  # A LocalGuc capture abort must be classified BEFORE the generic ConnectionError clause
+  # below: it is raised as a `DBConnection.ConnectionError` (deliberately — see
+  # `LocalGuc.capture_fallback!/2`), so without this branch it lands as `"db_error"` and
+  # reads as a pool fault. It is not one: it is this poller declining to override a GUC an
+  # enclosing scope owns, which is a correctness-preserving refusal with a completely
+  # different remedy. Both Oban pollers run inside `LocalGuc.timed_transaction/3` (see
+  # `poll_oban_queue_state/0` and `count_oban_executing_orphans/0`), so this is reachable,
+  # not defensive. Matches the three sites that already discriminate it —
+  # `Loopctl.Knowledge`, `LoopctlWeb.KnowledgeIngestionController` and
+  # `Loopctl.Workers.ArticleLinkingWorker` — on the same `"guc_capture_abort"` tag.
+  defp oban_poll_error_class(%DBConnection.ConnectionError{} = e) do
+    if LocalGuc.capture_abort?(e), do: "guc_capture_abort", else: "db_error"
+  end
+
   defp oban_poll_error_class(%DBConnection.OwnershipError{}), do: "db_error"
   defp oban_poll_error_class(%ArgumentError{}), do: "config_error"
   defp oban_poll_error_class(%FunctionClauseError{}), do: "config_error"

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -35,8 +35,8 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   US-36.4 adds the article-linking corpus-size gauge (metric 22 below). US-38.3 adds
   the clustering-readiness peer gauge (metric 23 below — `loopctl.cluster.peers.count`,
   a `last_value/2` gauge of `length(Node.list/0)` tagged by the bounded readiness
-  `status`, fed by `poll_cluster_readiness/0`), so `scale_metrics/0` now returns 23
-  metrics total.
+  `status`, fed by `poll_cluster_readiness/0`). `scale_metrics/0` itself is the
+  inventory — never a count repeated here.
 
   ## The metrics (23 total)
 
@@ -338,17 +338,21 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
         genuinely wedged past Lifeline's own rescue point, not merely mid-flight).
         `EXPLAIN` confirms this query is already an `Index Scan` over the tiny
         `executing` partition — unaffected by the Seq Scan risk metric 18 fixes.
-    20. **Oban poll-failure counter** (US-34.1, review finding) —
-        `loopctl.oban.poll.error.count`, keyed by `[:poller, :error_class]` — BOTH
-        bounded, fixed sets (`poller` is `"queue_state"`/`"executing_orphans"`;
+    20. **Periodic-measurement poll-failure counter** (US-34.1, review finding) —
+        `loopctl.oban.poll.error.count` (the `oban.` name predates the other
+        measurements adopting it; renaming would break existing dashboards), keyed by
+        `[:poller, :error_class]` — BOTH bounded, fixed sets (`poller` is one per
+        measurement in `LoopctlWeb.Telemetry.periodic_measurements/0`:
+        `"queue_state"`/`"executing_orphans"`/`"cluster_readiness"`/`"tenant_label_gate"`;
         `error_class` is CLASSIFIED via `oban_poll_error_class/1` into
-        `"db_error"`/`"guc_capture_abort"`/`"config_error"`/`"exit"`/`"other"`/
-        `"unknown"`, never the raw exception message).
-        Emitted from BOTH pollers' catch-all `rescue` AND `catch :exit` clauses
-        (a pool checkout against a wedged pool EXITS rather than raising), so a frozen gauge
-        (metrics 18/19 retaining their last value because a poll cycle failed) is
-        now distinguishable in Prometheus from a genuinely stable reading — a
-        non-zero, incrementing rate on this counter means the OTHER two gauges are
+        `"db_error"`/`"guc_capture_abort"`/`"config_error"`/`"exit"`/`"throw"`/
+        `"other"`/`"unknown"`, never the raw exception message or exit reason).
+        Emitted from `guarded_measurement/5` — the ONE guard every periodic
+        measurement runs under — on the `rescue` AND the `catch :exit`/`:throw` path
+        alike, so a frozen gauge (metrics 18/19/23 retaining their last value, or the
+        tenant-label gate holding/forcing OFF, because a cycle failed) is
+        distinguishable in Prometheus from a genuinely stable reading — a
+        non-zero, incrementing rate on this counter means the corresponding gauge is
         stale, not that the system is actually quiet.
   """
 
@@ -358,11 +362,16 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
 
   require Logger
 
+  alias Loopctl.ExitTag
   alias Loopctl.LocalGuc
   alias Loopctl.Repo
   alias Loopctl.Tenants
 
   @persistent_term_key {__MODULE__, :tenant_label?}
+
+  # Process-dictionary key for the tenant-label gate's consecutive-failure streak — see
+  # `resolve_gate/1`.
+  @gate_failure_key {__MODULE__, :tenant_label_gate_failed?}
 
   # US-34.2 (review finding): the `:persistent_term` slot `poll_oban_executing_orphans/0`
   # writes on every SUCCESSFUL poll, and `cached_executing_orphan_count/0` reads —
@@ -401,7 +410,7 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   @oban_terminal_states [:completed, :discarded, :cancelled]
 
   @doc """
-  All 23 scale metrics: the original US-27.15 trio, #297's semantic-fallback
+  The scale metrics: the original US-27.15 trio, #297's semantic-fallback
   counter, US-31.2's hybrid-provenance counter, US-33.1's two per-pool checkout
   `queue_time` distributions, US-34.4's ten emitted-but-dead-event counters
   (LLM/embedding-blocked, index-health, secrets/witness/memory-promotion
@@ -449,6 +458,22 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
         tag_values: &scale_tags/1
       ),
 
+      # 3b. Under-fill PROBE degradation counter (#550 review). The probe's fail-soft exit
+      #     turns a would-be 503 into a valid 200 whose truncation signal is simply ABSENT,
+      #     so metric 3 above just stops firing — a log line alone is invisible to a
+      #     dashboard (`TelemetryEvents.vector_search_under_fill_probe_degraded/0` says as
+      #     much), and without this definition the emitted event terminated in a
+      #     handler-less no-op. `error_class` is the same bounded set as the fail-open
+      #     counter below; `tenant_id` is cap-gated to the sentinel.
+      counter("loopctl.knowledge.vector_search.under_fill_probe_degraded.count",
+        event_name: [:loopctl, :knowledge, :vector_search, :under_fill_probe_degraded],
+        measurement: :count,
+        description:
+          "Vector-search under-fill PROBE degraded (no truncation signal), by error_class and tenant.",
+        tags: [:error_class, :tenant_id],
+        tag_values: &degraded_read_tags/1
+      ),
+
       # 4. Semantic-fallback counter (#297), by REASON only. Turns the silent
       #    semantic→keyword degradation into an alertable trend. `reason` is a
       #    BOUNDED, sanitized tag set (no api key / provider body / raw query ever
@@ -483,8 +508,9 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
       # it could not measure the tenant's in-flight :ingestion backlog (count timed out /
       # lost its connection) and ADMITTED the request rather than shedding it. Makes "the
       # ingestion backpressure valve is currently admitting because it can't measure" an
-      # alertable signal instead of a silent warning log. `error_class` is a bounded
-      # 2-value tag; `tenant_id` is cap-gated to a sentinel (same convention as the other
+      # alertable signal instead of a silent warning log. `error_class` is a bounded tag —
+      # `TelemetryEvents.ingestion_backlog_gate_failed_open/0` is the source of truth for
+      # its value set; `tenant_id` is cap-gated to a sentinel (same convention as the other
       # scale counters).
       counter("loopctl.ingestion.backlog_gate.failed_open.count",
         event_name: [:loopctl, :ingestion, :backlog_gate, :failed_open],
@@ -492,7 +518,7 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
         description:
           "Ingestion backlog admission gate failed open (unmeasurable backlog count), by error_class and tenant.",
         tags: [:error_class, :tenant_id],
-        tag_values: &ingestion_backlog_failed_open_tags/1
+        tag_values: &degraded_read_tags/1
       ),
 
       # 6. Per-pool checkout queue_time (US-33.1): the RLS `Loopctl.Repo` pool (size
@@ -678,15 +704,18 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
         tags: []
       ),
 
-      # 20. Oban poll-failure counter (US-34.1, review finding). Emitted from BOTH
-      #     pollers' catch-all rescue clause so a stale (frozen) gauge above is
-      #     distinguishable in Prometheus from a genuinely stable reading. `poller`
-      #     identifies which poll failed; `error_class` is CLASSIFIED (never the raw
-      #     exception message/struct) into a small bounded set.
+      # 20. Periodic-measurement poll-failure counter (US-34.1, review finding). Emitted
+      #     from `guarded_measurement/5` — the single guard EVERY periodic measurement
+      #     runs under — so a stale (frozen) gauge above is distinguishable in Prometheus
+      #     from a genuinely stable reading. `poller` identifies which measurement failed
+      #     (bounded, one per entry in `periodic_measurements/0`); `error_class` is
+      #     CLASSIFIED (never the raw exception message or exit reason) into a small
+      #     bounded set. The `oban.` in the name predates the non-Oban measurements
+      #     adopting the counter; it is kept so existing dashboards keep working.
       counter("loopctl.oban.poll.error.count",
         event_name: [:loopctl, :oban, :poll, :error],
         measurement: :count,
-        description: "Oban metrics poll failures, by poller and classified error class.",
+        description: "Periodic-measurement poll failures, by poller and classified error class.",
         tags: [:poller, :error_class],
         tag_values: &oban_poll_error_tags/1
       ),
@@ -821,13 +850,20 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   end
 
   @doc """
-  `tag_values` for the ingestion backlog gate fail-open counter (US-36.3 review).
-  `error_class` is a small fixed-cardinality tag (`"timeout"` | `"connection"`, default
-  `"unknown"`); `tenant_id` reuses the same cap-gated sentinel collapse as the other
-  scale counters to keep cardinality bounded.
+  `tag_values` for the two DEGRADED-READ counters — the ingestion backlog gate fail-open
+  (US-36.3 review) and the under-fill probe degradation — which share the same
+  `(error_class, tenant_id)` shape.
+
+  `error_class` is a small fixed-cardinality tag, defaulting to `"unknown"`. Its value set
+  is NOT enumerated here — it is per-emitter, and enumerating it twice is how this doc came
+  to claim a "2-value" tag long after a fourth value shipped: see
+  `Loopctl.TelemetryEvents.ingestion_backlog_gate_failed_open/0` and
+  `vector_search_under_fill_probe_degraded/0`, which document their own bounded sets.
+  `tenant_id` reuses the same cap-gated sentinel collapse as the other scale counters to
+  keep cardinality bounded.
   """
-  @spec ingestion_backlog_failed_open_tags(map()) :: map()
-  def ingestion_backlog_failed_open_tags(metadata) do
+  @spec degraded_read_tags(map()) :: map()
+  def degraded_read_tags(metadata) do
     %{
       error_class: Map.get(metadata, :error_class, "unknown"),
       tenant_id: gated_tenant_id(metadata)
@@ -1097,6 +1133,16 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   """
   @spec poll_oban_queue_state() :: :ok
   def poll_oban_queue_state do
+    guarded_measurement(
+      :queue_state,
+      "Oban queue/state poll",
+      "the oban.jobs.count gauge simply keeps its last-recorded value until the next poll",
+      :ok,
+      &collect_oban_queue_state/0
+    )
+  end
+
+  defp collect_oban_queue_state do
     timeout_ms = oban_metrics_poll_statement_timeout_ms()
     active_states = Enum.map(oban_active_states(), &Atom.to_string/1)
 
@@ -1125,32 +1171,6 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
     end
 
     :ok
-  rescue
-    e ->
-      Logger.warning(
-        "Oban queue/state poll failed (#{inspect(e.__struct__)}); skipping this cycle — " <>
-          "the oban.jobs.count gauge simply keeps its last-recorded value until the next poll"
-      )
-
-      emit_oban_poll_error(:queue_state, e)
-
-      :ok
-  catch
-    # `rescue` alone left this gauge's own hole open. A `Repo` checkout against a saturated,
-    # wedged or restarting pool EXITS (`{:timeout, {DBConnection, :checkout, ...}}`,
-    # `{:noproc, ...}`) rather than raising, so it walks past the clause above — and
-    # `telemetry_poller` PERMANENTLY drops a measurement MFA that escapes, so this gauge
-    # would go dark for the life of the node with metric 20 (whose whole purpose is making a
-    # frozen gauge distinguishable from a stable one) never firing on that path.
-    :exit, reason ->
-      Logger.warning(
-        "Oban queue/state poll exited (#{poll_exit_tag(reason)}); skipping this cycle — " <>
-          "the oban.jobs.count gauge simply keeps its last-recorded value until the next poll"
-      )
-
-      emit_oban_poll_error(:queue_state, {:exit, reason})
-
-      :ok
   end
 
   @doc """
@@ -1261,38 +1281,26 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
 
   @spec poll_oban_executing_orphans() :: :ok
   def poll_oban_executing_orphans do
-    count = count_oban_executing_orphans()
+    guarded_measurement(
+      :executing_orphans,
+      "Oban executing-orphan poll",
+      "the executing_orphan gauge AND the health-check cache simply keep their last-recorded " <>
+        "value until the next successful poll",
+      :ok,
+      fn ->
+        count = count_oban_executing_orphans()
 
-    :persistent_term.put(@executing_orphan_cache_key, count)
+        :persistent_term.put(@executing_orphan_cache_key, count)
 
-    :telemetry.execute([:loopctl, :oban, :jobs, :executing_orphan, :count], %{count: count}, %{})
+        :telemetry.execute(
+          [:loopctl, :oban, :jobs, :executing_orphan, :count],
+          %{count: count},
+          %{}
+        )
 
-    :ok
-  rescue
-    e ->
-      Logger.warning(
-        "Oban executing-orphan poll failed (#{inspect(e.__struct__)}); skipping this cycle — " <>
-          "the executing_orphan gauge AND the health-check cache simply keep their last-recorded " <>
-          "value until the next successful poll"
-      )
-
-      emit_oban_poll_error(:executing_orphans, e)
-
-      :ok
-  catch
-    # Same exit shape as `poll_oban_queue_state/0` above, with one extra consequence: an
-    # escaping exit permanently drops this measurement, so `cached_executing_orphan_count/0`
-    # would hand `HealthCheck.Default` a frozen `:persistent_term` orphan count forever.
-    :exit, reason ->
-      Logger.warning(
-        "Oban executing-orphan poll exited (#{poll_exit_tag(reason)}); skipping this cycle — " <>
-          "the executing_orphan gauge AND the health-check cache simply keep their " <>
-          "last-recorded value until the next successful poll"
-      )
-
-      emit_oban_poll_error(:executing_orphans, {:exit, reason})
-
-      :ok
+        :ok
+      end
+    )
   end
 
   @doc """
@@ -1301,57 +1309,80 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   connected BEAM peer COUNT with the bounded readiness `status` as the sole tag —
   NEVER a node name or the DNS query string. Wired into
   `LoopctlWeb.Telemetry.periodic_measurements/0` (the same 10s poller as the Oban
-  gauges). Self-contained (catch-all `rescue` AND `catch :exit`, per the
-  periodic-measurements invariant): neither a raise NOR an exit here may let
-  `telemetry_poller` permanently drop this MFA — the gauge
-  simply keeps its last value for one cycle. On a single node it reads
-  `{status="single_node", count=0}`.
+  gauges). Runs under `guarded_measurement/5` like every other periodic measurement,
+  so neither a raise nor an exit/throw can let `telemetry_poller` permanently drop
+  this MFA, and a failed cycle increments the poll-failure counter (metric 20,
+  `poller="cluster_readiness"`) instead of freezing this gauge silently.
+  `ClusterReadiness.readiness/0` makes no inter-process call today (env reads,
+  `Node.list/0`, pure classification), so only its RAISE path is reachable — the
+  exit/throw half is the uniform guard, not a claim that a readiness process exists
+  to die. On a single node it reads `{status="single_node", count=0}`.
   """
   @spec poll_cluster_readiness() :: :ok
   def poll_cluster_readiness do
-    readiness = Loopctl.ClusterReadiness.readiness()
+    guarded_measurement(
+      :cluster_readiness,
+      "Clustering-readiness poll",
+      "the cluster.peers gauge keeps its last-recorded value until the next successful poll",
+      :ok,
+      fn ->
+        readiness = Loopctl.ClusterReadiness.readiness()
 
-    :telemetry.execute([:loopctl, :cluster, :peers], %{count: readiness.peers}, %{
-      status: readiness.status
-    })
+        :telemetry.execute([:loopctl, :cluster, :peers], %{count: readiness.peers}, %{
+          status: readiness.status
+        })
 
-    :ok
-  rescue
-    e ->
-      Logger.warning(
-        "Clustering-readiness poll failed (#{inspect(e.__struct__)}); skipping this cycle — " <>
-          "the cluster.peers gauge keeps its last-recorded value until the next successful poll"
-      )
-
-      :ok
-  catch
-    # A readiness read that EXITS (a DNS/cluster helper process that is down mid-call) escapes
-    # the `rescue` above and would permanently drop this MFA from the poll rotation.
-    :exit, reason ->
-      Logger.warning(
-        "Clustering-readiness poll exited (#{poll_exit_tag(reason)}); skipping this cycle — " <>
-          "the cluster.peers gauge keeps its last-recorded value until the next successful poll"
-      )
-
-      :ok
+        :ok
+      end
+    )
   end
 
-  # Bounded classification of an exit reason for the poller logs — a small closed set, never
-  # the raw reason (which carries the full DBConnection call tuple, module and args). Mirrors
-  # `Loopctl.Workers.ArticleLinkingWorker.exit_tag/1`, including the crash-propagation shape
-  # (`{{reason_or_exception, stacktrace}, call}`) an atom-only tagger degrades to "unknown".
-  defp poll_exit_tag(reason) when is_atom(reason), do: to_string(reason)
-  defp poll_exit_tag({reason, _call}) when is_atom(reason), do: to_string(reason)
-  defp poll_exit_tag({{%module{}, _stack}, _call}), do: inspect(module)
-  defp poll_exit_tag({{reason, _stack}, _call}) when is_atom(reason), do: to_string(reason)
-  defp poll_exit_tag(_reason), do: "unknown"
+  @doc false
+  # Runs a periodic measurement's body under the guard `telemetry_poller` requires, and
+  # returns `fallback` if it fails.
+  #
+  # ONE implementation for all four measurements (`LoopctlWeb.Telemetry.periodic_measurements/0`):
+  # telemetry_poller PERMANENTLY drops a measurement MFA that escapes, so an unguarded gauge
+  # goes dark for the life of the node — and it drops it on ALL THREE non-local exit kinds,
+  # which is why this catches `:exit` and `:throw` alongside the catch-all `rescue` (a pool
+  # checkout against a saturated/wedged pool EXITS rather than raising; four hand-written
+  # copies of that guard had already diverged). Every failure also emits the poll-failure
+  # counter (metric 20), so a frozen gauge stays distinguishable from a genuinely stable one.
+  #
+  # Public-but-`@doc false`: not API, but the seam that lets the guard be tested ONCE,
+  # directly, with a body that exits/throws — no poller can be made to exit on demand through
+  # Ecto (which raises on every lookup/ownership failure), which is how four copies of this
+  # shipped unexercised.
+  @spec guarded_measurement(atom(), String.t(), String.t(), term(), (-> term())) :: term()
+  def guarded_measurement(poller, subject, consequence, fallback, fun) do
+    fun.()
+  rescue
+    e ->
+      Logger.warning("#{subject} failed (#{inspect(e.__struct__)}); #{consequence}")
 
-  # Emits the poll-failure counter (metric 20) from a poller's catch-all rescue.
-  # The RAW exception struct is passed through in metadata (like
-  # `secrets_orphan_cleanup_tags/1`'s raw `{:error, term()}`) — classification into
-  # the bounded `error_class` tag happens at `tag_values` time (`oban_poll_error_tags/1`),
-  # not here, so any other handler attached to this event still sees the real error.
-  defp emit_oban_poll_error(poller, exception) do
+      emit_poll_error(poller, e)
+
+      fallback
+  catch
+    kind, reason when kind in [:exit, :throw] ->
+      tag = ExitTag.tag(reason)
+
+      Logger.warning("#{subject} aborted (#{kind}: #{tag}); #{consequence}")
+
+      emit_poll_error(poller, {kind, tag})
+
+      fallback
+  end
+
+  # Emits the poll-failure counter (metric 20) from `guarded_measurement/5`.
+  # `metadata.exception` is a UNION: the RAW exception struct on the rescue path (like
+  # `secrets_orphan_cleanup_tags/1`'s raw `{:error, term()}`, so another attached handler
+  # still sees the real error), or `{:exit | :throw, bounded_tag}` on the catch path — an
+  # exit is not an exception, and its raw reason carries the whole DBConnection call tuple,
+  # module and args, so only `ExitTag.tag/1`'s bounded class travels. A consumer must NOT
+  # assume a struct. Classification into the bounded `error_class` tag happens at
+  # `tag_values` time (`oban_poll_error_tags/1`), never here.
+  defp emit_poll_error(poller, exception) do
     :telemetry.execute([:loopctl, :oban, :poll, :error], %{count: 1}, %{
       poller: poller,
       exception: exception
@@ -1359,9 +1390,11 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   end
 
   @doc """
-  `tag_values` for the Oban poll-failure counter (US-34.1, metric 20). `poller`
-  passes through as a bounded atom (`:queue_state`/`:executing_orphans`);
-  `error_class` CLASSIFIES the raw `metadata.exception` into a small bounded set
+  `tag_values` for the periodic-measurement poll-failure counter (US-34.1, metric 20).
+  `poller` passes through as a bounded atom (one per measurement in
+  `LoopctlWeb.Telemetry.periodic_measurements/0`: `:queue_state`/`:executing_orphans`/
+  `:cluster_readiness`/`:tenant_label_gate`);
+  `error_class` CLASSIFIES `metadata.exception` into a small bounded set
   (never the raw exception message/struct) — the same "mapped_code"/
   `secrets_reason_class/1` classification precedent used elsewhere in this
   module. Defaults missing keys to `"unknown"` so this can never raise.
@@ -1396,10 +1429,10 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   defp oban_poll_error_class(%DBConnection.OwnershipError{}), do: "db_error"
   defp oban_poll_error_class(%ArgumentError{}), do: "config_error"
   defp oban_poll_error_class(%FunctionClauseError{}), do: "config_error"
-  # An EXIT is not an exception, so it can never be a struct above: the pollers' `catch :exit`
-  # clauses hand it over wrapped as `{:exit, reason}`. Its own class because a pool checkout
-  # that exits has a different remedy from one that raises.
-  defp oban_poll_error_class({:exit, _reason}), do: "exit"
+  # An EXIT/THROW is not an exception, so it can never be a struct above:
+  # `guarded_measurement/5` hands it over wrapped as `{kind, bounded_tag}`. Its own class
+  # because a pool checkout that exits has a different remedy from one that raises.
+  defp oban_poll_error_class({kind, _reason}) when kind in [:exit, :throw], do: to_string(kind)
   defp oban_poll_error_class(nil), do: "unknown"
   defp oban_poll_error_class(_other), do: "other"
 
@@ -1488,9 +1521,11 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   This is the `telemetry_poller` periodic measurement (wired in
   `LoopctlWeb.Telemetry`). It performs the ONLY DB read in the gating mechanism — one
   cheap `Tenants.count()` per poll interval — so the per-emit `tag_values` path never
-  touches the DB. A DB fault during the count is fail-soft: the gate is forced OFF
-  (aggregate to the sentinel) rather than crashing the poller, keeping cardinality
-  bounded. Returns the boolean it stored.
+  touches the DB. A failed count is fail-soft: the gate holds its current value for ONE
+  cycle and is forced OFF (aggregate to the sentinel) from the second CONSECUTIVE failure
+  on, rather than crashing the poller — bounded cardinality without flapping the gate
+  (and the label) every 10s through an intermittent pool incident. Returns the boolean it
+  stored.
 
   Note: this returns the gate boolean rather than calling `:telemetry.execute/3`
   itself — the poller only needs the side effect of refreshing the cached gate, and
@@ -1498,36 +1533,23 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   """
   @spec refresh_tenant_label_gate() :: boolean()
   def refresh_tenant_label_gate do
+    # Fail-soft for EVERY failure shape — this is a `telemetry_poller` measurement, and
+    # telemetry_poller PERMANENTLY drops an MFA that escapes. A narrow rescue (DB exceptions
+    # only, everything else re-raised) did not surface a programmer error here: it froze the
+    # gate at whatever boolean `:persistent_term` last held, with nothing left to re-evaluate
+    # it. If that value was `true`, `tenant_id` stays a live label after the fleet crosses the
+    # cap — the unbounded cardinality AC-27.15.3 forbids. Visibility comes from the :warning
+    # log and metric 20, not from crashing the poller.
     allowed? =
-      try do
-        Tenants.count() <= tenant_label_cap()
-      rescue
-        # Fail-soft to a BOUNDED gate (force OFF → aggregate to the sentinel), for EVERY
-        # failure shape — this is a `telemetry_poller` measurement, and telemetry_poller
-        # PERMANENTLY drops an MFA that escapes. A narrow rescue (DB exceptions only, everything
-        # else re-raised) did not surface a programmer error here: it froze the gate at whatever
-        # boolean `:persistent_term` last held, with nothing left to re-evaluate it. If that
-        # value was `true`, `tenant_id` stays a live label after the fleet crosses the cap —
-        # the unbounded cardinality AC-27.15.3 forbids. Visibility comes from the :warning log
-        # (a persistently-failing gate is loud, not silent), not from crashing the poller.
-        e ->
-          Logger.warning(
-            "tenant-label gate refresh failed (#{inspect(e.__struct__)}); forcing gate OFF " <>
-              "(tenant_id label aggregates to the sentinel until the count succeeds)"
-          )
-
-          false
-      catch
-        # A pool checkout against a saturated/wedged pool EXITS rather than raising, so the
-        # clause above cannot see it.
-        :exit, reason ->
-          Logger.warning(
-            "tenant-label gate refresh exited (#{poll_exit_tag(reason)}); forcing gate OFF " <>
-              "(tenant_id label aggregates to the sentinel until the count succeeds)"
-          )
-
-          false
-      end
+      :tenant_label_gate
+      |> guarded_measurement(
+        "tenant-label gate refresh",
+        "holding the gate for one cycle, then forcing it OFF (tenant_id label aggregates to " <>
+          "the sentinel until the count succeeds)",
+        :failed,
+        fn -> Tenants.count() <= tenant_label_cap() end
+      )
+      |> resolve_gate()
 
     # Put ONLY on an actual transition (team review F3). `:persistent_term.put/2` triggers
     # a global term-table scan, so writing the unchanged steady-state value every 10s is
@@ -1537,6 +1559,24 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
       :persistent_term.put(@persistent_term_key, allowed?)
     end
 
+    allowed?
+  end
+
+  # One GRACE cycle before a failed count flips the gate (review finding): an intermittently
+  # wedged pool otherwise alternates OFF/ON every 10s, and each flip pays the global
+  # `:persistent_term.put/2` term-table scan the transition check above exists to avoid —
+  # during the incident when the node can least afford it, while every per-tenant series
+  # alternates between the real `tenant_id` and the sentinel and gaps the dashboards. TWO
+  # CONSECUTIVE failures still force the gate OFF, so a persistently-failing count can never
+  # leave an unbounded label live (AC-27.15.3). The streak lives in the poller PROCESS's
+  # dictionary — this measurement always runs in the single `telemetry_poller` process, so it
+  # costs no global write and needs no extra term.
+  defp resolve_gate(:failed) do
+    if Process.put(@gate_failure_key, true), do: false, else: tenant_label?()
+  end
+
+  defp resolve_gate(allowed?) do
+    Process.delete(@gate_failure_key)
     allowed?
   end
 

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -342,8 +342,10 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
         `loopctl.oban.poll.error.count`, keyed by `[:poller, :error_class]` — BOTH
         bounded, fixed sets (`poller` is `"queue_state"`/`"executing_orphans"`;
         `error_class` is CLASSIFIED via `oban_poll_error_class/1` into
-        `"db_error"`/`"config_error"`/`"other"`, never the raw exception message).
-        Emitted from BOTH pollers' catch-all `rescue` clause, so a frozen gauge
+        `"db_error"`/`"guc_capture_abort"`/`"config_error"`/`"exit"`/`"other"`/
+        `"unknown"`, never the raw exception message).
+        Emitted from BOTH pollers' catch-all `rescue` AND `catch :exit` clauses
+        (a pool checkout against a wedged pool EXITS rather than raising), so a frozen gauge
         (metrics 18/19 retaining their last value because a poll cycle failed) is
         now distinguishable in Prometheus from a genuinely stable reading — a
         non-zero, incrementing rate on this counter means the OTHER two gauges are
@@ -1133,6 +1135,22 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
       emit_oban_poll_error(:queue_state, e)
 
       :ok
+  catch
+    # `rescue` alone left this gauge's own hole open. A `Repo` checkout against a saturated,
+    # wedged or restarting pool EXITS (`{:timeout, {DBConnection, :checkout, ...}}`,
+    # `{:noproc, ...}`) rather than raising, so it walks past the clause above — and
+    # `telemetry_poller` PERMANENTLY drops a measurement MFA that escapes, so this gauge
+    # would go dark for the life of the node with metric 20 (whose whole purpose is making a
+    # frozen gauge distinguishable from a stable one) never firing on that path.
+    :exit, reason ->
+      Logger.warning(
+        "Oban queue/state poll exited (#{poll_exit_tag(reason)}); skipping this cycle — " <>
+          "the oban.jobs.count gauge simply keeps its last-recorded value until the next poll"
+      )
+
+      emit_oban_poll_error(:queue_state, {:exit, reason})
+
+      :ok
   end
 
   @doc """
@@ -1261,6 +1279,20 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
       emit_oban_poll_error(:executing_orphans, e)
 
       :ok
+  catch
+    # Same exit shape as `poll_oban_queue_state/0` above, with one extra consequence: an
+    # escaping exit permanently drops this measurement, so `cached_executing_orphan_count/0`
+    # would hand `HealthCheck.Default` a frozen `:persistent_term` orphan count forever.
+    :exit, reason ->
+      Logger.warning(
+        "Oban executing-orphan poll exited (#{poll_exit_tag(reason)}); skipping this cycle — " <>
+          "the executing_orphan gauge AND the health-check cache simply keep their " <>
+          "last-recorded value until the next successful poll"
+      )
+
+      emit_oban_poll_error(:executing_orphans, {:exit, reason})
+
+      :ok
   end
 
   @doc """
@@ -1269,8 +1301,9 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   connected BEAM peer COUNT with the bounded readiness `status` as the sole tag —
   NEVER a node name or the DNS query string. Wired into
   `LoopctlWeb.Telemetry.periodic_measurements/0` (the same 10s poller as the Oban
-  gauges). Self-rescuing (catch-all, per the periodic-measurements invariant): a
-  raise here must never let `telemetry_poller` permanently drop this MFA — the gauge
+  gauges). Self-contained (catch-all `rescue` AND `catch :exit`, per the
+  periodic-measurements invariant): neither a raise NOR an exit here may let
+  `telemetry_poller` permanently drop this MFA — the gauge
   simply keeps its last value for one cycle. On a single node it reads
   `{status="single_node", count=0}`.
   """
@@ -1291,7 +1324,27 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
       )
 
       :ok
+  catch
+    # A readiness read that EXITS (a DNS/cluster helper process that is down mid-call) escapes
+    # the `rescue` above and would permanently drop this MFA from the poll rotation.
+    :exit, reason ->
+      Logger.warning(
+        "Clustering-readiness poll exited (#{poll_exit_tag(reason)}); skipping this cycle — " <>
+          "the cluster.peers gauge keeps its last-recorded value until the next successful poll"
+      )
+
+      :ok
   end
+
+  # Bounded classification of an exit reason for the poller logs — a small closed set, never
+  # the raw reason (which carries the full DBConnection call tuple, module and args). Mirrors
+  # `Loopctl.Workers.ArticleLinkingWorker.exit_tag/1`, including the crash-propagation shape
+  # (`{{reason_or_exception, stacktrace}, call}`) an atom-only tagger degrades to "unknown".
+  defp poll_exit_tag(reason) when is_atom(reason), do: to_string(reason)
+  defp poll_exit_tag({reason, _call}) when is_atom(reason), do: to_string(reason)
+  defp poll_exit_tag({{%module{}, _stack}, _call}), do: inspect(module)
+  defp poll_exit_tag({{reason, _stack}, _call}) when is_atom(reason), do: to_string(reason)
+  defp poll_exit_tag(_reason), do: "unknown"
 
   # Emits the poll-failure counter (metric 20) from a poller's catch-all rescue.
   # The RAW exception struct is passed through in metadata (like
@@ -1328,9 +1381,12 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   # `LocalGuc.capture_fallback!/2`), so without this branch it lands as `"db_error"` and
   # reads as a pool fault. It is not one: it is this poller declining to override a GUC an
   # enclosing scope owns, which is a correctness-preserving refusal with a completely
-  # different remedy. Both Oban pollers run inside `LocalGuc.timed_transaction/3` (see
-  # `poll_oban_queue_state/0` and `count_oban_executing_orphans/0`), so this is reachable,
-  # not defensive. Matches the three sites that already discriminate it —
+  # different remedy. Reachability, precisely: `capture_fallback!/2` aborts only when an
+  # ENCLOSING scope in the SAME process already owns the name, and each poller opens the
+  # OUTERMOST `LocalGuc.timed_transaction/3` on the shared poller process — so no poller can
+  # abort today. The branch exists for uniform classification with the three sites that DO
+  # discriminate it, and to keep a future nested caller out of the `"db_error"` bucket, not
+  # because these two pollers can reach it. Matches those three sites —
   # `Loopctl.Knowledge`, `LoopctlWeb.KnowledgeIngestionController` and
   # `Loopctl.Workers.ArticleLinkingWorker` — on the same `"guc_capture_abort"` tag.
   defp oban_poll_error_class(%DBConnection.ConnectionError{} = e) do
@@ -1340,6 +1396,10 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   defp oban_poll_error_class(%DBConnection.OwnershipError{}), do: "db_error"
   defp oban_poll_error_class(%ArgumentError{}), do: "config_error"
   defp oban_poll_error_class(%FunctionClauseError{}), do: "config_error"
+  # An EXIT is not an exception, so it can never be a struct above: the pollers' `catch :exit`
+  # clauses hand it over wrapped as `{:exit, reason}`. Its own class because a pool checkout
+  # that exits has a different remedy from one that raises.
+  defp oban_poll_error_class({:exit, _reason}), do: "exit"
   defp oban_poll_error_class(nil), do: "unknown"
   defp oban_poll_error_class(_other), do: "other"
 
@@ -1442,16 +1502,27 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
       try do
         Tenants.count() <= tenant_label_cap()
       rescue
-        # Fail-soft to a BOUNDED gate (force OFF → aggregate to the sentinel) ONLY for DB
-        # faults — a transient connection / ownership / Postgres error must not crash the
-        # shared poller. But the rescue is NARROW (security AREA-6): a persistently-failing
-        # gate (schema drift / misconfig that always raises) would otherwise stay silently
-        # stuck OFF, so we LOG it at :warning to make it visible. A genuine programmer
-        # error (anything outside the DB-exception set) is re-raised so it still surfaces
-        # rather than being masked as "gate off".
-        e in [Postgrex.Error, DBConnection.ConnectionError, DBConnection.OwnershipError] ->
+        # Fail-soft to a BOUNDED gate (force OFF → aggregate to the sentinel), for EVERY
+        # failure shape — this is a `telemetry_poller` measurement, and telemetry_poller
+        # PERMANENTLY drops an MFA that escapes. A narrow rescue (DB exceptions only, everything
+        # else re-raised) did not surface a programmer error here: it froze the gate at whatever
+        # boolean `:persistent_term` last held, with nothing left to re-evaluate it. If that
+        # value was `true`, `tenant_id` stays a live label after the fleet crosses the cap —
+        # the unbounded cardinality AC-27.15.3 forbids. Visibility comes from the :warning log
+        # (a persistently-failing gate is loud, not silent), not from crashing the poller.
+        e ->
           Logger.warning(
             "tenant-label gate refresh failed (#{inspect(e.__struct__)}); forcing gate OFF " <>
+              "(tenant_id label aggregates to the sentinel until the count succeeds)"
+          )
+
+          false
+      catch
+        # A pool checkout against a saturated/wedged pool EXITS rather than raising, so the
+        # clause above cannot see it.
+        :exit, reason ->
+          Logger.warning(
+            "tenant-label gate refresh exited (#{poll_exit_tag(reason)}); forcing gate OFF " <>
               "(tenant_id label aggregates to the sentinel until the count succeeds)"
           )
 

--- a/lib/loopctl/workers/article_linking_worker.ex
+++ b/lib/loopctl/workers/article_linking_worker.ex
@@ -77,6 +77,7 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
   alias Loopctl.Embeddings
+  alias Loopctl.ExitTag
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleEmbedding
@@ -344,13 +345,12 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
     #
     # `:throw` is caught alongside `:exit` because "every way this call can fail" has three
     # kinds, not two — the same pairing the fail-soft rate-limiter taggers use. Tagged, not
-    # swallowed untagged, so the degraded signal stays greppable. `exit_tag/1` below is a
-    # local mirror of `HeavyRead`'s and `LocalGuc.failure_tag/1`'s exit clauses: both are
-    # `defp`, and this module following the same per-module convention is cheaper than
-    # promoting one to a public API for a third caller.
+    # swallowed untagged, so the degraded signal stays greppable, via the ONE shared
+    # `Loopctl.ExitTag` (four private copies of that clause list had already diverged on the
+    # crash-propagation shape).
     :exit, reason ->
       Logger.warning(
-        "Article linking: corpus-size count exited (#{exit_tag(reason)}) for " <>
+        "Article linking: corpus-size count exited (#{ExitTag.tag(reason)}) for " <>
           "article #{article.id}; skipping the observational corpus_size signal — " <>
           "linking proceeds"
       )
@@ -359,34 +359,13 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
 
     :throw, value ->
       Logger.warning(
-        "Article linking: corpus-size count threw (#{exit_tag(value)}) for " <>
+        "Article linking: corpus-size count threw (#{ExitTag.tag(value)}) for " <>
           "article #{article.id}; skipping the observational corpus_size signal — " <>
           "linking proceeds"
       )
 
       :ok
   end
-
-  # Bounded classification of an exit reason — a small closed set, never the raw reason
-  # (which carries the full DBConnection call tuple, module and args).
-  #
-  # The `{reason, call}` TUPLE clause is the load-bearing one, and it is modelled on
-  # `LocalGuc.failure_tag/1` rather than on `HeavyRead.exit_tag/1`. DBConnection reports a
-  # wedged or unstarted pool as `{:noproc, {DBConnection, :execute, []}}`, NOT as a bare
-  # `:noproc` — a tagger with only an atom clause therefore looks right against a hand-rolled
-  # `exit(:noproc)` while degrading every REAL production exit to "other". This module's test
-  # exits with the production shape for exactly that reason.
-  #
-  # The same argument covers CRASH PROPAGATION: when a called process dies of an exception
-  # rather than being absent, the reason is `{{exception_or_atom, stacktrace}, call}` — at
-  # least as common as `:noproc` for a supervised pool, and a shape the two clauses above
-  # degrade to "unknown". Both inner shapes stay bounded: an atom, or the exception MODULE
-  # (never its message).
-  defp exit_tag(reason) when is_atom(reason), do: to_string(reason)
-  defp exit_tag({reason, _call}) when is_atom(reason), do: to_string(reason)
-  defp exit_tag({{%module{}, _stack}, _call}), do: inspect(module)
-  defp exit_tag({{reason, _stack}, _call}) when is_atom(reason), do: to_string(reason)
-  defp exit_tag(_reason), do: "unknown"
 
   # Deterministic-by-id sampling so the same article always makes the same decision (stable
   # across a job's retries). `phash2(id, 1) == 0` always, so a rate of 1 samples every job;

--- a/lib/loopctl/workers/article_linking_worker.ex
+++ b/lib/loopctl/workers/article_linking_worker.ex
@@ -332,7 +332,41 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
       )
 
       :ok
+  catch
+    # `rescue` alone left the hole this whole block exists to close. A pool checkout against
+    # a wedged, saturated or unstarted `AdminRepo` EXITS (`{:timeout, {DBConnection, ...}}`,
+    # `:noproc`) rather than raising, so it walks straight past the clause above and aborts
+    # `perform/1` — and because sampling is deterministic by `article_id`, all three Oban
+    # attempts re-sample, re-exit and discard, leaving that article permanently unlinked.
+    # That is the exact regression the rescue was written to prevent, reached by the other
+    # of the two ways this call can fail.
+    #
+    # Tagged, not swallowed untagged, so the degraded signal stays greppable. `exit_tag/1`
+    # below is a local mirror of `HeavyRead`'s and `LocalGuc.failure_tag/1`'s exit clauses:
+    # both are `defp`, and this module following the same per-module convention is cheaper
+    # than promoting one to a public API for a third caller.
+    :exit, reason ->
+      Logger.warning(
+        "Article linking: corpus-size count exited (#{exit_tag(reason)}) for " <>
+          "article #{article.id}; skipping the observational corpus_size signal — " <>
+          "linking proceeds"
+      )
+
+      :ok
   end
+
+  # Bounded classification of an exit reason — a small closed set, never the raw reason
+  # (which carries the full DBConnection call tuple, module and args).
+  #
+  # The `{reason, call}` TUPLE clause is the load-bearing one, and it is modelled on
+  # `LocalGuc.failure_tag/1` rather than on `HeavyRead.exit_tag/1`. DBConnection reports a
+  # wedged or unstarted pool as `{:noproc, {DBConnection, :execute, []}}`, NOT as a bare
+  # `:noproc` — a tagger with only an atom clause therefore looks right against a hand-rolled
+  # `exit(:noproc)` while degrading every REAL production exit to "other". This module's test
+  # exits with the production shape for exactly that reason.
+  defp exit_tag(reason) when is_atom(reason), do: to_string(reason)
+  defp exit_tag({reason, _call}) when is_atom(reason), do: to_string(reason)
+  defp exit_tag(_reason), do: "unknown"
 
   # Deterministic-by-id sampling so the same article always makes the same decision (stable
   # across a job's retries). `phash2(id, 1) == 0` always, so a rate of 1 samples every job;

--- a/lib/loopctl/workers/article_linking_worker.ex
+++ b/lib/loopctl/workers/article_linking_worker.ex
@@ -333,21 +333,33 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
 
       :ok
   catch
-    # `rescue` alone left the hole this whole block exists to close. A pool checkout against
-    # a wedged, saturated or unstarted `AdminRepo` EXITS (`{:timeout, {DBConnection, ...}}`,
-    # `:noproc`) rather than raising, so it walks straight past the clause above and aborts
-    # `perform/1` — and because sampling is deterministic by `article_id`, all three Oban
-    # attempts re-sample, re-exit and discard, leaving that article permanently unlinked.
-    # That is the exact regression the rescue was written to prevent, reached by the other
-    # of the two ways this call can fail.
+    # `rescue` alone left the non-exception half open. A pool checkout against a wedged,
+    # saturated or unstarted `AdminRepo` EXITS (`{:timeout, {DBConnection, ...}}`, `:noproc`)
+    # rather than raising, so it walked straight past the clause above and aborted `perform/1`
+    # over a purely observational count. Scope of the guarantee, exactly: a failure CONFINED
+    # TO THE COUNT — of any of the three kinds — no longer aborts linking. A pool fault that
+    # OUTLIVES the count still aborts the job at the next unguarded `AdminRepo` call
+    # (`get_existing_link_pairs/3`, the batched insert); that one is a genuine linking failure
+    # and belongs to Oban's retries, not to this block.
     #
-    # Tagged, not swallowed untagged, so the degraded signal stays greppable. `exit_tag/1`
-    # below is a local mirror of `HeavyRead`'s and `LocalGuc.failure_tag/1`'s exit clauses:
-    # both are `defp`, and this module following the same per-module convention is cheaper
-    # than promoting one to a public API for a third caller.
+    # `:throw` is caught alongside `:exit` because "every way this call can fail" has three
+    # kinds, not two — the same pairing the fail-soft rate-limiter taggers use. Tagged, not
+    # swallowed untagged, so the degraded signal stays greppable. `exit_tag/1` below is a
+    # local mirror of `HeavyRead`'s and `LocalGuc.failure_tag/1`'s exit clauses: both are
+    # `defp`, and this module following the same per-module convention is cheaper than
+    # promoting one to a public API for a third caller.
     :exit, reason ->
       Logger.warning(
         "Article linking: corpus-size count exited (#{exit_tag(reason)}) for " <>
+          "article #{article.id}; skipping the observational corpus_size signal — " <>
+          "linking proceeds"
+      )
+
+      :ok
+
+    :throw, value ->
+      Logger.warning(
+        "Article linking: corpus-size count threw (#{exit_tag(value)}) for " <>
           "article #{article.id}; skipping the observational corpus_size signal — " <>
           "linking proceeds"
       )
@@ -364,8 +376,16 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
   # `:noproc` — a tagger with only an atom clause therefore looks right against a hand-rolled
   # `exit(:noproc)` while degrading every REAL production exit to "other". This module's test
   # exits with the production shape for exactly that reason.
+  #
+  # The same argument covers CRASH PROPAGATION: when a called process dies of an exception
+  # rather than being absent, the reason is `{{exception_or_atom, stacktrace}, call}` — at
+  # least as common as `:noproc` for a supervised pool, and a shape the two clauses above
+  # degrade to "unknown". Both inner shapes stay bounded: an atom, or the exception MODULE
+  # (never its message).
   defp exit_tag(reason) when is_atom(reason), do: to_string(reason)
   defp exit_tag({reason, _call}) when is_atom(reason), do: to_string(reason)
+  defp exit_tag({{%module{}, _stack}, _call}), do: inspect(module)
+  defp exit_tag({{reason, _stack}, _call}) when is_atom(reason), do: to_string(reason)
   defp exit_tag(_reason), do: "unknown"
 
   # Deterministic-by-id sampling so the same article always makes the same decision (stable

--- a/test/loopctl/telemetry/scale_metrics_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_test.exs
@@ -47,6 +47,7 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
     "loopctl.db.error.count",
     "loopctl.heavy_read_repo.query.duration",
     "loopctl.knowledge.vector_search.under_fill.count",
+    "loopctl.knowledge.vector_search.under_fill_probe_degraded.count",
     "loopctl.knowledge.semantic_fallback.count",
     "loopctl.knowledge.hybrid_provenance.count",
     "loopctl.repo.checkout.queue_time",
@@ -83,8 +84,9 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
   # `:purpose`/`:state` (index_health.invalid — three bounded fixed sets), `:op`
   # (secrets.orphan_cleanup_failed — normalized `:delete`/`:restore`/`:unknown`), and
   # `:stage` (memory_promotion.failed — bounded `:compile`/`:persist`/`:enqueue`). US-34.1
-  # adds `:poller` (oban.poll.error.count — bounded `:queue_state`/`:executing_orphans`)
-  # and `:error_class` (oban.poll.error.count — CLASSIFIED, never a raw exception).
+  # adds `:poller` (oban.poll.error.count — bounded, one value per entry in
+  # `LoopctlWeb.Telemetry.periodic_measurements/0`) and `:error_class` (CLASSIFIED, never a
+  # raw exception or exit reason — also carried by the two degraded-read counters).
   @allowed_tags MapSet.new([
                   :endpoint,
                   :mapped_code,
@@ -981,14 +983,20 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
                exception: %RuntimeError{}
              }) == %{poller: :queue_state, error_class: "other"}
 
-      # An EXIT is not an exception, so the pollers' `catch :exit` clauses hand it over
-      # wrapped. Without its own class a wedged-pool checkout — which exits rather than
-      # raising — would report as the generic "other" bucket, or (before the catch clauses
-      # existed) not report at all, because telemetry_poller had already dropped the MFA.
+      # An EXIT/THROW is not an exception, so `guarded_measurement/5` hands it over wrapped
+      # (with a BOUNDED tag, never the raw reason). Without its own class a wedged-pool
+      # checkout — which exits rather than raising — would report as the generic "other"
+      # bucket, or (before the catch clause existed) not report at all, because
+      # telemetry_poller had already dropped the MFA.
       assert ScaleMetrics.oban_poll_error_tags(%{
                poller: :executing_orphans,
-               exception: {:exit, {:noproc, {DBConnection, :execute, []}}}
+               exception: {:exit, "noproc"}
              }) == %{poller: :executing_orphans, error_class: "exit"}
+
+      assert ScaleMetrics.oban_poll_error_tags(%{
+               poller: :cluster_readiness,
+               exception: {:throw, "unknown"}
+             }) == %{poller: :cluster_readiness, error_class: "throw"}
     end
 
     test "oban_poll_error_tags/1 defaults missing keys to \"unknown\", never raises" do
@@ -1005,13 +1013,149 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
       assert counter.event_name == [:loopctl, :oban, :poll, :error]
       assert MapSet.new(counter.tags) == MapSet.new([:poller, :error_class])
     end
+  end
 
-    # The DB-backed zero-fill / drain-to-zero behavior of poll_oban_queue_state/0
-    # itself is covered in oban_metrics_poller_test.exs (TC-34.1.1b/c), which uses
-    # `Loopctl.DataCase` for `Loopctl.Repo` sandbox isolation — this file is
-    # intentionally pure/no-DB (see moduledoc), so it only covers the fixed
-    # matrix inputs (`oban_states/0`/`oban_active_states/0`/`oban_queues/0`) here.
+  # R2 review finding: the four measurement guards were four hand-written copies that NO
+  # test drove — deleting every `catch` clause left the suite green, and a poller cannot be
+  # made to exit on demand through Ecto (which raises on every lookup/ownership failure), so
+  # nothing was ever going to. They are now ONE guard, and this is the test that fails if its
+  # `catch`/`rescue` is removed.
+  describe "guarded_measurement/5 — the one periodic-measurement guard" do
+    setup do
+      test_pid = self()
+      handler_id = "test-guarded-measurement-#{System.unique_integer([:positive])}"
 
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :oban, :poll, :error],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:poll_error, metadata, measurements})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+      :ok
+    end
+
+    defp guarded(fun),
+      do: ScaleMetrics.guarded_measurement(:queue_state, "Probe poll", "consequence", :held, fun)
+
+    test "an EXITING body returns the fallback, logs a BOUNDED tag, and fires the counter" do
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert guarded(fn -> exit({:noproc, {DBConnection, :execute, []}}) end) == :held
+        end)
+
+      # The production exit shape is a TUPLE, not a bare atom; and neither the log nor the
+      # telemetry metadata may carry the raw reason (it holds the DBConnection call tuple,
+      # module and args).
+      assert log =~ "Probe poll aborted (exit: noproc); consequence"
+      refute log =~ "DBConnection"
+
+      assert_receive {:poll_error, %{poller: :queue_state, exception: exception}, %{count: 1}},
+                     500
+
+      refute inspect(exception) =~ "DBConnection"
+
+      assert ScaleMetrics.oban_poll_error_tags(%{poller: :queue_state, exception: exception}) ==
+               %{poller: :queue_state, error_class: "exit"}
+    end
+
+    test "a THROWING body is guarded too — telemetry_poller drops an MFA on all three kinds" do
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert guarded(fn -> throw(:boom) end) == :held
+        end)
+
+      assert log =~ "Probe poll aborted (throw: boom)"
+
+      assert_receive {:poll_error, %{poller: :queue_state, exception: exception}, %{count: 1}},
+                     500
+
+      assert ScaleMetrics.oban_poll_error_tags(%{poller: :queue_state, exception: exception}) ==
+               %{poller: :queue_state, error_class: "throw"}
+    end
+
+    test "a RAISING body keeps its own message and passes the struct through for classification" do
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert guarded(fn -> raise ArgumentError, "bad tunable" end) == :held
+        end)
+
+      assert log =~ "Probe poll failed (ArgumentError); consequence"
+      refute log =~ "bad tunable"
+
+      assert_receive {:poll_error, %{poller: :queue_state, exception: %ArgumentError{}},
+                      %{count: 1}},
+                     500
+    end
+
+    test "a SUCCEEDING body returns its own value and fires no counter" do
+      assert guarded(fn -> :ok end) == :ok
+      refute_receive {:poll_error, _metadata, _measurements}, 200
+    end
+  end
+
+  describe "tenant-label gate — one grace cycle before a failed count flips it" do
+    setup do
+      original = :persistent_term.get({ScaleMetrics, :tenant_label?}, :unset)
+      on_exit(fn -> :persistent_term.put({ScaleMetrics, :tenant_label?}, original) end)
+
+      # Make `Tenants.count()` fail DETERMINISTICALLY and without a DB: an Ecto dynamic repo
+      # that was never started raises on lookup. Process-local, so it dies with this test.
+      Loopctl.AdminRepo.put_dynamic_repo(:scale_metrics_unstarted_repo)
+      :ok
+    end
+
+    test "the first failure HOLDS the gate; the second consecutive failure forces it OFF" do
+      :persistent_term.put({ScaleMetrics, :tenant_label?}, true)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          # Cycle 1: held. An intermittently wedged pool used to flip the gate (and every
+          # per-tenant series' label) OFF here, then back ON the next cycle, paying the
+          # global `:persistent_term.put/2` term-table scan on each flap.
+          assert ScaleMetrics.refresh_tenant_label_gate()
+          assert ScaleMetrics.tenant_label?()
+
+          # Cycle 2: a PERSISTENTLY unmeasurable count can never leave an unbounded tenant
+          # label live (AC-27.15.3), so the grace is exactly one cycle.
+          refute ScaleMetrics.refresh_tenant_label_gate()
+          refute ScaleMetrics.tenant_label?()
+        end)
+
+      assert log =~ "tenant-label gate refresh failed"
+      assert log =~ "holding the gate for one cycle"
+    end
+
+    test "a failed refresh is alertable: it fires the poll-failure counter like every other measurement" do
+      test_pid = self()
+      handler_id = "test-gate-poll-error-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :oban, :poll, :error],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:poll_error, metadata, measurements})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      ExUnit.CaptureLog.capture_log(fn -> ScaleMetrics.refresh_tenant_label_gate() end)
+
+      assert_receive {:poll_error, %{poller: :tenant_label_gate}, %{count: 1}}, 500
+    end
+  end
+
+  # The DB-backed zero-fill / drain-to-zero behavior of poll_oban_queue_state/0
+  # itself is covered in oban_metrics_poller_test.exs (TC-34.1.1b/c), which uses
+  # `Loopctl.DataCase` for `Loopctl.Repo` sandbox isolation — this file is
+  # intentionally pure/no-DB (see moduledoc), so it only covers the fixed
+  # matrix inputs (`oban_states/0`/`oban_active_states/0`/`oban_queues/0`) here.
+  describe "Oban gauges — reporter round-trip (US-34.1)" do
     test "the reporter round-trip: both gauges record and scrape end to end" do
       reporter_name = :"scale_metrics_oban_gauges_test_#{System.unique_integer([:positive])}"
 

--- a/test/loopctl/telemetry/scale_metrics_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_test.exs
@@ -951,6 +951,20 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
                exception: %DBConnection.OwnershipError{}
              }) == %{poller: :queue_state, error_class: "db_error"}
 
+      # A LocalGuc capture ABORT is raised AS a DBConnection.ConnectionError on purpose, so
+      # without its own branch it landed in the clause above and read as a pool fault. It is
+      # not one: it is the poller declining to override a GUC an enclosing scope owns — a
+      # correctness-preserving refusal with a completely different remedy. Both Oban pollers
+      # run inside `LocalGuc.timed_transaction/3`, so this is reachable, and the three sites
+      # that already discriminate it (`Knowledge`, `KnowledgeIngestionController`,
+      # `ArticleLinkingWorker`) all use this same tag.
+      assert ScaleMetrics.oban_poll_error_tags(%{
+               poller: :queue_state,
+               exception: %DBConnection.ConnectionError{
+                 message: "LocalGuc: could not capture [\"statement_timeout\"]"
+               }
+             }) == %{poller: :queue_state, error_class: "guc_capture_abort"}
+
       assert ScaleMetrics.oban_poll_error_tags(%{
                poller: :queue_state,
                exception: %ArgumentError{}

--- a/test/loopctl/telemetry/scale_metrics_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_test.exs
@@ -953,11 +953,12 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
 
       # A LocalGuc capture ABORT is raised AS a DBConnection.ConnectionError on purpose, so
       # without its own branch it landed in the clause above and read as a pool fault. It is
-      # not one: it is the poller declining to override a GUC an enclosing scope owns — a
-      # correctness-preserving refusal with a completely different remedy. Both Oban pollers
-      # run inside `LocalGuc.timed_transaction/3`, so this is reachable, and the three sites
-      # that already discriminate it (`Knowledge`, `KnowledgeIngestionController`,
-      # `ArticleLinkingWorker`) all use this same tag.
+      # not one: it is a caller declining to override a GUC an enclosing scope owns — a
+      # correctness-preserving refusal with a completely different remedy. Neither poller can
+      # currently reach it (each opens the OUTERMOST scope on the poller process, and the abort
+      # needs an enclosing owner), so this branch is uniform classification with the three sites
+      # that DO discriminate it (`Knowledge`, `KnowledgeIngestionController`,
+      # `ArticleLinkingWorker`), which all use this same tag.
       assert ScaleMetrics.oban_poll_error_tags(%{
                poller: :queue_state,
                exception: %DBConnection.ConnectionError{
@@ -979,6 +980,15 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
                poller: :queue_state,
                exception: %RuntimeError{}
              }) == %{poller: :queue_state, error_class: "other"}
+
+      # An EXIT is not an exception, so the pollers' `catch :exit` clauses hand it over
+      # wrapped. Without its own class a wedged-pool checkout — which exits rather than
+      # raising — would report as the generic "other" bucket, or (before the catch clauses
+      # existed) not report at all, because telemetry_poller had already dropped the MFA.
+      assert ScaleMetrics.oban_poll_error_tags(%{
+               poller: :executing_orphans,
+               exception: {:exit, {:noproc, {DBConnection, :execute, []}}}
+             }) == %{poller: :executing_orphans, error_class: "exit"}
     end
 
     test "oban_poll_error_tags/1 defaults missing keys to \"unknown\", never raises" do

--- a/test/loopctl/workers/article_linking_worker_test.exs
+++ b/test/loopctl/workers/article_linking_worker_test.exs
@@ -586,6 +586,60 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
       # ...and the linking it merely observes still happened. That is the whole point.
       assert [_] = links_of_type(tenant.id, source.id, target.id, :relates_to)
     end
+
+    test "a propagated CRASH exit is tagged by exception module, not degraded to \"unknown\"" do
+      # A pool process that dies of an exception (rather than being absent) propagates
+      # `{{exception, stacktrace}, call}`. An atom-only tagger degrades that — at least as
+      # common as `:noproc` — to the catch-all, costing the operator the usable class.
+      %{tenant: tenant} = setup_tenant()
+      source = create_article_in_bucket(tenant.id, true)
+      target = create_published_article(tenant.id)
+
+      stub(Loopctl.MockEmbeddingReadPath, :side_table_reads_enabled?, fn ->
+        exit({{%RuntimeError{message: "pool died"}, []}, {GenServer, :call, [self(), :req]}})
+      end)
+
+      stub(MockArticleSimilaritySearch, :nearest, fn _t, _emb, _k, _opts ->
+        [candidate(target, 0.88)]
+      end)
+
+      log =
+        capture_log(fn ->
+          assert :ok =
+                   ArticleLinkingWorker.perform(%Oban.Job{
+                     args: %{"article_id" => source.id, "tenant_id" => tenant.id}
+                   })
+        end)
+
+      assert log =~ "corpus-size count exited (RuntimeError)"
+      refute log =~ "pool died"
+      assert [_] = links_of_type(tenant.id, source.id, target.id, :relates_to)
+    end
+
+    test "a THROW from the observational count degrades softly and still links" do
+      # The third non-local exit kind. `rescue` + `catch :exit` alone still let it abort
+      # `perform/1` over a signal the job does not depend on.
+      %{tenant: tenant} = setup_tenant()
+      source = create_article_in_bucket(tenant.id, true)
+      target = create_published_article(tenant.id)
+
+      stub(Loopctl.MockEmbeddingReadPath, :side_table_reads_enabled?, fn -> throw(:boom) end)
+
+      stub(MockArticleSimilaritySearch, :nearest, fn _t, _emb, _k, _opts ->
+        [candidate(target, 0.88)]
+      end)
+
+      log =
+        capture_log(fn ->
+          assert :ok =
+                   ArticleLinkingWorker.perform(%Oban.Job{
+                     args: %{"article_id" => source.id, "tenant_id" => tenant.id}
+                   })
+        end)
+
+      assert log =~ "corpus-size count threw (boom)"
+      assert [_] = links_of_type(tenant.id, source.id, target.id, :relates_to)
+    end
   end
 
   describe "batched insert_all (AC-36.4.2 / AC-36.4.3)" do

--- a/test/loopctl/workers/article_linking_worker_test.exs
+++ b/test/loopctl/workers/article_linking_worker_test.exs
@@ -2,6 +2,8 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
   use Loopctl.DataCase, async: true
   use Oban.Testing, repo: Loopctl.Repo
 
+  import ExUnit.CaptureLog
+
   setup :verify_on_exit!
 
   alias Loopctl.AdminRepo
@@ -534,6 +536,55 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
       assert measurements.limit == 50
       assert metadata.tenant_id == tenant.id
       assert metadata.article_id == source.id
+    end
+  end
+
+  describe "corpus-size count degradation (AC-36.4.3)" do
+    test "an EXIT from the observational count degrades softly and still links" do
+      # The count's rescue clause was `rescue`-only, so it caught the raise shape
+      # (`Postgrex.Error` 57014) and missed the other one. A pool checkout against a wedged,
+      # saturated or unstarted `AdminRepo` EXITS rather than raising — `{:noproc, {DBConnection,
+      # ...}}` — which walked straight past it and aborted `perform/1`. Because sampling is
+      # deterministic by `article_id`, all three Oban attempts re-sampled and re-exited, so the
+      # article was left permanently unlinked: the exact regression the rescue exists to
+      # prevent, reached by the other of the two ways this call can fail.
+      #
+      # `corpus_count_query/2` consults the injected read path and is the ONLY caller of it in
+      # this module, so stubbing that to exit puts a production-shaped exit precisely inside
+      # the observational block and nowhere else.
+      %{tenant: tenant} = setup_tenant()
+      source = create_article_in_bucket(tenant.id, true)
+      target = create_published_article(tenant.id)
+
+      ref = attach_corpus_telemetry(source.id)
+
+      stub(Loopctl.MockEmbeddingReadPath, :side_table_reads_enabled?, fn ->
+        exit({:noproc, {DBConnection, :execute, []}})
+      end)
+
+      stub(MockArticleSimilaritySearch, :nearest, fn _t, _emb, _k, _opts ->
+        [candidate(target, 0.88)]
+      end)
+
+      log =
+        capture_log(fn ->
+          assert :ok =
+                   ArticleLinkingWorker.perform(%Oban.Job{
+                     args: %{"article_id" => source.id, "tenant_id" => tenant.id}
+                   })
+        end)
+
+      # The observational signal is the ONLY casualty...
+      refute_received {^ref, :corpus_size, _measurements, _metadata}
+      assert log =~ "corpus-size count exited"
+
+      # ...tagged, not swallowed anonymously: a bounded class, never the raw exit reason
+      # (which carries the whole DBConnection call tuple).
+      assert log =~ "(noproc)"
+      refute log =~ "DBConnection"
+
+      # ...and the linking it merely observes still happened. That is the whole point.
+      assert [_] = links_of_type(tenant.id, source.id, target.id, :relates_to)
     end
   end
 


### PR DESCRIPTION
Opened to carry the three findings the #551 enhanced review confirmed but could not fix on that branch. Its own review then found the same defect class in the file I was already editing, and that turned out to be the more serious half — so this PR is now about one thing: **a fail-soft guard that only catches raises is not fail-soft.**

## The systemic bug

`telemetry_poller` does not merely skip a measurement that raises — `make_measurements_and_filter_misbehaving/1` **permanently removes it** from the poller's list. Confirmed directly: it dropped `ScaleMetrics.refresh_tenant_label_gate/0` in this very session, before any change here.

So a single wedged-pool moment did not degrade one poll. It froze `oban.jobs.count`, `oban.jobs.executing_orphan.count`, `cluster.peers.count` and the tenant-label gate **for the life of the node**, with the gauges still reporting their last value — indistinguishable from a healthy steady state.

The tenant-label gate is the sharp end. Frozen at `true`, `tenant_id` stays a live Prometheus label after the fleet crosses the cap — the unbounded cardinality AC-27.15.3 exists to forbid. It now fails the gate **OFF** (the safe direction) instead of freezing it.

## Why a `rescue` was never enough

A DBConnection checkout against a wedged, saturated or unstarted pool **exits**; it does not raise. Every guard here caught one of the two shapes and missed the other:

| Site | Was | Now |
|---|---|---|
| 4 `ScaleMetrics` measurements | `rescue` only (one narrowed to 3 exception types) | `guarded_measurement/5` — rescue + `catch :exit` + `catch :throw` |
| `ArticleLinkingWorker` corpus count | `rescue` only | + `catch :exit` |

The worker case is the user-visible one: sampling is deterministic by `article_id`, so all three Oban attempts re-sample, re-exit and discard — leaving that article **permanently unlinked**. Exactly the regression its rescue was written to prevent, reached by the other failure shape.

## `Loopctl.ExitTag`

The "log a stable, low-cardinality tag, never the raw reason" rule had grown **four private copies with two different behaviours**, so the same wedged pool read as `RuntimeError` through one guard and `unknown`/`other` through another. Now one module.

Its `{{reason, stacktrace}, call}` clause is load-bearing and was missing everywhere: that is crash *propagation* (the pooled process died of an exception rather than being absent), at least as common as `:noproc`. Bounded either way — an atom, or the exception **module** name, never its message, which carries host, database, role and query args.

`LocalGuc.failure_tag/1` keeps all five of its exception-specific clauses and delegates only the generic tail, so its tags are a strict superset of before.

## `local_guc.ex` — documentation that contradicted itself

The `capture_fallback!/2` comment claimed a fail-soft rescue *"re-raises on it instead of swallowing it"*, then said *"Today's rescues deliberately do not"* — reading as an aspiration the call sites hadn't reached. They had. It contradicted `capture_abort?/1`'s own `@doc` twenty lines above, which settled in #550 that re-raising out of a fail-soft path turns an unmeasurable diagnostic into a failed request. Rewritten: telling the two apart is a **logging** distinction, never a control-flow one.

## Also fixed

- `poll_cluster_readiness/0` now emits the poll-failure counter, so a frozen `cluster.peers` gauge is distinguishable from a stable one.
- `under_fill_probe_degraded` counter definition added — the event was emitted but consumed by no `Telemetry.Metrics` definition, so the class was log-only.
- Tenant-label gate given a one-cycle grace streak, so an intermittent wedge does not flap the gate and re-scan the global `:persistent_term` table every 10s.
- Two stale bounded-tag comments corrected to the sets actually emitted.

The poll-failure counter keeps the name `loopctl.oban.poll.error.count` though it now covers two non-Oban measurements — renaming breaks existing dashboards, and the historical prefix is documented at both the moduledoc and the metric definition.

## Verification

- `mix precommit` green: 6561 tests, 0 failures.
- Guards mutation-verified: deleting `guarded_measurement/5`'s `catch kind, reason when kind in [:exit, :throw]` clause fails 2 of the 4 new tests; removing the worker's `catch`, narrowing its head, dropping `ExitTag`'s tuple clause, or dropping the capture-abort branch each fail a test.
- One local run failed 1 test (`embeddings_side_table_reads_test.exs`, `left: []`) in 83.8s. Diagnosed, not waved away: CI runs on the same self-hosted beelink box, so the local suite was contending with the CI Test job for Postgres — the documented two-suite condition. The re-run after CI settled passed 6561/6561 in 35.8s. The two mechanisms that could have made it a real regression were checked and are intact: the load-bearing `hnsw_iterative_scan_default` pin (`config/test.exs:767`) and LocalGuc's control flow (unchanged — only the logging tag moved).

## Follow-up (one more PR, then the class is closed)

Five confirmed findings land outside this diff, all the same class. Two are live request-path bugs:

- `knowledge_ingestion_controller.ex` — a pool exit escapes the class-restricted rescue, so the backlog gate **500s the request** instead of failing open at 0.
- `knowledge.ex` — same shape; an exit destroys an already-computed suggestions response.
- `heavy_read.ex` — the last remaining copy of the exit tagger.
- `telemetry.ex` — `periodic_measurements/0`'s invariant note still says a catch-all *rescue* suffices, which is how the next measurement reproduces this bug.
- `local_guc.ex` — one qualifier in the new comment can be dropped once the first lands.

After those there are no copies of the pattern left, so the chain terminates rather than spawning another.
