### PR TITLE
Sanitize the exit-shaped DB fault, and make the spec and the body one string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to loopctl are documented here.
 
 Operator-facing changes for deployments outside the hosted instance.
 
+### Changed
+
+- **`loopctl.oban.poll.error.count` label values changed — re-point any Prometheus selector
+  or Grafana panel (#558).** The `error_class` label moved from a bare `exit` / `throw` to the
+  kind-prefixed, closed set produced by `Loopctl.ExitClass` — `exit:noproc`, `exit:timeout`,
+  `exit:Postgrex.Error`, `throw:other`, and so on. A selector matching the old bare values
+  **silently stops firing** rather than erroring, which is the worst failure mode an alert
+  has. The same vocabulary is now shared by the ingestion backlog-gate and vector-search
+  under-fill counters, so one query shape works across all three.
+
+- **`loopctl.ingestion.backlog_gate.failed_open.*` gained an `:outcome` label, and a `jobs`
+  sum alongside the counter.** The event now fires on refusals as well as admissions, so a
+  dashboard reading the counter alone over-reports admissions during exactly the sustained
+  incident it is alerted on; slice by `outcome` (`admitted` / `unmetered` / `exhausted`). The
+  `jobs` series is job-denominated — one 50-item batch is one check but fifty jobs.
+
+- **A `throw` from the ingestion backlog count no longer consumes a tenant's fail-open
+  allowance.** It still admits and still emits the counter; it is simply not treated as pool
+  pressure, because a deterministic counting fault recurs regardless of capacity and would
+  otherwise drain the window and 429 an under-threshold tenant.
+
 ### Added
 
 - **A retirement trigger for the US-41.1 legacy embedding columns (#551).** New migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,19 @@ Operator-facing changes for deployments outside the hosted instance.
   incident it is alerted on; slice by `outcome` (`admitted` / `unmetered` / `exhausted`). The
   `jobs` series is job-denominated — one 50-item batch is one check but fifty jobs.
 
-- **A `throw` from the ingestion backlog count no longer consumes a tenant's fail-open
-  allowance.** It still admits and still emits the counter; it is simply not treated as pool
-  pressure, because a deterministic counting fault recurs regardless of capacity and would
-  otherwise drain the window and 429 an under-threshold tenant.
+- **A DB pool fault that arrives as an EXIT now renders the pinned 503/504 instead of a bare
+  500, and counts in `loopctl.db.error.count`.** Crash propagation from a pooled process is an
+  exit, not a raise, so it previously escaped the endpoint backstop untranslated: no
+  structured SQLSTATE line, no counter increment (the aggregate under-counted DB faults during
+  exactly the pool wedge it is read in), and the raw reason — the failing statement plus the
+  call's bound parameters — reached the web-server crash log. Exits the backstop cannot place
+  in the pool are still re-exited untouched.
+
+- **The ingestion fail-open allowance is metered on the node-local limiter even under
+  `RATE_LIMITER=postgres`.** The Postgres limiter store is `AdminRepo` — the same pool whose
+  exhaustion makes the backlog unmeasurable — so the allowance was unconsultable for exactly
+  the fault it bounds and admission stayed unbounded during a sustained wedge. Every other
+  limiter bucket still follows `RATE_LIMITER`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ Operator-facing changes for deployments outside the hosted instance.
   the fault it bounds and admission stayed unbounded during a sustained wedge. Every other
   limiter bucket still follows `RATE_LIMITER`.
 
+- **`POST /knowledge/ingest[/batch]` can now answer `503 ingestion_gate_unavailable` where it
+  previously answered `429 ingestion_backlog_exceeded`.** Only for the refusals that are NOT
+  backlog pressure: the gate could not MEASURE the backlog because of a driver/config fault or
+  a defect in the counting code, and the bounded allowance for admitting unmeasured work is
+  spent. The 429 asserted a backlog nobody counted and advised waiting for a drain that a
+  deterministic fault never reaches. `Retry-After` is set on both; a client branching on
+  `error.code` needs no change, one branching on the status does.
+
 ### Added
 
 - **A retirement trigger for the US-41.1 legacy embedding columns (#551).** New migration

--- a/lib/loopctl/api_spec/messages.ex
+++ b/lib/loopctl/api_spec/messages.ex
@@ -21,11 +21,14 @@ defmodule Loopctl.ApiSpec.Messages do
   is spent. On the second, nothing was counted and the real backlog may be zero, so the older
   wording ("already has too many … once the backlog drains") stated a fact the server does not
   have and pointed the client at a remedy that may not apply.
+
+  Route-NEUTRAL wording: the single-item route (`POST /knowledge/ingest`) renders this same
+  string, so it must not speak of "this batch" to a client that submitted one item.
   """
   @spec ingestion_backlog_exceeded(pos_integer()) :: String.t()
   def ingestion_backlog_exceeded(retry_after_seconds) do
     "Ingestion is shedding for this tenant: the in-flight backlog is at or over the " <>
-      "threshold, or it could not be measured. No items from this batch were " <>
+      "threshold, or it could not be measured. Nothing from this request was " <>
       "enqueued. Retry after #{retry_after_seconds} seconds."
   end
 end

--- a/lib/loopctl/api_spec/messages.ex
+++ b/lib/loopctl/api_spec/messages.ex
@@ -1,0 +1,31 @@
+defmodule Loopctl.ApiSpec.Messages do
+  @moduledoc """
+  Error-message text that BOTH the runtime response and the published OpenAPI spec render.
+
+  One definition, two readers. `LoopctlWeb.FallbackController` builds the body a client
+  actually receives; `Loopctl.ApiSpec.Schemas` publishes the `example` and the documented
+  response body. When those are two string literals they drift the moment either changes —
+  and the drift is invisible, because nothing compares a spec example to a runtime body.
+
+  It happened here (#558): the 429 copy was corrected in the controller to stop asserting a
+  backlog that, on the metered fail-open path, was never measured — and the spec kept telling
+  clients the opposite. Same technique as `@max_inline_content_bytes`, which CLAUDE.md already
+  prescribes for a limit that is both enforced and documented.
+  """
+
+  @doc """
+  The 429 `ingestion_backlog_exceeded` message.
+
+  Deliberately does NOT claim the backlog is full. The code has TWO causes: the backlog is
+  genuinely at/over threshold, OR it could not be MEASURED and the bounded fail-open allowance
+  is spent. On the second, nothing was counted and the real backlog may be zero, so the older
+  wording ("already has too many … once the backlog drains") stated a fact the server does not
+  have and pointed the client at a remedy that may not apply.
+  """
+  @spec ingestion_backlog_exceeded(pos_integer()) :: String.t()
+  def ingestion_backlog_exceeded(retry_after_seconds) do
+    "Ingestion is shedding for this tenant: the in-flight backlog is at or over the " <>
+      "threshold, or it could not be measured. No items from this batch were " <>
+      "enqueued. Retry after #{retry_after_seconds} seconds."
+  end
+end

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -1,4 +1,6 @@
 defmodule Loopctl.ApiSpec.Schemas do
+  alias Loopctl.ApiSpec.Messages
+
   @moduledoc """
   Reusable OpenAPI schema definitions for loopctl API request/response shapes.
   """
@@ -242,10 +244,7 @@ defmodule Loopctl.ApiSpec.Schemas do
             },
             message: %Schema{
               type: :string,
-              example:
-                "This tenant already has too many in-flight ingestion jobs queued. " <>
-                  "No items from this batch were enqueued. Retry after 5 seconds " <>
-                  "once the backlog drains."
+              example: Messages.ingestion_backlog_exceeded(5)
             },
             retry_after_seconds: %Schema{type: :integer, example: 5}
           }
@@ -255,10 +254,7 @@ defmodule Loopctl.ApiSpec.Schemas do
         error: %{
           status: 429,
           code: "ingestion_backlog_exceeded",
-          message:
-            "This tenant already has too many in-flight ingestion jobs queued. " <>
-              "No items from this batch were enqueued. Retry after 5 seconds " <>
-              "once the backlog drains.",
+          message: Messages.ingestion_backlog_exceeded(5),
           retry_after_seconds: 5
         }
       }

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -219,16 +219,19 @@ defmodule Loopctl.ApiSpec.Schemas do
     OpenApiSpex.schema(%{
       title: "IngestionBacklogError",
       description:
-        "Batch-ingest backlog backpressure (HTTP 429). Distinct from the generic " <>
-          "request RateLimitError: this is triggered BEFORE any item is enqueued when " <>
-          "the calling tenant's in-flight `:ingestion` backlog (non-terminal Oban jobs) " <>
-          "is at/over the `OBAN_INGEST_BACKLOG_MAX` threshold. The rejection is " <>
-          "all-or-nothing — NO jobs from the request are enqueued (no partial pile-up). " <>
-          "The check is tenant-scoped: only the caller's own backlog counts. Unlike the " <>
-          "Hammer request-rate limiter, this response carries a machine-readable " <>
-          "`error.code` of `ingestion_backlog_exceeded`, so dashboards/clients can tell " <>
-          "backlog backpressure apart from the request-rate 429. It DOES set " <>
-          "`Retry-After` (seconds) — back off and retry once the backlog drains.",
+        "Ingest backpressure (HTTP 429). Distinct from the generic request " <>
+          "RateLimitError: this is triggered BEFORE any item is enqueued, for one of TWO " <>
+          "causes — the calling tenant's in-flight `:ingestion` backlog (non-terminal Oban " <>
+          "jobs) is at/over the `OBAN_INGEST_BACKLOG_MAX` threshold, OR that backlog could " <>
+          "not be MEASURED (transient count-path fault) and the bounded fail-open allowance " <>
+          "for that fault is spent. On the second the backlog was never counted and may be " <>
+          "zero, so waiting for it to drain is not necessarily the remedy — it is a " <>
+          "server-side condition. The rejection is all-or-nothing — NO jobs from the " <>
+          "request are enqueued (no partial pile-up). The check is tenant-scoped: only the " <>
+          "caller's own backlog counts. Unlike the Hammer request-rate limiter, this " <>
+          "response carries a machine-readable `error.code` of `ingestion_backlog_exceeded`, " <>
+          "so dashboards/clients can tell it apart from the request-rate 429. It DOES set " <>
+          "`Retry-After` (seconds) — honour it either way.",
       type: :object,
       required: [:error],
       properties: %{

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -250,22 +250,22 @@ defmodule Loopctl.TelemetryEvents do
 
       `error_class` is a BOUNDED 5-value tag: `"timeout"` (57014 query_canceled — the
       count's own statement_timeout), `"db_pressure"` (SQLSTATE class 53/57/08 — the
-      exhaustion/connection classes a saturated pool raises behind pgbouncer), `"db_error"`
-      (any OTHER `Postgrex.Error` SQLSTATE — a query bug in the count path, and `08P01`
-      protocol_violation, which is a driver bug rather than pressure), `"connection"`
+      exhaustion/connection classes a saturated pool raises behind pgbouncer — plus a
+      `Postgrex.Error` carrying NO server SQLSTATE, i.e. a client-side driver fault on a
+      degrading connection), `"db_error"` (any OTHER SERVER SQLSTATE — a query bug in the
+      count path, and `08P01` protocol_violation, a driver bug rather than pressure),
+      `"connection"`
       (`DBConnection.ConnectionError` pool-checkout timeout), `"guc_capture_abort"`
       (`Loopctl.LocalGuc` REFUSED to override a GUC an enclosing scope owns — raised only
       once the connection is ALREADY wedged, hence metered), plus the `exit:<t>` / `throw:<t>`
       families from `Loopctl.ExitClass`.
 
       METERED classes (bounded allowance, then 429): `connection`, `timeout`, `db_pressure`,
-      `guc_capture_abort`, `exit:*`. UNMETERED (always admits): `db_error` and `throw:*`.
-
-      `throw:*` is deliberately NOT symmetric with `exit:*` (#558). An exit means the pool
-      process was absent or wedged — sustained, and what the allowance exists to bound. A
-      throw is a DETERMINISTIC fault in the counting code: it recurs at the same rate however
-      much capacity the pool has, so metering it drains the window and then 429s an
-      under-threshold tenant over something waiting will not clear.
+      `guc_capture_abort`, `exit:*`, `throw:*`. UNMETERED (always admits): `db_error` ONLY —
+      a query-shape bug in the count path is not backlog pressure, and capping it would 429 an
+      under-threshold tenant with a code it has not earned. Every other class leaves the
+      backlog UNMEASURED, and an unmeasured backlog is not evidence of an under-threshold
+      tenant, so its admissions stay bounded.
 
       `tenant_id` is an id, cap-gated to a sentinel in the metric's `tag_values`
       (`ScaleMetrics.backlog_gate_tags/1`) so label cardinality stays bounded.

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -84,10 +84,17 @@ defmodule Loopctl.TelemetryEvents do
   ## Payload (bounded tags only — NEVER the query, the vector, or a PG message body)
 
     * `measurements`: `%{count: 1}` — a pure increment.
-    * `metadata`: `%{tenant_id, endpoint, error_class}` where `error_class` is a BOUNDED tag:
+    * `metadata`: `%{tenant_id, endpoint, error_class}` where `error_class` is BOUNDED:
       `"guc_capture_abort"` (`Loopctl.LocalGuc` REFUSED to override a GUC an enclosing scope
       owns — deliberate, not a blip) | `"connection"` (pool/connection fault) | `"timeout"`
-      (57014 server-side cancel).
+      (57014 server-side cancel) | `"overloaded"` (a `HeavyRead` TenantGate shed — added with
+      the exit guard, because an overload escaping the probe turned an already-computed 200
+      into a 429) | `exit:<t>` / `throw:<t>` over `Loopctl.ExitClass`'s CLOSED tag set (a pool
+      that exits rather than raises).
+
+  This list is the DECLARED source of truth that `ScaleMetrics.degraded_read_tags/1` points
+  at, so a stale entry here is how an unbounded label reaches Prometheus unnoticed. It has
+  gone stale twice; update it in the same change that adds a class.
   """
   def vector_search_under_fill_probe_degraded,
     do: [:loopctl, :knowledge, :vector_search, :under_fill_probe_degraded]
@@ -252,13 +259,21 @@ defmodule Loopctl.TelemetryEvents do
       families from `Loopctl.ExitClass`.
 
       METERED classes (bounded allowance, then 429): `connection`, `timeout`, `db_pressure`,
-      `guc_capture_abort`, `exit:*`, `throw:*`. UNMETERED (always admits): `db_error`.
+      `guc_capture_abort`, `exit:*`. UNMETERED (always admits): `db_error` and `throw:*`.
+
+      `throw:*` is deliberately NOT symmetric with `exit:*` (#558). An exit means the pool
+      process was absent or wedged — sustained, and what the allowance exists to bound. A
+      throw is a DETERMINISTIC fault in the counting code: it recurs at the same rate however
+      much capacity the pool has, so metering it drains the window and then 429s an
+      under-threshold tenant over something waiting will not clear.
 
       `tenant_id` is an id, cap-gated to a sentinel in the metric's `tag_values`
       (`ScaleMetrics.backlog_gate_tags/1`) so label cardinality stays bounded.
 
-  Aggregated by `Loopctl.Telemetry.ScaleMetrics` as a counter tagged by
-  `[:error_class, :tenant_id]`.
+  Aggregated by `Loopctl.Telemetry.ScaleMetrics` as TWO series — a counter on `count` and a
+  sum on `jobs` — both tagged `[:error_class, :outcome, :tenant_id]`. The `:outcome` label is
+  load-bearing: this event fires on refusals as well as admissions, so without it a refusal
+  increments the same series as an admission.
   """
   def ingestion_backlog_gate_failed_open,
     do: [:loopctl, :ingestion, :backlog_gate, :failed_open]

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -243,16 +243,19 @@ defmodule Loopctl.TelemetryEvents do
     * `metadata`: `%{tenant_id, error_class, outcome}`.
 
       `outcome` is a BOUNDED 3-value atom: `:admitted` (unmetered fault class, or within
-      allowance), `:unmetered` (the METER was unconsultable — under `RATE_LIMITER=postgres`
-      its store is the same wedged pool — so the request was admitted rather than 429-ing a
-      tenant whose backlog was neither measured nor metered), `:exhausted` (allowance spent;
-      the request got the ordinary backlog 429).
+      allowance), `:unmetered` (the METER was unconsultable — this ONE bucket is metered on
+      the node-local ETS limiter whatever `RATE_LIMITER` says, precisely so the meter does not
+      share a failure domain with the count it bounds, so `:unmetered` means an ETS/Hammer
+      fault, NOT a DB-pool one — the request was admitted rather than refusing a tenant whose
+      backlog was neither measured nor metered), `:exhausted` (allowance spent; the request was
+      refused — the backlog 429 for a pressure class, otherwise a 503 that claims no backlog).
 
-      `error_class` is a BOUNDED 5-value tag: `"timeout"` (57014 query_canceled — the
+      `error_class` is a BOUNDED tag: `"timeout"` (57014 query_canceled — the
       count's own statement_timeout), `"db_pressure"` (SQLSTATE class 53/57/08 — the
-      exhaustion/connection classes a saturated pool raises behind pgbouncer — plus a
-      `Postgrex.Error` carrying NO server SQLSTATE, i.e. a client-side driver fault on a
-      degrading connection), `"db_error"` (any OTHER SERVER SQLSTATE — a query bug in the
+      exhaustion/connection classes a saturated pool raises behind pgbouncer),
+      `"driver_fault"` (a `Postgrex.Error` carrying NO server SQLSTATE — a client-side
+      protocol/decode fault, or a PERMANENT ssl/config one; metered, but never attributed to
+      backlog), `"db_error"` (any OTHER SERVER SQLSTATE — a query bug in the
       count path, and `08P01` protocol_violation, a driver bug rather than pressure),
       `"connection"`
       (`DBConnection.ConnectionError` pool-checkout timeout), `"guc_capture_abort"`
@@ -260,8 +263,12 @@ defmodule Loopctl.TelemetryEvents do
       once the connection is ALREADY wedged, hence metered), plus the `exit:<t>` / `throw:<t>`
       families from `Loopctl.ExitClass`.
 
-      METERED classes (bounded allowance, then 429): `connection`, `timeout`, `db_pressure`,
-      `guc_capture_abort`, `exit:*`, `throw:*`. UNMETERED (always admits): `db_error` ONLY —
+      METERED classes (bounded allowance, then a refusal): `connection`, `timeout`,
+      `db_pressure`, `driver_fault`, `guc_capture_abort`, `exit:*`, `throw:*`. Of those,
+      `driver_fault` and `throw:*` are refused as a 503 `ingestion_gate_unavailable` rather
+      than the backlog 429 — metered so admissions stay bounded, but not backlog-attributable,
+      so a deterministic fault never tells an under-threshold tenant its backlog is full.
+      UNMETERED (always admits): `db_error` ONLY —
       a query-shape bug in the count path is not backlog pressure, and capping it would 429 an
       under-threshold tenant with a code it has not earned. Every other class leaves the
       backlog UNMEASURED, and an unmeasured backlog is not evidence of an under-threshold

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -237,7 +237,8 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
         "Max 50 items per batch. Role: orchestrator+.\n\n" <>
         "**Backpressure (429):** before enqueuing anything, the endpoint checks the " <>
         "calling tenant's in-flight `:ingestion` backlog. If it is at/over the " <>
-        "`OBAN_INGEST_BACKLOG_MAX` threshold, the WHOLE request is rejected " <>
+        "`OBAN_INGEST_BACKLOG_MAX` threshold — or could not be MEASURED and the bounded " <>
+        "fail-open allowance for that fault is spent — the WHOLE request is rejected " <>
         "all-or-nothing with 429 + `Retry-After` and `error.code: " <>
         "\"ingestion_backlog_exceeded\"` — zero jobs are enqueued. This is distinct " <>
         "from the generic Hammer request-rate 429 (which has no `error.code`).",
@@ -378,35 +379,33 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   defp metered_fail_open?("guc_capture_abort"), do: true
   defp metered_fail_open?("exit:" <> _tag), do: true
 
-  # #558: a THROW is NOT metered, and deliberately not symmetric with `exit:`. An exit here
-  # means the pool process was absent or wedged — sustained, and exactly what the allowance
-  # exists to bound. A throw is a DETERMINISTIC fault in the counting code: it recurs on every
-  # request, at the same rate, no matter how much capacity the pool has. Metering it therefore
-  # drains the tenant's per-window allowance and then 429s an under-threshold tenant with a
-  # backlog error code, over a fault that is not its backlog and that waiting will not clear.
-  #
-  # It still ADMITS (the count is genuinely unmeasurable, and this gate must never block work
-  # over its own defect) and still emits the counter, so the fault stays alertable rather than
-  # silent — it just does not consume the budget reserved for real pool pressure. Same
-  # reasoning as `db_error` below.
-  defp metered_fail_open?("throw:" <> _tag), do: false
+  # A THROW is metered, SYMMETRIC with `exit:`. Un-metering it on the premise that a throw is
+  # always a deterministic counting-code defect restored, for that class, precisely the
+  # unbounded fail-open this allowance exists to close: an admit with no bound, forever. The
+  # premise does not hold either — Ecto/DBConnection re-raise a throw out of a transaction
+  # fun, so a throw is not structurally capacity-independent. And when the count is
+  # unmeasurable the server does not know the tenant IS under threshold, which is the whole
+  # reason admissions are bounded rather than free. The counter (`fail_open_event/4`) is what
+  # keeps a deterministic defect alertable; the allowance is not the alerting mechanism.
+  defp metered_fail_open?("throw:" <> _tag), do: true
   defp metered_fail_open?(_class), do: false
 
   # ONE token per SUBMITTED ITEM (an upper bound on the jobs this request would enqueue),
-  # halting on the first REFUSAL so a doomed request does not queue up to @batch_max more
-  # checkouts onto an already-starved pool. Tokens charged before the halt are not refunded
+  # halting on the first NON-ADMIT — a refusal OR an unconsultable meter — so a doomed request
+  # does not queue up to @batch_max more checkouts onto an already-starved pool. Halting on
+  # `:unmetered` too is load-bearing: an unconsultable meter recurs for the rest of the
+  # request, so continuing meant up to @batch_max sequential doomed checkouts on the web
+  # request process during exactly the wedge this gate bounds. Tokens charged before the halt
+  # are not refunded
   # (the limiter has no reservation), which is why `fail_open_jobs_per_window/0` is floored
   # at one full batch: an allowance smaller than a batch would be converted into nothing.
   #
   # TRI-STATE, because a limiter FAULT is not a spent allowance and neither
   # `RateLimiter.within_limit?/3` (fail-OPEN) nor `gate_ok?/3` (fail-CLOSED) can tell them
-  # apart. That distinction is load-bearing here: under `RATE_LIMITER=postgres` the limiter
-  # store IS `AdminRepo`, the same pool whose exhaustion produced this unmeasurable count, so
-  # the two faults are perfectly correlated. Fail-CLOSED 429s an innocent tenant on the FIRST
-  # transient blip with a backlog code it has not earned — the very thing this gate exists to
-  # prevent — while fail-OPEN goes silently inert in the wedge it bounds. So an unconsultable
-  # meter ADMITS (availability wins on a capacity gate) and reports `:unmetered`, which keeps
-  # "the valve is admitting because its METER is unreachable" alertable rather than silent.
+  # apart. An unconsultable meter ADMITS (availability wins on a capacity gate) and reports
+  # `:unmetered`, which keeps "the valve is admitting because its METER is unreachable"
+  # alertable rather than silent; fail-CLOSED would 429 an innocent tenant on the FIRST
+  # transient blip with a backlog code it has not earned.
   defp consume_fail_open_allowance(tenant_id, jobs) do
     bucket = "ingest_backlog_fail_open:#{tenant_id}"
     limit = fail_open_jobs_per_window()
@@ -414,16 +413,30 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     Enum.reduce_while(1..jobs//1, :admitted, fn _item, outcome ->
       case allowance_token(bucket, limit) do
         :exhausted -> {:halt, :exhausted}
-        :unmetered -> {:cont, :unmetered}
+        :unmetered -> {:halt, :unmetered}
         :admitted -> {:cont, outcome}
       end
     end)
   end
 
+  # The METER must not share a FAILURE DOMAIN with the count it bounds. `RateLimiter.impl/0`
+  # is honoured except for one case: under `RATE_LIMITER=postgres` the limiter store IS
+  # `AdminRepo` — the same 3-connection pool whose exhaustion produced the unmeasurable count —
+  # so every token would be unconsultable for exactly the fault the allowance exists to bound,
+  # and the bound would go inert in the sustained wedge instead of closing the valve. This
+  # bucket therefore pins to the node-local ETS limiter there, which is already the unit
+  # `fail_open_jobs_per_window/0` derives for (@fail_open_fleet_nodes) — not a compromise.
+  defp fail_open_meter do
+    case RateLimiter.impl() do
+      RateLimiter.Postgres -> RateLimiter.default_impl()
+      impl -> impl
+    end
+  end
+
   # `{:allow, 0}` is the Postgres impl's own fail-open sentinel and `{:error, _}` is a Hammer
   # soft-error: both mean UNCONSULTABLE, never "denied". Raise/exit/throw likewise.
   defp allowance_token(bucket, limit) do
-    case RateLimiter.impl().check_rate(bucket, @fail_open_window_ms, limit) do
+    case fail_open_meter().check_rate(bucket, @fail_open_window_ms, limit) do
       {:allow, count} when is_integer(count) and count > 0 -> :admitted
       {:deny, _limit} -> :exhausted
       _other -> :unmetered
@@ -542,7 +555,15 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
        when class in ~w(53 57 08),
        do: "db_pressure"
 
-  defp fail_open_class(%Postgrex.Error{}), do: "db_error"
+  # UNMETERED `db_error` is restricted to an error that actually carries a server SQLSTATE —
+  # i.e. a query-shape bug, which is not backlog pressure. A `Postgrex.Error` with NO
+  # `postgres` map is a CLIENT-side driver fault (protocol/decode failure on a degrading
+  # connection), which is pool pressure; letting it fall into the catch-all admitted it
+  # unconditionally and forever, charging nothing.
+  defp fail_open_class(%Postgrex.Error{postgres: %{pg_code: pg_code}}) when is_binary(pg_code),
+    do: "db_error"
+
+  defp fail_open_class(%Postgrex.Error{}), do: "db_pressure"
 
   # The non-local-exit shapes, already tagged by `Loopctl.ExitTag` at the catch site.
   # Prefixed by KIND so a triaging operator can tell a dead pool (`exit:noproc`) from a

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -377,7 +377,19 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   defp metered_fail_open?("timeout"), do: true
   defp metered_fail_open?("guc_capture_abort"), do: true
   defp metered_fail_open?("exit:" <> _tag), do: true
-  defp metered_fail_open?("throw:" <> _tag), do: true
+
+  # #558: a THROW is NOT metered, and deliberately not symmetric with `exit:`. An exit here
+  # means the pool process was absent or wedged — sustained, and exactly what the allowance
+  # exists to bound. A throw is a DETERMINISTIC fault in the counting code: it recurs on every
+  # request, at the same rate, no matter how much capacity the pool has. Metering it therefore
+  # drains the tenant's per-window allowance and then 429s an under-threshold tenant with a
+  # backlog error code, over a fault that is not its backlog and that waiting will not clear.
+  #
+  # It still ADMITS (the count is genuinely unmeasurable, and this gate must never block work
+  # over its own defect) and still emits the counter, so the fault stays alertable rather than
+  # silent — it just does not consume the budget reserved for real pool pressure. Same
+  # reasoning as `db_error` below.
+  defp metered_fail_open?("throw:" <> _tag), do: false
   defp metered_fail_open?(_class), do: false
 
   # ONE token per SUBMITTED ITEM (an upper bound on the jobs this request would enqueue),

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -65,6 +65,18 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   @fail_open_window_ms 3_600_000
   @fail_open_fleet_nodes 10
 
+  # The OTHER refusal the same admission gate can return, shared by both routes' specs so the
+  # documented status set matches `backlog_fail_open_verdict/3` (CLAUDE.md: a new API
+  # constraint is documented in the `operation/2` spec, not just enforced in the controller).
+  @gate_unavailable_description "Service Unavailable — the ingest admission gate could not " <>
+                                  "MEASURE your in-flight backlog, the fault is not pool " <>
+                                  "pressure (a driver/config fault, or a defect in the " <>
+                                  "counting code), and the bounded allowance for admitting " <>
+                                  "unmeasured work is spent. `error.code: " <>
+                                  "\"ingestion_gate_unavailable\"`, sets `Retry-After`. Zero " <>
+                                  "jobs are enqueued. Distinct from the 429s: this one does " <>
+                                  "NOT assert anything about your backlog."
+
   # Max batch size for POST /knowledge/ingest/batch. Declared HERE, above
   # `fail_open_jobs_per_window/0`, which floors the fail-open allowance at one full batch.
   @batch_max 50
@@ -176,7 +188,8 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
            "way.", "application/json",
          %OpenApiSpex.Schema{
            oneOf: [Schemas.IngestionBacklogError, Schemas.RateLimitError]
-         }}
+         }},
+      503 => {@gate_unavailable_description, "application/json", Schemas.ErrorResponse}
     }
   )
 
@@ -289,7 +302,8 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
          "application/json",
          %OpenApiSpex.Schema{
            oneOf: [Schemas.IngestionBacklogError, Schemas.RateLimitError]
-         }}
+         }},
+      503 => {@gate_unavailable_description, "application/json", Schemas.ErrorResponse}
     }
   )
 
@@ -349,8 +363,9 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # SUSTAINED, so an unconditional admit makes "no backpressure at all" the steady state
   # during exactly the overload the valve exists to bound. (Before the exit shape was caught
   # at all, the 500 at least shed the flood incidentally.) So those admissions are metered
-  # (`fail_open_jobs_per_window/0` per tenant per `@fail_open_window_ms`), and the rest get
-  # the ordinary backlog 429 with its Retry-After — no new status code, no new error code.
+  # (`fail_open_jobs_per_window/0` per tenant per `@fail_open_window_ms`), and the rest are
+  # refused — as the backlog 429 where the fault IS pool pressure, otherwise as the
+  # server-side 503 (`backlog_attributable?/1`).
   # EVERY outcome emits `fail_open_event/4`: the only signal that the backlog is UNMEASURABLE
   # must not go silent at the moment the fault stops being a blip and becomes the wedge.
   defp backlog_fail_open_verdict(tenant_id, error_class, jobs) do
@@ -360,11 +375,26 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
         else: :admitted
 
     fail_open_event(tenant_id, error_class, outcome, jobs)
+    retry_after = backlog_retry_after_seconds()
 
-    if outcome == :exhausted,
-      do: {:error, :ingestion_backlog_exceeded, backlog_retry_after_seconds()},
-      else: :ok
+    cond do
+      outcome != :exhausted -> :ok
+      backlog_attributable?(error_class) -> {:error, :ingestion_backlog_exceeded, retry_after}
+      true -> {:error, :ingestion_gate_unavailable, retry_after}
+    end
   end
+
+  # WHAT A REFUSAL MAY CLAIM — a different question from whether admissions are BOUNDED. A
+  # class that is not demonstrable pool pressure — a counting-code `throw:*`, or a
+  # `Postgrex.Error` carrying no server SQLSTATE (`driver_fault`, which covers the PERMANENT
+  # ssl/protocol/status faults as well as a decode fault on a degrading connection) — still
+  # leaves the backlog UNMEASURED, so its admissions stay metered. But answering
+  # `429 ingestion_backlog_exceeded` there asserts a backlog nobody counted and advertises a
+  # remedy (wait for the drain) that a deterministic fault never reaches: the tenant may be at
+  # zero backlog and is refused for the whole window. Those get the server-side 503 instead.
+  defp backlog_attributable?("throw:" <> _tag), do: false
+  defp backlog_attributable?("driver_fault"), do: false
+  defp backlog_attributable?(_class), do: true
 
   # Meter every class that means the POOL is under pressure, including `guc_capture_abort`:
   # `LocalGuc` raises that abort only after the capture round-trip ITSELF failed, i.e. the
@@ -375,6 +405,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # under-threshold tenant with a backlog error code it has not earned.
   defp metered_fail_open?("connection"), do: true
   defp metered_fail_open?("db_pressure"), do: true
+  defp metered_fail_open?("driver_fault"), do: true
   defp metered_fail_open?("timeout"), do: true
   defp metered_fail_open?("guc_capture_abort"), do: true
   defp metered_fail_open?("exit:" <> _tag), do: true
@@ -387,16 +418,20 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # unmeasurable the server does not know the tenant IS under threshold, which is the whole
   # reason admissions are bounded rather than free. The counter (`fail_open_event/4`) is what
   # keeps a deterministic defect alertable; the allowance is not the alerting mechanism.
+  # What the round-tripping of this decision was actually about — a client told "your backlog
+  # is too big, wait" for a counting-code defect — is settled in `backlog_attributable?/1`:
+  # metered here, refused as a 503 there. Metering and the error CODE are separate questions.
   defp metered_fail_open?("throw:" <> _tag), do: true
   defp metered_fail_open?(_class), do: false
 
   # ONE token per SUBMITTED ITEM (an upper bound on the jobs this request would enqueue),
-  # halting on the first NON-ADMIT — a refusal OR an unconsultable meter — so a doomed request
-  # does not queue up to @batch_max more checkouts onto an already-starved pool. Halting on
-  # `:unmetered` too is load-bearing: an unconsultable meter recurs for the rest of the
-  # request, so continuing meant up to @batch_max sequential doomed checkouts on the web
-  # request process during exactly the wedge this gate bounds. Tokens charged before the halt
-  # are not refunded
+  # halting on a REFUSAL so a doomed request does not queue up to @batch_max more checks. An
+  # unconsultable meter does NOT halt: `fail_open_meter/1` pins this bucket to the node-local
+  # ETS limiter, so a remaining token is a microsecond ETS read, not a pool checkout — and
+  # halting on it converted ONE transient soft-error into a whole batch admitted with ZERO
+  # tokens charged, so an ALREADY-SPENT allowance stopped refusing. The `:unmetered` verdict is
+  # carried forward instead (it is what keeps the unconsultable meter alertable), and a later
+  # `{:deny, _}` still refuses. Tokens charged before the halt are not refunded
   # (the limiter has no reservation), which is why `fail_open_jobs_per_window/0` is floored
   # at one full batch: an allowance smaller than a batch would be converted into nothing.
   #
@@ -413,7 +448,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     Enum.reduce_while(1..jobs//1, :admitted, fn _item, outcome ->
       case allowance_token(bucket, limit) do
         :exhausted -> {:halt, :exhausted}
-        :unmetered -> {:halt, :unmetered}
+        :unmetered -> {:cont, :unmetered}
         :admitted -> {:cont, outcome}
       end
     end)
@@ -426,12 +461,15 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # and the bound would go inert in the sustained wedge instead of closing the valve. This
   # bucket therefore pins to the node-local ETS limiter there, which is already the unit
   # `fail_open_jobs_per_window/0` derives for (@fail_open_fleet_nodes) — not a compromise.
-  defp fail_open_meter do
-    case RateLimiter.impl() do
-      RateLimiter.Postgres -> RateLimiter.default_impl()
-      impl -> impl
-    end
-  end
+  # Resolution is a PUBLIC pure function of the configured impl so the pin is testable: in the
+  # test env `RateLimiter.impl/0` is always the Mox mock, so the `Postgres` clause would
+  # otherwise be dead code that a later edit could invert with a green suite.
+  @doc false
+  @spec fail_open_meter(module()) :: module()
+  def fail_open_meter(RateLimiter.Postgres), do: RateLimiter.default_impl()
+  def fail_open_meter(impl), do: impl
+
+  defp fail_open_meter, do: fail_open_meter(RateLimiter.impl())
 
   # `{:allow, 0}` is the Postgres impl's own fail-open sentinel and `{:error, _}` is a Hammer
   # soft-error: both mean UNCONSULTABLE, never "denied". Raise/exit/throw likewise.
@@ -558,12 +596,16 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # UNMETERED `db_error` is restricted to an error that actually carries a server SQLSTATE —
   # i.e. a query-shape bug, which is not backlog pressure. A `Postgrex.Error` with NO
   # `postgres` map is a CLIENT-side driver fault (protocol/decode failure on a degrading
-  # connection), which is pool pressure; letting it fall into the catch-all admitted it
-  # unconditionally and forever, charging nothing.
+  # connection); letting it fall into the catch-all admitted it unconditionally and forever,
+  # charging nothing. It gets its OWN class rather than `db_pressure`, because the same shape
+  # also carries PERMANENT config faults ("ssl not available", "unexpected postgres status"):
+  # metered, so admissions stay bounded, but NOT backlog-attributable, so exhausting the
+  # allowance on one never answers an under-threshold tenant with a backlog code
+  # (`backlog_attributable?/1`).
   defp fail_open_class(%Postgrex.Error{postgres: %{pg_code: pg_code}}) when is_binary(pg_code),
     do: "db_error"
 
-  defp fail_open_class(%Postgrex.Error{}), do: "db_pressure"
+  defp fail_open_class(%Postgrex.Error{}), do: "driver_fault"
 
   # The non-local-exit shapes, already tagged by `Loopctl.ExitTag` at the catch site.
   # Prefixed by KIND so a triaging operator can tell a dead pool (`exit:noproc`) from a

--- a/lib/loopctl_web/fallback_controller.ex
+++ b/lib/loopctl_web/fallback_controller.ex
@@ -37,6 +37,7 @@ defmodule LoopctlWeb.FallbackController do
   use LoopctlWeb, :controller
 
   alias Ecto.Changeset
+  alias Loopctl.ApiSpec.Messages
   alias Loopctl.Llm.Remediation
   alias LoopctlWeb.DBError
   alias LoopctlWeb.DBErrorLogger
@@ -369,10 +370,9 @@ defmodule LoopctlWeb.FallbackController do
         # the real backlog may be zero, so the old copy ("already has too many ... once the
         # backlog drains") told the client a fact the server does not have, and pointed it
         # at a remedy that may not apply.
-        message:
-          "Ingestion is shedding for this tenant: the in-flight backlog is at or over the " <>
-            "threshold, or it could not be measured. No items from this batch were " <>
-            "enqueued. Retry after #{retry_after} seconds.",
+        # ONE definition, shared with the published OpenAPI example/body (#558) so the spec
+        # cannot keep telling clients something this response stopped saying.
+        message: Messages.ingestion_backlog_exceeded(retry_after),
         retry_after_seconds: retry_after
       }
     })

--- a/lib/loopctl_web/fallback_controller.ex
+++ b/lib/loopctl_web/fallback_controller.ex
@@ -26,6 +26,9 @@ defmodule LoopctlWeb.FallbackController do
     a machine-readable `code: "ingestion_backlog_exceeded"` (US-36.3 ingest backpressure —
     the backlog is at/over threshold OR it could not be measured and the bounded fail-open
     allowance is spent; distinct from the generic Hammer request-rate 429, which has no `code`)
+  - `{:error, :ingestion_gate_unavailable, retry_after}` -> 503 with `Retry-After` and
+    `code: "ingestion_gate_unavailable"` (the same gate refusing for a fault that is NOT
+    backlog pressure, so the refusal does not claim a backlog nobody measured)
   - `{:error, %Ecto.Changeset{}}` -> 422 with field-level details
   - `{:error, :bad_request, message}` -> 400 with custom message
   - `{:error, :unprocessable_entity, message}` -> 422 with custom message
@@ -374,6 +377,31 @@ defmodule LoopctlWeb.FallbackController do
         # ONE definition, shared with the published OpenAPI example/body (#558) so the spec
         # cannot keep telling clients something this response stopped saying.
         message: Messages.ingestion_backlog_exceeded(retry_after),
+        retry_after_seconds: retry_after
+      }
+    })
+  end
+
+  # #558: the SAME admission gate, refusing for a fault that is NOT backlog pressure — the
+  # backlog could not be measured (a driver/config fault, or a defect in the counting code)
+  # and the bounded fail-open allowance for it is spent. Answering `429
+  # ingestion_backlog_exceeded` there asserted a backlog nobody counted and pointed the client
+  # at a drain that a deterministic fault never reaches; this is a server-side condition, so it
+  # gets the server-side status. `Retry-After` is still set — retrying is all the client can do.
+  def call(conn, {:error, :ingestion_gate_unavailable, retry_after})
+      when is_integer(retry_after) and retry_after > 0 do
+    conn
+    |> put_resp_header("retry-after", Integer.to_string(retry_after))
+    |> put_status(:service_unavailable)
+    |> json(%{
+      error: %{
+        status: 503,
+        code: "ingestion_gate_unavailable",
+        message:
+          "Ingestion is shedding for this tenant: the in-flight backlog could not be " <>
+            "measured, and the bounded allowance for admitting unmeasured work is spent. " <>
+            "This is a server-side condition, not your backlog. Nothing from this request " <>
+            "was enqueued. Retry after #{retry_after} seconds.",
         retry_after_seconds: retry_after
       }
     })

--- a/lib/loopctl_web/fallback_controller.ex
+++ b/lib/loopctl_web/fallback_controller.ex
@@ -23,8 +23,9 @@ defmodule LoopctlWeb.FallbackController do
   - `{:error, :unresolvable_dispatch_lineage}` -> 409 (a dispatch the story references — implementer, or verifier on verify — could not be resolved; custody gate failed closed on an integrity error, tenant NOT halted)
   - `{:error, :rate_limited}` -> 429 with retry_after_seconds from header
   - `{:error, :ingestion_backlog_exceeded, retry_after}` -> 429 with `Retry-After` header and
-    a machine-readable `code: "ingestion_backlog_exceeded"` (US-36.3 batch-ingest backpressure —
-    distinct from the generic Hammer request-rate 429, which has no `code`)
+    a machine-readable `code: "ingestion_backlog_exceeded"` (US-36.3 ingest backpressure —
+    the backlog is at/over threshold OR it could not be measured and the bounded fail-open
+    allowance is spent; distinct from the generic Hammer request-rate 429, which has no `code`)
   - `{:error, %Ecto.Changeset{}}` -> 422 with field-level details
   - `{:error, :bad_request, message}` -> 400 with custom message
   - `{:error, :unprocessable_entity, message}` -> 422 with custom message

--- a/lib/loopctl_web/plugs/db_error_backstop.ex
+++ b/lib/loopctl_web/plugs/db_error_backstop.ex
@@ -51,13 +51,15 @@ defmodule LoopctlWeb.Plugs.DBErrorBackstop do
   pooled process) rather than a raise — see `handle_exit/4`.
 
   It wraps the router so it sees the dispatched `conn` (controller/action/assigns
-  populated) carried on the `Plug.Conn.WrapperError`. Non-DB exceptions, and exits
-  this plug cannot place in the DB pool, are re-raised/re-exited untouched
+  populated) carried on the `Plug.Conn.WrapperError`; an EXIT unwinds that frame, so the
+  exit path restores what it can (`restore_request_context/1`). Non-DB exceptions, and
+  exits this plug cannot place as a DB fault, are re-raised/re-exited untouched
   (let-it-crash) — this plug only translates recognized DB error classes.
   """
 
   alias Loopctl.ExitClass
   alias LoopctlWeb.{DBError, DBErrorLogger, SanitizedDBError}
+  alias Plug.Conn
   alias Plug.Conn.WrapperError
 
   @behaviour Plug
@@ -78,46 +80,66 @@ defmodule LoopctlWeb.Plugs.DBErrorBackstop do
 
   # #558: a rescue sees only the RAISE shape, so crash PROPAGATION from a pooled process —
   # `exit({{%Postgrex.Error{}, stack}, {DBConnection, :execute, args}})` — walked past this
-  # backstop into the crash log RAW (the struct carries the failing statement, `args` its
-  # bound parameters: query text and vector literals on this app's read paths).
-  #
-  # A DEMONSTRABLE pool exit (`ExitClass.pool_exit?/1`) is not a status we must guess at — it
-  # is the same DB fault the raise path maps — so it takes the same route: structured SQLSTATE
-  # line, `[:loopctl, :db, :error]` counter, pinned 504/503/500, sanitized reason. Re-exiting
-  # it unchanged left the leak open AND under-counted DB faults during exactly the wedge that
-  # counter is read in. Anything else is FOREIGN: re-exited untouched and NOT logged here (the
-  # crash report already records it, and a per-request line would spam a wedge while pointing
-  # a triaging operator at the database for someone else's `{:timeout, {GenServer, :call, _}}`).
+  # backstop into the crash log RAW (the struct carries the failing statement, `args` its bound
+  # parameters). A DB fault `db_exception/1` can PLACE takes the SAME route as the raise path;
+  # anything else is FOREIGN — re-exited untouched and NOT logged here (the crash report records
+  # it, and a line per request would point a triaging operator at the DB for someone else).
   @spec handle_exit(Plug.Conn.t(), :exit | :throw, term(), Exception.stacktrace()) :: no_return()
   defp handle_exit(conn, kind, reason, stack) do
-    if kind == :exit and ExitClass.pool_exit?(reason) do
-      sanitize(conn, pool_exception(reason, kind), stack)
+    if kind == :exit do
+      case db_exception(reason) do
+        nil -> :ok
+        exception -> sanitize(restore_request_context(conn), exception, stack)
+      end
     end
 
     :erlang.raise(kind, reason, stack)
   end
 
-  # The mappable DB exception a pool exit carries. The crash-PROPAGATION shape nests the
-  # original; a bare pool exit (`{:noproc, {DBConnection, :execute, _}}`) carries none and IS
-  # connection unavailability, described by its BOUNDED class — never the raw reason, which is
-  # the thing holding the bound parameters.
-  defp pool_exception({{%struct{} = exception, _stack}, _call}, _kind)
+  # Placed by the NESTED reason FIRST: the leak is a property of the `%Postgrex.Error{}` and the
+  # bound args, not of WHICH process called the pool, so `{{%Postgrex.Error{}, _}, {Task, ...}}`
+  # is sanitized too; a nested NON-DB exception is a real fault even under a pool call element,
+  # re-exited so the crash report still NAMES it rather than re-dressed as a retryable 503; a
+  # BARE pool exit nests nothing and IS unavailability, named by its BOUNDED class alone.
+  defp db_exception({{%struct{} = exception, _stack}, _call})
        when struct in [Postgrex.Error, DBConnection.ConnectionError],
        do: exception
 
-  defp pool_exception(reason, kind),
-    do: %DBConnection.ConnectionError{message: "pool #{ExitClass.classify(kind, reason)}"}
+  defp db_exception({{%_{}, _stack}, _call}), do: nil
 
-  # Config-based DI (CLAUDE.md convention) so a test can inject a router that
-  # raises a DB exception uncaught, exercising the backstop's catch/log/sanitize
-  # path without mounting a test-only route on the production router.
+  defp db_exception(reason) do
+    if ExitClass.pool_exit?(reason),
+      do: %DBConnection.ConnectionError{message: "pool #{ExitClass.classify(:exit, reason)}"},
+      else: nil
+  end
+
+  # The exit unwinds the ROUTER, so this plug holds the PRE-router conn: unrestored, every
+  # exit-shaped DB fault logs and counts UNATTRIBUTED (`tenant_id=`, `endpoint: :unknown`) in
+  # exactly the wedge those are read in, and `render_errors` gives a JSON client HTML.
+  # `tenant_id` survives in Logger metadata (`SeedTenantMetadata`); controller/action do not.
+  defp restore_request_context(conn) do
+    conn
+    |> restore_tenant(Logger.metadata()[:tenant_id])
+    |> restore_format(conn.private[:phoenix_format], conn.request_path)
+  end
+
+  defp restore_tenant(%{assigns: %{current_api_key: _}} = conn, _tid), do: conn
+  defp restore_tenant(conn, nil), do: conn
+  defp restore_tenant(conn, tid), do: Conn.assign(conn, :current_api_key, %{tenant_id: tid})
+
+  defp restore_format(conn, nil, "/api/" <> _),
+    do: Conn.put_private(conn, :phoenix_format, "json")
+
+  defp restore_format(conn, _format, _path), do: conn
+
+  # Config-based DI (CLAUDE.md convention) so a test can inject a router that raises/exits a DB
+  # fault uncaught, exercising this backstop without a test-only production route.
   defp router do
     Application.get_env(:loopctl, :db_error_backstop_router, LoopctlWeb.Router)
   end
 
-  # Only translate recognized DB exceptions. The reason may itself be a nested
-  # WrapperError (defensive) — unwrap once. Anything non-DB is re-raised as-is.
-  # Always re-raises (translated or untouched), so it never returns normally.
+  # Only translate recognized DB exceptions; anything non-DB is re-raised as-is. Always
+  # re-raises (translated or untouched), so it never returns normally.
   @spec handle(Plug.Conn.t(), term(), Exception.t(), Exception.stacktrace()) :: no_return()
   defp handle(conn, %struct{} = reason, wrapper, stack)
        when struct in [Postgrex.Error, DBConnection.ConnectionError] do
@@ -127,8 +149,8 @@ defmodule LoopctlWeb.Plugs.DBErrorBackstop do
 
   defp handle(_conn, _reason, wrapper, stack), do: reraise(wrapper, stack)
 
-  # Log the structured SQLSTATE line and re-raise the scrubbed stand-in — shared by the raise
-  # and pool-EXIT paths. Returns `:unmapped` (without raising) for an unrecognized error.
+  # Log the structured SQLSTATE line and re-raise the scrubbed stand-in — shared by the raise and
+  # EXIT paths. Returns `:unmapped` (without raising) for an unrecognized error.
   @spec sanitize(Plug.Conn.t(), term(), Exception.stacktrace()) :: :unmapped | no_return()
   defp sanitize(conn, reason, stack) do
     case DBError.map(reason) do
@@ -141,13 +163,21 @@ defmodule LoopctlWeb.Plugs.DBErrorBackstop do
           sqlstate: mapping.sqlstate
         }
 
-        # Re-wrap in a Plug.Conn.WrapperError carrying the dispatched conn so
-        # Phoenix's render_errors path renders against the right conn and the
-        # crash log only ever sees the sanitized message (never the raw query).
-        WrapperError.reraise(conn, :error, sanitized, stack)
+        # Re-wrap in a Plug.Conn.WrapperError carrying the dispatched conn so render_errors
+        # renders against the right conn and the crash log only sees the sanitized message.
+        conn
+        |> maybe_retry_after(mapping.retry_after)
+        |> WrapperError.reraise(:error, sanitized, stack)
 
       :unmapped ->
         :unmapped
     end
   end
+
+  # `db_unavailable`/`db_serialization_failure` are DOCUMENTED as carrying `Retry-After` (the
+  # `DBError` table, the FallbackController rescue path) and `Plug.Exception` has no header hook.
+  defp maybe_retry_after(conn, nil), do: conn
+
+  defp maybe_retry_after(conn, seconds) when is_integer(seconds),
+    do: Conn.register_before_send(conn, &Conn.put_resp_header(&1, "retry-after", "#{seconds}"))
 end

--- a/lib/loopctl_web/plugs/db_error_backstop.ex
+++ b/lib/loopctl_web/plugs/db_error_backstop.ex
@@ -55,6 +55,7 @@ defmodule LoopctlWeb.Plugs.DBErrorBackstop do
 
   require Logger
 
+  alias Loopctl.ExitClass
   alias LoopctlWeb.{DBError, DBErrorLogger, SanitizedDBError}
   alias Plug.Conn.WrapperError
 
@@ -69,6 +70,25 @@ defmodule LoopctlWeb.Plugs.DBErrorBackstop do
   rescue
     wrapper in WrapperError ->
       handle(wrapper.conn || conn, wrapper.reason, wrapper, __STACKTRACE__)
+  catch
+    # #558: a rescue sees only the RAISE shape. Crash PROPAGATION from a pooled process —
+    # `exit({{%Postgrex.Error{}, stacktrace}, {DBConnection, :execute, args}})` — is an EXIT,
+    # so it walked past this backstop entirely and reached the crash log RAW: the Postgrex
+    # struct carries the failing statement, and `args` carries its bound parameters, which on
+    # this app's read paths means query text and vector literals.
+    #
+    # This does NOT translate the response. The backstop's contract is that a DB exception
+    # gets a pinned status, and an exit is not something we can turn into one here without
+    # guessing at the request's state. It logs the BOUNDED class so the fault is attributable,
+    # then re-exits unchanged so supervision and the crash report behave exactly as before.
+    # The only thing that changes is that the raw reason stops being the first record of it.
+    kind, reason when kind in [:exit, :throw] ->
+      Logger.error(
+        "DBErrorBackstop: request #{kind} (#{ExitClass.classify(kind, reason)}) " <>
+          "on #{conn.method} #{conn.request_path}"
+      )
+
+      :erlang.raise(kind, reason, __STACKTRACE__)
   end
 
   # Config-based DI (CLAUDE.md convention) so a test can inject a router that

--- a/lib/loopctl_web/plugs/db_error_backstop.ex
+++ b/lib/loopctl_web/plugs/db_error_backstop.ex
@@ -47,13 +47,14 @@ defmodule LoopctlWeb.Plugs.DBErrorBackstop do
       the query, so any subsequent crash log is leak-free while the pinned
       504/503/500 status is preserved.
 
-  It wraps the router so it sees the dispatched `conn` (controller/action/assigns
-  populated) carried on the `Plug.Conn.WrapperError`. Non-DB exceptions are
-  re-raised untouched (let-it-crash) — this plug only translates recognized DB
-  error classes.
-  """
+  Both hold for a DB fault that arrives as an EXIT (crash PROPAGATION from a
+  pooled process) rather than a raise — see `handle_exit/4`.
 
-  require Logger
+  It wraps the router so it sees the dispatched `conn` (controller/action/assigns
+  populated) carried on the `Plug.Conn.WrapperError`. Non-DB exceptions, and exits
+  this plug cannot place in the DB pool, are re-raised/re-exited untouched
+  (let-it-crash) — this plug only translates recognized DB error classes.
+  """
 
   alias Loopctl.ExitClass
   alias LoopctlWeb.{DBError, DBErrorLogger, SanitizedDBError}
@@ -71,25 +72,41 @@ defmodule LoopctlWeb.Plugs.DBErrorBackstop do
     wrapper in WrapperError ->
       handle(wrapper.conn || conn, wrapper.reason, wrapper, __STACKTRACE__)
   catch
-    # #558: a rescue sees only the RAISE shape. Crash PROPAGATION from a pooled process —
-    # `exit({{%Postgrex.Error{}, stacktrace}, {DBConnection, :execute, args}})` — is an EXIT,
-    # so it walked past this backstop entirely and reached the crash log RAW: the Postgrex
-    # struct carries the failing statement, and `args` carries its bound parameters, which on
-    # this app's read paths means query text and vector literals.
-    #
-    # This does NOT translate the response. The backstop's contract is that a DB exception
-    # gets a pinned status, and an exit is not something we can turn into one here without
-    # guessing at the request's state. It logs the BOUNDED class so the fault is attributable,
-    # then re-exits unchanged so supervision and the crash report behave exactly as before.
-    # The only thing that changes is that the raw reason stops being the first record of it.
     kind, reason when kind in [:exit, :throw] ->
-      Logger.error(
-        "DBErrorBackstop: request #{kind} (#{ExitClass.classify(kind, reason)}) " <>
-          "on #{conn.method} #{conn.request_path}"
-      )
-
-      :erlang.raise(kind, reason, __STACKTRACE__)
+      handle_exit(conn, kind, reason, __STACKTRACE__)
   end
+
+  # #558: a rescue sees only the RAISE shape, so crash PROPAGATION from a pooled process —
+  # `exit({{%Postgrex.Error{}, stack}, {DBConnection, :execute, args}})` — walked past this
+  # backstop into the crash log RAW (the struct carries the failing statement, `args` its
+  # bound parameters: query text and vector literals on this app's read paths).
+  #
+  # A DEMONSTRABLE pool exit (`ExitClass.pool_exit?/1`) is not a status we must guess at — it
+  # is the same DB fault the raise path maps — so it takes the same route: structured SQLSTATE
+  # line, `[:loopctl, :db, :error]` counter, pinned 504/503/500, sanitized reason. Re-exiting
+  # it unchanged left the leak open AND under-counted DB faults during exactly the wedge that
+  # counter is read in. Anything else is FOREIGN: re-exited untouched and NOT logged here (the
+  # crash report already records it, and a per-request line would spam a wedge while pointing
+  # a triaging operator at the database for someone else's `{:timeout, {GenServer, :call, _}}`).
+  @spec handle_exit(Plug.Conn.t(), :exit | :throw, term(), Exception.stacktrace()) :: no_return()
+  defp handle_exit(conn, kind, reason, stack) do
+    if kind == :exit and ExitClass.pool_exit?(reason) do
+      sanitize(conn, pool_exception(reason, kind), stack)
+    end
+
+    :erlang.raise(kind, reason, stack)
+  end
+
+  # The mappable DB exception a pool exit carries. The crash-PROPAGATION shape nests the
+  # original; a bare pool exit (`{:noproc, {DBConnection, :execute, _}}`) carries none and IS
+  # connection unavailability, described by its BOUNDED class — never the raw reason, which is
+  # the thing holding the bound parameters.
+  defp pool_exception({{%struct{} = exception, _stack}, _call}, _kind)
+       when struct in [Postgrex.Error, DBConnection.ConnectionError],
+       do: exception
+
+  defp pool_exception(reason, kind),
+    do: %DBConnection.ConnectionError{message: "pool #{ExitClass.classify(kind, reason)}"}
 
   # Config-based DI (CLAUDE.md convention) so a test can inject a router that
   # raises a DB exception uncaught, exercising the backstop's catch/log/sanitize
@@ -104,6 +121,16 @@ defmodule LoopctlWeb.Plugs.DBErrorBackstop do
   @spec handle(Plug.Conn.t(), term(), Exception.t(), Exception.stacktrace()) :: no_return()
   defp handle(conn, %struct{} = reason, wrapper, stack)
        when struct in [Postgrex.Error, DBConnection.ConnectionError] do
+    sanitize(conn, reason, stack)
+    reraise(wrapper, stack)
+  end
+
+  defp handle(_conn, _reason, wrapper, stack), do: reraise(wrapper, stack)
+
+  # Log the structured SQLSTATE line and re-raise the scrubbed stand-in — shared by the raise
+  # and pool-EXIT paths. Returns `:unmapped` (without raising) for an unrecognized error.
+  @spec sanitize(Plug.Conn.t(), term(), Exception.stacktrace()) :: :unmapped | no_return()
+  defp sanitize(conn, reason, stack) do
     case DBError.map(reason) do
       {:ok, mapping} ->
         DBErrorLogger.log(conn, reason, mapping)
@@ -120,9 +147,7 @@ defmodule LoopctlWeb.Plugs.DBErrorBackstop do
         WrapperError.reraise(conn, :error, sanitized, stack)
 
       :unmapped ->
-        reraise(wrapper, stack)
+        :unmapped
     end
   end
-
-  defp handle(_conn, _reason, wrapper, stack), do: reraise(wrapper, stack)
 end

--- a/test/loopctl/api_spec/messages_test.exs
+++ b/test/loopctl/api_spec/messages_test.exs
@@ -35,6 +35,12 @@ defmodule Loopctl.ApiSpec.MessagesTest do
     assert msg =~ "Retry after 5 seconds"
   end
 
+  test "the message is route-neutral — the single-item route renders it too" do
+    # `POST /knowledge/ingest` submits ONE item and shares this definition, so batch-specific
+    # copy ("this batch") tells that client about a batch it never sent.
+    refute Messages.ingestion_backlog_exceeded(5) =~ "batch"
+  end
+
   test "the schema DESCRIPTION states both causes, not just the measured one" do
     # The prose one level up from the example is what an API consumer actually reads; it
     # carried the single-cause claim and the "wait for the drain" remedy long after the

--- a/test/loopctl/api_spec/messages_test.exs
+++ b/test/loopctl/api_spec/messages_test.exs
@@ -1,0 +1,37 @@
+defmodule Loopctl.ApiSpec.MessagesTest do
+  @moduledoc """
+  #558 — the published spec and the runtime body must render the SAME text.
+
+  This is what makes the shared definition load-bearing rather than decorative: it reads the
+  OpenAPI schema's example and compares it to the canonical message. Without it, someone
+  re-inlines a literal at either site and the drift is invisible again — nothing else in the
+  suite compares a spec example to a response body.
+  """
+  use ExUnit.Case, async: true
+
+  alias Loopctl.ApiSpec.Messages
+  alias Loopctl.ApiSpec.Schemas.IngestionBacklogError
+
+  test "the OpenAPI example for a 429 is the canonical message" do
+    spec_example = IngestionBacklogError.schema().example.error.message
+
+    assert spec_example == Messages.ingestion_backlog_exceeded(5)
+  end
+
+  test "the documented message property uses it too" do
+    props = IngestionBacklogError.schema().properties.error.properties
+
+    assert props.message.example == Messages.ingestion_backlog_exceeded(5)
+  end
+
+  test "the message does not assert a backlog that may never have been measured" do
+    # Two causes, and on the metered fail-open path nothing was counted — the real backlog
+    # may be zero. Wording that promises "drains" points at a remedy that may not apply.
+    msg = Messages.ingestion_backlog_exceeded(5)
+
+    refute msg =~ "already has too many"
+    refute msg =~ "once the backlog drains"
+    assert msg =~ "could not be measured"
+    assert msg =~ "Retry after 5 seconds"
+  end
+end

--- a/test/loopctl/api_spec/messages_test.exs
+++ b/test/loopctl/api_spec/messages_test.exs
@@ -34,4 +34,14 @@ defmodule Loopctl.ApiSpec.MessagesTest do
     assert msg =~ "could not be measured"
     assert msg =~ "Retry after 5 seconds"
   end
+
+  test "the schema DESCRIPTION states both causes, not just the measured one" do
+    # The prose one level up from the example is what an API consumer actually reads; it
+    # carried the single-cause claim and the "wait for the drain" remedy long after the
+    # message stopped making them.
+    description = IngestionBacklogError.schema().description
+
+    refute description =~ "once the backlog drains"
+    assert description =~ "could not be MEASURED"
+  end
 end

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -1175,11 +1175,10 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert metadata.outcome == :admitted
     end
 
-    test "#558: a THROW admits but is NOT metered — it is not pool pressure", %{conn: conn} do
-      # An exit means the pool was absent or wedged: sustained, and what the allowance exists
-      # to bound. A throw is a deterministic fault in the counting code — it recurs at the same
-      # rate regardless of capacity, so metering it drains the budget and then 429s an
-      # under-threshold tenant over a fault that waiting will never clear.
+    test "#558: a THROW is METERED, symmetric with an exit", %{conn: conn} do
+      # Un-metering it left that class an unconditional, unbounded admit — the state the
+      # allowance exists to remove. When the count is unmeasurable the server does not know
+      # the tenant is under threshold either, so admissions stay bounded whatever the shape.
       tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
@@ -1189,7 +1188,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
         throw(:boom)
       end)
 
-      # Allowance fully spent: a METERED class would 429 here. This one must still admit.
+      # Allowance fully spent: a metered class 429s here.
       stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
         if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
           do: {:deny, limit},
@@ -1203,12 +1202,60 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
           items: [%{content: "Throwing counter item", source_type: "newsletter"}]
         })
 
-      assert length(json_response(conn, 200)["data"]) == 1
+      assert json_response(conn, 429)["error"]["code"] == "ingestion_backlog_exceeded"
 
-      # Still ALERTABLE — admitting silently would hide a deterministic defect.
+      # Still ALERTABLE — a deterministic defect must not go silent either way.
       assert_receive {:backlog_failed_open, _measurements, metadata}
       assert metadata.error_class == "throw:other"
-      assert metadata.outcome == :admitted
+      assert metadata.outcome == :exhausted
+    end
+
+    test "an UNCONSULTABLE meter halts the charge loop instead of re-checking per item",
+         %{conn: conn} do
+      # The meter is unconsultable for the rest of the request once it is unconsultable at
+      # all, and under RATE_LIMITER=postgres each check is an AdminRepo checkout — the same
+      # starved pool that produced the unmeasurable count. Continuing meant up to @batch_max
+      # sequential doomed checkouts on the web request process during that very wedge.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        exit({:noproc, {DBConnection, :execute, []}})
+      end)
+
+      test_pid = self()
+
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, _limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:") do
+          send(test_pid, :fail_open_token)
+          # The Postgres impl's own fail-open sentinel: unconsultable, never "denied".
+          {:allow, 0}
+        else
+          {:allow, 1}
+        end
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [
+            %{content: "Unmetered item one", source_type: "newsletter"},
+            %{content: "Unmetered item two", source_type: "newsletter"},
+            %{content: "Unmetered item three", source_type: "newsletter"}
+          ]
+        })
+
+      # Availability still wins on a capacity gate — it admits, it just stops re-asking.
+      assert length(json_response(conn, 200)["data"]) == 3
+
+      assert_receive :fail_open_token
+      refute_receive :fail_open_token, 20
+
+      assert_receive {:backlog_failed_open, %{count: 1, jobs: 3}, metadata}
+      assert metadata.outcome == :unmetered
     end
 
     test "a NON-timeout SQLSTATE is not reported as a timeout", %{conn: conn} do
