### PR TITLE
Close the fail-soft guard class: an exit is not a raise, in the last four places

### DIFF
--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -26,29 +26,29 @@ never pass `tenant_id`/`subject_id`.
 ## Invariants (cited)
 
 1. **Novelty / dedup gate on create** — `Knowledge.propose_article/3` → the private `gate_proposal/4`
-   (`propose_article/3` at `knowledge.ex:453`; the four `gate_proposal/4` clauses at `:463-515`).
+   (`propose_article/3` at `knowledge.ex:456`; the four `gate_proposal/4` clauses at `:466-518`).
    **SIX outcomes, not four** — `:duplicate`, `:low_novelty`, `:unknown`, `:novel`,
    `:deduplicated` (`created: false`, returned when `create_article` hits the idempotency-key path,
-   `knowledge.ex:580-581`), and `:skipped_low_novelty` (`created: false`, `article` may be `nil`).
+   `knowledge.ex:571-573`), and `:skipped_low_novelty` (`created: false`, `article` may be `nil`).
    A caller matching only the first four falls through on either of the last two, both reachable.
    `:duplicate` returns the canonical neighbor without creating; `:low_novelty`
-   is created but **forced to `status: "draft"`** (`:484`) with novelty stamped into
-   `metadata.proposal_novelty` (`stamp_proposal_metadata/2`, `:636-649`) so a smarter consumer decides
+   is created but **forced to `status: "draft"`** (`:492`) with novelty stamped into
+   `metadata.proposal_novelty` (`stamp_proposal_metadata/2`, `:692-705`) so a smarter consumer decides
    — UNLESS the caller passes `on_low_novelty: :skip` (for an UNATTENDED writer whose drafts nothing
    would review), which creates NOTHING and returns `:skipped_low_novelty` with the near-neighbor
-   (`skip_low_novelty/4`, `:512-556`). That skip is decided LAST: an invalid `project_id`, an
+   (`skip_low_novelty/4`, `:538-556`). That skip is decided LAST: an invalid `project_id`, an
    `idempotency_key` match, and an exact active-title collision are all still answered normally
    rather than dropped.
    Two branches that are easy to miss: `:duplicate` **falls through to create** if the canonical
-   neighbor vanished between assess and now (`:465-474`), and `:unknown` creates only BY DEFAULT — a
+   neighbor vanished between assess and now (`:472-480`), and `:unknown` creates only BY DEFAULT — a
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
-   created (`:499-505`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:461-463`)
+   created (`:507-513`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:462-464`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8376`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8407`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
-   (`absolute_score/1`, `:8484-8489`) clears a scale-matched threshold AND beats the best retrieved
-   candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:8535-8545`; the pure decision is
-   `resolve_provenance/4`, `:8588-8600`) AND is authoritative (not superseded/conflicted — the caller
+   (`absolute_score/1`, `:8534-8539`) clears a scale-matched threshold AND beats the best retrieved
+   candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:8585-8595`; the pure decision is
+   `resolve_provenance/4`, `:8638-8650`) AND is authoritative (not superseded/conflicted — the caller
    passes only `list_curated_sources/2`-filtered scores). Otherwise `:retrieved`. Both branches return identical `results`/`meta`
    key sets — callers branch on `meta.provenance` alone. A sparse pool must never let a near-but-wrong
    curated doc win.

--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -44,7 +44,7 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:499-505`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:461-463`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8357`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8376`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
    (`absolute_score/1`, `:8484-8489`) clears a scale-matched threshold AND beats the best retrieved
    candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:8535-8545`; the pure decision is

--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -44,11 +44,11 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:507-513`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:462-464`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8407`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8419`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
-   (`absolute_score/1`, `:8534-8539`) clears a scale-matched threshold AND beats the best retrieved
-   candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:8585-8595`; the pure decision is
-   `resolve_provenance/4`, `:8638-8650`) AND is authoritative (not superseded/conflicted — the caller
+   (`absolute_score/1`, `:8546-8551`) clears a scale-matched threshold AND beats the best retrieved
+   candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:8597-8607`; the pure decision is
+   `resolve_provenance/4`, `:8650-8662`) AND is authoritative (not superseded/conflicted — the caller
    passes only `list_curated_sources/2`-filtered scores). Otherwise `:retrieved`. Both branches return identical `results`/`meta`
    key sets — callers branch on `meta.provenance` alone. A sparse pool must never let a near-but-wrong
    curated doc win.

--- a/.claude/skills/tenancy-rls/SKILL.md
+++ b/.claude/skills/tenancy-rls/SKILL.md
@@ -54,29 +54,31 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 6. **On `AdminRepo`/`HeavyReadRepo`, RLS does NOTHING — the explicit `tenant_id` predicate is the only
    isolation there** (`knowledge.ex:9-14`, `heavy_read.ex:3-7`). This is the compensating invariant for
    the other two repos, and it is enforced structurally on the heavy path: the private `guard!/2`
-   (`heavy_read.ex:1255-1275`) RAISES unless EVERY base-table source — `from`, every join, and every
+   (`heavy_read.ex:1263-1281`) RAISES unless EVERY base-table source — `from`, every join, and every
    subquery, recursively — carries a conjunctive `x.tenant_id == ^tenant_id` bound to the passed
    `tenant_id`; `test/loopctl/heavy_read_guard_test.exs` additionally bars direct `HeavyReadRepo` calls.
-   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:1016`) also requires a conjunctive
-   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1277-1300`), because `subject_id`
+   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:1024`) also requires a conjunctive
+   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1285-1307`), because `subject_id`
    scoping is application-level only. Always go through `Loopctl.HeavyRead`, never `HeavyReadRepo`
    directly; on `AdminRepo` there is no guard at all, so the predicate is on you.
-7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:965`),
-   `one/3` (`heavy_read.ex:985`) and `all_memory/4` (`heavy_read.ex:1021`) are specced to return it: the
-   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:1045-1065`) sheds over the cap —
+7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:968`),
+   `one/3` (`heavy_read.ex:988`) and `all_memory/4` (`heavy_read.ex:1024`) are specced to return it: the
+   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:1053-1067`) sheds over the cap —
    `on_overload: :raise` (default) raises → 429, `on_overload: :tag` returns the tuple. Binding the
-   result as a list crashes exactly under the load the gate exists for.
-8. **A consistency-coupled heavy read must be PRIMARY-PINNED.** `repo_for/1` (`heavy_read.ex:114-117`,
-   pure decision in `route_repo/4`, `heavy_read.ex:129-137`) routes an endpoint listed in
-   `primary_pinned_endpoints/0` (`heavy_read.ex:93`, today `:sth_incremental`) onto the PRIMARY pool
+   result as a list crashes exactly under the load the gate exists for. An ADVISORY read (a diagnostic
+   probe running after the response is computed) must ask for `:tag` — a raising shed there trades a
+   valid 200 for a 429.
+8. **A consistency-coupled heavy read must be PRIMARY-PINNED.** `repo_for/1` (`heavy_read.ex:117-119`,
+   pure decision in `route_repo/4`, `heavy_read.ex:132-138`) routes an endpoint listed in
+   `primary_pinned_endpoints/0` (`heavy_read.ex:95`, today `:sth_incremental`) onto the PRIMARY pool
    whenever a distinct replica is configured — so it is NOT always `HeavyReadRepo`. Add a new endpoint
    to that list when it cannot tolerate replica lag.
 
 ## The pgbouncer gotcha (US-27.13 — production outage, do not regress)
 
 `HeavyReadRepo` enforces a server-side `statement_timeout` **per-read via `SET LOCAL` inside the
-transaction** (`all/3` at `heavy_read.ex:965` and `one/3` at `:985`, both via
-`with_statement_timeout/5` at `:1081`;
+transaction** (`all/3` at `heavy_read.ex:968` and `one/3` at `:988`, both via
+`with_statement_timeout/5` at `:1089`;
 `heavy_read_repo.ex:19-32`) — NOT as a connection startup
 `:parameters` value. Fly MPG fronts Postgres with **pgbouncer**, which rejects a `statement_timeout`
 startup parameter with `FATAL 08P01 unsupported startup parameter`, crash-looping the whole pool so it

--- a/.claude/skills/tenancy-rls/SKILL.md
+++ b/.claude/skills/tenancy-rls/SKILL.md
@@ -61,8 +61,8 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
    `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1277-1300`), because `subject_id`
    scoping is application-level only. Always go through `Loopctl.HeavyRead`, never `HeavyReadRepo`
    directly; on `AdminRepo` there is no guard at all, so the predicate is on you.
-7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:960`),
-   `one/3` (`heavy_read.ex:980`) and `all_memory/4` (`heavy_read.ex:1016`) are specced to return it: the
+7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:965`),
+   `one/3` (`heavy_read.ex:985`) and `all_memory/4` (`heavy_read.ex:1021`) are specced to return it: the
    per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:1045-1065`) sheds over the cap —
    `on_overload: :raise` (default) raises → 429, `on_overload: :tag` returns the tuple. Binding the
    result as a list crashes exactly under the load the gate exists for.
@@ -75,7 +75,7 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 ## The pgbouncer gotcha (US-27.13 — production outage, do not regress)
 
 `HeavyReadRepo` enforces a server-side `statement_timeout` **per-read via `SET LOCAL` inside the
-transaction** (`all/3` at `heavy_read.ex:960` and `one/3` at `:980`, both via
+transaction** (`all/3` at `heavy_read.ex:965` and `one/3` at `:985`, both via
 `with_statement_timeout/5` at `:1081`;
 `heavy_read_repo.ex:19-32`) — NOT as a connection startup
 `:parameters` value. Fly MPG fronts Postgres with **pgbouncer**, which rejects a `statement_timeout`

--- a/.claude/skills/tenancy-rls/SKILL.md
+++ b/.claude/skills/tenancy-rls/SKILL.md
@@ -54,16 +54,16 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 6. **On `AdminRepo`/`HeavyReadRepo`, RLS does NOTHING — the explicit `tenant_id` predicate is the only
    isolation there** (`knowledge.ex:9-14`, `heavy_read.ex:3-7`). This is the compensating invariant for
    the other two repos, and it is enforced structurally on the heavy path: the private `guard!/2`
-   (`heavy_read.ex:1263-1281`) RAISES unless EVERY base-table source — `from`, every join, and every
+   (`heavy_read.ex:1272-1290`) RAISES unless EVERY base-table source — `from`, every join, and every
    subquery, recursively — carries a conjunctive `x.tenant_id == ^tenant_id` bound to the passed
    `tenant_id`; `test/loopctl/heavy_read_guard_test.exs` additionally bars direct `HeavyReadRepo` calls.
-   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:1024`) also requires a conjunctive
-   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1285-1307`), because `subject_id`
+   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:1033`) also requires a conjunctive
+   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1294-1316`), because `subject_id`
    scoping is application-level only. Always go through `Loopctl.HeavyRead`, never `HeavyReadRepo`
    directly; on `AdminRepo` there is no guard at all, so the predicate is on you.
