### PR TITLE
Make the last fail-soft guards actually fail soft, and unify the exit label

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -340,7 +340,7 @@ config :loopctl, :scale_alerts_config_checker, Loopctl.MockScaleAlertsConfigChec
 config :loopctl, :oban_orphan_count_checker, Loopctl.MockObanOrphanCountChecker
 
 # US-36.3: batch-ingest backlog admission gate's count DI seam. Default stub in
-# DataCase.stub_all_defaults/0 delegates to the real FairShare.in_flight_count/2;
+# DataCase.stub_all_defaults/0 delegates to the real FairShare.in_flight_ingestion_backlog/1;
 # the fail-open test overrides it to raise.
 config :loopctl, :ingestion_backlog_counter, Loopctl.MockBacklogCounter
 
@@ -712,6 +712,11 @@ config :loopctl, :embedding_read_path, Loopctl.MockEmbeddingReadPath
 # to the real `Loopctl.Embeddings.LegacyRetirement`, so every other test sees production
 # behaviour.
 config :loopctl, :legacy_retirement, Loopctl.MockLegacyRetirement
+
+# #558: FairShare's count is injected so the gate's fail-open EXIT branch is reachable.
+# DataCase stubs it back to the real `Loopctl.Oban.FairShare`, so every other test — including
+# the ones that seed real oban_jobs rows — exercises the real count unchanged.
+config :loopctl, :fair_share_counter, Loopctl.MockFairShareCounter
 
 # GH #551: a SHORT evidence window in tests. The production bar is 30 days; asserting
 # against it would mean fabricating 30 observation rows per test to say something that

--- a/lib/loopctl/exit_class.ex
+++ b/lib/loopctl/exit_class.ex
@@ -39,5 +39,10 @@ defmodule Loopctl.ExitClass do
   def classify(kind, reason), do: bounded(kind, ExitTag.tag(reason))
 
   defp closed(tag) when tag in @tags, do: tag
+
+  # Everything else, INCLUDING `ExitTag`'s own catch-all string "unknown". The two mean the
+  # same thing ("could not classify"), and a metric wants ONE label for that, not two
+  # spellings an operator has to know are synonyms. A log line may still say `unknown` — that
+  # is `ExitTag`'s vocabulary, and the translation is deliberate rather than drift.
   defp closed(_tag), do: "other"
 end