@@ -1223,7 +1270,11 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
       expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
         raise %Postgrex.Error{
-          postgres: %{code: :undefined_column, message: "column j.args does not exist"}
+          postgres: %{
+            code: :undefined_column,
+            pg_code: "42703",
+            message: "column j.args does not exist"
+          }
         }
       end)
 
@@ -1337,6 +1388,40 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert_receive {:backlog_failed_open, %{count: 1}, metadata}
       assert metadata.error_class == "db_error"
       assert metadata.outcome == :admitted
+    end
+
+    test "a Postgrex error with NO server SQLSTATE is METERED, not waved through as a query bug",
+         %{conn: conn} do
+      # A client-side driver fault (protocol/decode failure on a degrading connection) carries
+      # no `postgres` map. Falling into the unmetered `db_error` catch-all admitted it
+      # unconditionally and forever, over a shape that IS the pool degrading.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        raise %Postgrex.Error{message: "unexpected message from the server"}
+      end)
+
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
+          do: {:deny, limit},
+          else: {:allow, 1}
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Driver fault item", source_type: "newsletter"}]
+        })
+
+      assert json_response(conn, 429)["error"]["code"] == "ingestion_backlog_exceeded"
+
+      assert_receive {:backlog_failed_open, %{count: 1}, metadata}
+      assert metadata.error_class == "db_pressure"
+      assert metadata.outcome == :exhausted
     end
 
     test "a LocalGuc capture ABORT is METERED like the other pool faults", %{conn: conn} do

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -1175,6 +1175,42 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert metadata.outcome == :admitted
     end
 