-7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:968`),
-   `one/3` (`heavy_read.ex:988`) and `all_memory/4` (`heavy_read.ex:1024`) are specced to return it: the
-   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:1053-1067`) sheds over the cap —
+7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:977`),
+   `one/3` (`heavy_read.ex:997`) and `all_memory/4` (`heavy_read.ex:1033`) are specced to return it: the
+   per-tenant cost-weighted in-flight gate (`gated/4`, `heavy_read.ex:1062-1076`) sheds over the cap —
    `on_overload: :raise` (default) raises → 429, `on_overload: :tag` returns the tuple. Binding the
    result as a list crashes exactly under the load the gate exists for. An ADVISORY read (a diagnostic
    probe running after the response is computed) must ask for `:tag` — a raising shed there trades a
@@ -77,8 +77,8 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 ## The pgbouncer gotcha (US-27.13 — production outage, do not regress)
 
 `HeavyReadRepo` enforces a server-side `statement_timeout` **per-read via `SET LOCAL` inside the
-transaction** (`all/3` at `heavy_read.ex:968` and `one/3` at `:988`, both via
-`with_statement_timeout/5` at `:1089`;
+transaction** (`all/3` at `heavy_read.ex:977` and `one/3` at `:997`, both via
+`with_statement_timeout/5` at `:1098`;
 `heavy_read_repo.ex:19-32`) — NOT as a connection startup
 `:parameters` value. Fly MPG fronts Postgres with **pgbouncer**, which rejects a `statement_timeout`
 startup parameter with `FATAL 08P01 unsupported startup parameter`, crash-looping the whole pool so it

--- a/lib/loopctl/exit_class.ex
+++ b/lib/loopctl/exit_class.ex
@@ -1,0 +1,38 @@
+defmodule Loopctl.ExitClass do
+  @moduledoc """
+  The BOUNDED, kind-prefixed metric CLASS for a non-local exit / throw.
+
+  `Loopctl.ExitTag` answers "what was the reason", and its answer is deliberately
+  open-ended: ANY exit-reason atom, or ANY exception MODULE name. That is the right
+  answer for a log line and the wrong one for a Prometheus LABEL — `error_class` is a
+  tag multiplied by `tenant_id` (`Loopctl.ScaleMetrics`), so passing `ExitTag` through
+  verbatim grows the label's value set with whatever failure modes the fleet happens to
+  have, rather than an enumerable set an operator can write an alert against.
+
+  So the tag is collapsed onto a CLOSED set: the shapes an operator actually triages —
+  an absent pool (`noproc`), a wedged one (`timeout`), one shutting down (`shutdown`)
+  or killed (`killed`) — and `other` for everything else. The kind prefix stays, because
+  a dead pool and a throw escaping a guard call for different investigations.
+
+  Extracted rather than copied into each guard for the same reason `ExitTag` itself was:
+  four private copies of "classify this exit" had already diverged.
+  """
+
+  alias Loopctl.ExitTag
+
+  @tags ~w(noproc timeout shutdown killed)
+
+  @doc """
+  Bound an already-`ExitTag`-tagged reason to `"<kind>:<tag>"` over the closed tag set.
+  """
+  @spec bounded(:exit | :throw, String.t()) :: String.t()
+  def bounded(kind, tag) when kind in [:exit, :throw] and is_binary(tag),
+    do: "#{kind}:#{closed(tag)}"
+
+  @doc "Tag a raw exit/throw reason and bound it in one step."
+  @spec classify(:exit | :throw, term()) :: String.t()
+  def classify(kind, reason), do: bounded(kind, ExitTag.tag(reason))
+
+  defp closed(tag) when tag in @tags, do: tag
+  defp closed(_tag), do: "other"
+end

--- a/lib/loopctl/exit_class.ex
+++ b/lib/loopctl/exit_class.ex
@@ -5,14 +5,19 @@ defmodule Loopctl.ExitClass do
   `Loopctl.ExitTag` answers "what was the reason", and its answer is deliberately
   open-ended: ANY exit-reason atom, or ANY exception MODULE name. That is the right
   answer for a log line and the wrong one for a Prometheus LABEL — `error_class` is a
-  tag multiplied by `tenant_id` (`Loopctl.ScaleMetrics`), so passing `ExitTag` through
-  verbatim grows the label's value set with whatever failure modes the fleet happens to
-  have, rather than an enumerable set an operator can write an alert against.
+  tag multiplied by `tenant_id` (`Loopctl.ScaleMetrics.degraded_read_tags/1`), so passing
+  `ExitTag` through verbatim grows the label's value set with whatever failure modes the
+  fleet happens to have, rather than an enumerable set an operator can write an alert
+  against.
 
   So the tag is collapsed onto a CLOSED set: the shapes an operator actually triages —
-  an absent pool (`noproc`), a wedged one (`timeout`), one shutting down (`shutdown`)
-  or killed (`killed`) — and `other` for everything else. The kind prefix stays, because
-  a dead pool and a throw escaping a guard call for different investigations.
+  an absent pool (`noproc`), a wedged one (`timeout`), one shutting down (`shutdown`) or
+  killed (`killed`), plus the two exception MODULES a pooled process actually dies of
+  (`Postgrex.Error`, `DBConnection.ConnectionError`) — and `other` for everything else.
+  The crash-PROPAGATION shapes are ENUMERATED rather than collapsed because `ExitTag`'s
+  clause list exists precisely to stop them degrading to a catch-all: dying of a backend
+  error is a different investigation from an unrecognised reason. The kind prefix stays,
+  because a dead pool and a throw escaping a guard call for different investigations too.
 
   Extracted rather than copied into each guard for the same reason `ExitTag` itself was:
   four private copies of "classify this exit" had already diverged.
@@ -20,7 +25,7 @@ defmodule Loopctl.ExitClass do
 
   alias Loopctl.ExitTag
 
-  @tags ~w(noproc timeout shutdown killed)
+  @tags ~w(noproc timeout shutdown killed Postgrex.Error DBConnection.ConnectionError)
 
   @doc """
   Bound an already-`ExitTag`-tagged reason to `"<kind>:<tag>"` over the closed tag set.

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -716,7 +716,7 @@ defmodule Loopctl.HeavyRead do
   # checkout and a warning per ANN read during the incident. That reasoning applies to pool
   # and connection failures — and to nothing else.
   #
-  # Two classes are therefore NEVER cached, and for one shared reason: caching `false` pins
+  # Three classes are therefore NEVER cached, and for one shared reason: caching `false` pins
   # iterative scan OFF for the whole VM for a window, and now that `config/test.exs` pins it ON so
   # the suite matches prod, a single blip silently reconfigures every ANN read in the run and
   # re-arms the `left: []` recall flake that pin exists to prevent.
@@ -726,6 +726,8 @@ defmodule Loopctl.HeavyRead do
   #   * `:transaction` — the backend ANSWERED but the connection was poisoned (25P02 after a
   #     deliberate constraint-violation or 57014 test). Also not backend pressure, and also
   #     silent about the version.
+  #   * `:unexpected` — a THROW escaping the probe. A code bug, so it must stay loud and
+  #     re-probe rather than be pinned into the negative cache.
   #
   # `:pool` (checkout timeouts, connection errors) IS the saturation case the negative cache
   # was built for, so it stays cached in prod — but NOT under the sandbox pool, where routine
@@ -775,7 +777,7 @@ defmodule Loopctl.HeavyRead do
   # depends on how the tag happens to be worded.
   @spec probe_iterative_scan_support() ::
           {:ok, boolean(), String.t() | :not_installed}
-          | {:inconclusive, String.t(), :ownership | :transaction | :pool}
+          | {:inconclusive, String.t(), :ownership | :transaction | :pool | :unexpected}
   defp probe_iterative_scan_support do
     # TIGHT timeout, because this round trip runs from `opts/1` — i.e. BEFORE `TenantGate`
     # can shed and before any `SET LOCAL statement_timeout` applies. DBConnection derives the
@@ -823,11 +825,18 @@ defmodule Loopctl.HeavyRead do
     # DBConnection/Postgrex EXIT rather than raise when the pool is not started (`:noproc`)
     # or wedged (`{:timeout, {GenServer, :call, _}}`). Without this clause the exit
     # propagates out of `opts/1` and aborts the caller's ANN read — the OPPOSITE of the
-    # documented fail-closed guarantee. `:throw` is folded in for the same reason
-    # `ScaleMetrics.guarded_measurement/5` folds it in: it is the third non-local exit kind,
-    # and enumerating two of three is how this class of hole keeps reappearing.
-    kind, reason when kind in [:exit, :throw] ->
-      {:inconclusive, "#{kind}:" <> exit_tag(reason), :pool}
+    # documented fail-closed guarantee. That IS the saturation case, so it keeps `:pool`.
+    :exit, reason ->
+      {:inconclusive, "exit:" <> exit_tag(reason), :pool}
+
+    # A THROW is caught for the same reason (it is the third non-local exit kind, and
+    # enumerating two of three is how this class of hole keeps reappearing) but NOT
+    # classified `:pool`: nothing on this path throws today, so a thrown term is a CODE bug,
+    # not backend pressure, and `:pool` is the one class `cacheable_inconclusive?/1` lets
+    # into the negative cache — which would pin iterative scan OFF VM-wide for the negative
+    # TTL over a bug, the exact silent fleet-wide disabling that cache is fenced against.
+    :throw, value ->
+      {:inconclusive, "throw:" <> exit_tag(value), :unexpected}
   end
 
   @probe_sql "SELECT extversion FROM pg_extension WHERE extname = 'vector'"

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -56,6 +56,7 @@ defmodule Loopctl.HeavyRead do
 
   require Logger
 
+  alias Loopctl.ExitTag
   alias Loopctl.HeavyRead.TenantGate
   alias Loopctl.LocalGuc
 
@@ -893,10 +894,14 @@ defmodule Loopctl.HeavyRead do
   defp probe_failure_tag({:error, reason}) when is_atom(reason), do: "query_error:#{reason}"
   defp probe_failure_tag(_other), do: "unexpected_result"
 
-  defp exit_tag({:timeout, _}), do: "timeout"
-  defp exit_tag(:noproc), do: "noproc"
-  defp exit_tag(reason) when is_atom(reason), do: to_string(reason)
-  defp exit_tag(_reason), do: "other"
+  # The LAST private copy of the exit tagger, now delegating to the shared
+  # `Loopctl.ExitTag`. The four clauses this replaces produced the same string for every
+  # shape they actually named (`{:timeout, _}`, `:noproc`, any atom); they differed only in
+  # lacking the crash-PROPAGATION clause — a pooled process that died of an exception rather
+  # than being absent, which they degraded to the catch-all. The catch-all string moves
+  # `"other"` -> `"unknown"`; nothing asserts either, and this tag reaches only the cached
+  # inconclusive-reason string, never a metric label.
+  defp exit_tag(reason), do: ExitTag.tag(reason)
 
   @doc """
   Compare a `"MAJOR.MINOR[.PATCH]"` pgvector extversion against a `{maj, min, patch}` floor.

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -823,8 +823,11 @@ defmodule Loopctl.HeavyRead do
     # DBConnection/Postgrex EXIT rather than raise when the pool is not started (`:noproc`)
     # or wedged (`{:timeout, {GenServer, :call, _}}`). Without this clause the exit
     # propagates out of `opts/1` and aborts the caller's ANN read — the OPPOSITE of the
-    # documented fail-closed guarantee.
-    :exit, reason -> {:inconclusive, "exit:" <> exit_tag(reason), :pool}
+    # documented fail-closed guarantee. `:throw` is folded in for the same reason
+    # `ScaleMetrics.guarded_measurement/5` folds it in: it is the third non-local exit kind,
+    # and enumerating two of three is how this class of hole keeps reappearing.
+    kind, reason when kind in [:exit, :throw] ->
+      {:inconclusive, "#{kind}:" <> exit_tag(reason), :pool}
   end
 
   @probe_sql "SELECT extversion FROM pg_extension WHERE extname = 'vector'"

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -52,6 +52,7 @@ defmodule Loopctl.Knowledge do
   alias Loopctl.Egress.Policy, as: EgressPolicy
   alias Loopctl.Egress.Scope, as: EgressScope
   alias Loopctl.Embeddings
+  alias Loopctl.ExitTag
   alias Loopctl.HeavyRead
   alias Loopctl.KeysetSeek
   alias Loopctl.Knowledge.Analytics
@@ -5149,6 +5150,18 @@ defmodule Loopctl.Knowledge do
       else
         reraise(e, __STACKTRACE__)
       end
+  catch
+    # Both clauses above cover only the RAISE shape. A DBConnection checkout against a wedged
+    # or unstarted pool EXITS, so it escaped the rescue entirely and destroyed an
+    # ALREADY-COMPUTED suggestions response — turning a diagnostic read into a failed request,
+    # the exact trade the AREA-5 fail-soft contract at `maybe_signal_under_fill/8` forbids and
+    # that the `DBConnection.ConnectionError` clause above was written to prevent.
+    #
+    # Unlike the Postgrex clause there is no re-raise branch here: an exit carries no SQLSTATE
+    # to tell a genuine query bug from a pool fault, and this probe runs after the response is
+    # in hand, so degrading is the only answer that keeps the contract.
+    kind, reason when kind in [:exit, :throw] ->
+      under_fill_probe_degraded(tenant_id, {kind, ExitTag.tag(reason)})
   end
 
   @doc false
@@ -5182,6 +5195,12 @@ defmodule Loopctl.Knowledge do
 
   # Only reachable for 57014 — the caller re-raises every other SQLSTATE.
   defp probe_error_class(%Postgrex.Error{}), do: "timeout"
+
+  # The non-local-exit shapes, classified by `Loopctl.ExitTag` at the catch site and prefixed
+  # by KIND so a dead pool (`exit:noproc`) is distinguishable from a throw escaping the probe.
+  # Bounded: an atom or an exception MODULE name, never a message naming host/database/role.
+  defp probe_error_class({kind, tag}) when kind in [:exit, :throw] and is_binary(tag),
+    do: "#{kind}:#{tag}"
 
   @doc false
   # Per-read options for a heavy endpoint (US-27.4). Delegates to the single source of

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -52,6 +52,7 @@ defmodule Loopctl.Knowledge do
   alias Loopctl.Egress.Policy, as: EgressPolicy
   alias Loopctl.Egress.Scope, as: EgressScope
   alias Loopctl.Embeddings
+  alias Loopctl.ExitClass
   alias Loopctl.ExitTag
   alias Loopctl.HeavyRead
   alias Loopctl.KeysetSeek
@@ -5115,7 +5116,14 @@ defmodule Loopctl.Knowledge do
   # / body data. Returns `:error` (NOT raising) on a DB connectivity / timeout fault so the
   # caller can fail-soft — a genuine query bug still surfaces (we re-raise non-cancel
   # Postgrex errors).
-  defp under_fill_probe(tenant_id, article_id, embedding, threshold, vis, pool, opts) do
+  #
+  # Public-but-`@doc false` (same precedent as `under_fill_probe_degraded/2` below) and the
+  # read is taken from `opts[:probe_read]` — a CLOSURE seam, defaulting to `HeavyRead.one/3`
+  # — so a test can drive a real pool EXIT through THIS function and the `catch` below is
+  # verified where it lives, instead of only its classifier being asserted from a hand-built
+  # tuple (an inert guard passes that test either way).
+  @doc false
+  def under_fill_probe(tenant_id, article_id, embedding, threshold, vis, pool, opts) do
     candidates = suggestion_candidates_inner(tenant_id, article_id, embedding, vis, pool, opts)
 
     probe =
@@ -5127,9 +5135,17 @@ defmodule Loopctl.Knowledge do
         }
       )
 
-    case HeavyRead.one(tenant_id, probe, suggested_links_read_opts(pool, opts)) do
-      %{ann_candidates: a, above_threshold: t} -> {a || 0, t || 0}
-      nil -> {0, 0}
+    read = Keyword.get(opts, :probe_read, &HeavyRead.one/3)
+
+    case read.(tenant_id, probe, probe_read_opts(pool, opts)) do
+      %{ann_candidates: a, above_threshold: t} ->
+        {a || 0, t || 0}
+
+      nil ->
+        {0, 0}
+
+      {:error, :heavy_read_overloaded} ->
+        under_fill_probe_degraded(tenant_id, :heavy_read_overloaded)
     end
   rescue
     e in DBConnection.ConnectionError ->
@@ -5196,11 +5212,26 @@ defmodule Loopctl.Knowledge do
   # Only reachable for 57014 — the caller re-raises every other SQLSTATE.
   defp probe_error_class(%Postgrex.Error{}), do: "timeout"
 
+  # The per-tenant heavy-read gate SHEDDING this advisory read (`on_overload: :tag`, see
+  # `probe_read_opts/2`) — its own class, because "the tenant is at its in-flight cap" is a
+  # different operator action from a pool fault.
+  defp probe_error_class(:heavy_read_overloaded), do: "overloaded"
+
   # The non-local-exit shapes, classified by `Loopctl.ExitTag` at the catch site and prefixed
   # by KIND so a dead pool (`exit:noproc`) is distinguishable from a throw escaping the probe.
-  # Bounded: an atom or an exception MODULE name, never a message naming host/database/role.
+  # `ExitClass` closes the tag set: this is a Prometheus label multiplied by `tenant_id`, and
+  # `ExitTag` names ANY exit atom or exception MODULE, which is a log answer, not a label one.
   defp probe_error_class({kind, tag}) when kind in [:exit, :throw] and is_binary(tag),
-    do: "#{kind}:#{tag}"
+    do: ExitClass.bounded(kind, tag)
+
+  # The probe's read opts: the suggested-links opts plus `on_overload: :tag`. The API default
+  # (`:raise`) turns a `TenantGate` shed into `Loopctl.HeavyRead.OverloadedError` — an
+  # `:error`-kind raise named by neither `rescue` clause above nor the `:exit`/`:throw`
+  # `catch` — so at exactly the load the gate exists for it escaped and sank an
+  # ALREADY-COMPUTED 200 into a 429, the AREA-5 trade `maybe_signal_under_fill/8` forbids.
+  defp probe_read_opts(pool, opts) do
+    Keyword.put(suggested_links_read_opts(pool, opts), :on_overload, :tag)
+  end
 
   @doc false
   # Per-read options for a heavy endpoint (US-27.4). Delegates to the single source of

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -5117,13 +5117,27 @@ defmodule Loopctl.Knowledge do
   # caller can fail-soft — a genuine query bug still surfaces (we re-raise non-cancel
   # Postgrex errors).
   #
-  # Public-but-`@doc false` (same precedent as `under_fill_probe_degraded/2` below) and the
-  # read is taken from `opts[:probe_read]` — a CLOSURE seam, defaulting to `HeavyRead.one/3`
-  # — so a test can drive a real pool EXIT through THIS function and the `catch` below is
-  # verified where it lives, instead of only its classifier being asserted from a hand-built
-  # tuple (an inert guard passes that test either way).
+  # Public-but-`@doc false` (same precedent as `under_fill_probe_degraded/2` below) with the
+  # read as a DEFAULTED trailing ARGUMENT — so a test can drive a real pool EXIT through THIS
+  # function and the `catch` below is verified where it lives, instead of only its classifier
+  # being asserted from a hand-built tuple (an inert guard passes that test either way).
+  # Deliberately NOT read from `opts`: `opts` is threaded down from the public
+  # `suggest_links_with_meta/3`, so a stray `:probe_read` key would silently replace
+  # `HeavyRead.one/3` — and with it `HeavyRead.guard!/2`'s structural tenant-scoping — for
+  # anyone who ever passes caller-influenced opts through. A positional argument no public
+  # caller supplies cannot be reached that way.
   @doc false
-  def under_fill_probe(tenant_id, article_id, embedding, threshold, vis, pool, opts) do
+  def under_fill_probe(
+        tenant_id,
+        article_id,
+        embedding,
+        threshold,
+        vis,
+        pool,
+        opts,
+        read \\ &HeavyRead.one/3
+      )
+      when is_function(read, 3) do
     candidates = suggestion_candidates_inner(tenant_id, article_id, embedding, vis, pool, opts)
 
     probe =
@@ -5134,8 +5148,6 @@ defmodule Loopctl.Knowledge do
             fragment("COUNT(*) FILTER (WHERE ? > ?)", c.similarity_score, ^threshold)
         }
       )
-
-    read = Keyword.get(opts, :probe_read, &HeavyRead.one/3)
 
     case read.(tenant_id, probe, probe_read_opts(pool, opts)) do
       %{ann_candidates: a, above_threshold: t} ->

--- a/lib/loopctl/local_guc.ex
+++ b/lib/loopctl/local_guc.ex
@@ -153,13 +153,18 @@ defmodule Loopctl.LocalGuc do
         # is a RAISE, and therefore exactly what a `rescue` clause sees — the ingestion backlog
         # gate (`LoopctlWeb.KnowledgeIngestionController`) fails OPEN at 0, `Knowledge`'s
         # under-fill probe degrades to `:error`, and `ArticleLinkingWorker` skips its
-        # observational count — all tagging, none re-raising. That is a claim about the abort,
-        # NOT about the separate EXIT shape of a wedged pool checkout: only
-        # `ArticleLinkingWorker` and the `ScaleMetrics` pollers catch that today; the first two
-        # still let an exit escape their class-restricted rescue. An earlier revision of this
-        # comment said such rescues "re-raise ... Today's rescues deliberately do not", which
-        # read as an aspiration the call sites had not caught up with. They had; the sentence
-        # was wrong, and it contradicted the @doc twenty lines above it.
+        # observational count — all tagging, none re-raising.
+        #
+        # The separate EXIT shape of a wedged pool checkout is now covered at every one of
+        # those sites too (plus the `ScaleMetrics` pollers, via `guarded_measurement/5`), so
+        # the abort and the exit degrade the same way and differ only in their tag. They did
+        # not always: an earlier revision of this comment carried a qualifier naming the two
+        # sites that still let an exit escape a class-restricted `rescue`, which is what
+        # closing that gap removed.
+        #
+        # Further back, this comment claimed such rescues "re-raise ... Today's rescues
+        # deliberately do not", which read as an aspiration the call sites had not caught up
+        # with. They had; the sentence was wrong, and it contradicted the @doc above it.
         raise DBConnection.ConnectionError,
               "#{@capture_abort_tag} #{inspect(owned)}, which an enclosing scope " <>
                 "already overrode — refusing to set an override this transaction cannot " <>

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -39,10 +39,18 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # `validate_content_length/1` read the SAME number and cannot drift.
   @max_inline_content_bytes 1_000_000
 
-  # Ceiling on FAIL-OPEN admissions per tenant per window (see `backlog_fail_open_verdict/1`).
-  # Deliberately a constant, not an env var: it is a safety bound on a degraded mode, not a
-  # capacity knob, and `OBAN_INGEST_BACKLOG_MAX` (default 500) remains the tunable one.
-  @fail_open_admissions_per_window 30
+  # Ceiling on FAIL-OPEN admissions per tenant per window (see `backlog_fail_open_verdict/3`),
+  # denominated in JOBS — the same unit as `OBAN_INGEST_BACKLOG_MAX` — and charged one token
+  # per job. A REQUEST-denominated allowance was the wrong unit: `create_batch/2` admits up to
+  # @batch_max (50) items in ONE request, so 30 requests/min was really 1500 jobs/min, three
+  # times the 500 it was supposed to sit far below. Deliberately a constant, not an env var:
+  # it is a safety bound on a degraded mode, not a capacity knob, and
+  # `OBAN_INGEST_BACKLOG_MAX` remains the tunable one.
+  #
+  # Scope: PER NODE with the default `Loopctl.RateLimiter.Hammer` (node-local ETS), so the
+  # fleet bound is this value x the web-node count. `RATE_LIMITER=postgres` makes the same
+  # bucket cluster-global with no code change here.
+  @fail_open_jobs_per_window 100
   @fail_open_window_ms 60_000
   alias LoopctlWeb.Helpers.Pagination
   alias LoopctlWeb.Helpers.ProjectId
@@ -144,8 +152,12 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
            "\"ingestion_backlog_exceeded\"`, sets `Retry-After`) — the single-item path " <>
            "is gated on the SAME per-tenant backlog threshold as /ingest/batch so it " <>
            "cannot be looped to bypass the valve — or (2) the generic shared Hammer " <>