--- a/lib/loopctl/exit_class.ex
+++ b/lib/loopctl/exit_class.ex
@@ -2,22 +2,20 @@ defmodule Loopctl.ExitClass do
   @moduledoc """
   The BOUNDED, kind-prefixed metric CLASS for a non-local exit / throw.
 
-  `Loopctl.ExitTag` answers "what was the reason", and its answer is deliberately
-  open-ended: ANY exit-reason atom, or ANY exception MODULE name. That is the right
-  answer for a log line and the wrong one for a Prometheus LABEL — `error_class` is a
-  tag multiplied by `tenant_id` (`Loopctl.ScaleMetrics.degraded_read_tags/1`), so passing
-  `ExitTag` through verbatim grows the label's value set with whatever failure modes the
-  fleet happens to have, rather than an enumerable set an operator can write an alert
-  against.
+  `Loopctl.ExitTag` answers "what was the reason", open-endedly: ANY exit-reason atom or
+  exception MODULE name. Right for a log line, wrong for a Prometheus LABEL — `error_class`
+  multiplies `tenant_id` (`ScaleMetrics.degraded_read_tags/1`), so verbatim it is unbounded.
 
   So the tag is collapsed onto a CLOSED set: the shapes an operator actually triages —
   an absent pool (`noproc`), a wedged one (`timeout`), one shutting down (`shutdown`) or
   killed (`killed`), plus the two exception MODULES a pooled process actually dies of
   (`Postgrex.Error`, `DBConnection.ConnectionError`) — and `other` for everything else.
   The crash-PROPAGATION shapes are ENUMERATED rather than collapsed because `ExitTag`'s
-  clause list exists precisely to stop them degrading to a catch-all: dying of a backend
-  error is a different investigation from an unrecognised reason. The kind prefix stays,
-  because a dead pool and a throw escaping a guard call for different investigations too.
+  clause list exists precisely to stop them degrading to a catch-all, and the kind prefix
+  stays because a dead pool and a throw escaping a guard are different investigations.
+
+  That set is a METRICS vocabulary: derived from the exit REASON, it cannot say WHICH process
+  died, so a caller deciding RETRYABILITY must ask `pool_exit?/1` instead.
 
   Extracted rather than copied into each guard for the same reason `ExitTag` itself was:
   four private copies of "classify this exit" had already diverged.
@@ -38,11 +36,22 @@ defmodule Loopctl.ExitClass do
   @spec classify(:exit | :throw, term()) :: String.t()
   def classify(kind, reason), do: bounded(kind, ExitTag.tag(reason))
 
+  @pool_modules [DBConnection, DBConnection.Holder, DBConnection.Ownership, Postgrex]
+
+  @doc """
+  Whether an EXIT `reason` is DEMONSTRABLY from the DB pool: its call element names a pool
+  module, as in `{:noproc, {DBConnection, :execute, []}}` (the crash-propagation shape
+  `{{exception, stack}, {DBConnection, ...}}` has the same two-element form). Conservative —
+  what it cannot place is NOT a pool exit — so a caller mapping pool exits onto a retryable
+  503 never dresses up a foreign `{:timeout, {GenServer, :call, _}}` as a database outage.
+  """
+  @spec pool_exit?(term()) :: boolean()
+  def pool_exit?({_reason, {module, _fun, _args}}) when module in @pool_modules, do: true
+  def pool_exit?(_reason), do: false
+
   defp closed(tag) when tag in @tags, do: tag
 
-  # Everything else, INCLUDING `ExitTag`'s own catch-all string "unknown". The two mean the
-  # same thing ("could not classify"), and a metric wants ONE label for that, not two
-  # spellings an operator has to know are synonyms. A log line may still say `unknown` — that
-  # is `ExitTag`'s vocabulary, and the translation is deliberate rather than drift.
+  # Everything else, INCLUDING `ExitTag`'s own catch-all "unknown": both mean "could not
+  # classify", and a metric wants ONE label for that, not two spellings that are synonyms.
   defp closed(_tag), do: "other"
 end

--- a/lib/loopctl/exit_tag.ex
+++ b/lib/loopctl/exit_tag.ex
@@ -20,6 +20,13 @@ defmodule Loopctl.ExitTag do
 
   @spec tag(term()) :: String.t()
   def tag(reason) when is_atom(reason), do: to_string(reason)
+
+  # A BARE exception struct, not wrapped in an exit reason. `FairShare.over_cap?/4`'s rescue
+  # branch hands one straight in, and without this clause it fell to the catch-all — so every
+  # raise logged "unknown" and the class was lost at exactly the site that needed it. The
+  # MODULE name only, never `Exception.message/1`, which on a Postgrex/DBConnection struct
+  # names the backend host, database and role.
+  def tag(%module{} = reason) when is_exception(reason), do: inspect(module)
   def tag({reason, _call}) when is_atom(reason), do: to_string(reason)
   def tag({{%module{}, _stack}, _call}), do: inspect(module)
   def tag({{reason, _stack}, _call}) when is_atom(reason), do: to_string(reason)

--- a/lib/loopctl/local_guc.ex
+++ b/lib/loopctl/local_guc.ex
@@ -65,11 +65,23 @@ defmodule Loopctl.LocalGuc do
     try do
       fun.()
     after
-      # `restore/2` pops what `capture/2` pushed (the hand-paired form), so it runs FIRST and
-      # the reset to `enclosing` is the final word — an inner pop must not erase an outer
-      # scope's ownership of the same name.
+      # `restore/2` pops what `capture/2` pushed (the hand-paired form), so it runs FIRST.
       restore(repo, prior)
-      put_active_names(enclosing)
+
+      # #558: remove OUR names, rather than resetting to the `enclosing` snapshot.
+      #
+      # The snapshot was taken before `fun` ran, so restoring it DISCARDS any ownership the
+      # body pushed through the hand-paired `capture/2` and has not yet popped. Those names
+      # are still held on the connection, so erasing them tells a later nested `scoped/3`
+      # that nobody owns them — and on a capture failure that sends it down the RESET branch
+      # for a name an outer scope is actively holding, which is exactly the clobber
+      # `capture_fallback!/2` aborts to prevent.
+      #
+      # Subtracting our own names instead is correct in both directions: a body that pushed
+      # and popped symmetrically lands back on `enclosing`, and a body still holding a name
+      # keeps it. `--` removes one occurrence per element, which matches the push of
+      # `enclosing ++ names` even when an inner scope legitimately re-owns the same name.
+      put_active_names(active_names() -- names)
     end
   end
 
@@ -151,7 +163,11 @@ defmodule Loopctl.LocalGuc do
         # fail-soft path converts "this diagnostic could not be measured" into a failed
         # request, which is the thing those paths exist to prevent. So ON THIS ABORT — which
         # is a RAISE, and therefore exactly what a `rescue` clause sees — the ingestion backlog
-        # gate (`LoopctlWeb.KnowledgeIngestionController`) fails OPEN at 0, `Knowledge`'s
+        # gate (`LoopctlWeb.KnowledgeIngestionController`) returns `{:unmeasurable,
+        # "guc_capture_abort"}` for `backlog_fail_open_verdict/3` to adjudicate — and that
+        # class is now METERED, since this abort is raised only once the connection is already
+        # wedged. It formerly read "fails OPEN at 0" here, which described the unconditional
+        # admit that metering closed; a `0` count is the bug, not the behaviour. `Knowledge`'s
         # under-fill probe degrades to `:error`, and `ArticleLinkingWorker` skips its
         # observational count — all tagging, none re-raising.
         #

--- a/lib/loopctl/local_guc.ex
+++ b/lib/loopctl/local_guc.ex
@@ -65,23 +65,17 @@ defmodule Loopctl.LocalGuc do
     try do
       fun.()
     after
-      # `restore/2` pops what `capture/2` pushed (the hand-paired form), so it runs FIRST.
+      # #558: `restore/2` ALREADY pops exactly `names` (`prior` is `names` on BOTH capture
+      # paths), so this is this scope's ONE and ONLY pop — pop exactly once.
+      #
+      # Not a reset to the `enclosing` snapshot: that snapshot predates `fun`, so restoring it
+      # DISCARDS ownership the body pushed through the hand-paired `capture/2` and has not yet
+      # popped. Not a second `-- names` either: `--` removes one occurrence per element, so
+      # with same-name nesting the extra subtraction steals the ENCLOSING scope's entry.
+      # Both mistakes end the same way — a later nested `scoped/3` reads a still-held name as
+      # unowned and, on a capture failure, takes the RESET branch for a GUC an outer scope is
+      # actively holding, the clobber `capture_fallback!/2` aborts to prevent.
       restore(repo, prior)
-
-      # #558: remove OUR names, rather than resetting to the `enclosing` snapshot.
-      #
-      # The snapshot was taken before `fun` ran, so restoring it DISCARDS any ownership the
-      # body pushed through the hand-paired `capture/2` and has not yet popped. Those names
-      # are still held on the connection, so erasing them tells a later nested `scoped/3`
-      # that nobody owns them — and on a capture failure that sends it down the RESET branch
-      # for a name an outer scope is actively holding, which is exactly the clobber
-      # `capture_fallback!/2` aborts to prevent.
-      #
-      # Subtracting our own names instead is correct in both directions: a body that pushed
-      # and popped symmetrically lands back on `enclosing`, and a body still holding a name
-      # keeps it. `--` removes one occurrence per element, which matches the push of
-      # `enclosing ++ names` even when an inner scope legitimately re-owns the same name.
-      put_active_names(active_names() -- names)
     end
   end
 

--- a/lib/loopctl/local_guc.ex
+++ b/lib/loopctl/local_guc.ex
@@ -76,6 +76,26 @@ defmodule Loopctl.LocalGuc do
       # unowned and, on a capture failure, takes the RESET branch for a GUC an outer scope is
       # actively holding, the clobber `capture_fallback!/2` aborts to prevent.
       restore(repo, prior)
+      warn_unpopped(enclosing)
+    end
+  end
+
+  # The other side of popping exactly once: an occurrence the BODY pushed via the hand-paired
+  # `capture/2` and never popped survives this scope. Popping it here is not an option (that is
+  # the second-`--` bug above), and on a per-request/per-job process that dies it is harmless —
+  # but on a long-lived one (the shared `ScaleMetrics` poller) it is permanent, and a phantom
+  # owner makes every later capture failure for that name ABORT a read it could safely have
+  # RESET. So make the missing `forget/1` VISIBLE instead of silently sticky.
+  defp warn_unpopped(enclosing) do
+    case active_names() -- enclosing do
+      [] ->
+        :ok
+
+      leaked ->
+        Logger.warning(
+          "LocalGuc: #{inspect(leaked)} still held after scope exit — a capture/2 without a " <>
+            "matching restore/2 or forget/1; later scopes will abort rather than reset it"
+        )
     end
   end
 

--- a/lib/loopctl/oban/fair_share.ex
+++ b/lib/loopctl/oban/fair_share.ex
@@ -153,6 +153,7 @@ defmodule Loopctl.Oban.FairShare do
   require Logger
 
   alias Loopctl.AdminRepo
+  alias Loopctl.ExitTag
   alias Loopctl.LocalGuc
   alias Loopctl.ObanConfig
 
@@ -227,15 +228,28 @@ defmodule Loopctl.Oban.FairShare do
   # gate must not be able to wedge a queue). A malformed CAP is deliberately NOT caught
   # here (it is read in `over_fair_share?/3`, above this rescue) so it fails loud.
   defp over_cap?(tenant_id, queue, job_id, cap) do
-    lower_ranked_executing_count(tenant_id, queue, job_id) >= cap
+    counter().lower_ranked_executing_count(tenant_id, queue, job_id) >= cap
   rescue
     e ->
-      Logger.warning(
-        "FairShare gate failed open on queue=#{queue} tenant=#{tenant_id}: " <>
-          Exception.message(e)
-      )
+      # The bounded CLASS, never `Exception.message/1`: a Postgrex/DBConnection message names
+      # the backend host, database and role, and this line is reachable from any wedged-pool
+      # moment on an ordinary job.
+      fair_share_degraded(tenant_id, queue, ExitTag.tag(e))
+  catch
+    # #558: the rescue above covers only the RAISE shape, so this gate — which DOCUMENTS
+    # failing open on any count error — failed CLOSED on the fault most likely to trigger it.
+    # A DBConnection checkout against a wedged, saturated or unstarted pool EXITS, escaping
+    # the rescue entirely, and the escape kills the Oban job rather than admitting it. The
+    # gate exists so a counting problem never blocks work; on an exit it did the opposite.
+    kind, reason when kind in [:exit, :throw] ->
+      fair_share_degraded(tenant_id, queue, "#{kind}:#{ExitTag.tag(reason)}")
+  end
 
-      false
+  # One degrade path for both shapes, so the fail-open promise cannot drift between them.
+  defp fair_share_degraded(tenant_id, queue, class) do
+    Logger.warning("FairShare gate failed open on queue=#{queue} tenant=#{tenant_id} (#{class})")
+
+    false
   end
 
   @doc """
@@ -284,11 +298,22 @@ defmodule Loopctl.Oban.FairShare do
   # moduledoc). A `nil` job_id (bare `perform/1` struct in a test — off the real
   # dispatch path) has no rank, so we fall back to the plain unscoped executing count
   # (counts every executing job, including the caller).
-  defp lower_ranked_executing_count(tenant_id, queue, job_id) when is_integer(job_id) do
+  # Injected (`Loopctl.Oban.FairShareCounterBehaviour`) so the fail-open EXIT branch above is
+  # reachable from a test; production resolves to this module.
+  defp counter do
+    Application.get_env(:loopctl, :fair_share_counter, __MODULE__)
+  end
+
+  @behaviour Loopctl.Oban.FairShareCounterBehaviour
+
+  @impl Loopctl.Oban.FairShareCounterBehaviour
+  def lower_ranked_executing_count(tenant_id, queue, job_id)
+
+  def lower_ranked_executing_count(tenant_id, queue, job_id) when is_integer(job_id) do
     count(tenant_id, {:queue, to_string(queue)}, ["executing"], {:lower_than, job_id})
   end
 