+    test "#558: a THROW admits but is NOT metered — it is not pool pressure", %{conn: conn} do
+      # An exit means the pool was absent or wedged: sustained, and what the allowance exists
+      # to bound. A throw is a deterministic fault in the counting code — it recurs at the same
+      # rate regardless of capacity, so metering it drains the budget and then 429s an
+      # under-threshold tenant over a fault that waiting will never clear.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        throw(:boom)
+      end)
+
+      # Allowance fully spent: a METERED class would 429 here. This one must still admit.
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
+          do: {:deny, limit},
+          else: {:allow, 1}
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Throwing counter item", source_type: "newsletter"}]
+        })
+
+      assert length(json_response(conn, 200)["data"]) == 1
+
+      # Still ALERTABLE — admitting silently would hide a deterministic defect.
+      assert_receive {:backlog_failed_open, _measurements, metadata}
+      assert metadata.error_class == "throw:other"
+      assert metadata.outcome == :admitted
+    end
+
     test "a NON-timeout SQLSTATE is not reported as a timeout", %{conn: conn} do
       # The rescue catches EVERY `Postgrex.Error`, not only 57014, so a query bug in the
       # count path (a column renamed out from under `FairShare`) also fails open. It must

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -873,7 +873,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       body = json_response(conn, 429)
       assert body["error"]["code"] == "ingestion_backlog_exceeded"
       assert body["error"]["status"] == 429