-           "request-rate limiter (NO `error.code`). Branch on the presence of `error.code`.",
-         "application/json",
+           "request-rate limiter (NO `error.code`). Branch on the presence of `error.code`." <>
+           "\n\n`ingestion_backlog_exceeded` covers TWO causes: your backlog is at/over the " <>
+           "threshold, OR the server could not MEASURE it (transient count-path fault) and " <>
+           "the bounded fail-open allowance for that fault is spent. The second is a " <>
+           "server-side condition, not a quota you can drain — honour `Retry-After` either " <>
+           "way.", "application/json",
          %OpenApiSpex.Schema{
            oneOf: [Schemas.IngestionBacklogError, Schemas.RateLimitError]
          }}
@@ -163,7 +175,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     # which endpoint the flood comes through. Checked AFTER require_llm_key so a keyless
     # tenant still gets the clearer 422 first.
     with :ok <- require_llm_key(tenant_id),
-         :ok <- check_ingestion_backlog(tenant_id) do
+         :ok <- check_ingestion_backlog(tenant_id, 1) do
       handle_create(conn, tenant_id, params)
     end
   end
@@ -251,7 +263,12 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
            "US-36.3 ingestion-backlog backpressure (`error.code: " <>
            "\"ingestion_backlog_exceeded\"`, sets `Retry-After`), or (2) the generic " <>
            "shared Hammer request-rate limiter (NO `error.code`; `error.message: " <>