-  defp lower_ranked_executing_count(tenant_id, queue, nil) do
+  def lower_ranked_executing_count(tenant_id, queue, nil) do
     count(tenant_id, {:queue, to_string(queue)}, ["executing"], :all)
   end
 

--- a/lib/loopctl/oban/fair_share.ex
+++ b/lib/loopctl/oban/fair_share.ex
@@ -28,9 +28,13 @@ defmodule Loopctl.Oban.FairShare do
   The cap (`Loopctl.ObanConfig.tenant_fair_share_cap/1`) is ALWAYS `>= 1`, so a
   tenant may always hold at least one slot and (with the rank decision below) the
   gate can never drive every job to snooze forever — even at jitter=0. The gate
-  FAILS OPEN on the COUNT only: if the executing-count query errors or times out,
-  `over_fair_share?/3` returns `false` (the job proceeds) rather than blocking — an
-  unmeasurable count must never stall work.
+  FAILS OPEN on the COUNT only, and only on the shapes that mean the count was
+  UNMEASURABLE: a `Postgrex.Error` / `DBConnection.{ConnectionError,EncodeError,
+  OwnershipError}` raise (a rolled-back count transaction is normalised into the first
+  of those by `count/4`), or a non-local EXIT. Then `over_fair_share?/3` returns `false`
+  (the job proceeds) rather than blocking — an unmeasurable count must never stall work.
+  A throw and any other raise are NOT count faults and fail LOUD, so a broken counter is
+  never mistaken for a wedged pool.
 
   The CAP, by contrast, FAILS LOUD. It is read in `over_fair_share?/3` OUTSIDE the
   count's rescue (in `over_cap?/4`), so a malformed `OBAN_TENANT_FAIRSHARE_<QUEUE>`
@@ -153,6 +157,7 @@ defmodule Loopctl.Oban.FairShare do
   require Logger
 
   alias Loopctl.AdminRepo
+  alias Loopctl.ExitClass
   alias Loopctl.ExitTag
   alias Loopctl.LocalGuc
   alias Loopctl.ObanConfig
@@ -212,10 +217,10 @@ defmodule Loopctl.Oban.FairShare do
   The CAP is read here, OUTSIDE the fail-open rescue below, so a malformed
   `OBAN_TENANT_FAIRSHARE_<QUEUE>` fails LOUD (crashes the job → visible) exactly like
   the snooze knobs, rather than being swallowed into a silent fail-open that disables
-  fairness. Only the COUNT query FAILS OPEN (`false`), and only on the shapes a wedged
-  pool actually produces — a `Postgrex.Error`/`DBConnection.ConnectionError` raise, or a
-  non-local exit/throw — so the gate can never wedge a queue while a broken caller still
-  fails loud. `ObanConfig.fair_share_config/0` also validates every cap at
+  fairness. Only the COUNT query FAILS OPEN (`false`), and only on the shapes an
+  unmeasurable count actually produces — a `Postgrex.Error`/`DBConnection.{ConnectionError,
+  EncodeError,OwnershipError}` raise, or a non-local exit — so the gate can never wedge a
+  queue while a broken counter still fails loud. `ObanConfig.fair_share_config/0` validates every cap at
   BOOT, so at runtime this parse cannot fail anyway.
   """
   @spec over_fair_share?(binary(), atom(), pos_integer() | nil) :: boolean()
@@ -225,23 +230,31 @@ defmodule Loopctl.Oban.FairShare do
     over_cap?(tenant_id, queue, job_id, cap)
   end
 
-  # The count-bearing half of the decision. FAILS OPEN (`false`) on a DB error/timeout or a
+  # The count-bearing half of the decision. FAILS OPEN (`false`) on a DB-layer raise or a
   # non-local exit — an unmeasurable count must NEVER block a job (SECURITY note: the
   # gate must not be able to wedge a queue). A malformed CAP is deliberately NOT caught
   # here (it is read in `over_fair_share?/3`, above this rescue) so it fails loud.
   defp over_cap?(tenant_id, queue, job_id, cap) do
     counter().lower_ranked_executing_count(tenant_id, queue, job_id) >= cap
   rescue
-    e in [Postgrex.Error, DBConnection.ConnectionError] ->
+    e in [
+      Postgrex.Error,
+      DBConnection.ConnectionError,
+      DBConnection.EncodeError,
+      DBConnection.OwnershipError
+    ] ->
       # The bounded CLASS, never `Exception.message/1`: a Postgrex/DBConnection message names
       # the backend host, database and role, and this line is reachable from any wedged-pool
       # moment on an ordinary job.
       #
-      # The DB shapes ONLY. A catch-all `e ->` also swallowed a broken DI seam: in `:test` the
-      # count resolves to a Mox mock, and a call from a process holding no stub raises
-      # `Mox.UnexpectedCallError` — which degraded into a silent admit, so every fair-share
-      # assertion made from such a process passed for the wrong reason. A non-DB raise is not
-      # a count error, and the fail-open promise does not cover it: it fails loud.
+      # The DB-LAYER shapes only — the ones that mean "the count was unmeasurable", including
+      # the encode/ownership failures `LocalGuc.failure_tag/1` already treats as first-class,
+      # and the `ConnectionError` `count/4` normalises a rolled-back count transaction into.
+      # A catch-all `e ->` also swallowed a broken DI seam: in `:test` the count resolves to a
+      # Mox mock, and a call from a process holding no stub raises `Mox.UnexpectedCallError` —
+      # which degraded into a silent admit, so every fair-share assertion made from such a
+      # process passed for the wrong reason. That is not a count error, and the fail-open
+      # promise does not cover it: it fails loud.
       fair_share_degraded(tenant_id, queue, ExitTag.tag(e))
   catch
     # #558: the rescue above covers only the RAISE shape, so this gate — which DOCUMENTS
@@ -249,8 +262,14 @@ defmodule Loopctl.Oban.FairShare do
     # A DBConnection checkout against a wedged, saturated or unstarted pool EXITS, escaping
     # the rescue entirely, and the escape kills the Oban job rather than admitting it. The
     # gate exists so a counting problem never blocks work; on an exit it did the opposite.
-    kind, reason when kind in [:exit, :throw] ->
-      fair_share_degraded(tenant_id, queue, "#{kind}:#{ExitTag.tag(reason)}")
+    #
+    # `:exit` ONLY, matching `KnowledgeSuggestLinksController`'s guard: a THROW is a
+    # deterministic fault in the counter itself, not an unmeasurable count, and blanket-catching
+    # it reopened for throws exactly the silent admit the narrowed rescue closed for raises.
+    # The class comes from `ExitClass` rather than a hand-rolled `"#{kind}:#{tag}"` — that
+    # spelling is the thing `ExitClass` was extracted to stop each guard re-deriving.
+    :exit, reason ->
+      fair_share_degraded(tenant_id, queue, ExitClass.classify(:exit, reason))
   end
 
   # One degrade path for both shapes, so the fail-open promise cannot drift between them.
@@ -368,12 +387,22 @@ defmodule Loopctl.Oban.FairShare do
 
     query = base |> apply_scope(scope) |> apply_id_predicate(id_predicate)
 
-    {:ok, result} =
-      LocalGuc.timed_transaction(AdminRepo, @count_statement_timeout_ms, fn ->
-        AdminRepo.one(query)
-      end)
+    # The transaction result is handled EXPLICITLY. A bare `{:ok, result} =` raised a
+    # `MatchError` on `{:error, _}` (a mid-transaction disconnect rolls the count back), which
+    # is neither a rescued DB shape nor an exit — so it escaped `over_cap?/4`'s fail-open
+    # entirely and killed the job, the exact inverse of this gate's contract. An unmeasurable
+    # count IS a connection failure, so it is normalised into the shape every caller of this
+    # helper already handles. The reason is a BOUNDED tag, never the raw term.
+    case LocalGuc.timed_transaction(AdminRepo, @count_statement_timeout_ms, fn ->
+           AdminRepo.one(query)
+         end) do
+      {:ok, result} ->
+        result || 0
 
-    result || 0
+      {:error, reason} ->
+        raise DBConnection.ConnectionError,
+              "oban_jobs count transaction failed (#{ExitTag.tag(reason)})"
+    end
   end
 
   defp apply_scope(query, {:queue, queue_str}) do

--- a/lib/loopctl/oban/fair_share.ex
+++ b/lib/loopctl/oban/fair_share.ex
@@ -212,8 +212,10 @@ defmodule Loopctl.Oban.FairShare do
   The CAP is read here, OUTSIDE the fail-open rescue below, so a malformed
   `OBAN_TENANT_FAIRSHARE_<QUEUE>` fails LOUD (crashes the job → visible) exactly like
   the snooze knobs, rather than being swallowed into a silent fail-open that disables
-  fairness. Only the COUNT query FAILS OPEN (`false`) on error/timeout so the gate can
-  never wedge a queue. `ObanConfig.fair_share_config/0` also validates every cap at
+  fairness. Only the COUNT query FAILS OPEN (`false`), and only on the shapes a wedged
+  pool actually produces — a `Postgrex.Error`/`DBConnection.ConnectionError` raise, or a
+  non-local exit/throw — so the gate can never wedge a queue while a broken caller still
+  fails loud. `ObanConfig.fair_share_config/0` also validates every cap at
   BOOT, so at runtime this parse cannot fail anyway.
   """
   @spec over_fair_share?(binary(), atom(), pos_integer() | nil) :: boolean()
