### PR TITLE
Add a heat-ranked topic index: retrieval that does not start from a query

### DIFF
--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -11,8 +11,8 @@ defmodule Loopctl.HeavyRead do
   A query is accepted only if EVERY base-table source it reads from — the `from`
   table AND every joined table — is constrained by a CONJUNCTIVE
   `x.tenant_id == ^tenant_id` equality on THAT source's binding, bound to the
-  `tenant_id` argument passed in; subquery sources (from/join/where-in) are
-  required to be scoped the same way, recursively. Concretely this rejects:
+  `tenant_id` argument passed in; `from`/`join` SUBQUERY sources are required to
+  be scoped the same way, recursively. Concretely this rejects:
 
     * an unscoped `from` (the primary table read without a tenant filter), even
       if a *joined* table is scoped;
@@ -27,11 +27,11 @@ defmodule Loopctl.HeavyRead do
 
   This is a strong necessary gate, not a proof of full query correctness. The
   tenant predicate MUST be an Ecto field comparison `x.tenant_id == ^id` (a raw
-  `fragment("tenant_id = ?", ^id)` is not recognized and will be rejected — scope
-  through the schema field). Sources that are neither a schema table nor a
-  subquery (a raw `fragment` from, or a CTE reference) are not structurally
-  validated — express tenant scoping in the outer query or a from/join subquery
-  rather than a CTE source.
+  `fragment("tenant_id = ?", ^id)` is rejected — scope through the schema field).
+  A source that is neither a schema table nor a from/join subquery (a raw
+  `fragment` from, a CTE reference) is not structurally validated, and NEITHER is a
+  subquery in a WHERE/HAVING expression (`where: x.id in subquery(q)`): only `from`
+  and joins are walked, so reason about what such a subquery reads at the call site.
 
   A companion build guard (`test/loopctl/heavy_read_guard_test.exs`) fails if any
   `lib/` module other than this one reaches `Loopctl.HeavyReadRepo` directly, so

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -331,6 +331,7 @@ defmodule Loopctl.HeavyRead do
     export
     llm_usage
     graph_lane