-           "\"Rate limit exceeded\"`). Branch on the presence of `error.code`.",
+           "\"Rate limit exceeded\"`). Branch on the presence of `error.code`." <>
+           "\n\n`ingestion_backlog_exceeded` covers TWO causes: your backlog is at/over the " <>
+           "threshold, OR the server could not MEASURE it (transient count-path fault) and " <>
+           "the bounded fail-open allowance for that fault is spent — the allowance is " <>
+           "charged per ITEM, so a large batch spends it faster. The second is a server-side " <>
+           "condition, not a quota you can drain — honour `Retry-After` either way.",
          "application/json",
          %OpenApiSpex.Schema{
            oneOf: [Schemas.IngestionBacklogError, Schemas.RateLimitError]
@@ -270,7 +287,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     # all-or-nothing, no partial pile-up). US-36.3.
     with :ok <- require_llm_key(tenant_id),
          :ok <- validate_batch_items(items),
-         :ok <- check_ingestion_backlog(tenant_id) do
+         :ok <- check_ingestion_backlog(tenant_id, length(items)) do
       results = process_batch_items(tenant_id, items)
       json(conn, LoopctlWeb.KnowledgeIngestionJSON.batch(results))
     end
@@ -294,12 +311,12 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # is by design — this is a backpressure VALVE to stop runaway monopolization, not a
   # guaranteed ceiling. Operators tuning OBAN_INGEST_BACKLOG_MAX should read it as a
   # "start shedding around here" floor, not an enforced maximum.
-  defp check_ingestion_backlog(tenant_id) do
+  defp check_ingestion_backlog(tenant_id, jobs) do
     max = ObanConfig.ingest_backlog_max()
 
     case in_flight_ingestion_backlog(tenant_id) do
-      :unmeasurable ->
-        backlog_fail_open_verdict(tenant_id)
+      {:unmeasurable, error_class} ->
+        backlog_fail_open_verdict(tenant_id, error_class, jobs)
 
       count when count >= max ->
         {:error, :ingestion_backlog_exceeded, backlog_retry_after_seconds()}
@@ -309,27 +326,46 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     end
   end
 
-  # Fail open, but BOUNDED. Admitting on an unmeasurable count is right for the transient
-  # blip it was written for; the trouble is that the dominant fault here — a saturated or
-  # wedged AdminRepo pool (3 connections, `config/runtime.exs`) — is SUSTAINED, so an
-  # unconditional admit makes "no backpressure at all" the steady state during exactly the
-  # overload the valve exists to bound. (Before the exit shape was caught at all, the 500 at
-  # least shed the flood incidentally.) So the fail-open ADMISSIONS are themselves metered:
-  # `@fail_open_admissions_per_window` per tenant per `@fail_open_window_ms` pass, and the
-  # rest get the ordinary backlog 429 with its Retry-After — no new status code, no new error
-  # code. The allowance sits far below `OBAN_INGEST_BACKLOG_MAX` (default 500), so a real blip
-  # costs a legitimate client nothing. `within_limit?/3` is the fail-OPEN limiter helper, so a
+  # Fail open, but BOUNDED for the SUSTAINED faults. Admitting on an unmeasurable count is
+  # right for the transient blip it was written for; the trouble is that the dominant fault
+  # here — a saturated or wedged AdminRepo pool (3 connections, `config/runtime.exs`) — is
+  # SUSTAINED, so an unconditional admit makes "no backpressure at all" the steady state
+  # during exactly the overload the valve exists to bound. (Before the exit shape was caught
+  # at all, the 500 at least shed the flood incidentally.) So those admissions are metered in
+  # JOBS (`@fail_open_jobs_per_window` per tenant per `@fail_open_window_ms`), and the rest
+  # get the ordinary backlog 429 with its Retry-After — no new status code, no new error code.
+  # The allowance is well under `OBAN_INGEST_BACKLOG_MAX` (default 500), so a real blip costs
+  # a legitimate client nothing. `within_limit?/3` is the fail-OPEN limiter helper, so a
   # limiter fault cannot invert this into a fail-CLOSED gate.
-  defp backlog_fail_open_verdict(tenant_id) do
-    if RateLimiter.within_limit?(
-         "ingest_backlog_fail_open:#{tenant_id}",
-         @fail_open_window_ms,
-         @fail_open_admissions_per_window
-       ) do
-      :ok
+  defp backlog_fail_open_verdict(tenant_id, error_class, jobs) do
+    if not metered_fail_open?(error_class) or consume_fail_open_allowance(tenant_id, jobs) do
+      fail_open_admitted(tenant_id, error_class)
     else
       {:error, :ingestion_backlog_exceeded, backlog_retry_after_seconds()}
     end
+  end
+
+  # Meter ONLY the classes that mean sustained pool pressure. A broken count QUERY
+  # (`db_error`, e.g. 42703 after a `FairShare` change) and `LocalGuc`'s deliberate refusal
+  # (`guc_capture_abort`) are not backlog pressure at all, and metering them converted a
+  # silent-but-serving degradation into a fleet-wide cap that 429s an under-threshold tenant
+  # with a backlog error code it has not earned, over a fault that is not its backlog.
+  defp metered_fail_open?("connection"), do: true
+  defp metered_fail_open?("timeout"), do: true
+  defp metered_fail_open?("exit:" <> _tag), do: true
+  defp metered_fail_open?("throw:" <> _tag), do: true
+  defp metered_fail_open?(_class), do: false
+
+  # ONE token per JOB this request would enqueue, so the metered quantity is the same unit as
+  # `OBAN_INGEST_BACKLOG_MAX`. Charging keeps going after the first denial (`and` on the right)
+  # so a 50-item batch can never slip through on a 1-token remainder.
+  defp consume_fail_open_allowance(tenant_id, jobs) do
+    bucket = "ingest_backlog_fail_open:#{tenant_id}"
+
+    Enum.reduce(1..jobs//1, true, fn _job, within ->
+      RateLimiter.within_limit?(bucket, @fail_open_window_ms, @fail_open_jobs_per_window) and
+        within
+    end)
   end
 
   # FAIL OPEN on an UNMEASURABLE count only: an unreachable/timed-out backlog count must
@@ -341,11 +377,11 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # error in the count path therefore propagates and 500s, LOUD, rather than being silently
   # swallowed into a fleet-wide disabling of backpressure that looks healthy; a SQL-level one
   # (a bad query change) is still rescued, and gets its own `db_error` class so it is not
-  # mistaken for a timeout. On the fail-open path we ALSO emit a telemetry counter
-  # (`[:loopctl, :ingestion, :backlog_gate, :failed_open]`) so "the backpressure valve is
-  # currently admitting because it can't measure" is an alertable signal, not just a
-  # warning-log line, and a sustained per-request timeout under a real flood is visible on
-  # a dashboard instead of only as log spam. The count is resolved through a
+  # mistaken for a timeout. Every admitted fail-open ALSO emits a telemetry counter
+  # (`fail_open_admitted/2`) so "the backpressure valve is currently admitting because it
+  # can't measure" is an alertable signal, not just a warning-log line, and a sustained
+  # per-request timeout under a real flood is visible on a dashboard instead of only as log
+  # spam. The count is resolved through a
   # config-swappable DI seam (`Loopctl.Oban.FairShare` in prod, a Mox mock in test) so
   # this fail-open path is deterministically covered.
   defp in_flight_ingestion_backlog(tenant_id) do
@@ -359,7 +395,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     # eats an error because the count path is momentarily degraded. See
     # `Loopctl.LocalGuc.capture_abort?/1`.
     e in [DBConnection.ConnectionError, Postgrex.Error] ->
-      fail_open(tenant_id, e)
+      {:unmeasurable, fail_open_class(e)}
   catch
     # The rescue above covers only the RAISE shape, and a DBConnection checkout against a
     # wedged, saturated or unstarted pool EXITS instead. So the one failure this gate exists
@@ -367,17 +403,24 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     # ordinary ingest, which is the opposite of failing open. `:throw` is folded in for the
     # same reason `ScaleMetrics.guarded_measurement/5` folds it in: it is the third non-local
     # exit kind, and enumerating two of three is how this class of hole keeps reappearing.
+    # NOT `0` ("an empty backlog"), which admitted unconditionally and forever. The count is
+    # UNMEASURABLE, and `backlog_fail_open_verdict/3` decides how many such admissions a
+    # tenant gets before the valve closes again.
     kind, reason when kind in [:exit, :throw] ->
-      fail_open(tenant_id, {kind, ExitTag.tag(reason)})
+      {:unmeasurable, fail_open_class({kind, ExitTag.tag(reason)})}
   end
 
-  defp fail_open(tenant_id, e) do
-    error_class = fail_open_class(e)
-
-    # The bounded CLASS tag only, never `Exception.message/1`: a `Postgrex.Error` /
-    # `DBConnection.ConnectionError` message names the backend host, database and role
-    # ("tcp connect (host:port): ..."), and this line is reachable from any wedged-pool
-    # moment on an ordinary ingest. Same policy as `Loopctl.LocalGuc`'s own failure log.
+  # The ADMIT branch, and ONLY it: `TelemetryEvents.ingestion_backlog_gate_failed_open/0`
+  # documents itself as "the valve is currently ADMITTING because it can't measure", so
+  # emitting it for the metered REFUSALS too would over-report admissions during precisely
+  # the incident an operator alerts on — and the warning would claim a fail-open for a
+  # request that got a 429.
+  #
+  # The bounded CLASS tag only, never `Exception.message/1`: a `Postgrex.Error` /
+  # `DBConnection.ConnectionError` message names the backend host, database and role
+  # ("tcp connect (host:port): ..."), and this line is reachable from any wedged-pool
+  # moment on an ordinary ingest. Same policy as `Loopctl.LocalGuc`'s own failure log.
+  defp fail_open_admitted(tenant_id, error_class) do
     Logger.warning("ingestion backlog gate failed open for tenant=#{tenant_id} (#{error_class})")
 
     :telemetry.execute(
@@ -386,10 +429,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
       %{tenant_id: tenant_id, error_class: error_class}
     )
 
-    # NOT `0` ("an empty backlog"), which admitted unconditionally and forever. The count is
-    # UNMEASURABLE, and `backlog_fail_open_verdict/1` decides how many such admissions a
-    # tenant gets before the valve closes again.
-    :unmeasurable
+    :ok
   end
 
   # BOUNDED, and every value must be TRUE. The rescue above catches EVERY `Postgrex.Error`,

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -22,7 +22,6 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   alias Loopctl.Net.UrlGuard
   alias Loopctl.Oban.FairShare
   alias Loopctl.ObanConfig
-  alias Loopctl.RateLimiter
   alias Loopctl.TelemetryEvents
   alias Loopctl.Workers.ContentIngestionWorker
 
@@ -39,19 +38,6 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # `validate_content_length/1` read the SAME number and cannot drift.
   @max_inline_content_bytes 1_000_000
 
-  # Ceiling on FAIL-OPEN admissions per tenant per window (see `backlog_fail_open_verdict/3`),
-  # denominated in JOBS — the same unit as `OBAN_INGEST_BACKLOG_MAX` — and charged one token
-  # per job. A REQUEST-denominated allowance was the wrong unit: `create_batch/2` admits up to
-  # @batch_max (50) items in ONE request, so 30 requests/min was really 1500 jobs/min, three
-  # times the 500 it was supposed to sit far below. Deliberately a constant, not an env var:
-  # it is a safety bound on a degraded mode, not a capacity knob, and
-  # `OBAN_INGEST_BACKLOG_MAX` remains the tunable one.
-  #
-  # Scope: PER NODE with the default `Loopctl.RateLimiter.Hammer` (node-local ETS), so the
-  # fleet bound is this value x the web-node count. `RATE_LIMITER=postgres` makes the same
-  # bucket cluster-global with no code change here.
-  @fail_open_jobs_per_window 100
-  @fail_open_window_ms 60_000
   alias LoopctlWeb.Helpers.Pagination
   alias LoopctlWeb.Helpers.ProjectId
 
@@ -152,12 +138,8 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
            "\"ingestion_backlog_exceeded\"`, sets `Retry-After`) — the single-item path " <>
            "is gated on the SAME per-tenant backlog threshold as /ingest/batch so it " <>
            "cannot be looped to bypass the valve — or (2) the generic shared Hammer " <>
-           "request-rate limiter (NO `error.code`). Branch on the presence of `error.code`." <>
-           "\n\n`ingestion_backlog_exceeded` covers TWO causes: your backlog is at/over the " <>
-           "threshold, OR the server could not MEASURE it (transient count-path fault) and " <>
-           "the bounded fail-open allowance for that fault is spent. The second is a " <>
-           "server-side condition, not a quota you can drain — honour `Retry-After` either " <>
-           "way.", "application/json",
+           "request-rate limiter (NO `error.code`). Branch on the presence of `error.code`.",
+         "application/json",
          %OpenApiSpex.Schema{
            oneOf: [Schemas.IngestionBacklogError, Schemas.RateLimitError]
          }}