-      assert body["error"]["message"] =~ "No items from this batch were enqueued"
+      assert body["error"]["message"] =~ "Nothing from this request was enqueued"
 
       # Retry-After header is a positive integer string, tied to the ingestion drain
       # cadence (NOT the sub-second fair-share snooze base) so a compliant client does
@@ -1202,7 +1202,12 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
           items: [%{content: "Throwing counter item", source_type: "newsletter"}]
         })
 
-      assert json_response(conn, 429)["error"]["code"] == "ingestion_backlog_exceeded"
+      # ...but the REFUSAL does not claim a backlog nobody counted: a counting-code defect is
+      # not pool pressure, and "wait for the drain" is a remedy it never reaches.
+      body = json_response(conn, 503)
+      assert body["error"]["code"] == "ingestion_gate_unavailable"
+      refute body["error"]["message"] =~ "at or over the"
+      assert [_retry_after] = get_resp_header(conn, "retry-after")
 
       # Still ALERTABLE — a deterministic defect must not go silent either way.
       assert_receive {:backlog_failed_open, _measurements, metadata}
@@ -1210,12 +1215,12 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert metadata.outcome == :exhausted
     end
 
-    test "an UNCONSULTABLE meter halts the charge loop instead of re-checking per item",
+    test "an UNCONSULTABLE meter keeps charging, so an already-spent allowance still refuses",
          %{conn: conn} do
