### PR TITLE
Gate the AGENTS.md usage-rules block against silent drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,22 @@ jobs:
       - name: Run Credo
         run: mix credo --strict
 
+      # #556: AGENTS.md's usage-rules block is GENERATED from the dependency set, so it
+      # goes stale the moment a dep is added, removed or upgraded — silently, because
+      # nothing regenerates or verifies it. Same failure shape as the undocumented-env-var
+      # problem already gated by `mix loopctl.check_env_docs`.
+      #
+      # Lives HERE and not in `mix precommit` for a concrete reason: `usage_rules` is
+      # `only: :dev`, and `precommit` runs under `preferred_envs: [precommit: :test]`, so
+      # the task does not exist there — adding it to that alias fails every local
+      # precommit with "task could not be found", which is the exact breakage the
+      # hex.audit comment in mix.exs records having already happened once. This job has no
+      # MIX_ENV, so it is dev and the dep is present. Offline, ~0.8s warm.
+      #
+      # `--check` reports drift and exits non-zero WITHOUT rewriting the file (verified).
+      - name: Check AGENTS.md usage-rules block is not stale
+        run: mix usage_rules.sync --check
+
       # #541 — nothing in CI compiled assets/js before this. A syntax or import
       # error in a LiveView hook therefore surfaced only in the Docker build at
       # DEPLOY time (Dockerfile runs `mix assets.deploy`), long after review.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,7 @@ jobs:
       - name: Run Credo
         run: mix credo --strict
 
-
-      # #541 — nothing in CI compiled assets/js before this. A syntax or import
+      # #541— nothing in CI compiled assets/js before this. A syntax or import
       # error in a LiveView hook therefore surfaced only in the Docker build at
       # DEPLOY time (Dockerfile runs `mix assets.deploy`), long after review.
       # That gap stopped being tolerable once /enroll shipped a ceremony that is
@@ -259,10 +258,14 @@ jobs:
       - name: Install dependencies
         run: mix deps.get
 
-      # #556: AGENTS.md's usage-rules block is GENERATED from the dependency set, so it
-      # goes stale the moment a dep is added, removed or upgraded — silently, because
-      # nothing regenerates or verifies it. Same failure shape as the undocumented-env-var
-      # problem already gated by `mix loopctl.check_env_docs`.
+      # #556: AGENTS.md's usage-rules block is GENERATED, and nothing regenerates or
+      # verifies it — same failure shape as the undocumented-env-var problem already gated
+      # by `mix loopctl.check_env_docs`. SCOPE, stated so nobody over-trusts this gate:
+      # mix.exs `usage_rules/0` names an EXPLICIT package list, not `:all`, so drift is
+      # caught for those packages (an upgrade that rewrites their rules text, a hand edit
+      # inside the markers, a change to the list itself). Adding an unrelated dependency
+      # produces no drift and stays green — even one shipping usage-rules, as igniter and
+      # mdex already do.
       #
       # It rides THIS job, whose subject is otherwise unrelated, for one reason:
       # `usage_rules` is `only: :dev` and the workflow-level default is `MIX_ENV: test`,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,21 +95,6 @@ jobs:
       - name: Run Credo
         run: mix credo --strict
 
-      # #556: AGENTS.md's usage-rules block is GENERATED from the dependency set, so it
-      # goes stale the moment a dep is added, removed or upgraded — silently, because
-      # nothing regenerates or verifies it. Same failure shape as the undocumented-env-var
-      # problem already gated by `mix loopctl.check_env_docs`.
-      #
-      # Lives HERE and not in `mix precommit` for a concrete reason: `usage_rules` is
-      # `only: :dev`, and `precommit` runs under `preferred_envs: [precommit: :test]`, so
-      # the task does not exist there — adding it to that alias fails every local
-      # precommit with "task could not be found", which is the exact breakage the
-      # hex.audit comment in mix.exs records having already happened once. This job has no
-      # MIX_ENV, so it is dev and the dep is present. Offline, ~0.8s warm.
-      #
-      # `--check` reports drift and exits non-zero WITHOUT rewriting the file (verified).
-      - name: Check AGENTS.md usage-rules block is not stale
-        run: mix usage_rules.sync --check
 
       # #541 — nothing in CI compiled assets/js before this. A syntax or import
       # error in a LiveView hook therefore surfaced only in the Docker build at
@@ -273,6 +258,26 @@ jobs:
 
       - name: Install dependencies
         run: mix deps.get
+
+      # #556: AGENTS.md's usage-rules block is GENERATED from the dependency set, so it
+      # goes stale the moment a dep is added, removed or upgraded — silently, because
+      # nothing regenerates or verifies it. Same failure shape as the undocumented-env-var
+      # problem already gated by `mix loopctl.check_env_docs`.
+      #
+      # It rides THIS job, whose subject is otherwise unrelated, for one reason:
+      # `usage_rules` is `only: :dev` and the workflow-level default is `MIX_ENV: test`,
+      # so this is the ONLY job where the task exists at all. Putting it in Lint failed
+      # with "task could not be found" (observed, not predicted — CI caught it), and
+      # setting MIX_ENV=dev on a single Lint step would build every dep in an uncached dev
+      # profile just to read a markdown block. It is also NOT in `mix precommit`: that
+      # alias runs under `preferred_envs: [precommit: :test]` and would hit the same
+      # missing task — the exact breakage the hex.audit note in mix.exs records once
+      # already.
+      #
+      # Runs before the DB setup below so it fails fast, and needs neither DB nor network.
+      # `--check` reports drift and exits non-zero WITHOUT rewriting the file (verified).
+      - name: Check AGENTS.md usage-rules block is not stale
+        run: mix usage_rules.sync --check
 
       - name: Create RLS roles
         run: |