@@ -175,7 +157,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     # which endpoint the flood comes through. Checked AFTER require_llm_key so a keyless
     # tenant still gets the clearer 422 first.
     with :ok <- require_llm_key(tenant_id),
-         :ok <- check_ingestion_backlog(tenant_id, 1) do
+         :ok <- check_ingestion_backlog(tenant_id) do
       handle_create(conn, tenant_id, params)
     end
   end
@@ -263,12 +245,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
            "US-36.3 ingestion-backlog backpressure (`error.code: " <>
            "\"ingestion_backlog_exceeded\"`, sets `Retry-After`), or (2) the generic " <>
            "shared Hammer request-rate limiter (NO `error.code`; `error.message: " <>
-           "\"Rate limit exceeded\"`). Branch on the presence of `error.code`." <>
-           "\n\n`ingestion_backlog_exceeded` covers TWO causes: your backlog is at/over the " <>
-           "threshold, OR the server could not MEASURE it (transient count-path fault) and " <>
-           "the bounded fail-open allowance for that fault is spent — the allowance is " <>
-           "charged per ITEM, so a large batch spends it faster. The second is a server-side " <>
-           "condition, not a quota you can drain — honour `Retry-After` either way.",
+           "\"Rate limit exceeded\"`). Branch on the presence of `error.code`.",
          "application/json",
          %OpenApiSpex.Schema{
            oneOf: [Schemas.IngestionBacklogError, Schemas.RateLimitError]
@@ -287,7 +264,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     # all-or-nothing, no partial pile-up). US-36.3.
     with :ok <- require_llm_key(tenant_id),
          :ok <- validate_batch_items(items),
-         :ok <- check_ingestion_backlog(tenant_id, length(items)) do
+         :ok <- check_ingestion_backlog(tenant_id) do
       results = process_batch_items(tenant_id, items)
       json(conn, LoopctlWeb.KnowledgeIngestionJSON.batch(results))
     end
@@ -311,12 +288,12 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # is by design — this is a backpressure VALVE to stop runaway monopolization, not a
   # guaranteed ceiling. Operators tuning OBAN_INGEST_BACKLOG_MAX should read it as a
   # "start shedding around here" floor, not an enforced maximum.
-  defp check_ingestion_backlog(tenant_id, jobs) do
+  defp check_ingestion_backlog(tenant_id) do
     max = ObanConfig.ingest_backlog_max()
 
     case in_flight_ingestion_backlog(tenant_id) do
       {:unmeasurable, error_class} ->
-        backlog_fail_open_verdict(tenant_id, error_class, jobs)
+        fail_open_admitted(tenant_id, error_class)
 
       count when count >= max ->
         {:error, :ingestion_backlog_exceeded, backlog_retry_after_seconds()}
@@ -324,48 +301,6 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
       _count ->
         :ok
     end
-  end
-
-  # Fail open, but BOUNDED for the SUSTAINED faults. Admitting on an unmeasurable count is
-  # right for the transient blip it was written for; the trouble is that the dominant fault
-  # here — a saturated or wedged AdminRepo pool (3 connections, `config/runtime.exs`) — is
-  # SUSTAINED, so an unconditional admit makes "no backpressure at all" the steady state
-  # during exactly the overload the valve exists to bound. (Before the exit shape was caught
-  # at all, the 500 at least shed the flood incidentally.) So those admissions are metered in
-  # JOBS (`@fail_open_jobs_per_window` per tenant per `@fail_open_window_ms`), and the rest
-  # get the ordinary backlog 429 with its Retry-After — no new status code, no new error code.
-  # The allowance is well under `OBAN_INGEST_BACKLOG_MAX` (default 500), so a real blip costs
-  # a legitimate client nothing. `within_limit?/3` is the fail-OPEN limiter helper, so a
-  # limiter fault cannot invert this into a fail-CLOSED gate.
-  defp backlog_fail_open_verdict(tenant_id, error_class, jobs) do
-    if not metered_fail_open?(error_class) or consume_fail_open_allowance(tenant_id, jobs) do
-      fail_open_admitted(tenant_id, error_class)
-    else
-      {:error, :ingestion_backlog_exceeded, backlog_retry_after_seconds()}
-    end
-  end
-
-  # Meter ONLY the classes that mean sustained pool pressure. A broken count QUERY
-  # (`db_error`, e.g. 42703 after a `FairShare` change) and `LocalGuc`'s deliberate refusal
-  # (`guc_capture_abort`) are not backlog pressure at all, and metering them converted a
-  # silent-but-serving degradation into a fleet-wide cap that 429s an under-threshold tenant
-  # with a backlog error code it has not earned, over a fault that is not its backlog.
-  defp metered_fail_open?("connection"), do: true
-  defp metered_fail_open?("timeout"), do: true
-  defp metered_fail_open?("exit:" <> _tag), do: true
-  defp metered_fail_open?("throw:" <> _tag), do: true
-  defp metered_fail_open?(_class), do: false
-
-  # ONE token per JOB this request would enqueue, so the metered quantity is the same unit as
-  # `OBAN_INGEST_BACKLOG_MAX`. Charging keeps going after the first denial (`and` on the right)
-  # so a 50-item batch can never slip through on a 1-token remainder.
-  defp consume_fail_open_allowance(tenant_id, jobs) do
-    bucket = "ingest_backlog_fail_open:#{tenant_id}"
-
-    Enum.reduce(1..jobs//1, true, fn _job, within ->
-      RateLimiter.within_limit?(bucket, @fail_open_window_ms, @fail_open_jobs_per_window) and
-        within
-    end)
   end
 
   # FAIL OPEN on an UNMEASURABLE count only: an unreachable/timed-out backlog count must
@@ -403,18 +338,16 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     # ordinary ingest, which is the opposite of failing open. `:throw` is folded in for the
     # same reason `ScaleMetrics.guarded_measurement/5` folds it in: it is the third non-local
     # exit kind, and enumerating two of three is how this class of hole keeps reappearing.
-    # NOT `0` ("an empty backlog"), which admitted unconditionally and forever. The count is
-    # UNMEASURABLE, and `backlog_fail_open_verdict/3` decides how many such admissions a
-    # tenant gets before the valve closes again.
+    # Returns `{:unmeasurable, class}` rather than `0` ("an empty backlog") so the caller
+    # can tell "nothing queued" from "could not look", and so the fail-open is an explicit
+    # decision at one site instead of a magic zero flowing into a threshold comparison.
     kind, reason when kind in [:exit, :throw] ->
       {:unmeasurable, fail_open_class({kind, ExitTag.tag(reason)})}
   end
 
-  # The ADMIT branch, and ONLY it: `TelemetryEvents.ingestion_backlog_gate_failed_open/0`
-  # documents itself as "the valve is currently ADMITTING because it can't measure", so
-  # emitting it for the metered REFUSALS too would over-report admissions during precisely
-  # the incident an operator alerts on — and the warning would claim a fail-open for a
-  # request that got a 429.
+  # The ADMIT branch: `TelemetryEvents.ingestion_backlog_gate_failed_open/0` documents
+  # itself as "the valve is currently ADMITTING because it can't measure", so the counter
+  # and the warning belong here, where that is exactly what happened.
   #
   # The bounded CLASS tag only, never `Exception.message/1`: a `Postgrex.Error` /
   # `DBConnection.ConnectionError` message names the backend host, database and role

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -12,6 +12,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   require Logger
 
   alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.ExitTag
   alias Loopctl.HeavyRead
   alias Loopctl.Ingestion.ContentEnvelope
   alias Loopctl.Knowledge.ContentChunker
@@ -323,6 +324,15 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     # `Loopctl.LocalGuc.capture_abort?/1`.
     e in [DBConnection.ConnectionError, Postgrex.Error] ->
       fail_open(tenant_id, e)
+  catch
+    # The rescue above covers only the RAISE shape, and a DBConnection checkout against a
+    # wedged, saturated or unstarted pool EXITS instead. So the one failure this gate exists
+    # for — "the count path is momentarily degraded" — walked straight past it and 500'd an
+    # ordinary ingest, which is the opposite of failing open. `:throw` is folded in for the
+    # same reason `ScaleMetrics.guarded_measurement/5` folds it in: it is the third non-local
+    # exit kind, and enumerating two of three is how this class of hole keeps reappearing.
+    kind, reason when kind in [:exit, :throw] ->
+      fail_open(tenant_id, {kind, ExitTag.tag(reason)})
   end
 
   defp fail_open(tenant_id, e) do
@@ -353,6 +363,13 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
 
   defp fail_open_class(%Postgrex.Error{postgres: %{code: :query_canceled}}), do: "timeout"
   defp fail_open_class(%Postgrex.Error{}), do: "db_error"
+
+  # The non-local-exit shapes, already classified by `Loopctl.ExitTag` at the catch site.
+  # Prefixed by KIND so a triaging operator can tell a dead pool (`exit:noproc`) from a
+  # throw escaping the counter, and still BOUNDED — `ExitTag` yields an atom or an
+  # exception module name, never a message carrying host, database, role or query args.
+  defp fail_open_class({kind, tag}) when kind in [:exit, :throw] and is_binary(tag),
+    do: "#{kind}:#{tag}"
 
   defp backlog_counter do
     Application.get_env(:loopctl, :ingestion_backlog_counter, FairShare)

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -12,6 +12,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   require Logger
 
   alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.ExitClass
   alias Loopctl.ExitTag
   alias Loopctl.HeavyRead
   alias Loopctl.Ingestion.ContentEnvelope
@@ -21,6 +22,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   alias Loopctl.Net.UrlGuard
   alias Loopctl.Oban.FairShare
   alias Loopctl.ObanConfig
+  alias Loopctl.RateLimiter
   alias Loopctl.TelemetryEvents
   alias Loopctl.Workers.ContentIngestionWorker
 
@@ -36,6 +38,12 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # `operation/2` specs, so the published OpenAPI `maxLength` and the enforcing
   # `validate_content_length/1` read the SAME number and cannot drift.
   @max_inline_content_bytes 1_000_000
+
+  # Ceiling on FAIL-OPEN admissions per tenant per window (see `backlog_fail_open_verdict/1`).
+  # Deliberately a constant, not an env var: it is a safety bound on a degraded mode, not a
+  # capacity knob, and `OBAN_INGEST_BACKLOG_MAX` (default 500) remains the tunable one.
+  @fail_open_admissions_per_window 30
+  @fail_open_window_ms 60_000
   alias LoopctlWeb.Helpers.Pagination
   alias LoopctlWeb.Helpers.ProjectId
 
@@ -289,10 +297,38 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   defp check_ingestion_backlog(tenant_id) do
     max = ObanConfig.ingest_backlog_max()
 
-    if in_flight_ingestion_backlog(tenant_id) >= max do
-      {:error, :ingestion_backlog_exceeded, backlog_retry_after_seconds()}
-    else
+    case in_flight_ingestion_backlog(tenant_id) do
+      :unmeasurable ->
+        backlog_fail_open_verdict(tenant_id)
+
+      count when count >= max ->
+        {:error, :ingestion_backlog_exceeded, backlog_retry_after_seconds()}
+
+      _count ->
+        :ok
+    end
+  end
+
+  # Fail open, but BOUNDED. Admitting on an unmeasurable count is right for the transient
+  # blip it was written for; the trouble is that the dominant fault here — a saturated or
+  # wedged AdminRepo pool (3 connections, `config/runtime.exs`) — is SUSTAINED, so an
+  # unconditional admit makes "no backpressure at all" the steady state during exactly the
+  # overload the valve exists to bound. (Before the exit shape was caught at all, the 500 at
+  # least shed the flood incidentally.) So the fail-open ADMISSIONS are themselves metered:
+  # `@fail_open_admissions_per_window` per tenant per `@fail_open_window_ms` pass, and the
+  # rest get the ordinary backlog 429 with its Retry-After — no new status code, no new error
+  # code. The allowance sits far below `OBAN_INGEST_BACKLOG_MAX` (default 500), so a real blip
+  # costs a legitimate client nothing. `within_limit?/3` is the fail-OPEN limiter helper, so a
+  # limiter fault cannot invert this into a fail-CLOSED gate.
+  defp backlog_fail_open_verdict(tenant_id) do
+    if RateLimiter.within_limit?(
+         "ingest_backlog_fail_open:#{tenant_id}",
+         @fail_open_window_ms,
+         @fail_open_admissions_per_window
+       ) do
       :ok
+    else
+      {:error, :ingestion_backlog_exceeded, backlog_retry_after_seconds()}
     end
   end
 
@@ -350,7 +386,10 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
       %{tenant_id: tenant_id, error_class: error_class}
     )
 