@@ -223,17 +225,23 @@ defmodule Loopctl.Oban.FairShare do
     over_cap?(tenant_id, queue, job_id, cap)
   end
 
-  # The count-bearing half of the decision. FAILS OPEN (`false`) on any count
-  # error/timeout — an unmeasurable count must NEVER block a job (SECURITY note: the
+  # The count-bearing half of the decision. FAILS OPEN (`false`) on a DB error/timeout or a
+  # non-local exit — an unmeasurable count must NEVER block a job (SECURITY note: the
   # gate must not be able to wedge a queue). A malformed CAP is deliberately NOT caught
   # here (it is read in `over_fair_share?/3`, above this rescue) so it fails loud.
   defp over_cap?(tenant_id, queue, job_id, cap) do
     counter().lower_ranked_executing_count(tenant_id, queue, job_id) >= cap
   rescue
-    e ->
+    e in [Postgrex.Error, DBConnection.ConnectionError] ->
       # The bounded CLASS, never `Exception.message/1`: a Postgrex/DBConnection message names
       # the backend host, database and role, and this line is reachable from any wedged-pool
       # moment on an ordinary job.
+      #
+      # The DB shapes ONLY. A catch-all `e ->` also swallowed a broken DI seam: in `:test` the
+      # count resolves to a Mox mock, and a call from a process holding no stub raises
+      # `Mox.UnexpectedCallError` — which degraded into a silent admit, so every fair-share
+      # assertion made from such a process passed for the wrong reason. A non-DB raise is not
+      # a count error, and the fail-open promise does not cover it: it fails loud.
       fair_share_degraded(tenant_id, queue, ExitTag.tag(e))
   catch
     # #558: the rescue above covers only the RAISE shape, so this gate — which DOCUMENTS

--- a/lib/loopctl/oban/fair_share_counter_behaviour.ex
+++ b/lib/loopctl/oban/fair_share_counter_behaviour.ex
@@ -1,0 +1,26 @@
+defmodule Loopctl.Oban.FairShareCounterBehaviour do
+  @moduledoc """
+  DI seam for the count behind `Loopctl.Oban.FairShare`'s per-tenant fair-share gate (#558).
+
+  It exists for ONE branch: the gate's fail-open handling of a count that EXITS rather than
+  raises. `over_cap?/4` documents failing open on any count error and delivered it with a
+  `rescue` alone, so a DBConnection checkout against a wedged, saturated or unstarted pool —
+  which exits — escaped and killed the Oban job instead of admitting it. That is the fault
+  most likely to trigger the gate, handled backwards.
+
+  The branch is unreachable from a test otherwise: the sandboxed test pool answers, and an
+  ownership failure raises rather than exits. An untested fail-open is indistinguishable from
+  an absent one, which is how the original defect survived review.
+
+  Injected the same way as `Loopctl.Embeddings.ReadPathBehaviour`: `config/test.exs` points
+  `:fair_share_counter` at a Mox mock and `Loopctl.DataCase.stub_all_defaults/0` stubs it back
+  to the real implementation, so every other test sees production behaviour.
+  """
+
+  @doc "Count this tenant's lower-ranked EXECUTING jobs on a queue."
+  @callback lower_ranked_executing_count(
+              tenant_id :: binary(),
+              queue :: atom() | binary(),
+              job_id :: integer() | nil
+            ) :: non_neg_integer()
+end

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -362,6 +362,7 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
 
   require Logger
 
+  alias Loopctl.ExitClass
   alias Loopctl.ExitTag
   alias Loopctl.LocalGuc
   alias Loopctl.Repo
@@ -1472,7 +1473,18 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   # An EXIT/THROW is not an exception, so it can never be a struct above:
   # `guarded_measurement/5` hands it over wrapped as `{kind, bounded_tag}`. Its own class
   # because a pool checkout that exits has a different remedy from one that raises.
-  defp oban_poll_error_class({kind, _reason}) when kind in [:exit, :throw], do: to_string(kind)
+  #
+  # #558: routed through `ExitClass.bounded/2` so the label reads `exit:noproc`, matching the
+  # ingest-gate and under-fill-probe counters. It previously emitted a bare `"exit"`, which
+  # made three coexisting encodings of one concept across three counters — an operator
+  # correlating them had to know which series used which spelling, and the bare form threw
+  # away the discriminator (`noproc` vs `timeout`) that decides where to look.
+  defp oban_poll_error_class({kind, tag}) when kind in [:exit, :throw] and is_binary(tag),
+    do: ExitClass.bounded(kind, tag)
+
+  defp oban_poll_error_class({kind, reason}) when kind in [:exit, :throw],
+    do: ExitClass.classify(kind, reason)
+
   defp oban_poll_error_class(nil), do: "unknown"
   defp oban_poll_error_class(_other), do: "other"
 

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -345,8 +345,11 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
         measurement in `LoopctlWeb.Telemetry.periodic_measurements/0`:
         `"queue_state"`/`"executing_orphans"`/`"cluster_readiness"`/`"tenant_label_gate"`;
         `error_class` is CLASSIFIED via `oban_poll_error_class/1` into