--- a/mix.exs
+++ b/mix.exs
@@ -207,6 +207,11 @@ defmodule Loopctl.MixProject do
         "credo --strict",
         "loopctl.check_skill_citations",
         "loopctl.check_env_docs",
+        # NB (#556): the AGENTS.md usage-rules drift check is deliberately NOT here. This
+        # alias runs under `preferred_envs: [precommit: :test]` and `usage_rules` is
+        # `only: :dev`, so `mix usage_rules.sync --check` would fail with "task could not
+        # be found" — the same breakage the hex.audit note above records. It runs in the
+        # CI Lint job instead, which has no MIX_ENV and therefore has the dep.
         "dialyzer",
         "test"
       ]

--- a/mix.exs
+++ b/mix.exs
@@ -176,6 +176,11 @@ defmodule Loopctl.MixProject do
   # usage-rules-start/end markers and rewrites that region wholesale. Never put
   # hand-written content inside it — in cron_books a hand-written migration-safety
   # section had been placed there and the first sync silently deleted it.
+  #
+  # This is an EXPLICIT package list, not `:all`, and the CI drift gate (#556) can only
+  # ever be as wide as it is: adding a dependency that ships usage-rules (igniter and
+  # mdex both do) changes nothing here and the gate stays green. Widen this list to widen
+  # the gate.
   defp usage_rules do
     [
       file: "AGENTS.md",

--- a/mix.exs
+++ b/mix.exs
@@ -211,7 +211,8 @@ defmodule Loopctl.MixProject do
         # alias runs under `preferred_envs: [precommit: :test]` and `usage_rules` is
         # `only: :dev`, so `mix usage_rules.sync --check` would fail with "task could not
         # be found" — the same breakage the hex.audit note above records. It runs in the
-        # CI Lint job instead, which has no MIX_ENV and therefore has the dep.
+        # CI Retrieval Eval job instead — the only job that sets MIX_ENV=dev, and so the
+        # only one where the task exists.
         "dialyzer",
         "test"
       ]


### PR DESCRIPTION
Closes #556 — **partially**; see the acceptance criteria below, one of which this does **not** meet.

`0b7555a` adopted `usage_rules`, so the AGENTS.md block is generated from the dependency set, and nothing verified it still matched. It drifts silently: no test, no regenerate step, no signal. Same shape as the undocumented-env-var problem already gated by `mix loopctl.check_env_docs`.

## Where it runs, and why not where the issue said

The issue proposed adding `usage_rules.sync --check` to the `precommit` alias. That breaks it: `precommit` runs under `preferred_envs: [precommit: :test]` and `usage_rules` is `only: :dev`, so the task does not exist — `** (Mix) The task "usage_rules.sync" could not be found`. Same breakage the `hex.audit` note in `mix.exs` records happening once already; the omission is now documented there.

I then put it in the **Lint** job, having grepped that job's *step* list for `MIX_ENV` and found none. Wrong: `MIX_ENV: test` is set at the **workflow** level, so Lint failed with the identical missing-task error. **CI caught what I asserted rather than verified.** It now runs in `retrieval-eval`, the one job that explicitly sets `MIX_ENV: dev` and has a dev dependency cache.

## Acceptance criteria — honestly

- [ ] **"Adding or removing a dependency without regenerating the block fails the gate" — NOT met.** `mix.exs` declares `usage_rules: [:usage_rules, :phoenix]`, an **explicit two-package list**, not `:all`. Adding a dependency — even one that ships usage-rules, as `igniter` and `mdex` both do — produces no diff, and the gate stays green. My original PR body claimed this criterion was satisfied; it is not, and the comments that made the same overclaim in `ci.yml` and `mix.exs` are corrected.
- [x] The gate does not rewrite files as a side effect — verified: injected a line into the managed block, got exit 1, and `git diff` showed only my own injection.
- [x] Runtime impact on `mix precommit`: **none** (it does not run there). ~0.8s in CI.

## What the gate actually covers

An upgrade that rewrites `usage_rules`' or `phoenix`' rules text; a hand edit inside the managed markers (the failure mode `mix.exs` already warns about, where a hand-written section was silently deleted); and a change to the package list itself. **Widening the list is the visible way to widen the gate**, and that bound is now stated at the config site.

Making AC 1 true as literally worded means `usage_rules: :all`, which regenerates AGENTS.md with rules from every dependency — a decision about how large that file should be, not a wiring fix. Left for you.

## Verification

`mix precommit` green (6572 tests, 0 failures). Note: the substantive comment correction here came from an enhanced-review run I **mis-dispatched at PR #560** — my working tree was on this branch, so it reviewed this diff instead. Its findings were real and are applied; #560 consequently has no review coverage and is being re-run.