-      # The meter is unconsultable for the rest of the request once it is unconsultable at
-      # all, and under RATE_LIMITER=postgres each check is an AdminRepo checkout — the same
-      # starved pool that produced the unmeasurable count. Continuing meant up to @batch_max
-      # sequential doomed checkouts on the web request process during that very wedge.
+      # Halting the loop on the FIRST soft-error converted one transient blip into a whole
+      # batch admitted with ZERO tokens charged — an already-exhausted allowance stopped
+      # refusing. The remaining checks are node-local ETS reads (`fail_open_meter/1`), not
+      # pool checkouts, so continuing costs nothing worth buying that regression for.
       tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
@@ -1227,11 +1232,15 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
       test_pid = self()
 
-      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, _limit ->
+      # Unconsultable on the FIRST token, spent on every later one.
+      counter = :counters.new(1, [])
+
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
         if String.starts_with?(bucket, "ingest_backlog_fail_open:") do
+          :counters.add(counter, 1, 1)
           send(test_pid, :fail_open_token)
           # The Postgres impl's own fail-open sentinel: unconsultable, never "denied".
-          {:allow, 0}
+          if :counters.get(counter, 1) == 1, do: {:allow, 0}, else: {:deny, limit}
         else
           {:allow, 1}
         end
@@ -1248,14 +1257,63 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
           ]
         })
 