-        `"db_error"`/`"guc_capture_abort"`/`"config_error"`/`"exit"`/`"throw"`/
-        `"other"`/`"unknown"`, never the raw exception message or exit reason).
+        `"db_error"`/`"guc_capture_abort"`/`"config_error"`/`"other"`/`"unknown"`,
+        or — for a non-local exit/throw — `"<kind>:<tag>"` over `Loopctl.ExitClass`'s
+        closed tag set (`"exit:noproc"`, `"exit:timeout"`, `"throw:other"`, …; #558
+        replaced the bare `"exit"`/`"throw"` labels, so re-point any selector on
+        those), never the raw exception message or exit reason).
         Emitted from `guarded_measurement/5` — the ONE guard every periodic
         measurement runs under — on the `rescue` AND the `catch :exit`/`:throw` path
         alike, so a frozen gauge (metrics 18/19/23 retaining their last value, or the

--- a/lib/loopctl_web/controllers/knowledge_suggest_links_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_suggest_links_controller.ex
@@ -13,6 +13,7 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksController do
   use OpenApiSpex.ControllerSpecs
 
   alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.ExitTag
   alias Loopctl.Knowledge
   alias LoopctlWeb.Helpers.Visibility
 
@@ -149,6 +150,22 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksController do
     knowledge().suggest_links_with_meta(tenant_id, article_id, opts)
   rescue
     e in [Postgrex.Error, DBConnection.ConnectionError] -> {:error, e}
+  catch
+    # #558: the rescue covers only the RAISE shape. A checkout against a wedged, saturated or
+    # unstarted pool EXITS, so it escaped this guard entirely and became a blanket 500 whose
+    # crash log carried the raw exit reason — which on this endpoint means the query text and
+    # its vector literals. That is both the unpinned status US-27.3 exists to prevent and an
+    # information-disclosure path the pinned response does not have.
+    #
+    # Classified as a `DBConnection.ConnectionError` deliberately rather than a new shape: a
+    # pool exit IS a connection failure, and this maps it onto the SAME pinned 503 +
+    # Retry-After the caller already understands. The message is the BOUNDED `ExitTag` class,
+    # never the reason itself.
+    kind, reason when kind in [:exit, :throw] ->
+      {:error,
+       %DBConnection.ConnectionError{
+         message: "suggest_links unavailable (#{kind}:#{ExitTag.tag(reason)})"
+       }}
   end
 
   defp knowledge do

--- a/lib/loopctl_web/controllers/knowledge_suggest_links_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_suggest_links_controller.ex
@@ -19,9 +19,6 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksController do
 
   action_fallback LoopctlWeb.FallbackController
 
-  # `ExitClass`'s catch-all bucket: the exits it could NOT place on a pool shape.
-  @unclassified_exit "exit:other"
-
   plug LoopctlWeb.Plugs.RequireRole, role: :agent
 
   tags(["Knowledge Wiki"])
@@ -166,18 +163,26 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksController do
     # Retry-After the caller already understands. The message is the BOUNDED `ExitClass`
     # class, never the reason itself.
     #
-    # ONLY the exits `ExitClass` recognises as pool shapes. A blanket `kind in [:exit,
-    # :throw]` told the client to retry a DETERMINISTIC fault (a throw, a non-DB `GenServer`
-    # timeout) as a transient database outage, and swallowed the crash report that would have
-    # named it. An unclassifiable exit is re-exited, and a throw is left alone, keeping the
-    # let-it-crash contract this guard narrows rather than replaces.
+    # ONLY an exit `ExitClass.pool_exit?/1` places on the POOL — i.e. one whose call tuple
+    # names a pool module. Not `classify/2`: that keys on the exit REASON, so a non-DB
+    # `{:timeout, {GenServer, :call, _}}` lands in its closed tag set and a blanket
+    # `kind in [:exit, :throw]` catch (or a tag-based one) still told the client to retry a
+    # DETERMINISTIC fault as a transient database outage, swallowing the crash report that
+    # would have named it. A throw is left alone entirely.
+    #
+    # An unplaceable exit is re-raised as a WRAPPED, SANITISED exit. Wrapped because a benign
+    # reason (`:normal`) re-exited verbatim is not a crash: the request process would just end,
+    # with no crash report and no status line — a closed connection instead of a 500. Sanitised
+    # because the raw reason is exactly what the comment above says must never reach a log on
+    # this endpoint: a DBConnection reason's call element carries the `%Postgrex.Query{}`
+    # statement and its bound vector literals, and `Plugs.DBErrorBackstop` rescues only, so
+    # nothing downstream would redact it.
     :exit, reason ->
-      case ExitClass.classify(:exit, reason) do
-        @unclassified_exit ->
-          exit(reason)
-
-        class ->
-          {:error, %DBConnection.ConnectionError{message: "suggest_links unavailable (#{class})"}}
+      if ExitClass.pool_exit?(reason) do
+        class = ExitClass.classify(:exit, reason)
+        {:error, %DBConnection.ConnectionError{message: "suggest_links unavailable (#{class})"}}
+      else
+        exit({:suggest_links_unclassified_exit, ExitClass.classify(:exit, reason)})
       end
   end
 

--- a/lib/loopctl_web/controllers/knowledge_suggest_links_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_suggest_links_controller.ex
@@ -13,11 +13,14 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksController do
   use OpenApiSpex.ControllerSpecs
 
   alias Loopctl.ApiSpec.Schemas
-  alias Loopctl.ExitTag
+  alias Loopctl.ExitClass
   alias Loopctl.Knowledge
   alias LoopctlWeb.Helpers.Visibility
 
   action_fallback LoopctlWeb.FallbackController
+
+  # `ExitClass`'s catch-all bucket: the exits it could NOT place on a pool shape.
+  @unclassified_exit "exit:other"
 
   plug LoopctlWeb.Plugs.RequireRole, role: :agent
 
@@ -134,8 +137,9 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksController do
 
   # Run the (possibly slow) vector-similarity query, translating a raised DB
   # exception into an `{:error, %Postgrex.Error{}}` / `{:error,
-  # %DBConnection.ConnectionError{}}` tuple. Only DB exceptions are caught;
-  # anything else is re-raised (let-it-crash). The suggest_links query runs on the
+  # %DBConnection.ConnectionError{}}` tuple. Only DB exceptions and the pool EXIT
+  # shapes `Loopctl.ExitClass` recognises are caught; anything else — an unclassifiable
+  # exit, a throw, any other raise — propagates (let-it-crash). The suggest_links query runs on the
   # dedicated HeavyReadRepo pool (via Loopctl.HeavyRead) — rescuing here does NOT
   # change which tenant's data is touched.
   #
@@ -159,13 +163,22 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksController do
     #
     # Classified as a `DBConnection.ConnectionError` deliberately rather than a new shape: a
     # pool exit IS a connection failure, and this maps it onto the SAME pinned 503 +
-    # Retry-After the caller already understands. The message is the BOUNDED `ExitTag` class,
-    # never the reason itself.
-    kind, reason when kind in [:exit, :throw] ->
-      {:error,
-       %DBConnection.ConnectionError{
-         message: "suggest_links unavailable (#{kind}:#{ExitTag.tag(reason)})"
-       }}
+    # Retry-After the caller already understands. The message is the BOUNDED `ExitClass`
+    # class, never the reason itself.
+    #
+    # ONLY the exits `ExitClass` recognises as pool shapes. A blanket `kind in [:exit,
+    # :throw]` told the client to retry a DETERMINISTIC fault (a throw, a non-DB `GenServer`
+    # timeout) as a transient database outage, and swallowed the crash report that would have
+    # named it. An unclassifiable exit is re-exited, and a throw is left alone, keeping the
+    # let-it-crash contract this guard narrows rather than replaces.
+    :exit, reason ->
+      case ExitClass.classify(:exit, reason) do
+        @unclassified_exit ->
+          exit(reason)
+
+        class ->
+          {:error, %DBConnection.ConnectionError{message: "suggest_links unavailable (#{class})"}}
+      end
   end
 
   defp knowledge do

--- a/lib/loopctl_web/fallback_controller.ex
+++ b/lib/loopctl_web/fallback_controller.ex
@@ -363,10 +363,16 @@ defmodule LoopctlWeb.FallbackController do
       error: %{
         status: 429,
         code: "ingestion_backlog_exceeded",
+        # #558: does NOT assert a measured backlog. This code now has TWO causes — the
+        # backlog is genuinely at/over threshold, OR the server could not measure it and
+        # the bounded fail-open allowance is spent. On the second, nothing was counted and
+        # the real backlog may be zero, so the old copy ("already has too many ... once the
+        # backlog drains") told the client a fact the server does not have, and pointed it
+        # at a remedy that may not apply.
         message:
-          "This tenant already has too many in-flight ingestion jobs queued. " <>
-            "No items from this batch were enqueued. Retry after #{retry_after} seconds " <>
-            "once the backlog drains.",
+          "Ingestion is shedding for this tenant: the in-flight backlog is at or over the " <>
+            "threshold, or it could not be measured. No items from this batch were " <>
+            "enqueued. Retry after #{retry_after} seconds.",
         retry_after_seconds: retry_after
       }
     })

--- a/test/loopctl/exit_tag_test.exs
+++ b/test/loopctl/exit_tag_test.exs
@@ -44,6 +44,27 @@ defmodule Loopctl.ExitTagTest do
     end
   end
 