-    0
+    # NOT `0` ("an empty backlog"), which admitted unconditionally and forever. The count is
+    # UNMEASURABLE, and `backlog_fail_open_verdict/1` decides how many such admissions a
+    # tenant gets before the valve closes again.
+    :unmeasurable
   end
 
   # BOUNDED, and every value must be TRUE. The rescue above catches EVERY `Postgrex.Error`,
@@ -364,12 +403,14 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   defp fail_open_class(%Postgrex.Error{postgres: %{code: :query_canceled}}), do: "timeout"
   defp fail_open_class(%Postgrex.Error{}), do: "db_error"
 
-  # The non-local-exit shapes, already classified by `Loopctl.ExitTag` at the catch site.
+  # The non-local-exit shapes, already tagged by `Loopctl.ExitTag` at the catch site.
   # Prefixed by KIND so a triaging operator can tell a dead pool (`exit:noproc`) from a
-  # throw escaping the counter, and still BOUNDED — `ExitTag` yields an atom or an
-  # exception module name, never a message carrying host, database, role or query args.
+  # throw escaping the counter, and closed by `ExitClass` so the value set stays ENUMERABLE:
+  # this string is a Prometheus label multiplied by `tenant_id`, and `ExitTag` names any exit
+  # atom or exception MODULE — bounded away from the raw reason (host, database, role, query
+  # args) but not bounded as a label.
   defp fail_open_class({kind, tag}) when kind in [:exit, :throw] and is_binary(tag),
-    do: "#{kind}:#{tag}"
+    do: ExitClass.bounded(kind, tag)
 
   defp backlog_counter do
     Application.get_env(:loopctl, :ingestion_backlog_counter, FairShare)

--- a/lib/loopctl_web/telemetry.ex
+++ b/lib/loopctl_web/telemetry.ex
@@ -154,13 +154,21 @@ defmodule LoopctlWeb.Telemetry do
     # poller or the other measurements (including the gate refresh). What it DOES do
     # is worse for the raising measurement specifically: telemetry_poller logs the
     # raise once and PERMANENTLY DROPS that MFA from the poll rotation until the next
-    # app restart — the gauge/effect goes dark forever, silently. So EVERY measurement
-    # added here MUST still be self-rescuing (a catch-all rescue, not just the DB-fault
-    # classes) so it is never itself the one that goes dark. `refresh_tenant_label_gate/0`
-    # guards its only raising op (the DB count) with try/rescue (fail-soft to a bounded
-    # gate); the two Oban pollers below use a catch-all rescue (US-34.1, review finding)
-    # plus a poll-failure counter so a stale gauge is detectable. Keep that invariant
-    # for future additions.
+    # app restart — the gauge/effect goes dark forever, silently.
+    #
+    # So EVERY measurement added here MUST run its body under
+    # `ScaleMetrics.guarded_measurement/5`, which covers ALL THREE non-local exit kinds:
+    # `rescue` + `catch :exit` + `catch :throw`, each degrading to a caller-supplied
+    # fallback and firing the `loopctl.oban.poll.error.count` counter so a stale gauge is
+    # detectable.
+    #
+    # An earlier version of this note asked only for "a catch-all rescue", and that
+    # wording is exactly how this bug reached production: a DBConnection checkout against
+    # a wedged, saturated or unstarted pool EXITS rather than raising, so every
+    # measurement here satisfied the stated invariant and still went permanently dark on
+    # the most likely fault. telemetry_poller drops the MFA on an exit and a throw the
+    # same way it does on a raise — enumerating one of the three is not a partial
+    # guarantee, it is none. Do not weaken this back to "rescue".
     [
       # US-27.15: refresh the metrics tenant-label cardinality gate (Tenants.count()
       # <= cap), caching the boolean in :persistent_term so the per-emit tag_values
@@ -168,19 +176,19 @@ defmodule LoopctlWeb.Telemetry do
       {ScaleMetrics, :refresh_tenant_label_gate, []},
 
       # US-34.1 (AC-34.1.1/.3): per-{state, queue} poll of the GLOBAL `oban_jobs`
-      # table, feeding the `loopctl.oban.jobs.count` gauge. Self-rescuing
-      # (catch-all rescue, per the note above) and reports failures via the
+      # table, feeding the `loopctl.oban.jobs.count` gauge. Guarded per the note
+      # above (`guarded_measurement/5`) and reports failures via the
       # `loopctl.oban.poll.error.count` counter.
       {ScaleMetrics, :poll_oban_queue_state, []},
 
       # US-34.1 (AC-34.1.2/.3): the `:executing`-older-than-N-min orphan poll,
       # feeding the `loopctl.oban.jobs.executing_orphan.count` gauge. Same
-      # self-rescuing contract.
+      # guarded-measurement contract.
       {ScaleMetrics, :poll_oban_executing_orphans, []},
 
       # US-38.3 (AC-38.3.2): the clustering-readiness peer poll, feeding the
       # `loopctl.cluster.peers.count` gauge from `Loopctl.ClusterReadiness.readiness/0`
-      # (peer COUNT + bounded `status`, never node names). Self-rescuing, same contract.
+      # (peer COUNT + bounded `status`, never node names). Same guarded contract.
       {ScaleMetrics, :poll_cluster_readiness, []}
     ]
   end