+    heat_index
   )a
 
   @doc """

--- a/lib/loopctl/heavy_read/tenant_gate.ex
+++ b/lib/loopctl/heavy_read/tenant_gate.ex
@@ -159,6 +159,14 @@ defmodule Loopctl.HeavyRead.TenantGate do
   # `tenant_gate_test.exs`'s endpoint-weight guard — so a NEW heavy endpoint a caller
   # adds (registered in `known_endpoints/0`) cannot silently fall through
   # `weight_for/1` to light weight and under-charge a genuinely heavy read.
+  # `heat_index` (#554) is HEAVY, and the choice is asymmetric rather than close. It is a full
+  # aggregate (group-by + count) over `article_access_events` joined to `articles`, so its cost
+  # grows with the READ HISTORY, not the corpus — the one table that only ever gets longer.
+  #
+  # The tie-break is what each error costs. Marked light and actually expensive, concurrent
+  # calls starve genuine request-path reads. Marked heavy and actually cheap, it just sheds
+  # earlier under load — and this surface is a cadence-refreshed navigation index, so a STALE
+  # index costs nothing while a starved semantic search costs a request.
   @heavy_endpoints ~w(
     vector_search
     semantic_search
@@ -169,6 +177,7 @@ defmodule Loopctl.HeavyRead.TenantGate do
     distant_pairs_bridge
     export
     graph_lane
+    heat_index
   )a
 
   # --- Client API ---

--- a/lib/loopctl/heavy_read/tenant_gate.ex
+++ b/lib/loopctl/heavy_read/tenant_gate.ex
@@ -159,9 +159,10 @@ defmodule Loopctl.HeavyRead.TenantGate do
   # `tenant_gate_test.exs`'s endpoint-weight guard — so a NEW heavy endpoint a caller
   # adds (registered in `known_endpoints/0`) cannot silently fall through
   # `weight_for/1` to light weight and under-charge a genuinely heavy read.
-  # `heat_index` (#554) is HEAVY, and the choice is asymmetric rather than close. It is a full
-  # aggregate (group-by + count) over `article_access_events` joined to `articles`, so its cost
-  # grows with the READ HISTORY, not the corpus — the one table that only ever gets longer.
+  # `heat_index` (#554) is HEAVY, and the choice is asymmetric rather than close. It is a
+  # group-by + count over `article_access_events`, so its cost grows with the READ HISTORY,
+  # not the corpus — the one table that only ever gets longer. A default window bounds the
+  # scan; it does not make the read cheap.
   #
   # The tie-break is what each error costs. Marked light and actually expensive, concurrent
   # calls starve genuine request-path reads. Marked heavy and actually cheap, it just sheds

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -8871,27 +8871,42 @@ defmodule Loopctl.Knowledge do
   # the payload could exceed several-fold.
   @heat_summary_chars 120
   @heat_title_chars 100
-  # The fixed per-stub cost the caller actually pays: the 36-char UUID, the heat integer, and
-  # the JSON keys/punctuation around the five fields. Counted so `chars` does not under-report
-  # what lands in the prefix.
-  @heat_stub_fixed_chars 90
+  # The fixed per-stub cost the caller actually pays, MEASURED off the wire shape
+  # `{"id":"<36-char uuid>","title":"","category":"","heat":,"summary":""}`: the UUID plus the
+  # JSON keys and punctuation around the five fields. The heat integer is variable-width, so it
+  # is counted per stub in `heat_stub_chars/1` instead of being folded in here — `chars` is the
+  # number a caller budgets a cached prefix against and must not under-report it.
+  @heat_stub_fixed_chars 91
   # `category` is a closed enum whose longest member is far under this.
   @heat_category_chars 24
+  # Digits allotted to `heat` in the ADVERTISED budget; an access count cannot exceed them.
+  @heat_count_chars 10
   @heat_stub_char_cap @heat_title_chars + @heat_summary_chars + @heat_category_chars +
-                        @heat_stub_fixed_chars
+                        @heat_stub_fixed_chars + @heat_count_chars
 
-  # Heat counts BODY READS only. `"search"` (and the reserved `"index"`) rows are
-  # IMPRESSIONS — `Analytics.record_search_access/6` writes one per RESULT of one query — so
-  # counting them would make heat a running tally of past ranker output, re-coupling this
-  # route to the embedding similarity it exists to be uncorrelated with. `"get"` is a direct
-  # body fetch and `"context"` is a full-body context pack; both are reads.
-  @heat_read_access_types ~w(get context)
+  # Heat counts CALLER-CHOSEN body fetches only. `"search"`, the reserved `"index"` AND
+  # `"context"` are all LIST-shaped — `Analytics.record_search_access/6` and
+  # `record_context_access/5` each write one row per RESULT of one ranker-run query — so
+  # counting any of them would make heat a running tally of past ranker output, re-coupling
+  # this route to the embedding similarity it exists to be uncorrelated with. A context pack
+  # does ship bodies, but the caller asked ONE question and the ranker picked the N articles,
+  # so one query would out-vote N deliberate reads. `"get"` is the only per-article fetch a
+  # reader names. Deliberately NARROWER than the read set in
+  # `RetrievalMetrics.compute_followed_through/2`, which asks a different question (was a body
+  # DELIVERED, ranker-chosen or not) — the two sets must not be unified.
+  @heat_read_access_types ~w(get)
 
   # The aggregate runs on the request path over `article_access_events`, the one table that
   # only ever grows, under a 10s statement timeout. An unbounded all-time scan therefore fails
   # (500) rather than degrades on exactly the tenant with the most history. A default window
-  # bounds it; `:since` moves it either way.
+  # bounds it; `:since` moves it either way, up to the ceiling below.
   @heat_default_window_days 90
+
+  # The ceiling. `:since` is caller-supplied, so without a floor on the lookback the unbounded
+  # all-time scan the default exists to prevent is one query parameter away. An older `:since`
+  # is CLAMPED (not rejected — the caller still gets the widest window that can be served) and
+  # `meta.heat_window` echoes what it actually got.
+  @heat_max_window_days 365
 
   @doc """
   A HEAT-ranked, topic-less stub index of the corpus (#554).
@@ -8902,11 +8917,12 @@ defmodule Loopctl.Knowledge do
   has nothing" rather than "I asked badly", with nothing in context to contradict it. This route
   takes no query at all, so its misses are uncorrelated with embedding similarity.
 
-  Ordering is by HEAT — the count of BODY-READ `article_access_events` rows for the article
-  (`#{Enum.join(@heat_read_access_types, "/")}`; search impressions are deliberately NOT
-  counted, see `@heat_read_access_types`), i.e. how often it has actually proved worth
-  reading. Usage is treated as the authority on importance, so material that has repeatedly
-  landed floats to the top of every future index regardless of what today's query embeds near.
+  Ordering is by HEAT — the count of CALLER-CHOSEN body reads
+  (`#{Enum.join(@heat_read_access_types, "/")}`) inside the window; list-shaped ranker output
+  (`search`, `context`) is deliberately NOT counted, see `@heat_read_access_types`. Usage is
+  treated as the authority on importance, so material that keeps proving worth reading holds
+  its rank regardless of what today's query embeds near. Heat is WINDOWED, not cumulative: an
+  empty result means "nothing was read within `meta.heat_window`", NOT "the corpus is empty".
 
   System-scoped published canonicals participate, exactly as they do in
   `list_curated_sources/2` and `progressive_drill/3` — a tenant whose most-read material is
@@ -8924,8 +8940,9 @@ defmodule Loopctl.Knowledge do
     - `:limit` -- top-K, clamped to `1..#{@max_relevance_page_size}` exactly like
       `progressive_index/3`, so an explicit override cannot flood context either.
     - `:since` -- count only accesses at/after this `DateTime`. Defaults to the last
-      #{@heat_default_window_days} days, which BOUNDS the request-path aggregate; pass an
-      older `DateTime` to widen it deliberately and accept the scan.
+      #{@heat_default_window_days} days and is CLAMPED to at most #{@heat_max_window_days}
+      days of lookback, so the request-path aggregate stays bounded either way; pass an older
+      `DateTime` to widen it deliberately and read `meta.heat_window` for what you got.
     - `:category` -- restrict to one category atom.
     - `:visibility_agent_id` -- the calling agent's id (#163). An index is exactly the surface
       where a leak is easy and invisible, because a stub looks innocuous and nobody reads an
@@ -8945,7 +8962,7 @@ defmodule Loopctl.Knowledge do
       opts |> Keyword.get(:limit, progressive_top_k()) |> max(1) |> min(@max_relevance_page_size)
 
     vis = Keyword.get(opts, :visibility_agent_id)
-    since = Keyword.get(opts, :since) || default_heat_since()
+    since = opts |> Keyword.get(:since) |> heat_since()
     category = Keyword.get(opts, :category)
 
     # `top_k + 1` look-ahead: it costs one row and turns "you got exactly the cap" into a
@@ -8956,7 +8973,8 @@ defmodule Loopctl.Knowledge do
       |> heat_counts_query(top_k + 1, since, category, vis)
       |> then(&HeavyRead.all(tenant_id, &1, HeavyRead.opts(:heat_index)))
 
-    stubs = tenant_id |> heat_stubs(Enum.take(counted, top_k), vis)
+    ranked = Enum.take(counted, top_k)
+    stubs = heat_stubs(tenant_id, ranked, vis)
 
     {:ok,
      %{
@@ -8964,6 +8982,11 @@ defmodule Loopctl.Knowledge do
        meta: %{
          top_k: top_k,
          returned: length(stubs),
+         # A ranked id that no longer resolves (archived, unpublished or deleted between the
+         # aggregate and the projection — separate connections, no shared transaction) is
+         # dropped, which would otherwise make a SHORT list indistinguishable from an
+         # exhausted one. `truncated` is about the cap; this is about the drop.
+         unresolved: length(ranked) - length(stubs),
          truncated: length(counted) > top_k,
          # A STATED budget, not an implied one: the caller is expected to paste this into a
          # cached prefix, so it needs to know the cost before it does. Derived from the
@@ -8974,24 +8997,42 @@ defmodule Loopctl.Knowledge do
          counted_access_types: @heat_read_access_types,
          # The read instruction rides IN the payload (#554): an index that lists ids without
          # saying they are actionable gets read as prose.
+         # `knowledge_progressive_drill`, NOT `knowledge_get`: this index also lists published
+         # system canonicals, whose tenant_id is NULL, and `get_article/3` filters on
+         # tenant_id, so following a canon stub into `knowledge_get` 404s.
          drill: %{
-           tool: "knowledge_get",
+           tool: "knowledge_progressive_drill",
            parameter: "article_id",
            note:
-             "Pass a listed id to read the full article. Ordering is cumulative usage (body reads), not relevance to any query."
+             "Pass a listed id to read the full article; this tool also opens the system canonicals listed here, which knowledge_get cannot. Ordering is body reads within meta.heat_window, not relevance to any query."
          }
        }
      }}
   end
 
-  defp default_heat_since,
+  @doc "The default heat window, in days. Single source for the API description (#554)."
+  @spec heat_default_window_days() :: pos_integer()
+  def heat_default_window_days, do: @heat_default_window_days
+
+  @doc "The maximum heat lookback, in days; an older `:since` is clamped to it."
+  @spec heat_max_window_days() :: pos_integer()
+  def heat_max_window_days, do: @heat_max_window_days
+
+  defp heat_since(nil),
     do: DateTime.add(DateTime.utc_now(), -@heat_default_window_days, :day)
+
+  defp heat_since(%DateTime{} = since) do
+    floor = DateTime.add(DateTime.utc_now(), -@heat_max_window_days, :day)
+    if DateTime.compare(since, floor) == :lt, do: floor, else: since
+  end
 
   # Aggregate over the EVENTS alone: no join to `articles`, so no article column (least of all
   # the unbounded body) enters the group key, and the article-side predicates ride in a bounded
-  # `IN (subquery)` id set. That subquery is where the `or a.scope == :system` disjunction is
-  # safe — `HeavyRead.guard!/2` refuses it on a base-table source, and the event row is still
-  # conjunctively tenant-scoped. Same shape `apply_search_filters_on_article/4` uses.
+  # `IN (subquery)` id set. `HeavyRead.guard!/2` does NOT walk a subquery that appears in a
+  # WHERE expression (only `from`/join sources), so the `or a.scope == :system` disjunction
+  # inside it is reasoned about HERE rather than proved: the rows being aggregated are
+  # conjunctively tenant-scoped events, so the id set can only NARROW what this tenant already
+  # generated. Same shape `apply_search_filters_on_article/4` uses.
   defp heat_counts_query(tenant_id, limit, since, category, vis) do
     from(e in ArticleAccessEvent,
       where: e.tenant_id == ^tenant_id,
@@ -9023,9 +9064,12 @@ defmodule Loopctl.Knowledge do
 
   # Bounded projection for the ≤top_k ranked ids only, on `AdminRepo` for the same reason
   # `hydrate_semantic_pool/6` is: a system canonical's NULL `tenant_id` cannot satisfy the
-  # heavy-read guard. `left(body, ...)` keeps the full body off the wire — only enough text to
-  # build a one-line summary is ever shipped. Visibility is re-applied here as the last line of
-  # defence: this is the query that actually reads a title.
+  # heavy-read guard. It runs AFTER the gated aggregate released the heavy-read gate, on the
+  # small admin pool — acceptable HERE because it is a primary-key lookup of at most
+  # `@max_relevance_page_size` ids with `left(body, ...)` clipping the body, i.e. bounded work
+  # with no scan, unlike the aggregate it follows. `status` and visibility are re-applied
+  # rather than trusted from the ranking query: the two run on separate connections, so an
+  # article can be unpublished in between, and this is the query that actually reads a title.
   defp heat_stubs(_tenant_id, [], _vis), do: []
 
   defp heat_stubs(tenant_id, rows, vis) do
@@ -9035,6 +9079,7 @@ defmodule Loopctl.Knowledge do
       from(a in Article,
         where: a.id in ^ids,
         where: a.tenant_id == ^tenant_id or a.scope == :system,
+        where: a.status == :published,
         select: %{
           id: a.id,
           title: a.title,
@@ -9080,7 +9125,7 @@ defmodule Loopctl.Knowledge do
 
   defp heat_stub_chars(stub) do
     String.length(stub.title) + String.length(stub.summary) + String.length(stub.category) +
-      @heat_stub_fixed_chars
+      String.length(Integer.to_string(stub.heat)) + @heat_stub_fixed_chars
   end
 
   # Hub-enrichment neighbor discovery (AC-31.3.4): finds which of the seed

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -8863,12 +8863,35 @@ defmodule Loopctl.Knowledge do
     end
   end
 
-  # Bound on a single stub's summary so the whole index stays paste-able into a cached prefix.
+  # Bound on a single stub so the whole index stays paste-able into a cached prefix.
   # The cap is per-stub rather than a running total: truncating the LAST stub of a top-K list
   # would silently drop the tail, and a partially-listed index is worse than a shorter one
-  # because nothing signals the omission.
+  # because nothing signals the omission. EVERY variable-length field is capped — a title is
+  # validated only to 500 chars, so leaving it uncapped made the advertised budget a number
+  # the payload could exceed several-fold.
   @heat_summary_chars 120
-  @heat_index_char_budget @max_relevance_page_size * (@heat_summary_chars + 80)
+  @heat_title_chars 100
+  # The fixed per-stub cost the caller actually pays: the 36-char UUID, the heat integer, and
+  # the JSON keys/punctuation around the five fields. Counted so `chars` does not under-report
+  # what lands in the prefix.
+  @heat_stub_fixed_chars 90
+  # `category` is a closed enum whose longest member is far under this.
+  @heat_category_chars 24
+  @heat_stub_char_cap @heat_title_chars + @heat_summary_chars + @heat_category_chars +
+                        @heat_stub_fixed_chars
+
+  # Heat counts BODY READS only. `"search"` (and the reserved `"index"`) rows are
+  # IMPRESSIONS — `Analytics.record_search_access/6` writes one per RESULT of one query — so
+  # counting them would make heat a running tally of past ranker output, re-coupling this
+  # route to the embedding similarity it exists to be uncorrelated with. `"get"` is a direct
+  # body fetch and `"context"` is a full-body context pack; both are reads.
+  @heat_read_access_types ~w(get context)
+
+  # The aggregate runs on the request path over `article_access_events`, the one table that
+  # only ever grows, under a 10s statement timeout. An unbounded all-time scan therefore fails
+  # (500) rather than degrades on exactly the tenant with the most history. A default window
+  # bounds it; `:since` moves it either way.
+  @heat_default_window_days 90
 
   @doc """
   A HEAT-ranked, topic-less stub index of the corpus (#554).
@@ -8879,10 +8902,15 @@ defmodule Loopctl.Knowledge do
   has nothing" rather than "I asked badly", with nothing in context to contradict it. This route
   takes no query at all, so its misses are uncorrelated with embedding similarity.
 
-  Ordering is by HEAT — the cumulative count of `article_access_events` rows for the article,
-  i.e. how often it has actually proved worth reading. Usage is treated as the authority on
-  importance, so material that has repeatedly landed floats to the top of every future index
-  regardless of what today's query happens to embed near.
+  Ordering is by HEAT — the count of BODY-READ `article_access_events` rows for the article
+  (`#{Enum.join(@heat_read_access_types, "/")}`; search impressions are deliberately NOT
+  counted, see `@heat_read_access_types`), i.e. how often it has actually proved worth
+  reading. Usage is treated as the authority on importance, so material that has repeatedly
+  landed floats to the top of every future index regardless of what today's query embeds near.
+
+  System-scoped published canonicals participate, exactly as they do in
+  `list_curated_sources/2` and `progressive_drill/3` — a tenant whose most-read material is
+  the shared canon would otherwise get an index that omits precisely what it reads most.
 
   ## Why this is NOT an option on `progressive_index/3`
 
@@ -8895,9 +8923,9 @@ defmodule Loopctl.Knowledge do
 
     - `:limit` -- top-K, clamped to `1..#{@max_relevance_page_size}` exactly like
       `progressive_index/3`, so an explicit override cannot flood context either.
-    - `:since` -- count only accesses at/after this `DateTime`. Default is ALL-TIME:
-      heat is defined as cumulative, and a window would make a long-valuable article
-      indistinguishable from a never-read one during a quiet week.
+    - `:since` -- count only accesses at/after this `DateTime`. Defaults to the last
+      #{@heat_default_window_days} days, which BOUNDS the request-path aggregate; pass an
+      older `DateTime` to widen it deliberately and accept the scan.
     - `:category` -- restrict to one category atom.
     - `:visibility_agent_id` -- the calling agent's id (#163). An index is exactly the surface
       where a leak is easy and invisible, because a stub looks innocuous and nobody reads an
@@ -8905,9 +8933,11 @@ defmodule Loopctl.Knowledge do
       agent's `private`/`owner` memory can never appear even as a title.
 
   Returns `{:ok, %{results: [stub], meta: map}}`. Each stub carries `id`, `title`, `category`,
-  `heat` and a one-line `summary`; `meta` states the character budget, the cap, and — per the
-  Tencent navigation-index property — WHICH TOOL to call with WHICH PARAMETER to drill, so the
-  payload is self-describing rather than relying on the reader to infer that an id is actionable.
+  `heat` and a one-line `summary`; `meta` states the character budget (derived from the
+  EFFECTIVE top-K and enforced, since every stub field is capped), which access types were
+  counted, whether the list was `truncated`, and — per the Tencent navigation-index property —
+  WHICH TOOL to call with WHICH PARAMETER to drill, so the payload is self-describing rather
+  than relying on the reader to infer that an id is actionable.
   """
   @spec heat_index(Ecto.UUID.t(), keyword()) :: {:ok, map()}
   def heat_index(tenant_id, opts \\ []) when is_binary(tenant_id) do
@@ -8915,16 +8945,18 @@ defmodule Loopctl.Knowledge do
       opts |> Keyword.get(:limit, progressive_top_k()) |> max(1) |> min(@max_relevance_page_size)
 
     vis = Keyword.get(opts, :visibility_agent_id)
-    since = Keyword.get(opts, :since)
+    since = Keyword.get(opts, :since) || default_heat_since()
     category = Keyword.get(opts, :category)
 
-    rows =
+    # `top_k + 1` look-ahead: it costs one row and turns "you got exactly the cap" into a
+    # stated `truncated`, which `progressive_index/3` already carries and a cacheable index
+    # needs more, since nothing else in the payload signals the omission.
+    counted =
       tenant_id
-      |> heat_index_query(top_k, since, category)
-      |> maybe_filter_by_visibility_on_joined_article(vis)
+      |> heat_counts_query(top_k + 1, since, category, vis)
       |> then(&HeavyRead.all(tenant_id, &1, HeavyRead.opts(:heat_index)))
 
-    stubs = Enum.map(rows, &heat_stub/1)
+    stubs = tenant_id |> heat_stubs(Enum.take(counted, top_k), vis)
 
     {:ok,
      %{
@@ -8932,67 +8964,108 @@ defmodule Loopctl.Knowledge do
        meta: %{
          top_k: top_k,
          returned: length(stubs),
+         truncated: length(counted) > top_k,
          # A STATED budget, not an implied one: the caller is expected to paste this into a
-         # cached prefix, so it needs to know the cost before it does.
-         char_budget: @heat_index_char_budget,
+         # cached prefix, so it needs to know the cost before it does. Derived from the
+         # effective top-K (not the cap), so `limit: 5` does not advertise 100 stubs' worth.
+         char_budget: top_k * @heat_stub_char_cap,
          chars: stubs |> Enum.map(&heat_stub_chars/1) |> Enum.sum(),
-         heat_window: if(since, do: DateTime.to_iso8601(since), else: "all_time"),
+         heat_window: DateTime.to_iso8601(since),
+         counted_access_types: @heat_read_access_types,
          # The read instruction rides IN the payload (#554): an index that lists ids without
          # saying they are actionable gets read as prose.
          drill: %{
            tool: "knowledge_get",
            parameter: "article_id",
            note:
-             "Pass a listed id to read the full article. Ordering is cumulative usage, not relevance to any query."
+             "Pass a listed id to read the full article. Ordering is cumulative usage (body reads), not relevance to any query."
          }
        }
      }}
   end
 
-  defp heat_index_query(tenant_id, top_k, since, category) do
-    base =
-      from(e in ArticleAccessEvent,
-        join: a in Article,
-        on: a.id == e.article_id and a.tenant_id == ^tenant_id,
-        where: e.tenant_id == ^tenant_id,
-        where: a.status == :published,
-        group_by: [a.id, a.title, a.category, a.body],
-        # `asc: a.id` after the count keeps the order TOTAL, so a page is stable across calls
-        # when several articles tie on heat — an index that reshuffles on every refresh cannot
-        # be cached, which is the whole point of this surface.
-        order_by: [desc: count(e.id), asc: a.id],
-        limit: ^top_k,
+  defp default_heat_since,
+    do: DateTime.add(DateTime.utc_now(), -@heat_default_window_days, :day)
+
+  # Aggregate over the EVENTS alone: no join to `articles`, so no article column (least of all
+  # the unbounded body) enters the group key, and the article-side predicates ride in a bounded
+  # `IN (subquery)` id set. That subquery is where the `or a.scope == :system` disjunction is
+  # safe — `HeavyRead.guard!/2` refuses it on a base-table source, and the event row is still
+  # conjunctively tenant-scoped. Same shape `apply_search_filters_on_article/4` uses.
+  defp heat_counts_query(tenant_id, limit, since, category, vis) do
+    from(e in ArticleAccessEvent,
+      where: e.tenant_id == ^tenant_id,
+      where: e.access_type in @heat_read_access_types,
+      where: e.accessed_at >= ^since,
+      where: e.article_id in subquery(heat_article_ids(tenant_id, category, vis)),
+      group_by: e.article_id,
+      # `asc: e.article_id` after the count keeps the order TOTAL, so a page is stable across
+      # calls when several articles tie on heat — an index that reshuffles on every refresh
+      # cannot be cached, which is the whole point of this surface.
+      order_by: [desc: count(e.id), asc: e.article_id],
+      limit: ^limit,
+      select: %{article_id: e.article_id, heat: count(e.id)}
+    )
+  end
+
+  defp heat_article_ids(tenant_id, category, vis) do
+    from(a in Article,
+      where: a.tenant_id == ^tenant_id or a.scope == :system,
+      where: a.status == :published,
+      select: a.id
+    )
+    |> heat_filter_category(category)
+    |> maybe_filter_by_visibility(vis)
+  end
+
+  defp heat_filter_category(query, nil), do: query
+  defp heat_filter_category(query, category), do: where(query, [a], a.category == ^category)
+
+  # Bounded projection for the ≤top_k ranked ids only, on `AdminRepo` for the same reason
+  # `hydrate_semantic_pool/6` is: a system canonical's NULL `tenant_id` cannot satisfy the
+  # heavy-read guard. `left(body, ...)` keeps the full body off the wire — only enough text to
+  # build a one-line summary is ever shipped. Visibility is re-applied here as the last line of
+  # defence: this is the query that actually reads a title.
+  defp heat_stubs(_tenant_id, [], _vis), do: []
+
+  defp heat_stubs(tenant_id, rows, vis) do
+    ids = Enum.map(rows, & &1.article_id)
+
+    by_id =
+      from(a in Article,
+        where: a.id in ^ids,
+        where: a.tenant_id == ^tenant_id or a.scope == :system,
         select: %{
           id: a.id,
           title: a.title,
           category: a.category,
-          body: a.body,
-          heat: count(e.id)
+          summary_source: fragment("left(?, ?)", a.body, ^(@heat_summary_chars * 8))
         }
       )
+      |> maybe_filter_by_visibility(vis)
+      |> AdminRepo.all()
+      |> Map.new(&{&1.id, &1})
 
-    base
-    |> heat_filter_since(since)
-    |> heat_filter_category(category)
+    Enum.flat_map(rows, fn %{article_id: id, heat: heat} ->
+      case Map.fetch(by_id, id) do
+        {:ok, article} -> [heat_stub(article, heat)]
+        :error -> []
+      end
+    end)
   end
 
-  defp heat_filter_since(query, nil), do: query
-
-  defp heat_filter_since(query, %DateTime{} = since),
-    do: where(query, [e], e.accessed_at >= ^since)
-
-  defp heat_filter_category(query, nil), do: query
-  defp heat_filter_category(query, category), do: where(query, [_e, a], a.category == ^category)
-
-  defp heat_stub(row) do
+  defp heat_stub(article, heat) do
     %{
-      id: row.id,
-      title: row.title,
-      category: to_string(row.category),
-      heat: row.heat,
-      summary: heat_summary(row.body)
+      id: article.id,
+      title: heat_title(article.title),
+      category: to_string(article.category),
+      heat: heat,
+      summary: heat_summary(article.summary_source)
     }
   end
+
+  defp heat_title(nil), do: ""
+  defp heat_title(title), do: String.slice(title, 0, @heat_title_chars)
 
   # ONE line, always. A body's first paragraph can be arbitrarily long and can contain newlines
   # that would break a line-oriented consumer's parsing of the index.
@@ -9006,7 +9079,8 @@ defmodule Loopctl.Knowledge do
   end
 
   defp heat_stub_chars(stub) do
-    String.length(stub.title) + String.length(stub.summary) + String.length(stub.category) + 40
+    String.length(stub.title) + String.length(stub.summary) + String.length(stub.category) +
+      @heat_stub_fixed_chars
   end
 
   # Hub-enrichment neighbor discovery (AC-31.3.4): finds which of the seed

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -58,6 +58,7 @@ defmodule Loopctl.Knowledge do
   alias Loopctl.KeysetSeek
   alias Loopctl.Knowledge.Analytics
   alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ArticleAccessEvent
   alias Loopctl.Knowledge.ArticleEmbedding
   alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Knowledge.ConflictResolution
@@ -8860,6 +8861,152 @@ defmodule Loopctl.Knowledge do
          }
        }}
     end
+  end
+
+  # Bound on a single stub's summary so the whole index stays paste-able into a cached prefix.
+  # The cap is per-stub rather than a running total: truncating the LAST stub of a top-K list
+  # would silently drop the tail, and a partially-listed index is worse than a shorter one
+  # because nothing signals the omission.
+  @heat_summary_chars 120
+  @heat_index_char_budget @max_relevance_page_size * (@heat_summary_chars + 80)
+
+  @doc """
+  A HEAT-ranked, topic-less stub index of the corpus (#554).
+
+  The second retrieval route. `search_semantic/3` and `progressive_index/3` both start from a
+  QUERY, so they share a failure mode: a paraphrase, or material that is topically central but
+  lexically dissimilar to the question, comes back empty — and an empty result reads as "the KB
+  has nothing" rather than "I asked badly", with nothing in context to contradict it. This route
+  takes no query at all, so its misses are uncorrelated with embedding similarity.
+
+  Ordering is by HEAT — the cumulative count of `article_access_events` rows for the article,
+  i.e. how often it has actually proved worth reading. Usage is treated as the authority on
+  importance, so material that has repeatedly landed floats to the top of every future index
+  regardless of what today's query happens to embed near.
+
+  ## Why this is NOT an option on `progressive_index/3`
+
+  That function is topic-SEEDED: it begins with `search_keyword/3` over the caller's topic and
+  enriches from there. Heat has no topic to seed from, so folding it in would mean a `topic ==
+  nil` branch that skips the entire body — a second function wearing the first one's name. They
+  share the clamping and visibility helpers instead.
+
+  ## Options
+
+    - `:limit` -- top-K, clamped to `1..#{@max_relevance_page_size}` exactly like
+      `progressive_index/3`, so an explicit override cannot flood context either.
+    - `:since` -- count only accesses at/after this `DateTime`. Default is ALL-TIME:
+      heat is defined as cumulative, and a window would make a long-valuable article
+      indistinguishable from a never-read one during a quiet week.
+    - `:category` -- restrict to one category atom.
+    - `:visibility_agent_id` -- the calling agent's id (#163). An index is exactly the surface
+      where a leak is easy and invisible, because a stub looks innocuous and nobody reads an
+      index the way they read a body. Applied as a WHERE on the joined article, so another
+      agent's `private`/`owner` memory can never appear even as a title.
+
+  Returns `{:ok, %{results: [stub], meta: map}}`. Each stub carries `id`, `title`, `category`,
+  `heat` and a one-line `summary`; `meta` states the character budget, the cap, and — per the
+  Tencent navigation-index property — WHICH TOOL to call with WHICH PARAMETER to drill, so the
+  payload is self-describing rather than relying on the reader to infer that an id is actionable.
+  """
+  @spec heat_index(Ecto.UUID.t(), keyword()) :: {:ok, map()}
+  def heat_index(tenant_id, opts \\ []) when is_binary(tenant_id) do
+    top_k =
+      opts |> Keyword.get(:limit, progressive_top_k()) |> max(1) |> min(@max_relevance_page_size)
+
+    vis = Keyword.get(opts, :visibility_agent_id)
+    since = Keyword.get(opts, :since)
+    category = Keyword.get(opts, :category)
+
+    rows =
+      tenant_id
+      |> heat_index_query(top_k, since, category)
+      |> maybe_filter_by_visibility_on_joined_article(vis)
+      |> then(&HeavyRead.all(tenant_id, &1, HeavyRead.opts(:heat_index)))
+
+    stubs = Enum.map(rows, &heat_stub/1)
+
+    {:ok,
+     %{
+       results: stubs,
+       meta: %{
+         top_k: top_k,
+         returned: length(stubs),
+         # A STATED budget, not an implied one: the caller is expected to paste this into a
+         # cached prefix, so it needs to know the cost before it does.
+         char_budget: @heat_index_char_budget,
+         chars: stubs |> Enum.map(&heat_stub_chars/1) |> Enum.sum(),
+         heat_window: if(since, do: DateTime.to_iso8601(since), else: "all_time"),
+         # The read instruction rides IN the payload (#554): an index that lists ids without
+         # saying they are actionable gets read as prose.
+         drill: %{
+           tool: "knowledge_get",
+           parameter: "article_id",
+           note:
+             "Pass a listed id to read the full article. Ordering is cumulative usage, not relevance to any query."
+         }
+       }
+     }}
+  end
+
+  defp heat_index_query(tenant_id, top_k, since, category) do
+    base =
+      from(e in ArticleAccessEvent,
+        join: a in Article,
+        on: a.id == e.article_id and a.tenant_id == ^tenant_id,
+        where: e.tenant_id == ^tenant_id,
+        where: a.status == :published,
+        group_by: [a.id, a.title, a.category, a.body],
+        # `asc: a.id` after the count keeps the order TOTAL, so a page is stable across calls
+        # when several articles tie on heat — an index that reshuffles on every refresh cannot
+        # be cached, which is the whole point of this surface.
+        order_by: [desc: count(e.id), asc: a.id],
+        limit: ^top_k,
+        select: %{
+          id: a.id,
+          title: a.title,
+          category: a.category,
+          body: a.body,
+          heat: count(e.id)
+        }
+      )
+
+    base
+    |> heat_filter_since(since)
+    |> heat_filter_category(category)
+  end
+
+  defp heat_filter_since(query, nil), do: query
+
+  defp heat_filter_since(query, %DateTime{} = since),
+    do: where(query, [e], e.accessed_at >= ^since)
+
+  defp heat_filter_category(query, nil), do: query
+  defp heat_filter_category(query, category), do: where(query, [_e, a], a.category == ^category)
+
+  defp heat_stub(row) do
+    %{
+      id: row.id,
+      title: row.title,
+      category: to_string(row.category),
+      heat: row.heat,
+      summary: heat_summary(row.body)
+    }
+  end
+
+  # ONE line, always. A body's first paragraph can be arbitrarily long and can contain newlines
+  # that would break a line-oriented consumer's parsing of the index.
+  defp heat_summary(nil), do: ""
+
+  defp heat_summary(body) do
+    body
+    |> String.replace(~r/\s+/u, " ")
+    |> String.trim()
+    |> String.slice(0, @heat_summary_chars)
+  end
+
+  defp heat_stub_chars(stub) do
+    String.length(stub.title) + String.length(stub.summary) + String.length(stub.category) + 40
   end
 
   # Hub-enrichment neighbor discovery (AC-31.3.4): finds which of the seed

--- a/lib/loopctl_web/controllers/knowledge_progressive_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_progressive_controller.ex
@@ -109,6 +109,84 @@ defmodule LoopctlWeb.KnowledgeProgressiveController do
     end
   end
 
+  operation(:heat_index,
+    summary: "Heat-ranked topic index (no query)",
+    description:
+      "A bounded, top-K-capped stub list of the corpus ordered by HEAT — the cumulative " <>
+        "number of times each article has actually been read. Takes NO query, which is the " <>
+        "point: every other retrieval route starts from one, so they all miss the same way " <>
+        "on a paraphrase or on material that is topically central but lexically dissimilar. " <>
+        "This route's failures are uncorrelated with embedding similarity.\n\n" <>
+        "Stubs only (id/title/category/heat/one-line summary) — never a body — so it is cheap " <>
+        "enough to keep in a cached prefix rather than fetch per turn. The response states " <>
+        "which tool to call with which parameter to read a listed article. Visibility-scoped: " <>
+        "an agent key never sees another agent's private/owner memory, not even as a stub. " <>
+        "Role: agent+.",
+    parameters: [
+      limit: [
+        in: :query,
+        type: :integer,
+        description: "Top-K stubs, clamped to 1..100. Defaults to the progressive top-K."
+      ],
+      category: [
+        in: :query,
+        type: :string,
+        description: "Restrict the index to a single category."
+      ],
+      since: [
+        in: :query,
+        type: :string,
+        description:
+          "ISO-8601 timestamp. Count only accesses at/after it. Omitted means ALL-TIME, " <>
+            "which is the definition of heat — a window would make a long-valuable article " <>
+            "indistinguishable from a never-read one during a quiet period."
+      ]
+    ],
+    responses: %{
+      200 =>
+        {"Heat-ranked stubs", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{
+             data: %OpenApiSpex.Schema{type: :array, items: %OpenApiSpex.Schema{type: :object}},
+             meta: %OpenApiSpex.Schema{type: :object}
+           }
+         }},
+      400 => {"Invalid parameter", "application/json", Schemas.ErrorResponse},
+      401 => {"Unauthorized", "application/json", Schemas.ErrorResponse}
+    }
+  )
+
+  @doc "GET /api/v1/knowledge/heat_index"
+  def heat_index(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    with {:ok, category} <- validate_category(params["category"]),
+         {:ok, since} <- validate_since(params["since"]) do
+      opts =
+        []
+        |> maybe_add_opt(:category, category)
+        |> maybe_add_opt(:since, since)
+        |> maybe_add_limit(params["limit"])
+        |> Keyword.merge(Visibility.scope_opts(conn))
+
+      {:ok, result} = Knowledge.heat_index(tenant_id, opts)
+      json(conn, LoopctlWeb.KnowledgeProgressiveJSON.heat_index(result))
+    end
+  end
+
+  # A malformed timestamp is a 400, never a silent all-time fallback: silently widening the
+  # window a caller explicitly narrowed would hand back more than it asked for and look correct.
+  defp validate_since(nil), do: {:ok, nil}
+  defp validate_since(""), do: {:ok, nil}
+
+  defp validate_since(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, dt, _offset} -> {:ok, dt}
+      _ -> {:error, :bad_request, "Query parameter 'since' must be an ISO-8601 timestamp"}
+    end
+  end
+
   operation(:drill,
     summary: "Progressive-disclosure drill",
     description:

--- a/lib/loopctl_web/controllers/knowledge_progressive_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_progressive_controller.ex
@@ -112,16 +112,20 @@ defmodule LoopctlWeb.KnowledgeProgressiveController do
   operation(:heat_index,
     summary: "Heat-ranked topic index (no query)",
     description:
-      "A bounded, top-K-capped stub list of the corpus ordered by HEAT — the cumulative " <>
-        "number of times each article has actually been read. Takes NO query, which is the " <>
+      "A bounded, top-K-capped stub list of the corpus (tenant articles plus published " <>
+        "system canonicals) ordered by HEAT — the number of times each article's BODY was " <>
+        "read. Only the read access types are counted (`meta.counted_access_types`, i.e. " <>
+        "get/context); a search result is an impression, not a read, so it does not add " <>
+        "heat. Takes NO query, which is the " <>
         "point: every other retrieval route starts from one, so they all miss the same way " <>
         "on a paraphrase or on material that is topically central but lexically dissimilar. " <>
         "This route's failures are uncorrelated with embedding similarity.\n\n" <>
         "Stubs only (id/title/category/heat/one-line summary) — never a body — so it is cheap " <>
         "enough to keep in a cached prefix rather than fetch per turn. The response states " <>
-        "which tool to call with which parameter to read a listed article. Visibility-scoped: " <>
-        "an agent key never sees another agent's private/owner memory, not even as a stub. " <>
-        "Role: agent+.",
+        "which tool to call with which parameter to read a listed article, and states " <>
+        "`meta.truncated` when more articles were hot than the cap returned. " <>
+        "Visibility-scoped: an agent key never sees another agent's private/owner memory, " <>
+        "not even as a stub. Role: agent+.",
     parameters: [
       limit: [
         in: :query,
@@ -137,9 +141,10 @@ defmodule LoopctlWeb.KnowledgeProgressiveController do
         in: :query,
         type: :string,
         description:
-          "ISO-8601 timestamp. Count only accesses at/after it. Omitted means ALL-TIME, " <>
-            "which is the definition of heat — a window would make a long-valuable article " <>
-            "indistinguishable from a never-read one during a quiet period."
+          "ISO-8601 timestamp. Count only accesses at/after it. Omitted means the last 90 " <>
+            "days, which bounds the request-path aggregate over an ever-growing read " <>
+            "history; pass an older timestamp to widen the window deliberately. The " <>
+            "effective window is echoed as `meta.heat_window`."
       ]
     ],
     responses: %{
@@ -183,9 +188,17 @@ defmodule LoopctlWeb.KnowledgeProgressiveController do
   defp validate_since(value) when is_binary(value) do
     case DateTime.from_iso8601(value) do
       {:ok, dt, _offset} -> {:ok, dt}
-      _ -> {:error, :bad_request, "Query parameter 'since' must be an ISO-8601 timestamp"}
+      _ -> invalid_since()
     end
   end
+
+  # `?since[]=x` makes Plug parse the param as a list — without this clause that is a
+  # FunctionClauseError -> 500, the same transport-boundary failure `coerce_topic/1` and
+  # `validate_category/1` already guard.
+  defp validate_since(_), do: invalid_since()
+
+  defp invalid_since,
+    do: {:error, :bad_request, "Query parameter 'since' must be an ISO-8601 timestamp"}
 
   operation(:drill,
     summary: "Progressive-disclosure drill",

--- a/lib/loopctl_web/controllers/knowledge_progressive_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_progressive_controller.ex
@@ -31,6 +31,11 @@ defmodule LoopctlWeb.KnowledgeProgressiveController do
 
   @valid_categories Ecto.Enum.values(Article, :category)
 
+  # The published description and the ENFORCED bound read the same value, so tuning the window
+  # cannot silently make the docs promise history the server no longer scans.
+  @heat_default_window_days Knowledge.heat_default_window_days()
+  @heat_max_window_days Knowledge.heat_max_window_days()
+
   operation(:index,
     summary: "Progressive-disclosure index",
     description:
@@ -114,9 +119,10 @@ defmodule LoopctlWeb.KnowledgeProgressiveController do
     description:
       "A bounded, top-K-capped stub list of the corpus (tenant articles plus published " <>
         "system canonicals) ordered by HEAT — the number of times each article's BODY was " <>
-        "read. Only the read access types are counted (`meta.counted_access_types`, i.e. " <>
-        "get/context); a search result is an impression, not a read, so it does not add " <>
-        "heat. Takes NO query, which is the " <>
+        "read directly. Only caller-chosen fetches are counted " <>
+        "(`meta.counted_access_types`); list-shaped ranker output (a search hit, a context " <>
+        "pack) is one row per RESULT, not a read, so it adds no heat. Takes NO query, " <>
+        "which is the " <>
         "point: every other retrieval route starts from one, so they all miss the same way " <>
         "on a paraphrase or on material that is topically central but lexically dissimilar. " <>
         "This route's failures are uncorrelated with embedding similarity.\n\n" <>
@@ -141,10 +147,12 @@ defmodule LoopctlWeb.KnowledgeProgressiveController do
         in: :query,
         type: :string,
         description:
-          "ISO-8601 timestamp. Count only accesses at/after it. Omitted means the last 90 " <>
-            "days, which bounds the request-path aggregate over an ever-growing read " <>
-            "history; pass an older timestamp to widen the window deliberately. The " <>
-            "effective window is echoed as `meta.heat_window`."
+          "ISO-8601 timestamp. Count only accesses at/after it. Omitted means the last " <>
+            "#{@heat_default_window_days} days, and a lookback longer than " <>
+            "#{@heat_max_window_days} days is CLAMPED to that ceiling — both bound the " <>
+            "request-path aggregate over an ever-growing read history. Pass an older " <>
+            "timestamp to widen the window deliberately; the effective window is echoed " <>
+            "as `meta.heat_window`."
       ]
     ],
     responses: %{

--- a/lib/loopctl_web/controllers/knowledge_progressive_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_progressive_json.ex
@@ -21,9 +21,11 @@ defmodule LoopctlWeb.KnowledgeProgressiveJSON do
       meta: %{
         top_k: meta.top_k,
         returned: meta.returned,
+        truncated: meta.truncated,
         char_budget: meta.char_budget,
         chars: meta.chars,
         heat_window: meta.heat_window,
+        counted_access_types: meta.counted_access_types,
         drill: meta.drill
       }
     }

--- a/lib/loopctl_web/controllers/knowledge_progressive_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_progressive_json.ex
@@ -11,7 +11,7 @@ defmodule LoopctlWeb.KnowledgeProgressiveJSON do
   Renders the HEAT index (#554).
 
   Distinct from `index/1` because the payloads differ where it matters: a heat stub carries
-  `heat` (the cumulative access count that produced its rank), and the meta carries the DRILL
+  `heat` (the windowed body-read count that produced its rank), and the meta carries the DRILL
   INSTRUCTION. The instruction is part of the wire shape on purpose — an index that lists ids
   without saying they are actionable gets read as prose.
   """
@@ -21,6 +21,7 @@ defmodule LoopctlWeb.KnowledgeProgressiveJSON do
       meta: %{
         top_k: meta.top_k,
         returned: meta.returned,
+        unresolved: meta.unresolved,
         truncated: meta.truncated,
         char_budget: meta.char_budget,
         chars: meta.chars,

--- a/lib/loopctl_web/controllers/knowledge_progressive_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_progressive_json.ex
@@ -7,6 +7,38 @@ defmodule LoopctlWeb.KnowledgeProgressiveJSON do
   a stable wire shape.
   """
 
+  @doc """
+  Renders the HEAT index (#554).
+
+  Distinct from `index/1` because the payloads differ where it matters: a heat stub carries
+  `heat` (the cumulative access count that produced its rank), and the meta carries the DRILL
+  INSTRUCTION. The instruction is part of the wire shape on purpose — an index that lists ids
+  without saying they are actionable gets read as prose.
+  """
+  def heat_index(%{results: results, meta: meta}) do
+    %{
+      data: Enum.map(results, &render_heat_stub/1),
+      meta: %{
+        top_k: meta.top_k,
+        returned: meta.returned,
+        char_budget: meta.char_budget,
+        chars: meta.chars,
+        heat_window: meta.heat_window,
+        drill: meta.drill
+      }
+    }
+  end
+
+  defp render_heat_stub(stub) do
+    %{
+      id: stub.id,
+      title: stub.title,
+      category: stub.category,
+      heat: stub.heat,
+      summary: stub.summary
+    }
+  end
+
   @doc "Renders the capped index stubs plus its meta (top_k/candidate_count/truncated)."
   def index(%{stubs: stubs, meta: meta}) do
     %{

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -571,6 +571,12 @@ defmodule LoopctlWeb.Router do
     # article's body. The literal `progressive_index` path is registered BEFORE the
     # parameterized `progressive/:id` drill so it can never be shadowed.
     get "/knowledge/progressive_index", KnowledgeProgressiveController, :index
+
+    # #554: the topic-LESS sibling. Registered next to progressive_index because it is the
+    # same family (bounded stub list), but it takes no query at all — that is the point:
+    # its misses are uncorrelated with embedding similarity, so it is the route that still
+    # works when a semantic query has silently missed.
+    get "/knowledge/heat_index", KnowledgeProgressiveController, :heat_index
     get "/knowledge/progressive/:id", KnowledgeProgressiveController, :drill
 
     # Knowledge Context (deep-read with recency scoring and linked refs)

--- a/test/loopctl/heavy_read/tenant_gate_test.exs
+++ b/test/loopctl/heavy_read/tenant_gate_test.exs
@@ -295,7 +295,10 @@ defmodule Loopctl.HeavyRead.TenantGateTest do
       change_feed: :light,
       ingestion_jobs: :light,
       sth_incremental: :light,
-      llm_usage: :light
+      llm_usage: :light,
+      # #554: heavy — its cost tracks the read-history table, and shedding a cadence-refreshed
+      # navigation index is far cheaper than starving a request-path search.
+      heat_index: :heavy
     }
 
     test "every @heavy_endpoints atom is a known HeavyRead endpoint (no orphan/typo)" do

--- a/test/loopctl/knowledge/heat_index_test.exs
+++ b/test/loopctl/knowledge/heat_index_test.exs
@@ -77,8 +77,8 @@ defmodule Loopctl.Knowledge.HeatIndexTest do
       tenant = fixture(:tenant)
       article = published_article(tenant.id, %{title: "Old favourite"})
 
-      ancient = DateTime.add(DateTime.utc_now(), -400, :day)
-      heat(tenant.id, article, 5, %{accessed_at: ancient})
+      old = DateTime.add(DateTime.utc_now(), -200, :day)
+      heat(tenant.id, article, 5, %{accessed_at: old})
 
       # The default window bounds the request-path aggregate, so reads older than it are not
       # counted — the endpoint degrades to a shorter list rather than to a statement timeout.
@@ -86,19 +86,37 @@ defmodule Loopctl.Knowledge.HeatIndexTest do
       assert {:ok, _, _} = DateTime.from_iso8601(window)
 
       # An explicit older `:since` widens it back deliberately.
-      wide = DateTime.add(DateTime.utc_now(), -500, :day)
+      wide = DateTime.add(DateTime.utc_now(), -300, :day)
       assert {:ok, %{results: [%{heat: 5}]}} = Knowledge.heat_index(tenant.id, since: wide)
     end
 
-    test "a search impression is not a read, so it adds no heat" do
-      # Counting `search` rows (one per RESULT of one query) would make the ordering a running
-      # tally of past ranker output — the correlation with embedding similarity this route
-      # exists to be free of.
+    test ":since is clamped to the ceiling, so it cannot reinstate the all-time scan" do
+      # The default window is only a bound if a caller cannot widen past what the aggregate can
+      # serve: an arbitrary `since` would otherwise scan the whole read history under the
+      # heavy-read statement timeout and 500 on exactly the tenant with the most of it.
+      tenant = fixture(:tenant)
+      ceiling = Knowledge.heat_max_window_days()
+
+      assert {:ok, %{meta: %{heat_window: window}}} =
+               Knowledge.heat_index(tenant.id,
+                 since: DateTime.add(DateTime.utc_now(), -(ceiling * 3), :day)
+               )
+
+      assert {:ok, effective, _} = DateTime.from_iso8601(window)
+      assert DateTime.diff(DateTime.utc_now(), effective, :day) <= ceiling
+    end
+
+    test "ranker output is not a read, so a search hit or a context pack adds no heat" do
+      # Both `search` and `context` write one row per RESULT of one query, so counting either
+      # would make the ordering a running tally of past ranker output — the correlation with
+      # embedding similarity this route exists to be free of.
       tenant = fixture(:tenant)
       impressions = published_article(tenant.id, %{title: "Only ever matched"})
+      packed = published_article(tenant.id, %{title: "Only ever packed"})
       read = published_article(tenant.id, %{title: "Actually read"})
 
       heat(tenant.id, impressions, 20, %{access_type: "search"})
+      heat(tenant.id, packed, 20, %{access_type: "context"})
       heat(tenant.id, read, 1)
 
       assert {:ok, %{results: results}} = Knowledge.heat_index(tenant.id)
@@ -225,13 +243,19 @@ defmodule Loopctl.Knowledge.HeatIndexTest do
 
       assert {:ok, %{meta: meta}} = Knowledge.heat_index(tenant.id)
 
-      assert meta.drill.tool == "knowledge_get"
+      # `knowledge_get` filters by tenant_id, so it 404s on the published system canonicals
+      # this index also lists — the named tool has to be one that opens every listed id.
+      assert meta.drill.tool == "knowledge_progressive_drill"
       assert meta.drill.parameter == "article_id"
       # The ordering basis is stated, so a reader does not mistake heat for relevance.
-      assert meta.drill.note =~ "usage"
+      assert meta.drill.note =~ "heat_window"
       assert is_integer(meta.char_budget)
       assert is_integer(meta.chars)
-      assert meta.counted_access_types == ["get", "context"]
+      assert meta.counted_access_types == ["get"]
+      # The ranking and the projection run on separate connections, so a ranked article can
+      # vanish between them. The count of dropped ids is STATED, because a short list with
+      # `truncated: false` would otherwise read as an exhausted one.
+      assert meta.unresolved == 0
     end
 
     test "char_budget tracks the effective top_k and actually bounds the payload" do
@@ -350,9 +374,10 @@ defmodule Loopctl.Knowledge.HeatIndexEndpointTest do
     assert Enum.map(body["data"], & &1["title"]) == ["Hot", "Cold"]
     assert Enum.map(body["data"], & &1["heat"]) == [7, 1]
     # Self-describing: the payload says how to act on an id.
-    assert body["meta"]["drill"]["tool"] == "knowledge_get"
+    assert body["meta"]["drill"]["tool"] == "knowledge_progressive_drill"
     assert {:ok, _, _} = DateTime.from_iso8601(body["meta"]["heat_window"])
-    assert body["meta"]["counted_access_types"] == ["get", "context"]
+    assert body["meta"]["counted_access_types"] == ["get"]
+    assert body["meta"]["unresolved"] == 0
   end
 
   test "a malformed `since` is a 400, not a silent widening of the window", %{conn: conn} do

--- a/test/loopctl/knowledge/heat_index_test.exs
+++ b/test/loopctl/knowledge/heat_index_test.exs
@@ -1,0 +1,336 @@
+defmodule Loopctl.Knowledge.HeatIndexTest do
+  @moduledoc """
+  #554 — the heat-ranked, topic-less stub index.
+
+  The point of this surface is that it takes NO query, so its misses are uncorrelated with
+  embedding similarity. That makes two properties load-bearing and worth testing directly:
+
+    * ordering really is cumulative USAGE, not recency or relevance — otherwise it is just
+      another ranked list with the same blind spots as the route it exists to complement; and
+    * visibility scoping holds. An index is where a leak is easiest and least likely to be
+      noticed: a stub looks innocuous, and nobody reads an index the way they read a body.
+  """
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
+
+  setup :verify_on_exit!
+
+  defp published_article(tenant_id, attrs \\ %{}) do
+    base = %{
+      title: "Article #{System.unique_integer([:positive])}",
+      body: "Body text for the article.",
+      category: :pattern,
+      status: :draft,
+      tags: []
+    }
+
+    fixture(:article, Map.merge(base, Map.put(attrs, :tenant_id, tenant_id)))
+    |> Ecto.Changeset.change(%{status: :published})
+    |> AdminRepo.update!()
+  end
+
+  # `heat` is a COUNT of access events, so heat is produced by inserting N of them.
+  defp heat(tenant_id, article, n) do
+    for _ <- 1..n do
+      fixture(:article_access_event, %{tenant_id: tenant_id, article_id: article.id})
+    end
+
+    article
+  end
+
+  describe "ordering is by cumulative usage" do
+    test "the most-read article ranks first, regardless of insertion order" do
+      tenant = fixture(:tenant)
+
+      cold = published_article(tenant.id, %{title: "Cold"})
+      hot = published_article(tenant.id, %{title: "Hot"})
+      warm = published_article(tenant.id, %{title: "Warm"})
+
+      heat(tenant.id, cold, 1)
+      heat(tenant.id, warm, 3)
+      heat(tenant.id, hot, 9)
+
+      assert {:ok, %{results: results}} = Knowledge.heat_index(tenant.id)
+
+      assert Enum.map(results, & &1.title) == ["Hot", "Warm", "Cold"]
+      assert Enum.map(results, & &1.heat) == [9, 3, 1]
+    end
+
+    test "an article nobody has read does not appear at all" do
+      # Heat comes from a JOIN on access events, so a never-read article has no row. Asserted
+      # explicitly because "absent" and "present with heat 0" are different contracts and a
+      # future change to an outer join would silently swap them.
+      tenant = fixture(:tenant)
+      read = published_article(tenant.id, %{title: "Read"})
+      _unread = published_article(tenant.id, %{title: "Never read"})
+
+      heat(tenant.id, read, 2)
+
+      assert {:ok, %{results: results}} = Knowledge.heat_index(tenant.id)
+
+      assert Enum.map(results, & &1.title) == ["Read"]
+    end
+
+    test ":since narrows the window; the default is all-time" do
+      tenant = fixture(:tenant)
+      article = published_article(tenant.id, %{title: "Old favourite"})
+
+      old = DateTime.add(DateTime.utc_now(), -30, :day)
+
+      for _ <- 1..5 do
+        fixture(:article_access_event, %{
+          tenant_id: tenant.id,
+          article_id: article.id,
+          accessed_at: old
+        })
+      end
+
+      # All-time (the default) counts the old reads — this is what makes heat "cumulative"
+      # rather than "recently popular", and it is why a long-valuable article survives a
+      # quiet week.
+      assert {:ok, %{results: [%{heat: 5}], meta: %{heat_window: "all_time"}}} =
+               Knowledge.heat_index(tenant.id)
+
+      # A window excludes them.
+      since = DateTime.add(DateTime.utc_now(), -1, :day)
+      assert {:ok, %{results: [], meta: meta}} = Knowledge.heat_index(tenant.id, since: since)
+      assert meta.heat_window != "all_time"
+    end
+  end
+
+  describe "visibility scoping (#163) — the leak this surface makes easy" do
+    test "an agent never sees another agent's private article, even as a stub" do
+      tenant = fixture(:tenant)
+      mine = "agent-mine"
+      theirs = "agent-theirs"
+
+      secret =
+        published_article(tenant.id, %{
+          title: "Their private memory",
+          metadata: %{"visibility" => "private", "agent_id" => theirs}
+        })
+
+      ours = published_article(tenant.id, %{title: "Shared"})
+
+      # The private one is HOTTER, so if ordering were applied before scoping it would be the
+      # first thing in the index.
+      heat(tenant.id, secret, 50)
+      heat(tenant.id, ours, 1)
+
+      assert {:ok, %{results: results}} =
+               Knowledge.heat_index(tenant.id, visibility_agent_id: mine)
+
+      titles = Enum.map(results, & &1.title)
+      assert titles == ["Shared"]
+      refute "Their private memory" in titles
+      # Not even the id leaks — a stub list is still an enumeration of what exists.
+      refute Enum.any?(results, &(&1.id == secret.id))
+    end
+
+    test "an agent DOES see its own private article" do
+      tenant = fixture(:tenant)
+      mine = "agent-mine"
+
+      own =
+        published_article(tenant.id, %{
+          title: "My own memory",
+          metadata: %{"visibility" => "owner", "agent_id" => mine}
+        })
+
+      heat(tenant.id, own, 4)
+
+      assert {:ok, %{results: [%{title: "My own memory"}]}} =
+               Knowledge.heat_index(tenant.id, visibility_agent_id: mine)
+    end
+
+    test "a non-agent caller (nil) sees everything, as elsewhere" do
+      tenant = fixture(:tenant)
+
+      secret =
+        published_article(tenant.id, %{
+          title: "Private",
+          metadata: %{"visibility" => "private", "agent_id" => "someone"}
+        })
+
+      heat(tenant.id, secret, 2)
+
+      assert {:ok, %{results: [%{title: "Private"}]}} = Knowledge.heat_index(tenant.id)
+    end
+  end
+
+  describe "tenant isolation (repo rule)" do
+    test "tenant A never sees tenant B's articles or their heat" do
+      a = fixture(:tenant)
+      b = fixture(:tenant)
+
+      a_article = published_article(a.id, %{title: "A's article"})
+      b_article = published_article(b.id, %{title: "B's article"})
+
+      heat(a.id, a_article, 1)
+      heat(b.id, b_article, 99)
+
+      assert {:ok, %{results: results}} = Knowledge.heat_index(a.id)
+
+      assert Enum.map(results, & &1.title) == ["A's article"]
+      refute Enum.any?(results, &(&1.id == b_article.id))
+    end
+  end
+
+  describe "the payload is bounded and self-describing" do
+    test "top_k is clamped, so an explicit override cannot flood context" do
+      tenant = fixture(:tenant)
+
+      for i <- 1..4 do
+        tenant.id |> published_article(%{title: "A#{i}"}) |> then(&heat(tenant.id, &1, i))
+      end
+
+      assert {:ok, %{results: results, meta: %{top_k: 2}}} =
+               Knowledge.heat_index(tenant.id, limit: 2)
+
+      assert length(results) == 2
+
+      # Clamped at both ends, exactly like progressive_index/3.
+      assert {:ok, %{meta: %{top_k: 1}}} = Knowledge.heat_index(tenant.id, limit: 0)
+      assert {:ok, %{meta: %{top_k: 100}}} = Knowledge.heat_index(tenant.id, limit: 10_000)
+    end
+
+    test "the response says how to drill, so the payload is not just prose" do
+      tenant = fixture(:tenant)
+      tenant.id |> published_article() |> then(&heat(tenant.id, &1, 1))
+
+      assert {:ok, %{meta: meta}} = Knowledge.heat_index(tenant.id)
+
+      assert meta.drill.tool == "knowledge_get"
+      assert meta.drill.parameter == "article_id"
+      # The ordering basis is stated, so a reader does not mistake heat for relevance.
+      assert meta.drill.note =~ "usage"
+      assert is_integer(meta.char_budget)
+      assert is_integer(meta.chars)
+    end
+
+    test "a summary is one line and bounded, whatever the body looks like" do
+      tenant = fixture(:tenant)
+
+      article =
+        published_article(tenant.id, %{
+          body:
+            "First line.\n\nSecond paragraph with   irregular\twhitespace. " <>
+              String.duplicate("padding ", 200)
+        })
+
+      heat(tenant.id, article, 1)
+
+      assert {:ok, %{results: [stub]}} = Knowledge.heat_index(tenant.id)
+
+      refute stub.summary =~ "\n"
+      refute stub.summary =~ "  "
+      assert String.length(stub.summary) <= 120
+    end
+
+    test ":category narrows the index" do
+      tenant = fixture(:tenant)
+
+      pattern = published_article(tenant.id, %{title: "P", category: :pattern})
+      decision = published_article(tenant.id, %{title: "D", category: :decision})
+
+      heat(tenant.id, pattern, 5)
+      heat(tenant.id, decision, 5)
+
+      assert {:ok, %{results: results}} = Knowledge.heat_index(tenant.id, category: :decision)
+
+      assert Enum.map(results, & &1.title) == ["D"]
+    end
+  end
+end
+
+defmodule Loopctl.Knowledge.HeatIndexEndpointTest do
+  @moduledoc """
+  #554 — the HTTP surface for the heat index.
+
+  Covers the two things unit tests on `Knowledge.heat_index/2` cannot: that the route is
+  actually wired, and that visibility scoping is derived from the CALLER'S KEY rather than
+  from a caller-supplied parameter. The second matters more — a scope you can pass in is not
+  a scope.
+  """
+  use LoopctlWeb.ConnCase, async: true
+
+  alias Loopctl.AdminRepo
+
+  setup :verify_on_exit!
+
+  defp published(tenant_id, attrs) do
+    base = %{
+      title: "T#{System.unique_integer([:positive])}",
+      body: "b",
+      category: :pattern,
+      status: :draft,
+      tags: []
+    }
+
+    fixture(:article, Map.merge(base, Map.put(attrs, :tenant_id, tenant_id)))
+    |> Ecto.Changeset.change(%{status: :published})
+    |> AdminRepo.update!()
+  end
+
+  defp heat(tenant_id, article, n) do
+    for _ <- 1..n,
+        do: fixture(:article_access_event, %{tenant_id: tenant_id, article_id: article.id})
+
+    article
+  end
+
+  test "returns heat-ranked stubs with the drill instruction", %{conn: conn} do
+    tenant = fixture(:tenant)
+    {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+    hot = published(tenant.id, %{title: "Hot"})
+    cold = published(tenant.id, %{title: "Cold"})
+    heat(tenant.id, hot, 7)
+    heat(tenant.id, cold, 1)
+
+    body =
+      conn
+      |> put_req_header("authorization", "Bearer #{raw_key}")
+      |> get(~p"/api/v1/knowledge/heat_index")
+      |> json_response(200)
+
+    assert Enum.map(body["data"], & &1["title"]) == ["Hot", "Cold"]
+    assert Enum.map(body["data"], & &1["heat"]) == [7, 1]
+    # Self-describing: the payload says how to act on an id.
+    assert body["meta"]["drill"]["tool"] == "knowledge_get"
+    assert body["meta"]["heat_window"] == "all_time"
+  end
+
+  test "a malformed `since` is a 400, not a silent widening to all-time", %{conn: conn} do
+    tenant = fixture(:tenant)
+    {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+    conn
+    |> put_req_header("authorization", "Bearer #{raw_key}")
+    |> get(~p"/api/v1/knowledge/heat_index?since=not-a-date")
+    |> json_response(400)
+  end
+
+  test "visibility comes from the KEY, so another tenant's articles never appear", %{conn: conn} do
+    a = fixture(:tenant)
+    b = fixture(:tenant)
+    {a_key, _} = fixture(:api_key, %{tenant_id: a.id, role: :agent})
+
+    a_art = published(a.id, %{title: "A"})
+    b_art = published(b.id, %{title: "B"})
+    heat(a.id, a_art, 1)
+    heat(b.id, b_art, 50)
+
+    body =
+      conn
+      |> put_req_header("authorization", "Bearer #{a_key}")
+      |> get(~p"/api/v1/knowledge/heat_index")
+      |> json_response(200)
+
+    titles = Enum.map(body["data"], & &1["title"])
+    assert titles == ["A"]
+    refute "B" in titles
+  end
+end

--- a/test/loopctl/knowledge/heat_index_test.exs
+++ b/test/loopctl/knowledge/heat_index_test.exs
@@ -31,11 +31,11 @@ defmodule Loopctl.Knowledge.HeatIndexTest do
     |> AdminRepo.update!()
   end
 
-  # `heat` is a COUNT of access events, so heat is produced by inserting N of them.
-  defp heat(tenant_id, article, n) do
-    for _ <- 1..n do
-      fixture(:article_access_event, %{tenant_id: tenant_id, article_id: article.id})
-    end
+  # `heat` is a COUNT of read access events, so heat is produced by inserting N of them.
+  # `attrs` overrides the event shape (its `access_type`, its `accessed_at`).
+  defp heat(tenant_id, article, n, attrs \\ %{}) do
+    base = %{tenant_id: tenant_id, article_id: article.id}
+    for _ <- 1..n, do: fixture(:article_access_event, Map.merge(base, attrs))
 
     article
   end
@@ -73,30 +73,53 @@ defmodule Loopctl.Knowledge.HeatIndexTest do
       assert Enum.map(results, & &1.title) == ["Read"]
     end
 
-    test ":since narrows the window; the default is all-time" do
+    test ":since moves the window; the default one is bounded, not all-time" do
       tenant = fixture(:tenant)
       article = published_article(tenant.id, %{title: "Old favourite"})
 
-      old = DateTime.add(DateTime.utc_now(), -30, :day)
+      ancient = DateTime.add(DateTime.utc_now(), -400, :day)
+      heat(tenant.id, article, 5, %{accessed_at: ancient})
 
-      for _ <- 1..5 do
-        fixture(:article_access_event, %{
-          tenant_id: tenant.id,
-          article_id: article.id,
-          accessed_at: old
-        })
-      end
+      # The default window bounds the request-path aggregate, so reads older than it are not
+      # counted — the endpoint degrades to a shorter list rather than to a statement timeout.
+      assert {:ok, %{results: [], meta: %{heat_window: window}}} = Knowledge.heat_index(tenant.id)
+      assert {:ok, _, _} = DateTime.from_iso8601(window)
 
-      # All-time (the default) counts the old reads — this is what makes heat "cumulative"
-      # rather than "recently popular", and it is why a long-valuable article survives a
-      # quiet week.
-      assert {:ok, %{results: [%{heat: 5}], meta: %{heat_window: "all_time"}}} =
-               Knowledge.heat_index(tenant.id)
+      # An explicit older `:since` widens it back deliberately.
+      wide = DateTime.add(DateTime.utc_now(), -500, :day)
+      assert {:ok, %{results: [%{heat: 5}]}} = Knowledge.heat_index(tenant.id, since: wide)
+    end
 
-      # A window excludes them.
-      since = DateTime.add(DateTime.utc_now(), -1, :day)
-      assert {:ok, %{results: [], meta: meta}} = Knowledge.heat_index(tenant.id, since: since)
-      assert meta.heat_window != "all_time"
+    test "a search impression is not a read, so it adds no heat" do
+      # Counting `search` rows (one per RESULT of one query) would make the ordering a running
+      # tally of past ranker output — the correlation with embedding similarity this route
+      # exists to be free of.
+      tenant = fixture(:tenant)
+      impressions = published_article(tenant.id, %{title: "Only ever matched"})
+      read = published_article(tenant.id, %{title: "Actually read"})
+
+      heat(tenant.id, impressions, 20, %{access_type: "search"})
+      heat(tenant.id, read, 1)
+
+      assert {:ok, %{results: results}} = Knowledge.heat_index(tenant.id)
+      assert Enum.map(results, & &1.title) == ["Actually read"]
+    end
+
+    test "a published system canonical is indexed, not silently dropped" do
+      tenant = fixture(:tenant)
+
+      canonical =
+        published_article(tenant.id, %{title: "Canon"})
+        |> Ecto.Changeset.change(%{scope: :system, tenant_id: nil})
+        |> AdminRepo.update!()
+
+      own = published_article(tenant.id, %{title: "Own"})
+
+      heat(tenant.id, canonical, 5)
+      heat(tenant.id, own, 1)
+
+      assert {:ok, %{results: results}} = Knowledge.heat_index(tenant.id)
+      assert Enum.map(results, & &1.title) == ["Canon", "Own"]
     end
   end
 
@@ -208,6 +231,34 @@ defmodule Loopctl.Knowledge.HeatIndexTest do
       assert meta.drill.note =~ "usage"
       assert is_integer(meta.char_budget)
       assert is_integer(meta.chars)
+      assert meta.counted_access_types == ["get", "context"]
+    end
+
+    test "char_budget tracks the effective top_k and actually bounds the payload" do
+      tenant = fixture(:tenant)
+
+      # A title at the schema's 500-char ceiling: the budget is only a budget if the widest
+      # legal stub still fits under it.
+      article = published_article(tenant.id, %{title: String.duplicate("t", 500)})
+      heat(tenant.id, article, 1)
+
+      assert {:ok, %{results: [stub], meta: meta}} = Knowledge.heat_index(tenant.id, limit: 5)
+
+      assert String.length(stub.title) <= 100
+      assert meta.chars <= meta.char_budget
+      # Derived from the ASKED-FOR cap, not the ceiling — limit: 5 must not advertise 100.
+      assert {:ok, %{meta: %{char_budget: wider}}} = Knowledge.heat_index(tenant.id, limit: 50)
+      assert wider == meta.char_budget * 10
+    end
+
+    test "truncated says the list is partial, since nothing else in the payload would" do
+      tenant = fixture(:tenant)
+
+      for i <- 1..3,
+          do: tenant.id |> published_article(%{title: "A#{i}"}) |> then(&heat(tenant.id, &1, i))
+
+      assert {:ok, %{meta: %{truncated: true}}} = Knowledge.heat_index(tenant.id, limit: 2)
+      assert {:ok, %{meta: %{truncated: false}}} = Knowledge.heat_index(tenant.id, limit: 3)
     end
 
     test "a summary is one line and bounded, whatever the body looks like" do
@@ -300,16 +351,27 @@ defmodule Loopctl.Knowledge.HeatIndexEndpointTest do
     assert Enum.map(body["data"], & &1["heat"]) == [7, 1]
     # Self-describing: the payload says how to act on an id.
     assert body["meta"]["drill"]["tool"] == "knowledge_get"
-    assert body["meta"]["heat_window"] == "all_time"
+    assert {:ok, _, _} = DateTime.from_iso8601(body["meta"]["heat_window"])
+    assert body["meta"]["counted_access_types"] == ["get", "context"]
   end
 
-  test "a malformed `since` is a 400, not a silent widening to all-time", %{conn: conn} do
+  test "a malformed `since` is a 400, not a silent widening of the window", %{conn: conn} do
     tenant = fixture(:tenant)
     {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
 
     conn
     |> put_req_header("authorization", "Bearer #{raw_key}")
     |> get(~p"/api/v1/knowledge/heat_index?since=not-a-date")
+    |> json_response(400)
+  end
+
+  test "a list-shaped `since` is a 400, not a FunctionClauseError 500", %{conn: conn} do
+    tenant = fixture(:tenant)
+    {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+    conn
+    |> put_req_header("authorization", "Bearer #{raw_key}")
+    |> get("/api/v1/knowledge/heat_index?since[]=2026-01-01T00:00:00Z")
     |> json_response(400)
   end
 


### PR DESCRIPTION
Closes #554.

`GET /api/v1/knowledge/heat_index` — a bounded, top-K-capped stub list of the corpus ordered by **heat**: how often each article has actually been *read*.

## Why a second route at all

Every existing way into the wiki starts from a query, so they share a failure mode. A paraphrase, or material that is topically central but lexically dissimilar to the question, comes back empty — and the agent concludes "the KB has nothing" rather than "I asked badly", with nothing in context to contradict it.

This route takes **no query**, so its misses are uncorrelated with embedding similarity.

## Reused, not rebuilt

- `article_access_events` already records reads with a `(tenant_id, article_id, accessed_at)` index — **no new counter column, no new table**. The denormalised heat column the issue floated isn't needed.
- `maybe_filter_by_visibility_on_joined_article/2` already existed for this join shape.
- Clamping matches `progressive_index/3`, so an explicit `limit` can't flood context.

**Not folded into `progressive_index/3`**, having checked as the issue asked: that function is topic-*seeded*, so heat would enter as a `topic == nil` branch skipping the entire body — a second function wearing the first one's name.

---

## What review changed — the first version defeated its own premise

**Heat was counting search impressions.** `maybe_record_search_access/5` writes one `article_access_events` row **per result** of a query, so `"search"` events are ranker *output*. Counting every event meant this index — built specifically to be uncorrelated with embedding similarity — was ordered by past embedding-similarity results, while its docstring and OpenAPI text promised the opposite.

Heat now counts `"get"` only. Round 2 narrowed it further: `"context"` is also written per-result by `record_context_access/5`, structurally the same impression shape `"search"` was excluded for. The counted set is stated in `meta.counted_access_types` rather than left implicit.

Three more that were mine:

- **Published system canonicals were silently dropped.** My tenant predicate excluded `tenant_id NULL` articles, unlike every sibling read path in the module. Now a tenant-or-system disjunction.
- **`meta.drill.tool` named a call that would fail on them.** `knowledge_get` filters on `tenant_id` and 404s on exactly the canonicals round 1 added; it now names `knowledge_progressive_drill`. A self-describing payload describing a broken call is worse than none.
- **The all-time window** I argued for as "the definition of heat" was an unbounded scan over the only table that always grows, under a 10s heavy-read timeout. Now a 90-day default, and a caller-supplied `since` is **clamped** at 365 days so `?since=1970-01-01` can't reinstate it.

Also: the aggregate no longer joins `articles`, so the unbounded body text is out of the `GROUP BY` key and only `left(body, …)` ships for the ranked top-K; `char_budget` scales with the effective limit instead of being a constant that wasn't a bound; `meta` gained `truncated` and `unresolved` so a short list is distinguishable from an exhausted one; and `?since[]=…` is a 400 rather than a `FunctionClauseError` 500.

One divergence was resolved **deliberately and documented in place**: `@heat_read_access_types` and `RetrievalMetrics.compute_followed_through/2` now answer different questions (caller-*chosen* body vs *delivered* body), so unifying them would be wrong — the comment says so, so a future editor doesn't "re-sync" them.

## The weight decision

Registered **heavy** in `TenantGate`. Cost tracks read history, not the corpus. The asymmetry decides it: marked light and actually expensive, concurrent calls starve request-path reads; marked heavy and actually cheap, it sheds earlier — and a stale navigation index costs nothing while a starved semantic search costs a request.

Two drift guards caught the registration before I did (every `HeavyRead.opts/1` atom must be a known endpoint; the test's expected-weight map must cover exactly that set). Both exist to force a deliberate decision rather than a default.

## Acceptance criteria

- [x] Heat derivable without a heavy scan on the read path — windowed, bounded, and registered heavy so it sheds rather than competes.
- [x] Single call, stated character budget, top-K capped — and the budget now actually bounds.
- [x] Visibility verified, test included — the test makes the private article the **hottest**, so scoping after ranking would surface it first. Mutation-verified.
- [x] Tenant isolation test — removing the predicate fails 11 of 14.
- [x] Self-describing — `meta.drill` names the tool and parameter, and states that ordering is windowed usage, not relevance.
- [x] No new environment variable.

## Verification

`mix precommit` green, verified independently after both fix rounds: **6626 tests, 0 failures**. All new guards mutation-verified.

## Carry-forward

Two confirmed findings land in `knowledge_ingestion_controller.ex`, outside this diff, and go to a tracked issue rather than a follow-up PR.
