### PR TITLE
Bound the ingestion fail-open, so overload stops meaning no backpressure

### DIFF
--- a/lib/loopctl/oban/backlog_counter_behaviour.ex
+++ b/lib/loopctl/oban/backlog_counter_behaviour.ex
@@ -11,19 +11,21 @@ defmodule Loopctl.Oban.BacklogCounterBehaviour do
   `Mox.expect/3` to RAISE a DB error, or to EXIT the way a wedged pool checkout really
   does — deterministically driving the gate's fail-open path.
 
-  What "fail open" means here has TWO branches, and the difference is the fault, not the
-  tenant:
+  What "fail open" means here depends on the fault, not on the tenant:
 
-    * a fault that is not backlog pressure — a query-shape SQLSTATE (`db_error`) or
-      `LocalGuc`'s deliberate refusal (`guc_capture_abort`) — ADMITS unconditionally;
-    * a SUSTAINED pool-pressure fault (`connection`, `timeout`, `exit:*`, `throw:*`, and
-      `db_pressure` — the resource-exhaustion / connection SQLSTATEs a saturated pool
-      raises behind pgbouncer) admits up to a bounded per-tenant JOB allowance and then
-      returns the ordinary backlog 429 — unbounded admission on these made "no
-      backpressure at all" the steady state during exactly the overload the valve bounds.
+    * not backlog pressure — a query-shape SQLSTATE (`db_error`, incl. 08P01
+      protocol_violation) — ADMITS unconditionally;
+    * POOL pressure (`connection`, `timeout`, `exit:*`, `throw:*`, `guc_capture_abort`
+      — raised only once the connection is already wedged — and `db_pressure`, the
+      exhaustion/connection SQLSTATEs a saturated pool raises behind pgbouncer) admits
+      up to a bounded per-tenant JOB allowance, then returns the ordinary backlog 429:
+      unbounded admission here made "no backpressure at all" the steady state;
+    * the METER itself unreachable (under `RATE_LIMITER=postgres` its store is the same
+      `AdminRepo` pool) admits as `:unmetered` — 429-ing a tenant whose backlog was
+      neither measured nor metered is a code it has not earned — and says so.
 
-  Neither branch may ever return a generic 500, and EVERY unmeasurable count stays
-  telemetry-visible — admitted or refused — so the alert cannot go silent.
+  No outcome may ever return a generic 500, and EVERY unmeasurable count stays
+  telemetry-visible — admitted, unmetered or refused — so the alert cannot go silent.
 
   The count is WORKER-scoped (`worker = ContentIngestionWorker`, the sole `:ingestion`
   worker) rather than queue-scoped, so it rides the partial index

--- a/lib/loopctl/oban/backlog_counter_behaviour.ex
+++ b/lib/loopctl/oban/backlog_counter_behaviour.ex
@@ -7,10 +7,22 @@ defmodule Loopctl.Oban.BacklogCounterBehaviour do
   resolve it to `Loopctl.Oban.FairShare` (the real bounded, tenant-scoped,
   index-backed count); `config/test.exs` maps a Mox mock whose default stub delegates
   back to the real `FairShare.in_flight_ingestion_backlog/1` (so the existing backlog
-  tests exercise the real count unchanged), while the fail-open test overrides it with
-  `Mox.expect/3` to RAISE a DB timeout/connection error — deterministically driving the
-  gate's fail-open path (an unmeasurable count must ADMIT the batch, never surface as a
-  generic HTTP 500).
+  tests exercise the real count unchanged), while the fail-open tests override it with
+  `Mox.expect/3` to RAISE a DB timeout/connection error, or to EXIT the way a wedged pool
+  checkout really does — deterministically driving the gate's fail-open path.
+
+  What "fail open" means here has TWO branches, and the difference is the fault, not the
+  tenant:
+
+    * a fault that is not backlog pressure — a broken count QUERY (`db_error`) or
+      `LocalGuc`'s deliberate refusal (`guc_capture_abort`) — ADMITS unconditionally, and
+      must never surface as a generic HTTP 500;
+    * a SUSTAINED pool-pressure fault (`connection`, `timeout`, `exit:*`, `throw:*`)
+      admits up to a bounded per-tenant JOB allowance and then returns the ordinary
+      backlog 429. Unbounded admission on these made "no backpressure at all" the steady
+      state during exactly the overload the valve exists to bound.
+
+  Neither branch may ever return a generic 500, and neither may fail CLOSED.
 
   The count is WORKER-scoped (`worker = ContentIngestionWorker`, the sole `:ingestion`
   worker) rather than queue-scoped, so it rides the partial index

--- a/lib/loopctl/oban/backlog_counter_behaviour.ex
+++ b/lib/loopctl/oban/backlog_counter_behaviour.ex
@@ -8,21 +8,22 @@ defmodule Loopctl.Oban.BacklogCounterBehaviour do
   index-backed count); `config/test.exs` maps a Mox mock whose default stub delegates
   back to the real `FairShare.in_flight_ingestion_backlog/1` (so the existing backlog
   tests exercise the real count unchanged), while the fail-open tests override it with
-  `Mox.expect/3` to RAISE a DB timeout/connection error, or to EXIT the way a wedged pool
-  checkout really does — deterministically driving the gate's fail-open path.
+  `Mox.expect/3` to RAISE a DB error, or to EXIT the way a wedged pool checkout really
+  does — deterministically driving the gate's fail-open path.
 
   What "fail open" means here has TWO branches, and the difference is the fault, not the
   tenant:
 
-    * a fault that is not backlog pressure — a broken count QUERY (`db_error`) or
-      `LocalGuc`'s deliberate refusal (`guc_capture_abort`) — ADMITS unconditionally, and
-      must never surface as a generic HTTP 500;
-    * a SUSTAINED pool-pressure fault (`connection`, `timeout`, `exit:*`, `throw:*`)
-      admits up to a bounded per-tenant JOB allowance and then returns the ordinary
-      backlog 429. Unbounded admission on these made "no backpressure at all" the steady
-      state during exactly the overload the valve exists to bound.
+    * a fault that is not backlog pressure — a query-shape SQLSTATE (`db_error`) or
+      `LocalGuc`'s deliberate refusal (`guc_capture_abort`) — ADMITS unconditionally;
+    * a SUSTAINED pool-pressure fault (`connection`, `timeout`, `exit:*`, `throw:*`, and
+      `db_pressure` — the resource-exhaustion / connection SQLSTATEs a saturated pool
+      raises behind pgbouncer) admits up to a bounded per-tenant JOB allowance and then
+      returns the ordinary backlog 429 — unbounded admission on these made "no
+      backpressure at all" the steady state during exactly the overload the valve bounds.
 
-  Neither branch may ever return a generic 500, and neither may fail CLOSED.
+  Neither branch may ever return a generic 500, and EVERY unmeasurable count stays
+  telemetry-visible — admitted or refused — so the alert cannot go silent.
 
   The count is WORKER-scoped (`worker = ContentIngestionWorker`, the sole `:ingestion`
   worker) rather than queue-scoped, so it rides the partial index

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -516,9 +516,23 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
         event_name: [:loopctl, :ingestion, :backlog_gate, :failed_open],
         measurement: :count,
         description:
-          "Ingestion backlog admission gate failed open (unmeasurable backlog count), by error_class and tenant.",
-        tags: [:error_class, :tenant_id],
-        tag_values: &degraded_read_tags/1
+          "Ingestion backlog admission gate could not MEASURE the backlog, sliced by outcome " <>
+            "(admitted / unmetered / exhausted), error_class and tenant.",
+        tags: [:error_class, :outcome, :tenant_id],
+        tag_values: &backlog_gate_tags/1
+      ),
+      # The event is JOB-denominated as well as per-request: one 50-item batch is ONE
+      # increment above but fifty jobs' worth of admission. Without this sum a burst of
+      # large batches and a trickle of single-item ingests look identical on the
+      # dashboard, which is the opposite of what an operator watching a wedged pool needs.
+      sum("loopctl.ingestion.backlog_gate.failed_open.jobs",
+        event_name: [:loopctl, :ingestion, :backlog_gate, :failed_open],
+        measurement: :jobs,
+        description:
+          "Jobs' worth of ingestion admitted or refused while the backlog was unmeasurable, " <>
+            "sliced by outcome, error_class and tenant.",
+        tags: [:error_class, :outcome, :tenant_id],
+        tag_values: &backlog_gate_tags/1
       ),
 
       # 6. Per-pool checkout queue_time (US-33.1): the RLS `Loopctl.Repo` pool (size