+  describe "a BARE exception struct" do
+    test "is tagged by module — the shape a rescue branch hands in directly" do
+      # Regression: `FairShare.over_cap?/4`'s rescue passes the exception itself, and with
+      # no clause for it every raise degraded to "unknown". The test that was supposed to
+      # catch that asserted only `refute log =~ "db.internal"`, which "unknown" satisfies —
+      # a guard test passing for the wrong reason.
+      assert ExitTag.tag(%DBConnection.ConnectionError{message: "tcp connect (h:5432)"}) ==
+               "DBConnection.ConnectionError"
+
+      assert ExitTag.tag(%Postgrex.Error{}) == "Postgrex.Error"
+      assert ExitTag.tag(%ArgumentError{message: "bad"}) == "ArgumentError"
+    end
+
+    test "never carries the message" do
+      tag = ExitTag.tag(%DBConnection.ConnectionError{message: "tcp connect (db.internal:5432)"})
+
+      refute tag =~ "db.internal"
+      refute tag =~ "5432"
+    end
+  end
+
   describe "the ordinary shapes" do
     test "a bare atom is its own tag" do
       assert ExitTag.tag(:noproc) == "noproc"

--- a/test/loopctl/exit_tag_test.exs
+++ b/test/loopctl/exit_tag_test.exs
@@ -1,0 +1,85 @@
+defmodule Loopctl.ExitTagTest do
+  @moduledoc """
+  #558 — `Loopctl.ExitTag` had five clauses, five call sites and no test of its own.
+
+  That is a silent-deletion hazard rather than a coverage gap: removing the
+  crash-PROPAGATION clause degrades every such exit to `"unknown"` at all five sites, and
+  nothing anywhere fails. The clause list IS the module — it was extracted precisely
+  because four private copies had already diverged into two behaviours — so it needs a test
+  that pins each clause to the SHAPE it exists for.
+
+  Every reason below is a real shape DBConnection/Postgrex produce, not a convenient
+  fixture. That distinction is the whole point: a tagger with only an atom clause passes
+  against a hand-written `exit(:noproc)` while degrading every genuine production exit.
+  """
+  use ExUnit.Case, async: true
+
+  alias Loopctl.ExitTag
+
+  describe "the shapes DBConnection actually exits with" do
+    test "a {reason, call} tuple — an absent or unstarted pool" do
+      # NOT a bare `:noproc`. This is the shape that matters, and the one an atom-only
+      # tagger silently misses.
+      assert ExitTag.tag({:noproc, {DBConnection, :execute, []}}) == "noproc"
+    end
+
+    test "a {reason, call} tuple — a wedged pool's checkout timeout" do
+      assert ExitTag.tag({:timeout, {DBConnection.Holder, :checkout, []}}) == "timeout"
+    end
+
+    test "crash PROPAGATION carrying an exception struct" do
+      # The pooled process died OF something rather than being absent. This is the clause
+      # the module was extracted to preserve: deleting it degrades this to "unknown" at
+      # every call site, and dying of a backend error is a different investigation from an
+      # unrecognised reason.
+      reason = {{%Postgrex.Error{message: "boom"}, [{:erl, :f, 0, []}]}, {DBConnection, :x, []}}
+
+      assert ExitTag.tag(reason) == "Postgrex.Error"
+    end
+
+    test "crash propagation carrying a bare atom reason" do
+      reason = {{:badarg, [{:erl, :f, 0, []}]}, {DBConnection, :x, []}}
+
+      assert ExitTag.tag(reason) == "badarg"
+    end
+  end
+
+  describe "the ordinary shapes" do
+    test "a bare atom is its own tag" do
+      assert ExitTag.tag(:noproc) == "noproc"
+      assert ExitTag.tag(:shutdown) == "shutdown"
+      assert ExitTag.tag(:killed) == "killed"
+    end
+
+    test "anything unrecognised collapses to a single catch-all" do
+      assert ExitTag.tag("a string") == "unknown"
+      assert ExitTag.tag(%{not: :a_reason}) == "unknown"
+      assert ExitTag.tag(12_345) == "unknown"
+    end
+  end
+
+  describe "the bound the tag exists to keep" do
+    test "it never returns an exception MESSAGE, only a module name" do
+      # The message on a Postgrex/DBConnection struct names the backend host, database and
+      # role. Every call site logs or tags with this value, so leaking the message here
+      # leaks it at all five.
+      reason =
+        {{%DBConnection.ConnectionError{message: "tcp connect (db.internal:5432): timeout"}, []},
+         {DBConnection, :execute, []}}
+
+      tag = ExitTag.tag(reason)
+
+      assert tag == "DBConnection.ConnectionError"
+      refute tag =~ "db.internal"
+      refute tag =~ "5432"
+    end
+
+    test "it never returns the call tuple, which carries module, function and args" do
+      tag = ExitTag.tag({:noproc, {DBConnection, :execute, [:secret_arg]}})
+
+      assert tag == "noproc"
+      refute tag =~ "secret_arg"
+      refute tag =~ "DBConnection"
+    end
+  end
+end

--- a/test/loopctl/local_guc_test.exs
+++ b/test/loopctl/local_guc_test.exs
@@ -1,0 +1,31 @@
+defmodule Loopctl.LocalGucTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.LocalGuc
+  alias Loopctl.Repo
+
+  # The stack `scoped/3` and the hand-paired `capture/2`+`restore/2` share. Read directly
+  # because the ownership bug it guards has no cheaper observable: its damage lands only on a
+  # LATER nested capture FAILURE, which needs a wedged connection to reproduce.
+  @active_names_key {LocalGuc, :active_names}
+
+  describe "scoped/3 ownership bookkeeping" do
+    test "a nested scope pops exactly its own names, leaving the enclosing owner intact" do
+      Repo.transaction(fn ->
+        LocalGuc.scoped(Repo, ["statement_timeout"], fn ->
+          LocalGuc.scoped(Repo, ["statement_timeout"], fn -> :ok end)
+
+          # A double pop (`restore/2` pops, and `scoped/3` popping again) removes the OUTER
+          # scope's occurrence too, so this reads `nil` — and the next nested capture failure
+          # takes `capture_fallback!/2`'s RESET branch instead of ABORT, clobbering a
+          # `statement_timeout` this scope is still holding.
+          assert Process.get(@active_names_key) == ["statement_timeout"]
+        end)
+      end)
+
+      assert Process.get(@active_names_key) == nil
+    end
+  end
+end

--- a/test/loopctl/oban/fair_share_test.exs
+++ b/test/loopctl/oban/fair_share_test.exs
@@ -125,9 +125,23 @@ defmodule Loopctl.Oban.FairShareTest do
       refute log =~ "DBConnection.execute"
     end
 
-    test "a THROW admits too — the third non-local kind", %{tenant: tenant} do
+    test "a THROW is NOT swallowed — it is a broken counter, not an unmeasurable count", %{
+      tenant: tenant
+    } do
+      # #559: blanket-catching `:throw` reopened for throws the same silent admit the narrowed
+      # rescue closed for raises — a counter that throws for control flow degraded into `:ok`
+      # and every fair-share assertion made through it passed for the wrong reason. The
+      # sibling guard in `KnowledgeSuggestLinksController` makes the same call.
       stub(Loopctl.MockFairShareCounter, :lower_ranked_executing_count, fn _t, _q, _j ->
         throw(:boom)
+      end)
+
+      assert catch_throw(FairShare.gate(tenant.id, :knowledge, 1)) == :boom
+    end
+
+    test "a DB-layer OwnershipError still fails open", %{tenant: tenant} do
+      stub(Loopctl.MockFairShareCounter, :lower_ranked_executing_count, fn _t, _q, _j ->
+        raise DBConnection.OwnershipError, "owner exited"
       end)
 
       log =
@@ -135,7 +149,8 @@ defmodule Loopctl.Oban.FairShareTest do
           assert FairShare.gate(tenant.id, :knowledge, 1) == :ok
         end)
 
-      assert log =~ "throw:"
+      assert log =~ "FairShare gate failed open"
+      assert log =~ "DBConnection.OwnershipError"
     end
 
     test "a RAISE still fails open, with its own bounded class", %{tenant: tenant} do

--- a/test/loopctl/oban/fair_share_test.exs
+++ b/test/loopctl/oban/fair_share_test.exs
@@ -98,9 +98,8 @@ defmodule Loopctl.Oban.FairShareTest do
 
   describe "#558: the gate fails OPEN on a count that EXITS, not just one that raises" do
     setup do
-      import Mox
-      setup_test_tenant = fixture(:tenant)
-      %{tenant: setup_test_tenant}
+      # Mox comes from `Loopctl.DataCase`'s `using` block; the stubs live in the test bodies.
+      %{tenant: fixture(:tenant)}
     end
 
     test "a wedged-pool EXIT admits the job instead of killing it", %{tenant: tenant} do