--- a/test/loopctl/knowledge/under_fill_probe_degraded_test.exs
+++ b/test/loopctl/knowledge/under_fill_probe_degraded_test.exs
@@ -16,6 +16,7 @@ defmodule Loopctl.Knowledge.UnderFillProbeDegradedTest do
 
   import ExUnit.CaptureLog
 
+  alias Loopctl.ExitTag
   alias Loopctl.Knowledge
   alias Loopctl.LocalGuc
   alias Loopctl.TelemetryEvents
@@ -80,6 +81,28 @@ defmodule Loopctl.Knowledge.UnderFillProbeDegradedTest do
 
     assert :error = Knowledge.under_fill_probe_degraded(tenant_id, cancel)
     assert_receive {:probe_degraded, %{count: 1}, %{error_class: "timeout"}}
+  end
+
+  test "a pool EXIT degrades under a kind-prefixed, bounded class" do
+    # The probe's two rescue clauses cover only the RAISE shape. A DBConnection checkout
+    # against a wedged or unstarted pool EXITS, escaping them entirely and destroying an
+    # ALREADY-COMPUTED suggestions response — turning a diagnostic read into a failed
+    # request, which is the trade the `DBConnection.ConnectionError` clause exists to
+    # prevent. `Loopctl.ExitTag` classifies the reason; the kind prefix keeps a dead pool
+    # distinguishable from a throw.
+    tenant_id = Ecto.UUID.generate()
+    attach_degraded(tenant_id)
+
+    assert :error =
+             Knowledge.under_fill_probe_degraded(
+               tenant_id,
+               {:exit, ExitTag.tag({:noproc, {DBConnection, :execute, []}})}
+             )
+
+    assert_receive {:probe_degraded, %{count: 1}, metadata}
+    assert metadata.error_class == "exit:noproc"
+    # Bounded: never the raw reason, which carries the DBConnection call tuple.
+    refute metadata.error_class =~ "DBConnection"
   end
 
   test "the log carries the class tag, never the backend host from the exception message" do

--- a/test/loopctl/knowledge/under_fill_probe_degraded_test.exs
+++ b/test/loopctl/knowledge/under_fill_probe_degraded_test.exs
@@ -16,7 +16,6 @@ defmodule Loopctl.Knowledge.UnderFillProbeDegradedTest do
 
   import ExUnit.CaptureLog
 
-  alias Loopctl.ExitTag
   alias Loopctl.Knowledge
   alias Loopctl.LocalGuc
   alias Loopctl.TelemetryEvents
@@ -83,26 +82,47 @@ defmodule Loopctl.Knowledge.UnderFillProbeDegradedTest do
     assert_receive {:probe_degraded, %{count: 1}, %{error_class: "timeout"}}
   end
 
-  test "a pool EXIT degrades under a kind-prefixed, bounded class" do
-    # The probe's two rescue clauses cover only the RAISE shape. A DBConnection checkout
-    # against a wedged or unstarted pool EXITS, escaping them entirely and destroying an
-    # ALREADY-COMPUTED suggestions response — turning a diagnostic read into a failed
-    # request, which is the trade the `DBConnection.ConnectionError` clause exists to
-    # prevent. `Loopctl.ExitTag` classifies the reason; the kind prefix keeps a dead pool
-    # distinguishable from a throw.
+  # Drives the REAL `under_fill_probe/7` — its `catch`, not just the classifier it feeds —
+  # through the `:probe_read` closure seam (default `HeavyRead.one/3`), because a wedged pool
+  # cannot be conjured in a sandboxed async test. Without it, deleting the catch left green.
+  defp probe(tenant_id, read) do
+    embedding = List.duplicate(0.0, 1536)
+
+    Knowledge.under_fill_probe(tenant_id, Ecto.UUID.generate(), embedding, 0.5, nil, 10,
+      probe_read: read
+    )
+  end
+
+  test "an EXIT escaping the probe's read degrades, under a CLOSED label set" do
+    tenant_id = Ecto.UUID.generate()
+    attach_degraded(tenant_id)
+
+    # The REAL shape DBConnection exits with when the pool is gone — `{reason, call}`.
+    assert :error =
+             probe(tenant_id, fn _t, _q, _o -> exit({:noproc, {DBConnection, :execute, []}}) end)
+
+    assert_receive {:probe_degraded, %{count: 1}, %{error_class: "exit:noproc"}}
+
+    # `error_class` is a Prometheus label multiplied by `tenant_id`, and `ExitTag` alone names
+    # ANY exit atom or exception MODULE, so an unrecognised reason must collapse.
+    assert :error = probe(tenant_id, fn _t, _q, _o -> exit(:some_novel_reason) end)
+    assert_receive {:probe_degraded, %{count: 1}, %{error_class: "exit:other"}}
+  end
+
+  test "a tenant-gate shed is TAGGED and degraded, never raised past the guards" do
+    # `HeavyRead.one/3` defaults to `on_overload: :raise`, and `OverloadedError` is named by
+    # neither rescue clause nor the `:exit`/`:throw` catch — so it escaped at exactly the load
+    # the gate exists for, 429ing a response already in hand.
     tenant_id = Ecto.UUID.generate()
     attach_degraded(tenant_id)
 
     assert :error =
-             Knowledge.under_fill_probe_degraded(
-               tenant_id,
-               {:exit, ExitTag.tag({:noproc, {DBConnection, :execute, []}})}
-             )
+             probe(tenant_id, fn _t, _q, opts ->
+               assert Keyword.fetch!(opts, :on_overload) == :tag
+               {:error, :heavy_read_overloaded}
+             end)
 
-    assert_receive {:probe_degraded, %{count: 1}, metadata}
-    assert metadata.error_class == "exit:noproc"
-    # Bounded: never the raw reason, which carries the DBConnection call tuple.
-    refute metadata.error_class =~ "DBConnection"
+    assert_receive {:probe_degraded, %{count: 1}, %{error_class: "overloaded"}}
   end
 
   test "the log carries the class tag, never the backend host from the exception message" do

--- a/test/loopctl/knowledge/under_fill_probe_degraded_test.exs
+++ b/test/loopctl/knowledge/under_fill_probe_degraded_test.exs
@@ -82,15 +82,15 @@ defmodule Loopctl.Knowledge.UnderFillProbeDegradedTest do
     assert_receive {:probe_degraded, %{count: 1}, %{error_class: "timeout"}}
   end
 
-  # Drives the REAL `under_fill_probe/7` — its `catch`, not just the classifier it feeds —
-  # through the `:probe_read` closure seam (default `HeavyRead.one/3`), because a wedged pool
+  # Drives the REAL `under_fill_probe/8` — its `catch`, not just the classifier it feeds —
+  # through the trailing read ARGUMENT (default `HeavyRead.one/3`), because a wedged pool
   # cannot be conjured in a sandboxed async test. Without it, deleting the catch left green.
+  # A positional argument, never an `opts` key: `opts` is caller-threaded, and a seam that
+  # can be reached from there can displace `HeavyRead`'s tenant guard.
   defp probe(tenant_id, read) do
     embedding = List.duplicate(0.0, 1536)
 
-    Knowledge.under_fill_probe(tenant_id, Ecto.UUID.generate(), embedding, 0.5, nil, 10,
-      probe_read: read
-    )
+    Knowledge.under_fill_probe(tenant_id, Ecto.UUID.generate(), embedding, 0.5, nil, 10, [], read)
   end
 
   test "an EXIT escaping the probe's read degrades, under a CLOSED label set" do

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -1033,6 +1033,40 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert metadata.error_class == "guc_capture_abort"
     end
 
+    test "a pool EXIT fails open too, instead of 500ing the ingest", %{conn: conn} do
+      # The gate rescued only the RAISE shape, but a DBConnection checkout against a wedged,
+      # saturated or unstarted pool EXITS. So the single failure this gate exists for — an
+      # unmeasurable count — walked past the rescue and 500'd an ordinary ingest, which is
+      # the exact opposite of failing open. The exit shape is the MORE likely one under real
+      # pool pressure, so this was the common case, not the exotic one.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
+
+      # The REAL shape DBConnection exits with when the pool is gone — a `{reason, call}`
+      # tuple, never a bare atom. A tagger with only an atom clause would pass against
+      # `exit(:noproc)` while degrading every production exit to a catch-all.
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        exit({:noproc, {DBConnection, :execute, []}})
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Pool exit item", source_type: "newsletter"}]
+        })
+
+      assert length(json_response(conn, 200)["data"]) == 1
+
+      # Kind-prefixed and BOUNDED: an operator can tell a dead pool from a throw, and the
+      # tag can never carry the DBConnection call tuple (host, database, role, query args).
+      assert_receive {:backlog_failed_open, %{count: 1}, metadata}
+      assert metadata.error_class == "exit:noproc"
+      refute metadata.error_class =~ "DBConnection"
+    end
+
     test "a NON-timeout SQLSTATE is not reported as a timeout", %{conn: conn} do
       # The rescue catches EVERY `Postgrex.Error`, not only 57014, so a query bug in the
       # count path (a column renamed out from under `FairShare`) also fails open. It must

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -1067,98 +1067,6 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       refute metadata.error_class =~ "DBConnection"
     end
 
-    test "the fail-open admissions are BOUNDED, not unconditional", %{conn: conn} do
-      # A wedged AdminRepo pool is SUSTAINED, so admitting on every unmeasurable count made
-      # "no backpressure at all" the steady state during exactly the overload the valve
-      # exists to bound. The admissions are now metered: past the per-tenant allowance the
-      # request gets the ordinary backlog 429 instead of enqueuing.
-      tenant = keyed_tenant()
-      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
-
-      # The counter means "the valve is currently ADMITTING because it can't measure", so a
-      # REFUSAL must not fire it — otherwise it over-reports admissions during exactly the
-      # incident an operator alerts on.
-      attach_failed_open(tenant.id)
-
-      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
-        exit({:noproc, {DBConnection, :execute, []}})
-      end)
-
-      # The allowance is spent — the limiter, not the (unmeasurable) count, is the decider.
-      # Scoped to the fail-open bucket alone: the auth pipeline shares this limiter, and
-      # denying THAT would 429 the request for an unrelated reason and prove nothing.
-      test_pid = self()
-
-      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
-        if String.starts_with?(bucket, "ingest_backlog_fail_open:") do
-          send(test_pid, {:fail_open_bucket, bucket})
-          {:deny, limit}
-        else
-          {:allow, 1}
-        end
-      end)
-
-      expect(Loopctl.MockContentExtractor, :extract_from_content, 0, fn _t, _c, _o ->
-        flunk("nothing may be enqueued once the fail-open allowance is spent")
-      end)
-
-      conn =
-        conn
-        |> auth_conn(raw_key)
-        |> post(~p"/api/v1/knowledge/ingest/batch", %{
-          items: [%{content: "Beyond the fail-open allowance", source_type: "newsletter"}]
-        })
-
-      assert json_response(conn, 429)["error"]["code"] == "ingestion_backlog_exceeded"
-
-      # Per-TENANT: one flooding tenant spending its allowance must not close the valve on
-      # everyone else.
-      assert_receive {:fail_open_bucket, bucket}
-      assert bucket =~ tenant.id
-
-      refute_receive {:backlog_failed_open, _measurements, _metadata}, 20
-    end
-
-    test "the fail-open allowance is charged per ITEM, not per request", %{conn: conn} do
-      # A REQUEST-denominated allowance was the wrong unit: one batch request enqueues up to
-      # @batch_max (50) jobs, so metering requests let a sustained fault admit 50x the bound
-      # it advertised — above `OBAN_INGEST_BACKLOG_MAX` instead of far below it. Each item
-      # must spend one token, so the meter is in the same unit as the threshold.
-      tenant = keyed_tenant()
-      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
-
-      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
-        exit({:noproc, {DBConnection, :execute, []}})
-      end)
-
-      test_pid = self()
-
-      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, _limit ->
-        if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
-          do: send(test_pid, :fail_open_token)
-
-        {:allow, 1}
-      end)
-
-      conn =
-        conn
-        |> auth_conn(raw_key)
-        |> post(~p"/api/v1/knowledge/ingest/batch", %{
-          items: [
-            %{content: "Metered item one", source_type: "newsletter"},
-            %{content: "Metered item two", source_type: "newsletter"},
-            %{content: "Metered item three", source_type: "newsletter"}
-          ]
-        })
-
-      assert length(json_response(conn, 200)["data"]) == 3
-
-      assert_receive :fail_open_token
-      assert_receive :fail_open_token
-      assert_receive :fail_open_token
-      refute_receive :fail_open_token, 20
-    end
-
     test "a NON-timeout SQLSTATE is not reported as a timeout", %{conn: conn} do
       # The rescue catches EVERY `Postgrex.Error`, not only 57014, so a query bug in the
       # count path (a column renamed out from under `FairShare`) also fails open. It must