-      # Availability still wins on a capacity gate — it admits, it just stops re-asking.
-      assert length(json_response(conn, 200)["data"]) == 3
+      # One blip does NOT buy the whole batch a free pass: the loop keeps asking and the
+      # spent allowance still closes the valve.
+      assert json_response(conn, 429)["error"]["code"] == "ingestion_backlog_exceeded"
 
       assert_receive :fail_open_token
-      refute_receive :fail_open_token, 20
+      assert_receive :fail_open_token
 
       assert_receive {:backlog_failed_open, %{count: 1, jobs: 3}, metadata}
+      assert metadata.outcome == :exhausted
+    end
+
+    test "an UNCONSULTABLE meter alone still ADMITS and reports `:unmetered`", %{conn: conn} do
+      # Availability wins on a capacity gate: a limiter fault is not a spent allowance, and
+      # the `:unmetered` outcome is what keeps "the valve is admitting because its METER is
+      # unreachable" alertable rather than silent.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        exit({:noproc, {DBConnection, :execute, []}})
+      end)
+
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, _limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
+          do: {:allow, 0},
+          else: {:allow, 1}
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Unmetered admit item", source_type: "newsletter"}]
+        })
+
+      assert length(json_response(conn, 200)["data"]) == 1
+
+      assert_receive {:backlog_failed_open, %{count: 1, jobs: 1}, metadata}
       assert metadata.outcome == :unmetered