@@ -158,6 +157,19 @@ defmodule Loopctl.Oban.FairShareTest do
       assert log =~ "DBConnection.ConnectionError"
       # The pre-existing rescue logged Exception.message/1, which names the backend host.
       refute log =~ "db.internal"
+    end
+
+    test "a NON-DB raise is not swallowed — the fail-open covers count faults only", %{
+      tenant: tenant
+    } do
+      # The catch-all `e ->` this narrowed also ate `Mox.UnexpectedCallError`, so a gate
+      # reached from a process holding no stub silently admitted every job and any assertion
+      # of `:ok` there passed for the wrong reason.
+      stub(Loopctl.MockFairShareCounter, :lower_ranked_executing_count, fn _t, _q, _j ->
+        raise ArgumentError, "broken seam"
+      end)
+
+      assert_raise ArgumentError, fn -> FairShare.gate(tenant.id, :knowledge, 1) end
     end
   end
 

--- a/test/loopctl/oban/fair_share_test.exs
+++ b/test/loopctl/oban/fair_share_test.exs
@@ -96,6 +96,65 @@ defmodule Loopctl.Oban.FairShareTest do
     end
   end
 
+  describe "#558: the gate fails OPEN on a count that EXITS, not just one that raises" do
+    setup do
+      import Mox
+      setup_test_tenant = fixture(:tenant)
+      %{tenant: setup_test_tenant}
+    end
+
+    test "a wedged-pool EXIT admits the job instead of killing it", %{tenant: tenant} do
+      # `over_cap?/4` DOCUMENTS failing open on any count error, and delivered that with a
+      # `rescue` alone. A DBConnection checkout against a wedged, saturated or unstarted pool
+      # EXITS — it does not raise — so the escape killed the Oban job rather than admitting
+      # it: the exact inverse of the contract, on the fault most likely to trigger the gate.
+      #
+      # The production exit shape, not a bare atom: an atom-only handler would pass here and
+      # still miss every real one.
+      stub(Loopctl.MockFairShareCounter, :lower_ranked_executing_count, fn _t, _q, _j ->
+        exit({:noproc, {DBConnection, :execute, []}})
+      end)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert FairShare.gate(tenant.id, :knowledge, 1) == :ok
+        end)
+
+      assert log =~ "FairShare gate failed open"
+      # BOUNDED class, never the raw reason — which carries the DBConnection call tuple.
+      assert log =~ "exit:noproc"
+      refute log =~ "DBConnection.execute"
+    end
+
+    test "a THROW admits too — the third non-local kind", %{tenant: tenant} do
+      stub(Loopctl.MockFairShareCounter, :lower_ranked_executing_count, fn _t, _q, _j ->
+        throw(:boom)
+      end)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert FairShare.gate(tenant.id, :knowledge, 1) == :ok
+        end)
+
+      assert log =~ "throw:"
+    end
+
+    test "a RAISE still fails open, with its own bounded class", %{tenant: tenant} do
+      stub(Loopctl.MockFairShareCounter, :lower_ranked_executing_count, fn _t, _q, _j ->
+        raise %DBConnection.ConnectionError{message: "tcp connect (db.internal:5432): timeout"}
+      end)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert FairShare.gate(tenant.id, :knowledge, 1) == :ok
+        end)
+
+      assert log =~ "FairShare gate failed open"
+      # The pre-existing rescue logged Exception.message/1, which names the backend host.
+      refute log =~ "db.internal"
+    end
+  end
+
   describe "tenant isolation (AC-36.2.6)" do
     test "tenant A's count never includes tenant B's jobs" do
       tenant_a = Ecto.UUID.generate()

--- a/test/loopctl/oban/fair_share_test.exs
+++ b/test/loopctl/oban/fair_share_test.exs
@@ -150,6 +150,12 @@ defmodule Loopctl.Oban.FairShareTest do
         end)
 
       assert log =~ "FairShare gate failed open"
+
+      # Assert the CLASS positively. The first version of this test only did the `refute`
+      # below, which "unknown" satisfies just as well as a correct tag — and that is exactly
+      # what shipped: `ExitTag.tag/1` had no clause for a bare exception struct, so every
+      # raise degraded to "unknown" and the test passed anyway.
+      assert log =~ "DBConnection.ConnectionError"
       # The pre-existing rescue logged Exception.message/1, which names the backend host.
       refute log =~ "db.internal"
     end

--- a/test/loopctl/telemetry/scale_metrics_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_test.exs
@@ -1038,12 +1038,16 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
       assert ScaleMetrics.oban_poll_error_tags(%{
                poller: :executing_orphans,
                exception: {:exit, "noproc"}
-             }) == %{poller: :executing_orphans, error_class: "exit"}
+             }) == %{poller: :executing_orphans, error_class: "exit:noproc"}
 
       assert ScaleMetrics.oban_poll_error_tags(%{
                poller: :cluster_readiness,
                exception: {:throw, "unknown"}
-             }) == %{poller: :cluster_readiness, error_class: "throw"}
+             }) == %{poller: :cluster_readiness, error_class: "throw:other"}
+
+      # `ExitTag`'s own catch-all is the string "unknown"; `ExitClass`'s is "other". They
+      # mean the same thing, and the metric deliberately keeps ONE catch-all label rather
+      # than two spellings of it — so an ExitTag "unknown" lands on "other" here by design.
     end
 
     test "oban_poll_error_tags/1 defaults missing keys to \"unknown\", never raises" do
@@ -1105,8 +1109,11 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
 
       refute inspect(exception) =~ "DBConnection"
 
+      # #558: the label carries the DISCRIMINATOR (`exit:noproc`), not a bare kind. A bare
+      # "exit" threw away the one bit that says where to look — a dead pool vs a checkout
+      # timeout — and spelled the same concept three different ways across three counters.
       assert ScaleMetrics.oban_poll_error_tags(%{poller: :queue_state, exception: exception}) ==
-               %{poller: :queue_state, error_class: "exit"}
+               %{poller: :queue_state, error_class: "exit:noproc"}
     end
 
     test "a THROWING body is guarded too — telemetry_poller drops an MFA on all three kinds" do
@@ -1121,7 +1128,7 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
                      500
 
       assert ScaleMetrics.oban_poll_error_tags(%{poller: :queue_state, exception: exception}) ==
-               %{poller: :queue_state, error_class: "throw"}
+               %{poller: :queue_state, error_class: "throw:other"}
     end
 
     test "a RAISING body keeps its own message and passes the struct through for classification" do
@@ -1140,7 +1147,13 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
 
     test "a SUCCEEDING body returns its own value and fires no counter" do
       assert guarded(fn -> :ok end) == :ok
-      refute_receive {:poll_error, _metadata, _measurements}, 200
+
+      # #558: SCOPED to this poller, like every sibling in the block. Unscoped, it also
+      # matched the APP's real 10s telemetry_poller, which shares the VM and legitimately
+      # emits poll errors of its own while the suite runs — so this asserted "nothing else
+      # in the system failed a poll", which is not this test's claim and reddens CI at
+      # random.
+      refute_receive {:poll_error, %{poller: :queue_state}, _measurements}, 200
     end
   end
 