@@ -866,6 +880,32 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   def degraded_read_tags(metadata) do
     %{
       error_class: Map.get(metadata, :error_class, "unknown"),
+      tenant_id: gated_tenant_id(metadata)
+    }
+  end
+
+  @doc """
+  `tag_values` for the ingestion backlog-gate counters ONLY.
+
+  Deliberately NOT an extension of `degraded_read_tags/1`: the under-fill probe shares that
+  function and has no `:outcome`, so widening it would add a permanently-`admitted` label to
+  an unrelated series.
+
+  `:outcome` exists because the gate's event now fires on EVERY unmeasurable-count outcome,
+  not just the admitting one. Without the label a REFUSAL increments the same counter as an
+  admission, so the series would over-report admissions during precisely the sustained
+  incident an operator alerts on — the failure the refusal-branch emit was added to prevent,
+  reintroduced one layer up. It defaults to `:admitted` so the pre-existing series keeps its
+  meaning for any emitter that has not been updated.
+
+  Bounded at three values (`:admitted | :unmetered | :exhausted`);
+  `Loopctl.TelemetryEvents.ingestion_backlog_gate_failed_open/0` is the source of truth.
+  """
+  @spec backlog_gate_tags(map()) :: map()
+  def backlog_gate_tags(metadata) do
+    %{
+      error_class: Map.get(metadata, :error_class, "unknown"),
+      outcome: Map.get(metadata, :outcome, :admitted),
       tenant_id: gated_tenant_id(metadata)
     }
   end

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -215,29 +215,47 @@ defmodule Loopctl.TelemetryEvents do
   def llm_provider_error, do: [:loopctl, :llm, :provider_error]
 
   @doc """
-  The US-36.3 batch/single ingest backlog admission gate FAILED OPEN — it could not
-  measure the calling tenant's in-flight `:ingestion` backlog (the count raised a
-  `Postgrex.Error` statement_timeout or a `DBConnection.ConnectionError` pool-checkout
-  timeout) and therefore ADMITTED the request rather than 429-ing it. While this fires,
-  the backpressure valve is effectively OFF for that request: a genuine flood deep
-  enough to time the count out will admit instead of shed.
+  The US-36.3 batch/single ingest backlog admission gate could not MEASURE the calling
+  tenant's in-flight `:ingestion` backlog. Read the OUTCOME, not the event name: the
+  event no longer implies an admission.
 
-  Turns an otherwise silent `:warning` log line into an alertable signal so operators
-  can see "the ingestion backpressure valve is currently admitting because it can't
-  measure" on a dashboard. Distinct from a valve that is simply BELOW threshold (that
-  path emits nothing). Fires once per failed-open admission check.
+  It fires on every unmeasurable-count outcome — admitted, admitted-because-the-meter
+  itself was unconsultable, and REFUSED once the bounded fail-open allowance is spent.
+  Emitting only on the admitting branch made the signal go silent exactly when the fault
+  turned sustained, which is when an operator needs it; so the branch is now in the
+  payload rather than in whether the payload exists.
+
+  Distinct from a valve that is simply BELOW threshold (that path emits nothing).
 
   ## Payload (id/atom only — never a query, key, or PG message body)
 
-    * `measurements`: `%{count: 1}` — a pure increment.
-    * `metadata`: `%{tenant_id, error_class}` where `error_class` is a BOUNDED 4-value
-      tag: `"timeout"` (57014 query_canceled — the count's own statement_timeout),
-      `"db_error"` (any OTHER `Postgrex.Error` SQLSTATE — a query bug in the count path,
-      NOT a timeout), `"connection"` (`DBConnection.ConnectionError` pool-checkout
-      timeout), `"guc_capture_abort"` (`Loopctl.LocalGuc` REFUSED to override a GUC an
-      enclosing scope owns — deliberate, not a blip). `tenant_id` is an id, and is
-      cap-gated to a sentinel in the metric's `tag_values` so label cardinality stays
-      bounded (same convention as the other scale counters).
+    * `measurements`: `%{count: 1, jobs: n}` — one increment per gate check, plus the
+      JOBS that check covered (a 50-item batch is one check and fifty jobs). Both are
+      exported; a per-request count alone cannot distinguish a burst of large batches
+      from a trickle of single ingests.
+    * `metadata`: `%{tenant_id, error_class, outcome}`.
+
+      `outcome` is a BOUNDED 3-value atom: `:admitted` (unmetered fault class, or within
+      allowance), `:unmetered` (the METER was unconsultable — under `RATE_LIMITER=postgres`
+      its store is the same wedged pool — so the request was admitted rather than 429-ing a
+      tenant whose backlog was neither measured nor metered), `:exhausted` (allowance spent;
+      the request got the ordinary backlog 429).
+
+      `error_class` is a BOUNDED 5-value tag: `"timeout"` (57014 query_canceled — the
+      count's own statement_timeout), `"db_pressure"` (SQLSTATE class 53/57/08 — the
+      exhaustion/connection classes a saturated pool raises behind pgbouncer), `"db_error"`
+      (any OTHER `Postgrex.Error` SQLSTATE — a query bug in the count path, and `08P01`
+      protocol_violation, which is a driver bug rather than pressure), `"connection"`
+      (`DBConnection.ConnectionError` pool-checkout timeout), `"guc_capture_abort"`
+      (`Loopctl.LocalGuc` REFUSED to override a GUC an enclosing scope owns — raised only
+      once the connection is ALREADY wedged, hence metered), plus the `exit:<t>` / `throw:<t>`
+      families from `Loopctl.ExitClass`.
+
+      METERED classes (bounded allowance, then 429): `connection`, `timeout`, `db_pressure`,
+      `guc_capture_abort`, `exit:*`, `throw:*`. UNMETERED (always admits): `db_error`.
+
+      `tenant_id` is an id, cap-gated to a sentinel in the metric's `tag_values`
+      (`ScaleMetrics.backlog_gate_tags/1`) so label cardinality stays bounded.
 
   Aggregated by `Loopctl.Telemetry.ScaleMetrics` as a counter tagged by
   `[:error_class, :tenant_id]`.

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -22,6 +22,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   alias Loopctl.Net.UrlGuard
   alias Loopctl.Oban.FairShare
   alias Loopctl.ObanConfig
+  alias Loopctl.RateLimiter
   alias Loopctl.TelemetryEvents
   alias Loopctl.Workers.ContentIngestionWorker
 
@@ -38,6 +39,19 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # `validate_content_length/1` read the SAME number and cannot drift.
   @max_inline_content_bytes 1_000_000
 
+  # Ceiling on FAIL-OPEN admissions per tenant per window (see `backlog_fail_open_verdict/3`),
+  # denominated in JOBS — the same unit as `OBAN_INGEST_BACKLOG_MAX` — and charged one token
+  # per job. A REQUEST-denominated allowance was the wrong unit: `create_batch/2` admits up to
+  # @batch_max (50) items in ONE request, so 30 requests/min was really 1500 jobs/min, three
+  # times the 500 it was supposed to sit far below. Deliberately a constant, not an env var:
+  # it is a safety bound on a degraded mode, not a capacity knob, and
+  # `OBAN_INGEST_BACKLOG_MAX` remains the tunable one.
+  #
+  # Scope: PER NODE with the default `Loopctl.RateLimiter.Hammer` (node-local ETS), so the
+  # fleet bound is this value x the web-node count. `RATE_LIMITER=postgres` makes the same
+  # bucket cluster-global with no code change here.
+  @fail_open_jobs_per_window 100
+  @fail_open_window_ms 60_000
   alias LoopctlWeb.Helpers.Pagination
   alias LoopctlWeb.Helpers.ProjectId
 
@@ -138,8 +152,12 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
            "\"ingestion_backlog_exceeded\"`, sets `Retry-After`) — the single-item path " <>
            "is gated on the SAME per-tenant backlog threshold as /ingest/batch so it " <>
            "cannot be looped to bypass the valve — or (2) the generic shared Hammer " <>
-           "request-rate limiter (NO `error.code`). Branch on the presence of `error.code`.",
-         "application/json",
+           "request-rate limiter (NO `error.code`). Branch on the presence of `error.code`." <>
+           "\n\n`ingestion_backlog_exceeded` covers TWO causes: your backlog is at/over the " <>
+           "threshold, OR the server could not MEASURE it (transient count-path fault) and " <>
+           "the bounded fail-open allowance for that fault is spent. The second is a " <>
+           "server-side condition, not a quota you can drain — honour `Retry-After` either " <>
+           "way.", "application/json",
          %OpenApiSpex.Schema{
            oneOf: [Schemas.IngestionBacklogError, Schemas.RateLimitError]
          }}
@@ -157,7 +175,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     # which endpoint the flood comes through. Checked AFTER require_llm_key so a keyless
     # tenant still gets the clearer 422 first.
     with :ok <- require_llm_key(tenant_id),
-         :ok <- check_ingestion_backlog(tenant_id) do
+         :ok <- check_ingestion_backlog(tenant_id, 1) do
       handle_create(conn, tenant_id, params)
     end
   end
@@ -245,7 +263,12 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
            "US-36.3 ingestion-backlog backpressure (`error.code: " <>
            "\"ingestion_backlog_exceeded\"`, sets `Retry-After`), or (2) the generic " <>
            "shared Hammer request-rate limiter (NO `error.code`; `error.message: " <>
-           "\"Rate limit exceeded\"`). Branch on the presence of `error.code`.",
+           "\"Rate limit exceeded\"`). Branch on the presence of `error.code`." <>
+           "\n\n`ingestion_backlog_exceeded` covers TWO causes: your backlog is at/over the " <>
+           "threshold, OR the server could not MEASURE it (transient count-path fault) and " <>
+           "the bounded fail-open allowance for that fault is spent — the allowance is " <>
+           "charged per ITEM, so a large batch spends it faster. The second is a server-side " <>
+           "condition, not a quota you can drain — honour `Retry-After` either way.",
          "application/json",
          %OpenApiSpex.Schema{
            oneOf: [Schemas.IngestionBacklogError, Schemas.RateLimitError]
@@ -264,7 +287,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     # all-or-nothing, no partial pile-up). US-36.3.
     with :ok <- require_llm_key(tenant_id),
          :ok <- validate_batch_items(items),
-         :ok <- check_ingestion_backlog(tenant_id) do
+         :ok <- check_ingestion_backlog(tenant_id, length(items)) do
       results = process_batch_items(tenant_id, items)
       json(conn, LoopctlWeb.KnowledgeIngestionJSON.batch(results))
     end
@@ -288,12 +311,12 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # is by design — this is a backpressure VALVE to stop runaway monopolization, not a
   # guaranteed ceiling. Operators tuning OBAN_INGEST_BACKLOG_MAX should read it as a
   # "start shedding around here" floor, not an enforced maximum.
-  defp check_ingestion_backlog(tenant_id) do
+  defp check_ingestion_backlog(tenant_id, jobs) do
     max = ObanConfig.ingest_backlog_max()
 
     case in_flight_ingestion_backlog(tenant_id) do
       {:unmeasurable, error_class} ->
-        fail_open_admitted(tenant_id, error_class)
+        backlog_fail_open_verdict(tenant_id, error_class, jobs)
 
       count when count >= max ->
         {:error, :ingestion_backlog_exceeded, backlog_retry_after_seconds()}
@@ -301,6 +324,48 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
       _count ->
         :ok
     end
+  end
+
+  # Fail open, but BOUNDED for the SUSTAINED faults. Admitting on an unmeasurable count is
+  # right for the transient blip it was written for; the trouble is that the dominant fault
+  # here — a saturated or wedged AdminRepo pool (3 connections, `config/runtime.exs`) — is
+  # SUSTAINED, so an unconditional admit makes "no backpressure at all" the steady state
+  # during exactly the overload the valve exists to bound. (Before the exit shape was caught
+  # at all, the 500 at least shed the flood incidentally.) So those admissions are metered in
+  # JOBS (`@fail_open_jobs_per_window` per tenant per `@fail_open_window_ms`), and the rest
+  # get the ordinary backlog 429 with its Retry-After — no new status code, no new error code.
+  # The allowance is well under `OBAN_INGEST_BACKLOG_MAX` (default 500), so a real blip costs
+  # a legitimate client nothing. `within_limit?/3` is the fail-OPEN limiter helper, so a
+  # limiter fault cannot invert this into a fail-CLOSED gate.
+  defp backlog_fail_open_verdict(tenant_id, error_class, jobs) do
+    if not metered_fail_open?(error_class) or consume_fail_open_allowance(tenant_id, jobs) do
+      fail_open_admitted(tenant_id, error_class)
+    else
+      {:error, :ingestion_backlog_exceeded, backlog_retry_after_seconds()}
+    end
+  end
+
+  # Meter ONLY the classes that mean sustained pool pressure. A broken count QUERY
+  # (`db_error`, e.g. 42703 after a `FairShare` change) and `LocalGuc`'s deliberate refusal
+  # (`guc_capture_abort`) are not backlog pressure at all, and metering them converted a
+  # silent-but-serving degradation into a fleet-wide cap that 429s an under-threshold tenant
+  # with a backlog error code it has not earned, over a fault that is not its backlog.
+  defp metered_fail_open?("connection"), do: true
+  defp metered_fail_open?("timeout"), do: true
+  defp metered_fail_open?("exit:" <> _tag), do: true
+  defp metered_fail_open?("throw:" <> _tag), do: true
+  defp metered_fail_open?(_class), do: false
+
+  # ONE token per JOB this request would enqueue, so the metered quantity is the same unit as
+  # `OBAN_INGEST_BACKLOG_MAX`. Charging keeps going after the first denial (`and` on the right)
+  # so a 50-item batch can never slip through on a 1-token remainder.
+  defp consume_fail_open_allowance(tenant_id, jobs) do
+    bucket = "ingest_backlog_fail_open:#{tenant_id}"
+
+    Enum.reduce(1..jobs//1, true, fn _job, within ->
+      RateLimiter.within_limit?(bucket, @fail_open_window_ms, @fail_open_jobs_per_window) and
+        within
+    end)
   end
 
   # FAIL OPEN on an UNMEASURABLE count only: an unreachable/timed-out backlog count must
@@ -338,16 +403,18 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     # ordinary ingest, which is the opposite of failing open. `:throw` is folded in for the
     # same reason `ScaleMetrics.guarded_measurement/5` folds it in: it is the third non-local
     # exit kind, and enumerating two of three is how this class of hole keeps reappearing.
-    # Returns `{:unmeasurable, class}` rather than `0` ("an empty backlog") so the caller
-    # can tell "nothing queued" from "could not look", and so the fail-open is an explicit
-    # decision at one site instead of a magic zero flowing into a threshold comparison.
+    # NOT `0` ("an empty backlog"), which admitted unconditionally and forever. The count is
+    # UNMEASURABLE, and `backlog_fail_open_verdict/3` decides how many such admissions a
+    # tenant gets before the valve closes again.
     kind, reason when kind in [:exit, :throw] ->
       {:unmeasurable, fail_open_class({kind, ExitTag.tag(reason)})}
   end
 
-  # The ADMIT branch: `TelemetryEvents.ingestion_backlog_gate_failed_open/0` documents
-  # itself as "the valve is currently ADMITTING because it can't measure", so the counter
-  # and the warning belong here, where that is exactly what happened.
+  # The ADMIT branch, and ONLY it: `TelemetryEvents.ingestion_backlog_gate_failed_open/0`
+  # documents itself as "the valve is currently ADMITTING because it can't measure", so
+  # emitting it for the metered REFUSALS too would over-report admissions during precisely
+  # the incident an operator alerts on — and the warning would claim a fail-open for a
+  # request that got a 429.
   #
   # The bounded CLASS tag only, never `Exception.message/1`: a `Postgrex.Error` /
   # `DBConnection.ConnectionError` message names the backend host, database and role

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -40,18 +40,25 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   @max_inline_content_bytes 1_000_000
 
   # Ceiling on FAIL-OPEN admissions per tenant per window (see `backlog_fail_open_verdict/3`),
-  # denominated in JOBS — the same unit as `OBAN_INGEST_BACKLOG_MAX` — and charged one token
-  # per job. A REQUEST-denominated allowance was the wrong unit: `create_batch/2` admits up to
-  # @batch_max (50) items in ONE request, so 30 requests/min was really 1500 jobs/min, three
-  # times the 500 it was supposed to sit far below. Deliberately a constant, not an env var:
-  # it is a safety bound on a degraded mode, not a capacity knob, and
-  # `OBAN_INGEST_BACKLOG_MAX` remains the tunable one.
+  # charged one token per SUBMITTED ITEM — an upper bound on the jobs the request can enqueue,
+  # so the meter is in the same unit as `OBAN_INGEST_BACKLOG_MAX` and errs CONSERVATIVELY (an
+  # item that 422s or dedupes still spends its token; the bound is never under-charged).
+  # A REQUEST-denominated allowance was the wrong unit: `create_batch/2` admits up to
+  # @batch_max (50) items in ONE request, so 30 requests/min was really 1500 jobs/min.
   #
-  # Scope: PER NODE with the default `Loopctl.RateLimiter.Hammer` (node-local ETS), so the
-  # fleet bound is this value x the web-node count. `RATE_LIMITER=postgres` makes the same
-  # bucket cluster-global with no code change here.
-  @fail_open_jobs_per_window 100
-  @fail_open_window_ms 60_000
+  # The WINDOW is the :ingestion queue's DRAIN cadence (hours — width 2, ~6-min LLM jobs),
+  # NOT a request cadence. A 60s window made the ceiling "100 jobs per MINUTE", which REFILLS
+  # to ~6000/hour/node against a ~20/hour drain: bounded for the transient blip, unbounded for
+  # the SUSTAINED wedge this meter exists for.
+  #
+  # The per-node allowance is DERIVED from the very threshold it must sit under, because the
+  # default limiter (`Loopctl.RateLimiter.Hammer`) is node-local ETS and the FLEET allowance
+  # is therefore per-node x web-node count — at a flat 100 that silently multiplied PAST the
+  # threshold from ~5 nodes up. Dividing the threshold by @fail_open_fleet_nodes holds the
+  # FLEET allowance at or under one `OBAN_INGEST_BACKLOG_MAX` per hour per tenant for any
+  # fleet up to that many web nodes, and retuning the threshold retunes this with it.
+  @fail_open_window_ms 3_600_000
+  @fail_open_fleet_nodes 10
   alias LoopctlWeb.Helpers.Pagination
   alias LoopctlWeb.Helpers.ProjectId
 
@@ -331,16 +338,17 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # here — a saturated or wedged AdminRepo pool (3 connections, `config/runtime.exs`) — is
   # SUSTAINED, so an unconditional admit makes "no backpressure at all" the steady state
   # during exactly the overload the valve exists to bound. (Before the exit shape was caught
-  # at all, the 500 at least shed the flood incidentally.) So those admissions are metered in
-  # JOBS (`@fail_open_jobs_per_window` per tenant per `@fail_open_window_ms`), and the rest
-  # get the ordinary backlog 429 with its Retry-After — no new status code, no new error code.
-  # The allowance is well under `OBAN_INGEST_BACKLOG_MAX` (default 500), so a real blip costs
-  # a legitimate client nothing. `within_limit?/3` is the fail-OPEN limiter helper, so a
-  # limiter fault cannot invert this into a fail-CLOSED gate.
+  # at all, the 500 at least shed the flood incidentally.) So those admissions are metered
+  # (`fail_open_jobs_per_window/0` per tenant per `@fail_open_window_ms`), and the rest get
+  # the ordinary backlog 429 with its Retry-After — no new status code, no new error code.
+  # BOTH branches emit `fail_open_event/4`: the only signal that the backlog is UNMEASURABLE
+  # must not go silent at the moment the fault stops being a blip and becomes the wedge.
   defp backlog_fail_open_verdict(tenant_id, error_class, jobs) do
     if not metered_fail_open?(error_class) or consume_fail_open_allowance(tenant_id, jobs) do
-      fail_open_admitted(tenant_id, error_class)
+      fail_open_event(tenant_id, error_class, :admitted, jobs)
+      :ok
     else
+      fail_open_event(tenant_id, error_class, :exhausted, jobs)
       {:error, :ingestion_backlog_exceeded, backlog_retry_after_seconds()}
     end
   end
@@ -351,21 +359,33 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # silent-but-serving degradation into a fleet-wide cap that 429s an under-threshold tenant
   # with a backlog error code it has not earned, over a fault that is not its backlog.
   defp metered_fail_open?("connection"), do: true
+  defp metered_fail_open?("db_pressure"), do: true
   defp metered_fail_open?("timeout"), do: true
   defp metered_fail_open?("exit:" <> _tag), do: true
   defp metered_fail_open?("throw:" <> _tag), do: true
   defp metered_fail_open?(_class), do: false
 
-  # ONE token per JOB this request would enqueue, so the metered quantity is the same unit as
-  # `OBAN_INGEST_BACKLOG_MAX`. Charging keeps going after the first denial (`and` on the right)
-  # so a 50-item batch can never slip through on a 1-token remainder.
+  # ONE token per SUBMITTED ITEM (an upper bound on the jobs this request would enqueue), and
+  # `gate_ok?/3` — the fail-CLOSED helper — NOT `within_limit?/3`. Under `RATE_LIMITER=postgres`
+  # the limiter store IS `AdminRepo`, the same 3-connection pool whose exhaustion produced this
+  # unmeasurable count, so a fail-OPEN check returns the `{:allow, 0}` sentinel on every token
+  # and the meter is inert in precisely the fault it bounds; `gate_ok?/3` treats that sentinel
+  # as spent allowance, so an unconsultable meter sheds instead. `reduce_while` HALTS on the
+  # first denial: the request is refused either way, and continuing would queue up to
+  # @batch_max more checkouts onto the starved pool and burn tokens the request never used.
   defp consume_fail_open_allowance(tenant_id, jobs) do
     bucket = "ingest_backlog_fail_open:#{tenant_id}"
+    limit = fail_open_jobs_per_window()
 
-    Enum.reduce(1..jobs//1, true, fn _job, within ->
-      RateLimiter.within_limit?(bucket, @fail_open_window_ms, @fail_open_jobs_per_window) and
-        within
+    Enum.reduce_while(1..jobs//1, true, fn _item, _within ->
+      if RateLimiter.gate_ok?(bucket, @fail_open_window_ms, limit),
+        do: {:cont, true},
+        else: {:halt, false}
     end)
+  end
+
+  defp fail_open_jobs_per_window do
+    max(1, div(ObanConfig.ingest_backlog_max(), @fail_open_fleet_nodes))
   end
 
   # FAIL OPEN on an UNMEASURABLE count only: an unreachable/timed-out backlog count must
@@ -377,11 +397,11 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # error in the count path therefore propagates and 500s, LOUD, rather than being silently
   # swallowed into a fleet-wide disabling of backpressure that looks healthy; a SQL-level one
   # (a bad query change) is still rescued, and gets its own `db_error` class so it is not
-  # mistaken for a timeout. Every admitted fail-open ALSO emits a telemetry counter
-  # (`fail_open_admitted/2`) so "the backpressure valve is currently admitting because it
-  # can't measure" is an alertable signal, not just a warning-log line, and a sustained
-  # per-request timeout under a real flood is visible on a dashboard instead of only as log
-  # spam. The count is resolved through a
+  # mistaken for a timeout. EVERY unmeasurable count ALSO emits a telemetry counter
+  # (`fail_open_event/4`, both the admitted and the metered-refusal outcome) so "the
+  # backpressure valve currently can't measure" is an alertable signal, not just a
+  # warning-log line, and a sustained per-request timeout under a real flood is visible on a
+  # dashboard instead of only as log spam. The count is resolved through a
   # config-swappable DI seam (`Loopctl.Oban.FairShare` in prod, a Mox mock in test) so
   # this fail-open path is deterministically covered.
   defp in_flight_ingestion_backlog(tenant_id) do
@@ -410,26 +430,31 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
       {:unmeasurable, fail_open_class({kind, ExitTag.tag(reason)})}
   end
 
-  # The ADMIT branch, and ONLY it: `TelemetryEvents.ingestion_backlog_gate_failed_open/0`
-  # documents itself as "the valve is currently ADMITTING because it can't measure", so
-  # emitting it for the metered REFUSALS too would over-report admissions during precisely
-  # the incident an operator alerts on — and the warning would claim a fail-open for a
-  # request that got a 429.
+  # BOTH branches, discriminated by `outcome` (`:admitted` | `:exhausted`). The event means
+  # "the gate could not MEASURE the backlog"; admissions are the `:admitted` slice. Emitting
+  # it on the admit branch ALONE made the only alertable signal for an unmeasurable count go
+  # SILENT exactly when the fault stopped being a blip and became the sustained wedge — the
+  # operator's alert auto-resolved while the pool was still wedged, and the resulting 429s
+  # were indistinguishable in metrics from an ordinary over-threshold backlog 429.
+  # `jobs` is the JOB-denominated measurement, the same unit as the allowance and
+  # `OBAN_INGEST_BACKLOG_MAX`; `count` alone is per-REQUEST and under-read the admitted work
+  # of a batch by up to @batch_max.
   #
   # The bounded CLASS tag only, never `Exception.message/1`: a `Postgrex.Error` /
   # `DBConnection.ConnectionError` message names the backend host, database and role
   # ("tcp connect (host:port): ..."), and this line is reachable from any wedged-pool
   # moment on an ordinary ingest. Same policy as `Loopctl.LocalGuc`'s own failure log.
-  defp fail_open_admitted(tenant_id, error_class) do
-    Logger.warning("ingestion backlog gate failed open for tenant=#{tenant_id} (#{error_class})")
+  defp fail_open_event(tenant_id, error_class, outcome, jobs) do
+    Logger.warning(
+      "ingestion backlog gate could not measure for tenant=#{tenant_id} " <>
+        "(#{error_class}, outcome=#{outcome}, jobs=#{jobs})"
+    )
 
     :telemetry.execute(
       TelemetryEvents.ingestion_backlog_gate_failed_open(),
-      %{count: 1},
-      %{tenant_id: tenant_id, error_class: error_class}
+      %{count: 1, jobs: jobs},
+      %{tenant_id: tenant_id, error_class: error_class, outcome: outcome}
     )
-
-    :ok
   end
 
   # BOUNDED, and every value must be TRUE. The rescue above catches EVERY `Postgrex.Error`,
@@ -441,6 +466,17 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   end
 
   defp fail_open_class(%Postgrex.Error{postgres: %{code: :query_canceled}}), do: "timeout"
+
+  # Resource exhaustion (SQLSTATE class 53, e.g. 53300 too_many_connections), operator
+  # intervention (57, e.g. 57P03 cannot_connect_now) and connection exceptions (08) arrive as
+  # a server ERROR, not a `DBConnection` exit — the NORMAL presentation of pool saturation
+  # behind pgbouncer. They ARE the sustained pressure the meter bounds, so they must not slip
+  # into the unmetered `db_error` bucket (and escape it unconditionally) merely because of the
+  # struct they travel in. Only a genuine query-shape error (42xxx et al) stays `db_error`.
+  defp fail_open_class(%Postgrex.Error{postgres: %{pg_code: <<class::binary-2, _::binary>>}})
+       when class in ~w(53 57 08),
+       do: "db_pressure"
+
   defp fail_open_class(%Postgrex.Error{}), do: "db_error"
 
   # The non-local-exit shapes, already tagged by `Loopctl.ExitTag` at the catch site.

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -23,6 +23,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   alias Loopctl.Oban.FairShare
   alias Loopctl.ObanConfig
   alias Loopctl.RateLimiter
+  alias Loopctl.RateLimiter.FailOpenLog
   alias Loopctl.TelemetryEvents
   alias Loopctl.Workers.ContentIngestionWorker
 
@@ -56,9 +57,17 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # is therefore per-node x web-node count — at a flat 100 that silently multiplied PAST the
   # threshold from ~5 nodes up. Dividing the threshold by @fail_open_fleet_nodes holds the
   # FLEET allowance at or under one `OBAN_INGEST_BACKLOG_MAX` per hour per tenant for any
-  # fleet up to that many web nodes, and retuning the threshold retunes this with it.
+  # fleet up to that many web nodes, and retuning the threshold retunes this with it. It is
+  # FLOORED at @batch_max because charging is incremental with no reservation or refund: an
+  # allowance smaller than one batch converts the whole window into nothing the first time a
+  # batch is refused mid-charge, and integer division floors to 0 (clamping to a useless 1
+  # job/hour) for any OBAN_INGEST_BACKLOG_MAX under @fail_open_fleet_nodes.
   @fail_open_window_ms 3_600_000
   @fail_open_fleet_nodes 10
+
+  # Max batch size for POST /knowledge/ingest/batch. Declared HERE, above
+  # `fail_open_jobs_per_window/0`, which floors the fail-open allowance at one full batch.
+  @batch_max 50
   alias LoopctlWeb.Helpers.Pagination
   alias LoopctlWeb.Helpers.ProjectId
 
@@ -341,51 +350,80 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # at all, the 500 at least shed the flood incidentally.) So those admissions are metered
   # (`fail_open_jobs_per_window/0` per tenant per `@fail_open_window_ms`), and the rest get
   # the ordinary backlog 429 with its Retry-After — no new status code, no new error code.
-  # BOTH branches emit `fail_open_event/4`: the only signal that the backlog is UNMEASURABLE
+  # EVERY outcome emits `fail_open_event/4`: the only signal that the backlog is UNMEASURABLE
   # must not go silent at the moment the fault stops being a blip and becomes the wedge.
   defp backlog_fail_open_verdict(tenant_id, error_class, jobs) do
-    if not metered_fail_open?(error_class) or consume_fail_open_allowance(tenant_id, jobs) do
-      fail_open_event(tenant_id, error_class, :admitted, jobs)
-      :ok
-    else
-      fail_open_event(tenant_id, error_class, :exhausted, jobs)
-      {:error, :ingestion_backlog_exceeded, backlog_retry_after_seconds()}
-    end
+    outcome =
+      if metered_fail_open?(error_class),
+        do: consume_fail_open_allowance(tenant_id, jobs),
+        else: :admitted
+
+    fail_open_event(tenant_id, error_class, outcome, jobs)
+
+    if outcome == :exhausted,
+      do: {:error, :ingestion_backlog_exceeded, backlog_retry_after_seconds()},
+      else: :ok
   end
 
-  # Meter ONLY the classes that mean sustained pool pressure. A broken count QUERY
-  # (`db_error`, e.g. 42703 after a `FairShare` change) and `LocalGuc`'s deliberate refusal
-  # (`guc_capture_abort`) are not backlog pressure at all, and metering them converted a
-  # silent-but-serving degradation into a fleet-wide cap that 429s an under-threshold tenant
-  # with a backlog error code it has not earned, over a fault that is not its backlog.
+  # Meter every class that means the POOL is under pressure, including `guc_capture_abort`:
+  # `LocalGuc` raises that abort only after the capture round-trip ITSELF failed, i.e. the
+  # connection is already wedged, which is exactly the sustained pressure this bound exists
+  # for — leaving it unmetered let the wedge keep its unconditional admit under any nested
+  # scope. Only a broken count QUERY (`db_error`, e.g. 42703 after a `FairShare` change)
+  # stays unmetered: it is not backlog pressure at all, and capping it would 429 an
+  # under-threshold tenant with a backlog error code it has not earned.
   defp metered_fail_open?("connection"), do: true
   defp metered_fail_open?("db_pressure"), do: true
   defp metered_fail_open?("timeout"), do: true
+  defp metered_fail_open?("guc_capture_abort"), do: true
   defp metered_fail_open?("exit:" <> _tag), do: true
   defp metered_fail_open?("throw:" <> _tag), do: true
   defp metered_fail_open?(_class), do: false
 
-  # ONE token per SUBMITTED ITEM (an upper bound on the jobs this request would enqueue), and
-  # `gate_ok?/3` — the fail-CLOSED helper — NOT `within_limit?/3`. Under `RATE_LIMITER=postgres`
-  # the limiter store IS `AdminRepo`, the same 3-connection pool whose exhaustion produced this
-  # unmeasurable count, so a fail-OPEN check returns the `{:allow, 0}` sentinel on every token
-  # and the meter is inert in precisely the fault it bounds; `gate_ok?/3` treats that sentinel
-  # as spent allowance, so an unconsultable meter sheds instead. `reduce_while` HALTS on the
-  # first denial: the request is refused either way, and continuing would queue up to
-  # @batch_max more checkouts onto the starved pool and burn tokens the request never used.
+  # ONE token per SUBMITTED ITEM (an upper bound on the jobs this request would enqueue),
+  # halting on the first REFUSAL so a doomed request does not queue up to @batch_max more
+  # checkouts onto an already-starved pool. Tokens charged before the halt are not refunded
+  # (the limiter has no reservation), which is why `fail_open_jobs_per_window/0` is floored
+  # at one full batch: an allowance smaller than a batch would be converted into nothing.
+  #
+  # TRI-STATE, because a limiter FAULT is not a spent allowance and neither
+  # `RateLimiter.within_limit?/3` (fail-OPEN) nor `gate_ok?/3` (fail-CLOSED) can tell them
+  # apart. That distinction is load-bearing here: under `RATE_LIMITER=postgres` the limiter
+  # store IS `AdminRepo`, the same pool whose exhaustion produced this unmeasurable count, so
+  # the two faults are perfectly correlated. Fail-CLOSED 429s an innocent tenant on the FIRST
+  # transient blip with a backlog code it has not earned — the very thing this gate exists to
+  # prevent — while fail-OPEN goes silently inert in the wedge it bounds. So an unconsultable
+  # meter ADMITS (availability wins on a capacity gate) and reports `:unmetered`, which keeps
+  # "the valve is admitting because its METER is unreachable" alertable rather than silent.
   defp consume_fail_open_allowance(tenant_id, jobs) do
     bucket = "ingest_backlog_fail_open:#{tenant_id}"
     limit = fail_open_jobs_per_window()
 
-    Enum.reduce_while(1..jobs//1, true, fn _item, _within ->
-      if RateLimiter.gate_ok?(bucket, @fail_open_window_ms, limit),
-        do: {:cont, true},
-        else: {:halt, false}
+    Enum.reduce_while(1..jobs//1, :admitted, fn _item, outcome ->
+      case allowance_token(bucket, limit) do
+        :exhausted -> {:halt, :exhausted}
+        :unmetered -> {:cont, :unmetered}
+        :admitted -> {:cont, outcome}
+      end
     end)
   end
 
+  # `{:allow, 0}` is the Postgres impl's own fail-open sentinel and `{:error, _}` is a Hammer
+  # soft-error: both mean UNCONSULTABLE, never "denied". Raise/exit/throw likewise.
+  defp allowance_token(bucket, limit) do
+    case RateLimiter.impl().check_rate(bucket, @fail_open_window_ms, limit) do
+      {:allow, count} when is_integer(count) and count > 0 -> :admitted
+      {:deny, _limit} -> :exhausted
+      _other -> :unmetered
+    end
+  rescue
+    _e -> :unmetered
+  catch
+    kind, _reason when kind in [:exit, :throw] -> :unmetered
+  end
+
   defp fail_open_jobs_per_window do
-    max(1, div(ObanConfig.ingest_backlog_max(), @fail_open_fleet_nodes))
+    max(@batch_max, div(ObanConfig.ingest_backlog_max(), @fail_open_fleet_nodes))
   end
 
   # FAIL OPEN on an UNMEASURABLE count only: an unreachable/timed-out backlog count must
@@ -398,7 +436,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # swallowed into a fleet-wide disabling of backpressure that looks healthy; a SQL-level one
   # (a bad query change) is still rescued, and gets its own `db_error` class so it is not
   # mistaken for a timeout. EVERY unmeasurable count ALSO emits a telemetry counter
-  # (`fail_open_event/4`, both the admitted and the metered-refusal outcome) so "the
+  # (`fail_open_event/4`, on every outcome — admitted, unmetered and refused) so "the
   # backpressure valve currently can't measure" is an alertable signal, not just a
   # warning-log line, and a sustained per-request timeout under a real flood is visible on a
   # dashboard instead of only as log spam. The count is resolved through a
@@ -410,9 +448,10 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     # `LocalGuc`'s capture ABORT shares `DBConnection.ConnectionError` with the transient
     # pool faults this clause is for. It is raised DELIBERATELY, so it gets its OWN
     # `error_class` (`fail_open_class/1`) rather than hiding inside "connection" — a refusal
-    # whose purpose is to be noticed stays alertable. It still fails OPEN: an abort IS an
+    # whose purpose is to be noticed stays alertable. It still fails OPEN — an abort IS an
     # unmeasurable count, and this gate exists so an innocent, under-threshold tenant never
-    # eats an error because the count path is momentarily degraded. See
+    # eats an error because the count path is momentarily degraded — but METERED like the
+    # other pool faults, since it is raised only once the connection is already wedged. See
     # `Loopctl.LocalGuc.capture_abort?/1`.
     e in [DBConnection.ConnectionError, Postgrex.Error] ->
       {:unmeasurable, fail_open_class(e)}
@@ -430,24 +469,32 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
       {:unmeasurable, fail_open_class({kind, ExitTag.tag(reason)})}
   end
 
-  # BOTH branches, discriminated by `outcome` (`:admitted` | `:exhausted`). The event means
-  # "the gate could not MEASURE the backlog"; admissions are the `:admitted` slice. Emitting
-  # it on the admit branch ALONE made the only alertable signal for an unmeasurable count go
-  # SILENT exactly when the fault stopped being a blip and became the sustained wedge — the
-  # operator's alert auto-resolved while the pool was still wedged, and the resulting 429s
-  # were indistinguishable in metrics from an ordinary over-threshold backlog 429.
+  # EVERY outcome (`:admitted` | `:unmetered` | `:exhausted`). The event means "the gate could
+  # not MEASURE the backlog"; admissions are the `:admitted` slice. Emitting it on the admit
+  # branch ALONE made the only alertable signal for an unmeasurable count go SILENT exactly
+  # when the fault stopped being a blip and became the sustained wedge — the operator's alert
+  # auto-resolved while the pool was still wedged, and the resulting 429s were
+  # indistinguishable in metrics from an ordinary over-threshold backlog 429.
   # `jobs` is the JOB-denominated measurement, the same unit as the allowance and
-  # `OBAN_INGEST_BACKLOG_MAX`; `count` alone is per-REQUEST and under-read the admitted work
-  # of a batch by up to @batch_max.
+  # `OBAN_INGEST_BACKLOG_MAX`; `count` alone is per-REQUEST and under-reads the admitted work
+  # of a batch by up to @batch_max. `jobs` is raw-payload-only until `ScaleMetrics` sums it —
+  # the exported counter is still `count`.
+  #
+  # THROTTLED through `RateLimiter.FailOpenLog` (one line per bucket family per node per
+  # minute) rather than a bare `Logger.warning`: refusals are unbounded — the meter bounds
+  # ADMISSIONS, not requests — so a wedged pool plus a client retry loop wrote one warning per
+  # request during exactly the incident that already stresses disk. The telemetry above is
+  # unthrottled and stays the alertable signal.
   #
   # The bounded CLASS tag only, never `Exception.message/1`: a `Postgrex.Error` /
   # `DBConnection.ConnectionError` message names the backend host, database and role
   # ("tcp connect (host:port): ..."), and this line is reachable from any wedged-pool
   # moment on an ordinary ingest. Same policy as `Loopctl.LocalGuc`'s own failure log.
   defp fail_open_event(tenant_id, error_class, outcome, jobs) do
-    Logger.warning(
-      "ingestion backlog gate could not measure for tenant=#{tenant_id} " <>
-        "(#{error_class}, outcome=#{outcome}, jobs=#{jobs})"
+    FailOpenLog.warn(
+      :ingest_backlog,
+      "ingest_backlog_fail_open:#{tenant_id}",
+      "backlog unmeasurable (#{error_class}, outcome=#{outcome}, jobs=#{jobs})"
     )
 
     :telemetry.execute(
@@ -466,6 +513,12 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   end
 
   defp fail_open_class(%Postgrex.Error{postgres: %{code: :query_canceled}}), do: "timeout"
+
+  # 08P01 protocol_violation is a driver / query-shape bug that happens to live in the
+  # connection-exception class — not saturation. Metering it would cap an under-threshold
+  # tenant over a fault that is not its backlog, so it is excluded from `db_pressure` BEFORE
+  # the class match below.
+  defp fail_open_class(%Postgrex.Error{postgres: %{pg_code: "08P01"}}), do: "db_error"
 
   # Resource exhaustion (SQLSTATE class 53, e.g. 53300 too_many_connections), operator
   # intervention (57, e.g. 57P03 cannot_connect_now) and connection exceptions (08) arrive as
@@ -637,9 +690,6 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   end
 
   # --- Private ---
-
-  # Max batch size for POST /knowledge/ingest/batch
-  @batch_max 50
 
   defp validate_batch_items(items) when is_list(items) and items != [] do
     if length(items) > @batch_max do

--- a/test/loopctl/telemetry/scale_metrics_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_test.exs
@@ -66,6 +66,7 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
     "loopctl.oban.jobs.executing_orphan.count",
     "loopctl.oban.poll.error.count",
     "loopctl.ingestion.backlog_gate.failed_open.count",
+    "loopctl.ingestion.backlog_gate.failed_open.jobs",
     "loopctl.knowledge.article_linking.corpus_size",
     "loopctl.cluster.peers.count",
     "loopctl.egress.blocked.count"
@@ -109,7 +110,16 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
                   :error_class,
                   # US-38.3: clustering-readiness peer gauge — bounded 3-value status
                   # (`:single_node`/`:clustered`/`:expected_peers_missing`), never a node name.
-                  :status
+                  :status,
+                  # #559: ingestion backlog-gate outcome — a bounded 3-value atom
+                  # (`:admitted`/`:unmetered`/`:exhausted`) set by the gate itself, never
+                  # derived from input. Carried ONLY by the two backlog_gate counters (via
+                  # `backlog_gate_tags/1`, deliberately not the shared `degraded_read_tags/1`).
+                  # Load-bearing rather than decorative: the gate's event fires on refusals as
+                  # well as admissions, so without this label a refusal increments the same
+                  # series as an admission and the counter over-reports admissions during
+                  # exactly the sustained incident it is alerted on.
+                  :outcome
                 ])
 
   defp scale_metrics, do: ScaleMetrics.scale_metrics()
@@ -151,6 +161,43 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
       assert hist.tags == [:endpoint]
       refute :tenant_id in hist.tags
       refute :mapped_code in hist.tags
+    end
+
+    test "#559: the backlog-gate counters carry :outcome, so a REFUSAL is not counted as an admission" do
+      # The gate's event fires on every unmeasurable-count outcome, admissions and refusals
+      # alike. Without this label both land on one series and the counter over-reports
+      # admissions during exactly the sustained incident an operator alerts on — the silence
+      # the refusal-branch emit was added to prevent, reintroduced one layer up.
+      for name <- [
+            "loopctl.ingestion.backlog_gate.failed_open.count",
+            "loopctl.ingestion.backlog_gate.failed_open.jobs"
+          ] do
+        m = metric(name)
+        assert :outcome in m.tags, "#{name} must slice by :outcome"
+        assert :error_class in m.tags
+        assert :tenant_id in m.tags
+      end
+
+      # The jobs series is JOB-denominated: a 50-item batch is one check but fifty jobs.
+      assert %Telemetry.Metrics.Sum{measurement: :jobs} =
+               metric("loopctl.ingestion.backlog_gate.failed_open.jobs")
+    end
+
+    test "#559: backlog_gate_tags/1 bounds :outcome and leaves the shared probe tags alone" do
+      assert %{outcome: :exhausted, error_class: "connection"} =
+               ScaleMetrics.backlog_gate_tags(%{
+                 error_class: "connection",
+                 outcome: :exhausted,
+                 tenant_id: Ecto.UUID.generate()
+               })
+
+      # Defaults to :admitted so an emitter that has not been updated keeps its meaning.
+      assert %{outcome: :admitted} = ScaleMetrics.backlog_gate_tags(%{error_class: "timeout"})
+
+      # Deliberately NOT folded into degraded_read_tags/1 — the under-fill probe shares that
+      # one and has no outcome, so widening it would bolt a permanently-"admitted" label onto
+      # an unrelated series.
+      refute Map.has_key?(ScaleMetrics.degraded_read_tags(%{error_class: "timeout"}), :outcome)
     end
 
     test "the two counters DO admit tenant_id as a (cap-gated) tag" do

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -1067,6 +1067,98 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       refute metadata.error_class =~ "DBConnection"
     end
 
+    test "the fail-open admissions are BOUNDED, not unconditional", %{conn: conn} do
+      # A wedged AdminRepo pool is SUSTAINED, so admitting on every unmeasurable count made
+      # "no backpressure at all" the steady state during exactly the overload the valve
+      # exists to bound. The admissions are now metered: past the per-tenant allowance the
+      # request gets the ordinary backlog 429 instead of enqueuing.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      # The counter means "the valve is currently ADMITTING because it can't measure", so a
+      # REFUSAL must not fire it — otherwise it over-reports admissions during exactly the
+      # incident an operator alerts on.
+      attach_failed_open(tenant.id)
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        exit({:noproc, {DBConnection, :execute, []}})
+      end)
+
+      # The allowance is spent — the limiter, not the (unmeasurable) count, is the decider.
+      # Scoped to the fail-open bucket alone: the auth pipeline shares this limiter, and
+      # denying THAT would 429 the request for an unrelated reason and prove nothing.
+      test_pid = self()
+
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:") do
+          send(test_pid, {:fail_open_bucket, bucket})
+          {:deny, limit}
+        else
+          {:allow, 1}
+        end
+      end)
+
+      expect(Loopctl.MockContentExtractor, :extract_from_content, 0, fn _t, _c, _o ->
+        flunk("nothing may be enqueued once the fail-open allowance is spent")
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Beyond the fail-open allowance", source_type: "newsletter"}]
+        })
+
+      assert json_response(conn, 429)["error"]["code"] == "ingestion_backlog_exceeded"
+
+      # Per-TENANT: one flooding tenant spending its allowance must not close the valve on
+      # everyone else.
+      assert_receive {:fail_open_bucket, bucket}
+      assert bucket =~ tenant.id
+
+      refute_receive {:backlog_failed_open, _measurements, _metadata}, 20
+    end
+
+    test "the fail-open allowance is charged per ITEM, not per request", %{conn: conn} do
+      # A REQUEST-denominated allowance was the wrong unit: one batch request enqueues up to
+      # @batch_max (50) jobs, so metering requests let a sustained fault admit 50x the bound
+      # it advertised — above `OBAN_INGEST_BACKLOG_MAX` instead of far below it. Each item
+      # must spend one token, so the meter is in the same unit as the threshold.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        exit({:noproc, {DBConnection, :execute, []}})
+      end)
+
+      test_pid = self()
+
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, _limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
+          do: send(test_pid, :fail_open_token)
+
+        {:allow, 1}
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [
+            %{content: "Metered item one", source_type: "newsletter"},
+            %{content: "Metered item two", source_type: "newsletter"},
+            %{content: "Metered item three", source_type: "newsletter"}
+          ]
+        })
+
+      assert length(json_response(conn, 200)["data"]) == 3
+
+      assert_receive :fail_open_token
+      assert_receive :fail_open_token
+      assert_receive :fail_open_token
+      refute_receive :fail_open_token, 20
+    end
+
     test "a NON-timeout SQLSTATE is not reported as a timeout", %{conn: conn} do
       # The rescue catches EVERY `Postgrex.Error`, not only 57014, so a query bug in the
       # count path (a column renamed out from under `FairShare`) also fails open. It must
@@ -1081,6 +1173,15 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
         raise %Postgrex.Error{
           postgres: %{code: :undefined_column, message: "column j.args does not exist"}
         }
+      end)
+
+      # ...and it is NOT metered: a broken count QUERY is not backlog pressure, so capping it
+      # would 429 an under-threshold tenant with a backlog code it has not earned. Even with
+      # the fail-open allowance fully spent, this class still admits.
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
+          do: {:deny, limit},
+          else: {:allow, 1}
       end)
 
       conn =

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -1138,9 +1138,9 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
       test_pid = self()
 
-      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, _limit ->
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, window, limit ->
         if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
-          do: send(test_pid, :fail_open_token)
+          do: send(test_pid, {:fail_open_token, window, limit})
 
         {:allow, 1}
       end)
@@ -1158,10 +1158,15 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
       assert length(json_response(conn, 200)["data"]) == 3
 
-      assert_receive :fail_open_token
-      assert_receive :fail_open_token
-      assert_receive :fail_open_token
-      refute_receive :fail_open_token, 20
+      # ...over the :ingestion queue's DRAIN cadence (an hour — a 60s window refills to ~60x
+      # the threshold against a ~20/hour drain), against a limit DERIVED from
+      # OBAN_INGEST_BACKLOG_MAX and floored at one full batch: integer division floors to 0
+      # for a small threshold, and charging is incremental with no refund.
+      assert_receive {:fail_open_token, 3_600_000, limit}
+      assert limit == max(50, div(ObanConfig.ingest_backlog_max(), 10))
+      assert_receive {:fail_open_token, _, _}
+      assert_receive {:fail_open_token, _, _}
+      refute_receive {:fail_open_token, _, _}, 20
 
       # The telemetry measurement is in the SAME unit as the allowance and the threshold. A
       # per-REQUEST `count` alone under-read the admitted work of a batch by up to @batch_max,
@@ -1260,6 +1265,114 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert_receive {:backlog_failed_open, %{count: 1, jobs: 2}, metadata}
       assert metadata.error_class == "db_pressure"
       assert metadata.outcome == :exhausted
+    end
+
+    test "08P01 protocol_violation is a query bug, not pool pressure (unmetered)",
+         %{conn: conn} do
+      # SQLSTATE class 08 is matched as pool pressure, but 08P01 is a driver/query-shape bug.
+      # Metering it would 429 an under-threshold tenant over a fault that is not its backlog.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        raise %Postgrex.Error{
+          postgres: %{code: :protocol_violation, pg_code: "08P01", message: "protocol violation"}
+        }
+      end)
+
+      # Allowance fully spent: an unmetered class must still admit.
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
+          do: {:deny, limit},
+          else: {:allow, 1}
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Protocol violation item", source_type: "newsletter"}]
+        })
+
+      assert length(json_response(conn, 200)["data"]) == 1
+
+      assert_receive {:backlog_failed_open, %{count: 1}, metadata}
+      assert metadata.error_class == "db_error"
+      assert metadata.outcome == :admitted
+    end
+
+    test "a LocalGuc capture ABORT is METERED like the other pool faults", %{conn: conn} do
+      # The abort is raised only after the capture ROUND TRIP itself failed — the connection
+      # is already wedged — so leaving it unmetered kept the unconditional admit this bound
+      # exists to remove for exactly the sustained fault it bounds.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        raise DBConnection.ConnectionError,
+              ~s(LocalGuc: could not capture ["statement_timeout"], which an enclosing ) <>
+                "scope already overrode"
+      end)
+
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
+          do: {:deny, limit},
+          else: {:allow, 1}
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Metered capture abort item", source_type: "newsletter"}]
+        })
+
+      assert json_response(conn, 429)["error"]["code"] == "ingestion_backlog_exceeded"
+
+      assert_receive {:backlog_failed_open, %{count: 1}, metadata}
+      assert metadata.error_class == "guc_capture_abort"
+      assert metadata.outcome == :exhausted
+    end
+
+    test "an UNCONSULTABLE meter admits (`:unmetered`), it does not 429 an innocent tenant",
+         %{conn: conn} do
+      # `{:allow, 0}` is the Postgres limiter's own fail-open sentinel, and under
+      # RATE_LIMITER=postgres that limiter store IS the AdminRepo pool whose exhaustion made
+      # the count unmeasurable — the two faults are perfectly correlated. A fail-CLOSED helper
+      # (`gate_ok?/3`) reads the sentinel as spent allowance and 429s on the FIRST blip with
+      # an untouched allowance; a fail-OPEN one (`within_limit?/3`) reports a plain admission.
+      # The verdict must tell "meter unreachable" apart from both.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        exit({:noproc, {DBConnection, :execute, []}})
+      end)
+
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, _limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
+          do: {:allow, 0},
+          else: {:allow, 1}
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Unconsultable meter item", source_type: "newsletter"}]
+        })
+
+      assert length(json_response(conn, 200)["data"]) == 1
+
+      assert_receive {:backlog_failed_open, %{count: 1, jobs: 1}, metadata}
+      assert metadata.outcome == :unmetered
+      assert metadata.error_class == "exit:noproc"
     end
 
     test "a 57014 cancel IS reported as a timeout", %{conn: conn} do

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -1075,9 +1075,9 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
-      # The counter means "the valve is currently ADMITTING because it can't measure", so a
-      # REFUSAL must not fire it — otherwise it over-reports admissions during exactly the
-      # incident an operator alerts on.
+      # The counter means "the gate could not MEASURE the backlog", so the REFUSAL must fire
+      # it too, tagged `outcome: :exhausted` — emitting only on admits made the sole alertable
+      # signal go silent at the moment the fault stopped being a blip and became the wedge.
       attach_failed_open(tenant.id)
 
       expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
@@ -1116,7 +1116,10 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert_receive {:fail_open_bucket, bucket}
       assert bucket =~ tenant.id
 
-      refute_receive {:backlog_failed_open, _measurements, _metadata}, 20
+      # Still alertable AFTER the allowance is spent, and distinguishable from an admission.
+      assert_receive {:backlog_failed_open, %{count: 1, jobs: 1}, metadata}
+      assert metadata.outcome == :exhausted
+      assert metadata.error_class == "exit:noproc"
     end
 
     test "the fail-open allowance is charged per ITEM, not per request", %{conn: conn} do
@@ -1126,6 +1129,8 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       # must spend one token, so the meter is in the same unit as the threshold.
       tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
 
       expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
         exit({:noproc, {DBConnection, :execute, []}})
@@ -1157,6 +1162,12 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert_receive :fail_open_token
       assert_receive :fail_open_token
       refute_receive :fail_open_token, 20
+
+      # The telemetry measurement is in the SAME unit as the allowance and the threshold. A
+      # per-REQUEST `count` alone under-read the admitted work of a batch by up to @batch_max,
+      # so a dashboard could not tell how close a tenant sat to the bound.
+      assert_receive {:backlog_failed_open, %{count: 1, jobs: 3}, metadata}
+      assert metadata.outcome == :admitted
     end
 
     test "a NON-timeout SQLSTATE is not reported as a timeout", %{conn: conn} do
@@ -1195,6 +1206,60 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
       assert_receive {:backlog_failed_open, %{count: 1}, metadata}
       assert metadata.error_class == "db_error"
+    end
+
+    test "a resource-exhaustion SQLSTATE is METERED, not waved through as a query bug",
+         %{conn: conn} do
+      # 53300 too_many_connections (and 57P03 / 08xxx) arrive as a Postgrex server ERROR, not
+      # a `DBConnection` exit — the normal presentation of a saturated pool behind pgbouncer.
+      # Lumping them into the unmetered `db_error` class meant the MOST LIKELY shape of the
+      # sustained pool fault kept the unconditional admit this bound exists to remove.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        raise %Postgrex.Error{
+          postgres: %{
+            code: :too_many_connections,
+            pg_code: "53300",
+            message: "sorry, too many clients already"
+          }
+        }
+      end)
+
+      test_pid = self()
+
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:") do
+          send(test_pid, :fail_open_token)
+          {:deny, limit}
+        else
+          {:allow, 1}
+        end
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [
+            %{content: "Pool pressure item one", source_type: "newsletter"},
+            %{content: "Pool pressure item two", source_type: "newsletter"}
+          ]
+        })
+
+      assert json_response(conn, 429)["error"]["code"] == "ingestion_backlog_exceeded"
+
+      # ONE token check for a 2-item batch: charging on past the first denial would queue
+      # more checkouts onto the very pool that is already starved.
+      assert_receive :fail_open_token
+      refute_receive :fail_open_token, 20
+
+      assert_receive {:backlog_failed_open, %{count: 1, jobs: 2}, metadata}
+      assert metadata.error_class == "db_pressure"
+      assert metadata.outcome == :exhausted
     end
 
     test "a 57014 cancel IS reported as a timeout", %{conn: conn} do


### PR DESCRIPTION
Split out of #557 at the owner's call. It is a **user-visible API behaviour change**, and #557 was about closing the `catch :exit` guard class.

## The problem

The backlog gate admits when it cannot **measure** a tenant's backlog — right for the transient blip it was written for. But the dominant fault here, a saturated or wedged `AdminRepo` pool (3 connections), is **sustained**, so an unconditional admit makes "no backpressure at all" the steady state during exactly the overload the valve exists to bound.

Worth stating plainly: before the exit shape was caught at all, the 500 *at least shed the flood incidentally*. #557 correctly stopped that 500 and thereby removed the accidental shedding. This is the other half of that fix, not an unrelated improvement — **if this doesn't merge, the unbounded-admission window is genuinely open on master** rather than incidentally covered.

## Numbers, since they changed a lot in review

| | value |
|---|---|
| Window | **1 hour** — the `:ingestion` queue's own drain cadence, not a minute |
| Per-node allowance | `max(@batch_max, div(OBAN_INGEST_BACKLOG_MAX, 10))` — **50 jobs/hour** at the default 500 |
| Fleet total | ~one threshold's worth per hour, and it auto-retunes with the threshold |

The first draft was 100 jobs *per minute* on a fixed constant. A per-minute window refills, so one sustained wedge admitted ~6000 jobs/hour — the meter named a sustained fault and bounded a transient one. Deriving the allowance from `OBAN_INGEST_BACKLOG_MAX` also means an operator retuning the threshold no longer silently invalidates the bound.

## Which faults are metered

**Metered** (pool pressure): `connection`, `timeout`, `db_pressure` (SQLSTATE 53/57/08 — exhaustion/connection classes a saturated pool raises behind pgbouncer), `exit:*`, `throw:*`, and `guc_capture_abort`.

`guc_capture_abort` **is** metered, reversing this PR's first draft: `LocalGuc` raises it only once the connection is *already* wedged, so its precondition is exactly the pressure the meter exists to bound.

**Unmetered** (admits unconditionally): `db_error` — a query-shape SQLSTATE is not backlog pressure, and capping it would 429 an under-threshold tenant with a backlog code it has not earned over a fault that is not its backlog. `08P01 protocol_violation` is carved back out of the 53/57/08 range for the same reason: a driver bug is not pool pressure.

## The tri-state, and why neither limiter helper sufficed

Under `RATE_LIMITER=postgres` the limiter's store is **the same `AdminRepo` pool** that is wedged — so the meter can be unconsultable by the very fault it meters. Neither existing helper could say that:

- `within_limit?/3` fails **open** → inert under precisely the correlated fault, so the meter silently does nothing.
- `gate_ok?/3` fails **closed** → 429s an innocent tenant on the first blip.

So the allowance is tri-state: `:admitted | :unmetered | :exhausted`. An unconsultable limiter admits as `:unmetered` and says so in telemetry — 429-ing a tenant whose backlog was neither measured *nor* metered is a code it has not earned.

## Observability

The `failed_open` event now fires on the **refusal** branch too, discriminated by an `outcome` key (`admitted` / `unmetered` / `refused`), plus a job-denominated `jobs` measurement alongside `count`. Without this the alert went silent exactly when the fault became sustained — the counter would stop firing at the moment an operator most needs it. Refusal logs are throttled through `FailOpenLog.warn/3`; telemetry is not.

## Known residual, not a deferral

A batch denied mid-charge **keeps the tokens it already spent**. `RateLimiter.Behaviour` exposes no reserve/refund primitive, so this is mitigated rather than eliminated: the allowance is floored at `@batch_max`, guaranteeing a fresh window always admits one whole batch, and the code comment says the tokens are unrefunded rather than claiming the halt avoids the burn. A true fix needs a `cost`/`reserve` argument on `check_rate/3` — a cross-file API change outside this branch.

## Blast radius

A tenant sees a 429 only when **all** of: the backlog count is unmeasurable, the fault is a pool-pressure class, the limiter is consultable, and it has already been admitted past its hourly job allowance. Normal operation and brief blips are unchanged.

## Docs kept true here

`BacklogCounterBehaviour`'s moduledoc stated an unmeasurable count must **unconditionally** admit — true on master, wrong the moment this merges. Corrected in this PR rather than left as a follow-up, and it now states all three outcomes plus the two invariants that hold regardless: never a generic 500, never fail-closed. That closes item 6 of #558.

## Verification

- `mix precommit` green: **6570 tests, 0 failures**, verified independently after the review's fixes.
- Guards mutation-verified: the tri-state, `guc_capture_abort` metering, and the `08P01` carve-out were each deleted and a specific test confirmed failing.
- The window value and the allowance derivation are asserted, so a future edit cannot silently revert the bound.

## Carry-forward

Eight further confirmed findings landed outside this diff and were appended to **#558** rather than spawning another PR, per the owner's decision to stop the chain. Two worth naming: `fallback_controller.ex`'s 429 body asserts "this tenant already has too many in-flight jobs queued", which on the metered path is a backlog that was never measured and may be zero; and `local_guc.ex`'s moduledoc still claims this gate "fails OPEN at 0".