+    end
+
+    test "the fail-open meter is pinned to the node-local ETS limiter under RATE_LIMITER=postgres",
+         %{conn: _conn} do
+      # The meter must not share a FAILURE DOMAIN with the count it bounds: the Postgres
+      # limiter store IS the AdminRepo pool whose exhaustion produced the unmeasurable count,
+      # so every token would be unconsultable for exactly the fault the allowance bounds.
+      # Asserted directly because `RateLimiter.impl/0` is the Mox mock in every test, which
+      # would leave this pin dead code that a later edit could invert with a green suite.
+      alias LoopctlWeb.KnowledgeIngestionController, as: Ctl
+
+      assert Ctl.fail_open_meter(Loopctl.RateLimiter.Postgres) ==
+               Loopctl.RateLimiter.default_impl()
+
+      # Every other configured limiter is honoured untouched.
+      assert Ctl.fail_open_meter(Loopctl.MockRateLimiter) == Loopctl.MockRateLimiter
     end
 
     test "a NON-timeout SQLSTATE is not reported as a timeout", %{conn: conn} do
@@ -1390,11 +1448,13 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert metadata.outcome == :admitted
     end
 
-    test "a Postgrex error with NO server SQLSTATE is METERED, not waved through as a query bug",
+    test "a Postgrex error with NO server SQLSTATE is METERED, but never claims a backlog",
          %{conn: conn} do
       # A client-side driver fault (protocol/decode failure on a degrading connection) carries
       # no `postgres` map. Falling into the unmetered `db_error` catch-all admitted it
-      # unconditionally and forever, over a shape that IS the pool degrading.
+      # unconditionally and forever. The SAME shape also carries PERMANENT faults ("ssl not
+      # available"), so it is metered — admissions bounded — under its own class, and its
+      # refusal is the 503, not a backlog 429 the tenant has not earned.
       tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
@@ -1417,10 +1477,10 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
           items: [%{content: "Driver fault item", source_type: "newsletter"}]
         })
 
-      assert json_response(conn, 429)["error"]["code"] == "ingestion_backlog_exceeded"
+      assert json_response(conn, 503)["error"]["code"] == "ingestion_gate_unavailable"
 
       assert_receive {:backlog_failed_open, %{count: 1}, metadata}
-      assert metadata.error_class == "db_pressure"
+      assert metadata.error_class == "driver_fault"
       assert metadata.outcome == :exhausted
     end
 

--- a/test/loopctl_web/plugs/db_error_backstop_test.exs
+++ b/test/loopctl_web/plugs/db_error_backstop_test.exs
@@ -118,4 +118,27 @@ defmodule LoopctlWeb.Plugs.DBErrorBackstopTest do
       assert_raise RuntimeError, "boom", fn -> LoopctlWeb.Endpoint.call(conn, []) end
     end
   end
+
+  describe "#558: crash propagation is an EXIT, not a raise" do
+    test "the backstop logs a BOUNDED class and re-exits unchanged", %{conn: conn} do
+      # A `rescue`-only backstop never saw this shape, so the raw reason reached the crash
+      # log — carrying the failing statement and its bound parameters.
+      {conn, _tenant} = authed_conn(conn)
+      conn = put_req_header(conn, "x-test-raise-db-error", "exit-propagation")
+
+      {reason, log} =
+        with_log(fn ->
+          catch_exit(LoopctlWeb.Endpoint.call(conn, []))
+        end)
+
+      # Re-exited UNCHANGED — the backstop attributes, it does not swallow or translate.
+      assert {{%Postgrex.Error{}, _stack}, {DBConnection, :execute, _args}} = reason
+
+      assert log =~ "DBErrorBackstop: request exit"
+      # The CLASS, from the closed ExitClass set — never the reason itself.
+      assert log =~ "exit:Postgrex.Error"
+      refute log =~ "secret_bound_param"
+      refute log =~ "0.123"
+    end
+  end
 end

--- a/test/loopctl_web/plugs/db_error_backstop_test.exs
+++ b/test/loopctl_web/plugs/db_error_backstop_test.exs
@@ -27,16 +27,14 @@ defmodule LoopctlWeb.Plugs.DBErrorBackstopTest do
     end)
   end
 