--- a/test/loopctl_web/controllers/knowledge_suggest_links_exit_guard_test.exs
+++ b/test/loopctl_web/controllers/knowledge_suggest_links_exit_guard_test.exs
@@ -1,0 +1,66 @@
+defmodule LoopctlWeb.KnowledgeSuggestLinksExitGuardTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  # #559: the `catch :exit` guard in `KnowledgeSuggestLinksController.suggest_links_guarded/3`
+  # decides RETRYABILITY, and shipped with no assertion on either branch — the repo's own
+  # recorded lesson being that a guard asserted only through its classifier goes inert. The
+  # article need not exist: the DI'd `:knowledge_suggest_links` seam IS the whole path here.
+  setup :verify_on_exit!
+
+  defp authed(conn) do
+    tenant = fixture(:tenant)
+    {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  defp request(conn),
+    do: get(conn, ~p"/api/v1/knowledge/articles/#{Ecto.UUID.generate()}/suggested_links")
+
+  test "a POOL-shaped exit -> pinned 503 db_unavailable + Retry-After", %{conn: conn} do
+    conn = authed(conn)
+
+    # The production shape (a call tuple naming a pool module), not a bare atom.
+    expect(Loopctl.MockSuggestLinks, :suggest_links_with_meta, fn _t, _a, _o ->
+      exit({:noproc, {DBConnection, :execute, []}})
+    end)
+
+    resp = request(conn)
+
+    assert resp.status == 503
+    assert json_response(resp, 503)["error"]["code"] == "db_unavailable"
+    assert get_resp_header(resp, "retry-after") != []
+  end
+
+  test "a NON-DB GenServer timeout is not dressed up as a database outage", %{conn: conn} do
+    conn = authed(conn)
+
+    # Same REASON atom as a wedged pool (`:timeout`), different SOURCE — which is why the
+    # guard asks `ExitClass.pool_exit?/1` and not the reason-keyed `classify/2`.
+    expect(Loopctl.MockSuggestLinks, :suggest_links_with_meta, fn _t, _a, _o ->
+      exit({:timeout, {GenServer, :call, [SomeForeignServer, :ping, 5000]}})
+    end)
+
+    assert catch_exit(request(conn)) == {:suggest_links_unclassified_exit, "exit:timeout"}
+  end
+
+  test "a benign unplaceable exit still crashes, and carries no raw reason", %{conn: conn} do
+    conn = authed(conn)
+
+    # `exit(:normal)` re-exited verbatim ends the request process with NO crash report and NO
+    # status line; the wrapper keeps it a crash. The re-exited term is the bounded class, so
+    # the query text and vector literals a pool reason carries can never reach the crash log.
+    expect(Loopctl.MockSuggestLinks, :suggest_links_with_meta, fn _t, _a, _o -> exit(:normal) end)
+
+    reason = catch_exit(request(conn))
+
+    assert {:suggest_links_unclassified_exit, "exit:other"} = reason
+  end
+
+  test "a THROW is left alone — the let-it-crash contract the guard narrows", %{conn: conn} do
+    conn = authed(conn)
+
+    expect(Loopctl.MockSuggestLinks, :suggest_links_with_meta, fn _t, _a, _o -> throw(:boom) end)
+
+    assert catch_throw(request(conn)) == :boom
+  end
+end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -102,6 +102,16 @@ defmodule Loopctl.DataCase do
 
     stub_embedding_read_path()
 
+    # #558: default to the REAL count, so every existing fair-share test (which seeds real
+    # oban_jobs rows in its own sandboxed transaction) is unaffected. Only the fail-open test
+    # overrides it to EXIT — the one shape a sandboxed pool cannot produce, and the reason
+    # this gate shipped failing CLOSED.
+    Mox.stub(
+      Loopctl.MockFairShareCounter,
+      :lower_ranked_executing_count,
+      &FairShare.lower_ranked_executing_count/3
+    )
+
     # GH #551: production behaviour by default — the retirement trigger really probes,
     # records and evaluates. Only the worker's fail-closed test overrides `probe/0` to
     # return an error, which is the one shape the test database cannot produce.

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -114,6 +114,12 @@ Mox.defmock(Loopctl.MockEmbeddingReadPath, for: Loopctl.Embeddings.ReadPathBehav
 # delegates to the real `Loopctl.Embeddings.LegacyRetirement`.
 Mox.defmock(Loopctl.MockLegacyRetirement, for: Loopctl.Embeddings.LegacyRetirementBehaviour)
 
+# #558: DI seam for FairShare's fair-share count. It exists for one branch — the gate's
+# fail-open handling of a count that EXITS — which the sandboxed pool cannot produce, and
+# which shipped BACKWARDS (fail-closed, killing the Oban job) precisely because nothing
+# could test it.
+Mox.defmock(Loopctl.MockFairShareCounter, for: Loopctl.Oban.FairShareCounterBehaviour)
+
 # US-27.16: DI seam for the streaming-export producer's per-body observation point. The
 # bounded-memory scale gate must prove its metric is LOAD-BEARING by turning the streaming
 # producer into a MATERIALIZING one, which needs a seam in the production emit path.


### PR DESCRIPTION
Addresses **8 of the 12 items in #558**. Three findings landed outside the diff and go to that issue.

## The severe one — `FairShare.over_cap?/4` failed CLOSED

It **documents** failing open on any count error and delivered that with a `rescue` alone. A DBConnection checkout against a wedged, saturated or unstarted pool **exits** — the fault most likely to trigger the gate — so it escaped and **killed the Oban job instead of admitting it**.

A new `FairShareCounterBehaviour` DI seam exists solely to make that branch reachable from a test: a sandboxed pool answers, and an ownership failure *raises* rather than exits, which is how the defect survived review in the first place.

## `suggest_links_guarded/3` — an exit became an unsanitized 500

The raw exit reason on this endpoint carries the query text and its vector literals. Now mapped onto the existing pinned 503 rather than a blanket crash report.

## Also

`HeavyRead.exit_tag/1` (the last private copy) folded into `Loopctl.ExitTag`; `oban_poll_error_class` routed through `ExitClass` so three counters share one label vocabulary; new `exit_tag_test.exs`; the ingestion 429 no longer asserts a backlog that was never measured; a `refute_receive` that matched the app's own live poller scoped to its own.

---

## What review changed — three of these were my defects

**This PR's first review run was mis-dispatched.** My working tree was on another branch, so it reviewed the wrong diff and returned clean — a clean result on the wrong diff being indistinguishable from a clean result on the right one. The re-run against the correct diff found **28 confirmed findings, 25 fixed**. Three were regressions in my own work:

1. **`LocalGuc.scoped/3`: my fix was itself a clobber.** `restore/2` *already* pops `names` (`prior == names` on both capture paths), so my added `-- names` was a **second** pop — and since `--` removes one occurrence per element, same-name nesting steals the **enclosing** scope's entry. A later nested capture failure then takes the RESET branch against a GUC an outer scope is actively holding: precisely the clobber `capture_fallback!/2` aborts to prevent, reintroduced by the fix meant to prevent it. Now pops exactly once, plus a warning when a hand-paired `capture/2` never reaches `forget/1`. KB decision `bb813c70` already prescribed this.

2. **`FairShare`'s catch-all `rescue e ->` swallowed `Mox.UnexpectedCallError`**, turning a test-infrastructure error into a silent fail-open admit. Narrowed to real DB shapes — `Postgrex.Error` plus `DBConnection.{ConnectionError, EncodeError, OwnershipError}` — so a genuinely unmeasurable count still fails open. Its `{:ok, result} =` destructure also became an explicit `{:error, _}` branch; that `MatchError` was killing the job.

3. **`suggest_links_guarded`'s blanket `kind in [:exit, :throw]` made *any* exit a retryable 503**, including non-DB ones. Round 2 added `ExitClass.pool_exit?/1`, keyed on the **call target** rather than the reason atom — so the Prometheus label vocabulary stopped doubling as the HTTP retry contract.

### Residual risk, stated rather than buried

`pool_exit?/1` is deliberately conservative: an exit shaped `{:timeout, {GenServer, :call, [pool_pid, ...]}}` that genuinely comes from the pool now re-exits (500 + crash report) instead of returning the pinned 503. The documented production shape `{:noproc, {DBConnection, :execute, []}}` **is** matched. If a real 503-worthy shape naming `GenServer` shows up, widen `@pool_modules` or catch at the `HeavyRead` boundary where the callee is known — do not revert to reason-keying.

One branch is knowingly untested: `count/4`'s `{:error, _}` transaction branch, which `LocalGuc.timed_transaction/4` only produces on a rollback that cannot be provoked from outside `FairShare`.

## Verification

- `mix precommit` green, verified independently after the review's fixes: **6592 tests, 0 failures**.
- Guards mutation-verified, including the new ones: forcing `pool_exit?/1` true fails both non-pool-exit tests; re-widening `FairShare`'s catch fails the throw test; re-adding the `LocalGuc` double pop fails its new guard test.

## Carry-forward

Three confirmed findings land outside this diff and go to **#558**, not a new PR — per the stopping rule in claude-config#204.