@@ -1173,15 +1081,6 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
         raise %Postgrex.Error{
           postgres: %{code: :undefined_column, message: "column j.args does not exist"}
         }
-      end)
-
-      # ...and it is NOT metered: a broken count QUERY is not backlog pressure, so capping it
-      # would 429 an under-threshold tenant with a backlog code it has not earned. Even with
-      # the fail-open allowance fully spent, this class still admits.
-      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
-        if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
-          do: {:deny, limit},
-          else: {:allow, 1}
       end)
 
       conn =

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -1075,6 +1075,11 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
+      # The counter means "the valve is currently ADMITTING because it can't measure", so a
+      # REFUSAL must not fire it — otherwise it over-reports admissions during exactly the
+      # incident an operator alerts on.
+      attach_failed_open(tenant.id)
+
       expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
         exit({:noproc, {DBConnection, :execute, []}})
       end)
@@ -1110,6 +1115,48 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       # everyone else.
       assert_receive {:fail_open_bucket, bucket}
       assert bucket =~ tenant.id
+
+      refute_receive {:backlog_failed_open, _measurements, _metadata}, 20
+    end
+
+    test "the fail-open allowance is charged per ITEM, not per request", %{conn: conn} do
+      # A REQUEST-denominated allowance was the wrong unit: one batch request enqueues up to
+      # @batch_max (50) jobs, so metering requests let a sustained fault admit 50x the bound
+      # it advertised — above `OBAN_INGEST_BACKLOG_MAX` instead of far below it. Each item
+      # must spend one token, so the meter is in the same unit as the threshold.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        exit({:noproc, {DBConnection, :execute, []}})
+      end)
+
+      test_pid = self()
+
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, _limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
+          do: send(test_pid, :fail_open_token)
+
+        {:allow, 1}
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [
+            %{content: "Metered item one", source_type: "newsletter"},
+            %{content: "Metered item two", source_type: "newsletter"},
+            %{content: "Metered item three", source_type: "newsletter"}
+          ]
+        })
+
+      assert length(json_response(conn, 200)["data"]) == 3
+
+      assert_receive :fail_open_token
+      assert_receive :fail_open_token
+      assert_receive :fail_open_token
+      refute_receive :fail_open_token, 20
     end
 
     test "a NON-timeout SQLSTATE is not reported as a timeout", %{conn: conn} do
@@ -1126,6 +1173,15 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
         raise %Postgrex.Error{
           postgres: %{code: :undefined_column, message: "column j.args does not exist"}
         }
+      end)
+
+      # ...and it is NOT metered: a broken count QUERY is not backlog pressure, so capping it
+      # would 429 an under-threshold tenant with a backlog code it has not earned. Even with
+      # the fail-open allowance fully spent, this class still admits.
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
+          do: {:deny, limit},
+          else: {:allow, 1}
       end)
 
       conn =

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -1067,6 +1067,51 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       refute metadata.error_class =~ "DBConnection"
     end
 
+    test "the fail-open admissions are BOUNDED, not unconditional", %{conn: conn} do
+      # A wedged AdminRepo pool is SUSTAINED, so admitting on every unmeasurable count made
+      # "no backpressure at all" the steady state during exactly the overload the valve
+      # exists to bound. The admissions are now metered: past the per-tenant allowance the
+      # request gets the ordinary backlog 429 instead of enqueuing.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        exit({:noproc, {DBConnection, :execute, []}})
+      end)
+
+      # The allowance is spent — the limiter, not the (unmeasurable) count, is the decider.
+      # Scoped to the fail-open bucket alone: the auth pipeline shares this limiter, and
+      # denying THAT would 429 the request for an unrelated reason and prove nothing.
+      test_pid = self()
+
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:") do
+          send(test_pid, {:fail_open_bucket, bucket})
+          {:deny, limit}
+        else
+          {:allow, 1}
+        end
+      end)
+
+      expect(Loopctl.MockContentExtractor, :extract_from_content, 0, fn _t, _c, _o ->
+        flunk("nothing may be enqueued once the fail-open allowance is spent")
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Beyond the fail-open allowance", source_type: "newsletter"}]
+        })
+
+      assert json_response(conn, 429)["error"]["code"] == "ingestion_backlog_exceeded"
+
+      # Per-TENANT: one flooding tenant spending its allowance must not close the valve on
+      # everyone else.
+      assert_receive {:fail_open_bucket, bucket}
+      assert bucket =~ tenant.id
+    end
+
     test "a NON-timeout SQLSTATE is not reported as a timeout", %{conn: conn} do
       # The rescue catches EVERY `Postgrex.Error`, not only 57014, so a query bug in the
       # count path (a column renamed out from under `FairShare`) also fails open. It must


### PR DESCRIPTION
Final PR of the #551 chain. It closes the defect class #553 opened, in the last four places that carried it.

**A fail-soft guard that only catches raises is not fail-soft.** A DBConnection checkout against a wedged, saturated or unstarted pool **exits**; it does not raise. Every site below caught one of the two shapes and missed the other — and the exit is the *more* likely one under real pool pressure, so it was the common case, not the exotic one.

Two of these are live **request-path** bugs, not observability.

## 1. The ingestion backlog gate 500'd instead of failing open

`in_flight_ingestion_backlog/1` rescued only `DBConnection.ConnectionError` and `Postgrex.Error`, so the single failure the gate exists for — an unmeasurable count — walked past it and turned an ordinary ingest into a 500. The gate's whole purpose is that an innocent, under-threshold tenant never eats an error because the count path is momentarily degraded; on the most likely fault it did exactly that.

It now returns `{:unmeasurable, class}` rather than a magic `0`, so the caller can tell "nothing queued" from "could not look", and the fail-open is an explicit decision at one site instead of a zero flowing into a threshold comparison.

## 2. The under-fill probe destroyed an already-computed response

Same hole, worse consequence: the probe runs *only after* the suggestions are in hand, so an escaping exit traded a valid 200 for a failed request over a diagnostic read — what its `DBConnection.ConnectionError` clause was written to prevent, and what the AREA-5 fail-soft contract forbids.

Unlike the `Postgrex.Error` clause there is deliberately **no re-raise branch**: an exit carries no SQLSTATE, so there is no way to tell a query bug from a pool fault.

Review additions here: `HeavyRead.OverloadedError` (a TenantGate shed) also escaped both rescues, turning an already-computed 200 into a 429 — now degrades under an `"overloaded"` class. The read is behind a proper DI seam (`under_fill_probe/8` with a defaulted trailing `read`), deliberately **not** on caller-threaded opts, so a stray `:probe_read` key cannot displace `HeavyRead.guard!/2`'s tenant scoping.

## 3. `HeavyRead.exit_tag/1` — the last copy

Named the same shapes as the shared `Loopctl.ExitTag` and differed only in lacking the **crash-propagation** clause, which it degraded to a catch-all. Now delegates. Catch-all string moves `"other"` → `"unknown"`; nothing asserts either, and this tag reaches only a cached inconclusive-reason string.

Review addition: the probe's catch is split so `:exit` keeps the negative-cacheable `:pool` class while `:throw` gets an **uncacheable** `:unexpected` class — a code bug can no longer pin iterative scan off fleet-wide, the exact failure #547 exists to prevent.

## 4. The invariant note that would have reproduced this

`periodic_measurements/0` told the next author a **catch-all rescue** sufficed — and that wording is how the bug reached production: every measurement satisfied the stated invariant and still went permanently dark on the most likely fault, because `telemetry_poller` drops the MFA on an exit and a throw the same way it does on a raise. It now requires `ScaleMetrics.guarded_measurement/5` and says why enumerating one of three kinds is not a partial guarantee but none.

## 5. `Loopctl.ExitClass` (new)

`error_class` had stopped being an enumerable Prometheus label — `ExitTag` emits arbitrary atoms and exception module names, multiplied by `tenant_id`. `ExitClass` collapses an `ExitTag` onto a closed metric-label set, shared by both call sites rather than duplicated.

## Correction

An earlier version of this description claimed "guards mutation-verified" across the board. **That was overstated.** All four reviewers found the `catch :exit` I added to `under_fill_probe/7` was **mutation-inert**: my test called `under_fill_probe_degraded/2` directly, exercising the *classifier* and never the catch block, so deleting the catch failed nothing. The backlog-gate guard was genuinely verified; that one was not. It now has a real-path test through the DI seam, and deleting the catch fails 2 tests.

## Split out, not dropped

The review also added a **metered** fail-open: under sustained pool pressure a tenant would get a 429 once a per-tenant job allowance was spent, instead of always being admitted. The hole is real — an unconditional fail-open makes "no backpressure at all" the steady state during exactly the overload the valve exists to bound.

But it is a user-visible API behaviour change and a second logical change on a PR about closing a guard class, so it ships on its own branch with its own title and review. This PR leaves the gate failing open unconditionally, as before. Everything not dependent on metering was kept.

## Verification

- `mix precommit` green: **6564 tests, 0 failures**.
- Guards mutation-verified — including, now, the under-fill catch.
- Skill citations into `knowledge.ex` and `heavy_read.ex` re-pinned (`mix loopctl.check_skill_citations` is in the gate and caught the drift twice).

## Carry-forward

Eight confirmed findings landed outside this diff and are tracked in **#558** rather than a fifth PR — most seriously `FairShare.over_cap?/4`, which documents fail-open on any count error but has no `catch`, so a pool exit crashes the Oban job instead of admitting it. Verified by hand, not just relayed.