+  # Only the Bearer key — the identity is resolved by the REAL auth plugs INSIDE the test
+  # router. Pre-assigning `:current_api_key` on the endpoint conn would make the tenant_id
+  # assertions vacuous for the EXIT path, which unwinds the router frame in production.
   defp authed_conn(conn) do
     tenant = fixture(:tenant)
     {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
 
-    conn =
-      conn
-      |> put_req_header("authorization", "Bearer #{raw_key}")
-      |> Plug.Conn.assign(:current_api_key, %{tenant_id: tenant.id})
-
-    {conn, tenant}
+    {put_req_header(conn, "authorization", "Bearer #{raw_key}"), tenant}
   end
 
   describe "uncaught DB exception in ANY controller (AC-27.3.3 + AC-27.3.8)" do
@@ -148,6 +146,40 @@ defmodule LoopctlWeb.Plugs.DBErrorBackstopTest do
       assert log =~ "sqlstate=42P01"
       assert log =~ "mapped_code=db_error"
       assert log =~ "tenant_id=#{tenant.id}"
+    end
+
+    test "the same nested DB error through a Task call element is sanitized too", %{conn: conn} do
+      # The leak is a property of the nested struct (statement + bound args), not of WHICH
+      # process called the pool, so classifying by the call element alone left this shape raw.
+      {conn, tenant} = authed_conn(conn)
+      conn = put_req_header(conn, "x-test-raise-db-error", "exit-task")
+
+      {_, log} =
+        with_log(fn ->
+          error =
+            assert_raise LoopctlWeb.SanitizedDBError, fn -> LoopctlWeb.Endpoint.call(conn, []) end
+
+          refute Exception.message(error) =~ "embedding <=>"
+        end)
+
+      assert log =~ "sqlstate=42P01"
+      # The exit path attributes the fault WITHOUT the router frame (Logger metadata).
+      assert log =~ "tenant_id=#{tenant.id}"
+    end
+
+    test "a NON-DB exception nested under a pool call element keeps its identity",
+         %{conn: conn} do
+      # Dressing it as a `DBConnection.ConnectionError` advertised a permanent defect as a
+      # retryable 503 and erased the only record of what actually failed.
+      {conn, _tenant} = authed_conn(conn)
+      conn = put_req_header(conn, "x-test-raise-db-error", "exit-nested-runtime")
+
+      {reason, log} = with_log(fn -> catch_exit(LoopctlWeb.Endpoint.call(conn, [])) end)
+
+      assert {{%RuntimeError{message: "pool process defect"}, []}, {DBConnection, :run, []}} =
+               reason
+
+      refute log =~ "db_error mapped to HTTP"
     end
 
     test "a FOREIGN exit is re-exited untouched and not attributed to the database",

--- a/test/loopctl_web/plugs/db_error_backstop_test.exs
+++ b/test/loopctl_web/plugs/db_error_backstop_test.exs
@@ -120,25 +120,47 @@ defmodule LoopctlWeb.Plugs.DBErrorBackstopTest do
   end
 
   describe "#558: crash propagation is an EXIT, not a raise" do
-    test "the backstop logs a BOUNDED class and re-exits unchanged", %{conn: conn} do
+    test "a pool exit is translated exactly like the raise path", %{conn: conn} do
       # A `rescue`-only backstop never saw this shape, so the raw reason reached the crash
       # log — carrying the failing statement and its bound parameters.
-      {conn, _tenant} = authed_conn(conn)
+      {conn, tenant} = authed_conn(conn)
       conn = put_req_header(conn, "x-test-raise-db-error", "exit-propagation")
 
-      {reason, log} =
+      {_, log} =
         with_log(fn ->
-          catch_exit(LoopctlWeb.Endpoint.call(conn, []))
+          error =
+            assert_raise LoopctlWeb.SanitizedDBError, fn ->
+              LoopctlWeb.Endpoint.call(conn, [])
+            end
+
+          # AC-27.3.8: the REASON that reaches the crash log is now the sanitized stand-in, so
+          # `Exception.format/3` cannot render the nested struct's statement or the bound args.
+          # Asserting on the backstop's own log line would be vacuous — it never carried them.
+          message = Exception.message(error)
+          refute message =~ "secret_bound_param"
+          refute message =~ "embedding <=>"
+          refute message =~ "0.123"
+          assert Plug.Exception.status(error) == 500
         end)
 
-      # Re-exited UNCHANGED — the backstop attributes, it does not swallow or translate.
-      assert {{%Postgrex.Error{}, _stack}, {DBConnection, :execute, _args}} = reason
+      # AC-27.3.3: the exit shape gets the SAME structured SQLSTATE line (and the
+      # [:loopctl, :db, :error] counter DBErrorLogger emits with it).
+      assert log =~ "sqlstate=42P01"
+      assert log =~ "mapped_code=db_error"
+      assert log =~ "tenant_id=#{tenant.id}"
+    end
 
-      assert log =~ "DBErrorBackstop: request exit"
-      # The CLASS, from the closed ExitClass set — never the reason itself.
-      assert log =~ "exit:Postgrex.Error"
-      refute log =~ "secret_bound_param"
-      refute log =~ "0.123"
+    test "a FOREIGN exit is re-exited untouched and not attributed to the database",
+         %{conn: conn} do
+      {conn, _tenant} = authed_conn(conn)
+      conn = put_req_header(conn, "x-test-raise-db-error", "exit-foreign")
+
+      {reason, log} =
+        with_log(fn -> catch_exit(LoopctlWeb.Endpoint.call(conn, [])) end)
+
+      assert {:timeout, {GenServer, :call, _args}} = reason
+      refute log =~ "DBErrorBackstop"
+      refute log =~ "db_error mapped to HTTP"
     end
   end
 end

--- a/test/support/backstop_router.ex
+++ b/test/support/backstop_router.ex
@@ -22,6 +22,8 @@ defmodule Loopctl.Test.BackstopRouter do
     * `"42P01"` — `Postgrex.Error` `:undefined_table` (catch-all → 500)
     * `"conn"`  — `DBConnection.ConnectionError` (→ 503)
     * `"runtime"` — a plain `RuntimeError` (non-DB → let-it-crash, unchanged)
+    * `"exit-propagation"` — a pooled-process crash EXIT nesting a `Postgrex.Error`
+    * `"exit-foreign"` — an exit with no pool module in its call element
 
   The 57014 exception deliberately carries `query:` with SQL + a vector literal
   that WOULD leak if anything called `Exception.message/1` on it, so tests can
@@ -51,7 +53,7 @@ defmodule Loopctl.Test.BackstopRouter do
   # #558: crash PROPAGATION from a pooled process is an EXIT, not a raise, so it needs its
   # own shape here — a `rescue`-only backstop never sees it. The reason carries the failing
   # Postgrex struct (statement text) and the call's bound args, which is exactly what must not
-  # reach the crash log raw.
+  # reach the crash log raw: the backstop translates it to a SanitizedDBError instead.
   defp raise_uncaught(_conn, "exit-propagation") do
     exit(
       {{%Postgrex.Error{
@@ -59,6 +61,11 @@ defmodule Loopctl.Test.BackstopRouter do
           query: "SELECT id FROM things ORDER BY embedding <=> '[0.123,0.456]'::vector LIMIT 5"
         }, []}, {DBConnection, :execute, [:secret_bound_param]}}
     )
+  end
+
+  # A NON-pool exit: the backstop must leave it alone (no translation, no DB attribution).
+  defp raise_uncaught(_conn, "exit-foreign") do
+    exit({:timeout, {GenServer, :call, [:some_other_server, :ping]}})
   end
 
   defp raise_uncaught(conn, kind) do

--- a/test/support/backstop_router.ex
+++ b/test/support/backstop_router.ex
@@ -48,6 +48,19 @@ defmodule Loopctl.Test.BackstopRouter do
   # carrying the dispatched conn so controller/action/assigns are populated for
   # the structured log. We stamp a phoenix_controller so the log line has a
   # controller field, mirroring a real dispatched request.
+  # #558: crash PROPAGATION from a pooled process is an EXIT, not a raise, so it needs its
+  # own shape here — a `rescue`-only backstop never sees it. The reason carries the failing
+  # Postgrex struct (statement text) and the call's bound args, which is exactly what must not
+  # reach the crash log raw.
+  defp raise_uncaught(_conn, "exit-propagation") do
+    exit(
+      {{%Postgrex.Error{
+          postgres: %{code: :undefined_table, pg_code: "42P01", severity: "ERROR", message: "x"},
+          query: "SELECT id FROM things ORDER BY embedding <=> '[0.123,0.456]'::vector LIMIT 5"
+        }, []}, {DBConnection, :execute, [:secret_bound_param]}}
+    )
+  end
+
   defp raise_uncaught(conn, kind) do
     dispatched = %{conn | private: Map.put(conn.private, :phoenix_controller, SomeCtl)}
 

--- a/test/support/backstop_router.ex
+++ b/test/support/backstop_router.ex
@@ -23,17 +23,26 @@ defmodule Loopctl.Test.BackstopRouter do
     * `"conn"`  — `DBConnection.ConnectionError` (→ 503)
     * `"runtime"` — a plain `RuntimeError` (non-DB → let-it-crash, unchanged)
     * `"exit-propagation"` — a pooled-process crash EXIT nesting a `Postgrex.Error`
+    * `"exit-task"` — the same nested `Postgrex.Error` through a `Task` call element
+    * `"exit-nested-runtime"` — a NON-DB exception under a pool call element
     * `"exit-foreign"` — an exit with no pool module in its call element
 
-  The 57014 exception deliberately carries `query:` with SQL + a vector literal
-  that WOULD leak if anything called `Exception.message/1` on it, so tests can
-  prove neither the response, the structured log, nor the sanitized re-raise
-  echoes it.
+  It first runs the REAL identity plugs, so the tenant is established INSIDE the router as in
+  production: pre-assigning it on the endpoint conn proves nothing about the EXIT path, which
+  unwinds that frame and recovers only what the plugs left behind.
+
+  The 57014 exception deliberately carries `query:` with SQL + a vector literal that WOULD
+  leak if anything called `Exception.message/1` on it, so tests can prove neither the
+  response, the structured log, nor the sanitized re-raise echoes it.
   """
 
   @behaviour Plug
 
+  alias LoopctlWeb.Plugs.{ExtractApiKey, ResolveApiKey, SeedTenantMetadata}
+
   @header "x-test-raise-db-error"
+
+  @identity_plugs [ExtractApiKey, ResolveApiKey, SeedTenantMetadata]
 
   @impl true
   def init(opts), do: LoopctlWeb.Router.init(opts)
@@ -41,26 +50,34 @@ defmodule Loopctl.Test.BackstopRouter do
   @impl true
   def call(conn, opts) do
     case Plug.Conn.get_req_header(conn, @header) do
-      [kind | _] -> raise_uncaught(conn, kind)
+      [kind | _] -> conn |> authenticate() |> raise_uncaught(kind)
       [] -> LoopctlWeb.Router.call(conn, opts)
     end
   end
 
-  # Raise the way a controller action does: wrapped in a Plug.Conn.WrapperError
-  # carrying the dispatched conn so controller/action/assigns are populated for
-  # the structured log. We stamp a phoenix_controller so the log line has a
-  # controller field, mirroring a real dispatched request.
-  # #558: crash PROPAGATION from a pooled process is an EXIT, not a raise, so it needs its
-  # own shape here — a `rescue`-only backstop never sees it. The reason carries the failing
-  # Postgrex struct (statement text) and the call's bound args, which is exactly what must not
-  # reach the crash log raw: the backstop translates it to a SanitizedDBError instead.
+  defp authenticate(conn) do
+    Enum.reduce(@identity_plugs, conn, fn p, acc -> p.call(acc, p.init([])) end)
+  end
+
+  # Raise the way a controller action does: wrapped in a Plug.Conn.WrapperError carrying the
+  # dispatched conn so controller/action/assigns are populated for the structured log.
+  # #558: crash PROPAGATION from a pooled process is an EXIT, not a raise, so it needs its own
+  # shape here — a `rescue`-only backstop never sees it. The reason carries the failing Postgrex
+  # struct (statement text) and the call's bound args, exactly what must not reach the crash log
+  # raw: the backstop translates it to a SanitizedDBError instead.
   defp raise_uncaught(_conn, "exit-propagation") do
-    exit(
-      {{%Postgrex.Error{
-          postgres: %{code: :undefined_table, pg_code: "42P01", severity: "ERROR", message: "x"},
-          query: "SELECT id FROM things ORDER BY embedding <=> '[0.123,0.456]'::vector LIMIT 5"
-        }, []}, {DBConnection, :execute, [:secret_bound_param]}}
-    )
+    exit({{nested_postgrex_error(), []}, {DBConnection, :execute, [:secret_bound_param]}})
+  end
+
+  # The SAME nested payload through a NON-pool call element (`Knowledge.novelty_scores/3` reads
+  # inside a `Task.async_stream`): classifying by the call element alone left this shape raw.
+  defp raise_uncaught(_conn, "exit-task") do
+    exit({{nested_postgrex_error(), []}, {Task, :stream, [:secret_bound_param]}})
+  end
+
+  # A NON-DB exception under a POOL call element: a real fault that must keep its identity.
+  defp raise_uncaught(_conn, "exit-nested-runtime") do
+    exit({{%RuntimeError{message: "pool process defect"}, []}, {DBConnection, :run, []}})
   end
 
   # A NON-pool exit: the backstop must leave it alone (no translation, no DB attribution).
@@ -76,6 +93,13 @@ defmodule Loopctl.Test.BackstopRouter do
       kind: :error,
       reason: exception_for(kind),
       stack: []
+  end
+
+  defp nested_postgrex_error do
+    %Postgrex.Error{
+      postgres: %{code: :undefined_table, pg_code: "42P01", severity: "ERROR", message: "x"},
+      query: "SELECT id FROM things ORDER BY embedding <=> '[0.123,0.456]'::vector LIMIT 5"
+    }
   end
 
   defp exception_for("57014") do


### PR DESCRIPTION
Closes #558 — the remaining seven items. Eight were done in #560.

## 1. `DBErrorBackstop` leaked the raw reason, and lost the status

It rescued only `Plug.Conn.WrapperError`. Crash propagation from a pooled process is an **exit** — `{{%Postgrex.Error{}, stack}, {DBConnection, :execute, args}}` — so it walked past the backstop into the crash log **raw**. The struct carries the failing statement and `args` carries its bound parameters; on this app's read paths that means query text and vector literals.

A demonstrable pool exit (`ExitClass.pool_exit?/1`) now takes **the same path the rescue arm takes**: `DBError.map/1` → `DBErrorLogger.log/3` (structured SQLSTATE line plus the `[:loopctl, :db, :error]` counter) → `SanitizedDBError` with the pinned 504/503/500, and `Retry-After` on the 503 that the mapping table already promised. A **foreign** exit is re-exited untouched and not logged.

My first version only logged a bounded class and re-exited. That closed the leak but left the observability and status gap — a DB fault arriving as an exit still produced no SQLSTATE line, no counter, and an unpinned 500. Routing it through the existing path was the better answer.

The exit path also now logs against the **dispatched** conn rather than the pre-router one, so tenant/controller/action attribution survives the router unwind instead of emitting `tenant_id= controller= action=` and `endpoint: :unknown`.

## 2. The 429 message and the OpenAPI spec are one string

`schemas.ex` still carried the copy #560 corrected in `fallback_controller.ex` — asserting a backlog that, on the metered fail-open path, was never measured and may be zero.

Both sites now render one shared `Loopctl.ApiSpec.Messages` function, and a test reads the schema's example **and its description** and compares them, so they cannot drift again silently — nothing else in the suite compares a spec example to a response body. The copy is also route-neutral now: a single-item `POST /knowledge/ingest` caller is no longer told "No items from this batch were enqueued."

## 3. The fail-open meter was cheap to defeat and shared a failure domain

- The charge loop halted only on a **refusal**, so an unconsultable meter kept iterating — up to 50 sequential doomed `AdminRepo` checkouts per batch request, on the web process, during exactly the wedge the gate exists to bound. It halts on `:unmetered` too.
- Under `RATE_LIMITER=postgres` the limiter's store **is** `AdminRepo` — the same pool whose failure the meter is bounding. This one bucket now pins to the node-local ETS limiter, which is already the unit the allowance is derived in.
- A `Postgrex.Error` carrying no server SQLSTATE is a client-side driver fault on a degrading connection, so it is metered as `db_pressure` rather than falling into the unmetered `db_error` catch-all.

## 4. Docs of record resynced

Both `telemetry_events.ex` docstrings (the declared source of truth `ScaleMetrics.degraded_read_tags/1` points at, stale twice over), the `IngestionBacklogError` description, the `FallbackController` moduledoc, and `create_batch`'s operation description — all now state **both** 429 causes. `CHANGELOG.md` carries the operator notice that `oban.poll.error.count`'s `error_class` values changed from bare `exit`/`throw` to the kind-prefixed closed set: a selector matching the old values **silently stops firing** rather than erroring.

---

## Correction: one of #558's own items was wrong, and this PR does not do it

Item 15 said the gate should stop metering a `throw`, on the reasoning that a throw is a deterministic counting fault rather than sustained pool pressure. **I wrote that item, I implemented it here, and review reverted it. The reversal is right.**

Two reasons:

- **The meter is not punitive.** It bounds unbounded admission during any period the count is *unmeasurable* — and a throw leaves it exactly as unmeasurable as an exit does. I conflated "whose fault is this" with "what does admitting cost". Un-metering restored, for that class, precisely the unbounded admit the meter exists to close.
- **The premise was mechanically wrong.** Ecto re-raises a throw out of a transaction fun, so a throw arriving at that catch is not coming from the counting code in the first place.

`throw:*` is metered again, symmetric with `exit:*`. The CHANGELOG bullet claiming otherwise never shipped and has been replaced with the changes this PR actually makes.

## Verification

- `mix precommit` green after both fix rounds, verified independently: **6606 tests, 0 failures**.
- Mutation-verified: reverting the `:unmetered` halt fails the charge-loop test; removing the `pool_exit?/1` gate fails the foreign-exit test; short-circuiting the conn restoration fails both exit-path tests with exactly the production symptom while the raise path still passes.
- Two of my own assertions were **vacuous** and were rewritten: `refute log =~ ...` passed regardless because it checked a string the crash log never formats, and a parity assertion passed only because the test's helper pre-assigned `:current_api_key` on the outer conn. They now assert `Exception.message/1` of the re-raised reason and the structured `sqlstate=` line.

Chain depth 2 of 2 — this run does not recommend a follow-up PR. Three findings landed outside the diff and go to a tracked issue.
