### PR TITLE
Bound the last unbounded fail-open class, and stop the floor from breaking the fleet bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,29 @@ Operator-facing changes for deployments outside the hosted instance.
   deterministic fault never reaches. `Retry-After` is set on both; a client branching on
   `error.code` needs no change, one branching on the status does.
 
+- **Tightening `OBAN_INGEST_BACKLOG_MAX` now tightens the ingest fail-open allowance with it
+  (#564).** That allowance — how many jobs a tenant may have admitted while the gate cannot
+  MEASURE its backlog — is `max(1, OBAN_INGEST_BACKLOG_MAX / 10)` per web node, sized so a
+  10-node fleet stays at or under one threshold per hour. A floor at one full batch (50)
+  previously took over for any threshold below 500, so lowering the knob to e.g. `100` left
+  the allowance pinned at 50/node — a fleet admitting 500/hour against a threshold of 100,
+  silently, and in the direction an operator assumes is the safer one. Effect at the default
+  of 500 is unchanged. Below a threshold of 10 the allowance floors at 1 rather than 0, so
+  the valve can never fail CLOSED on the first transient blip. `OBAN_INGEST_BACKLOG_MAX` and
+  `OBAN_INGEST_BACKLOG_RETRY_AFTER` are now documented in `deploy/FLY_SECRETS.md`, where
+  they should have been all along.
+
+- **`POST /knowledge/ingest[/batch]` can answer `503 ingestion_gate_unavailable` for a
+  `db_error` too (#564).** It was the last unmeasurable-count class still admitting
+  UNCONDITIONALLY — on the reasoning that a broken count query is our defect, not the
+  tenant's backlog. That is a correct argument about the error CODE (and is kept: the refusal
+  is the 503, never a backlog 429) but it left the class unbounded, and a deterministic
+  query-shape fault recurs on every request — so the backpressure valve was simply OFF for as
+  long as the bug existed. Every class is now metered. Operator-visible as ingest requests
+  that previously succeeded during a counting-code fault now being refused once the hourly
+  allowance is spent; the `loopctl.ingestion.backlog_gate.failed_open.*` series with
+  `error_class="db_error"` is the signal to fix the query.
+
 ### Added
 
 - **A retirement trigger for the US-41.1 legacy embedding columns (#551).** New migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,10 @@ Operator-facing changes for deployments outside the hosted instance.
   previously took over for any threshold below 500, so lowering the knob to e.g. `100` left
   the allowance pinned at 50/node — a fleet admitting 500/hour against a threshold of 100,
   silently, and in the direction an operator assumes is the safer one. Effect at the default
-  of 500 is unchanged. Below a threshold of 10 the allowance floors at 1 rather than 0, so
-  the valve can never fail CLOSED on the first transient blip. `OBAN_INGEST_BACKLOG_MAX` and
+  of 500 is unchanged. Below a threshold of 10 the allowance floors at 1 rather than 0, so a
+  transient blip cannot refuse EVERY request — but a request asking for more items than one
+  window's allowance still cannot fit it, and is refused (without spending the allowance on
+  jobs it will not enqueue). `OBAN_INGEST_BACKLOG_MAX` and
   `OBAN_INGEST_BACKLOG_RETRY_AFTER` are now documented in `deploy/FLY_SECRETS.md`, where
   they should have been all along.
 
@@ -66,6 +68,24 @@ Operator-facing changes for deployments outside the hosted instance.
   that previously succeeded during a counting-code fault now being refused once the hourly
   allowance is spent; the `loopctl.ingestion.backlog_gate.failed_open.*` series with
   `error_class="db_error"` is the signal to fix the query.
+
+- **Which ingest fail-open refusals carry `429` vs `503` changed again, and the `Retry-After`
+  on them is now window-scaled (#565).** `429 ingestion_backlog_exceeded` is now an
+  ALLOWLIST — only a fault that is demonstrable pool pressure earns it (`connection`,
+  `timeout`, `db_pressure`, `guc_capture_abort`, and the two pool-shaped exits
+  `exit:timeout` / `exit:DBConnection.ConnectionError`). Every other exit class —
+  `exit:noproc` (an ABSENT pool), `exit:shutdown`, `exit:killed`, `exit:other`,
+  `exit:Postgrex.Error` — now answers `503 ingestion_gate_unavailable` like `db_error` and
+  `driver_fault` already did, because none of them is evidence that the refused tenant has a
+  backlog. In the other direction, the CONTENTION SQLSTATEs (class `40`, e.g. 40P01
+  deadlock_detected; class `55`, e.g. 55P03 lock_not_available) now classify as `db_pressure`
+  rather than `db_error`, so heavy `oban_jobs` churn reads as load on the dashboard instead
+  of as a defect in the counting query. The `Retry-After` on an allowance-exhausted refusal
+  now advises the time left in the hourly allowance window instead of
+  `OBAN_INGEST_BACKLOG_RETRY_AFTER` (~60s), which had a compliant client re-running the
+  backlog count ~60 times per window against the pool the gate is protecting. The fail-open
+  allowance is also now metered in two per-tenant lanes (pressure vs non-pressure), so a
+  counting-code defect can no longer spend the tokens a genuine pool fault is then refused on.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,8 @@ Operator-facing changes for deployments outside the hosted instance.
   silently, and in the direction an operator assumes is the safer one. Effect at the default
   of 500 is unchanged. Below a threshold of 10 the allowance floors at 1 rather than 0, so a
   transient blip cannot refuse EVERY request — but a request asking for more items than one
-  window's allowance still cannot fit it, and is refused (without spending the allowance on
-  jobs it will not enqueue). `OBAN_INGEST_BACKLOG_MAX` and
+  window's allowance still cannot fit it, and is refused after a single token rather than
+  burning the remainder on jobs it will not enqueue. `OBAN_INGEST_BACKLOG_MAX` and
   `OBAN_INGEST_BACKLOG_RETRY_AFTER` are now documented in `deploy/FLY_SECRETS.md`, where
   they should have been all along.
 
@@ -70,22 +70,28 @@ Operator-facing changes for deployments outside the hosted instance.
   `error_class="db_error"` is the signal to fix the query.
 
 - **Which ingest fail-open refusals carry `429` vs `503` changed again, and the `Retry-After`
-  on them is now window-scaled (#565).** `429 ingestion_backlog_exceeded` is now an
-  ALLOWLIST — only a fault that is demonstrable pool pressure earns it (`connection`,
-  `timeout`, `db_pressure`, `guc_capture_abort`, and the two pool-shaped exits
-  `exit:timeout` / `exit:DBConnection.ConnectionError`). Every other exit class —
-  `exit:noproc` (an ABSENT pool), `exit:shutdown`, `exit:killed`, `exit:other`,
-  `exit:Postgrex.Error` — now answers `503 ingestion_gate_unavailable` like `db_error` and
-  `driver_fault` already did, because none of them is evidence that the refused tenant has a
-  backlog. In the other direction, the CONTENTION SQLSTATEs (class `40`, e.g. 40P01
-  deadlock_detected; class `55`, e.g. 55P03 lock_not_available) now classify as `db_pressure`
-  rather than `db_error`, so heavy `oban_jobs` churn reads as load on the dashboard instead
-  of as a defect in the counting query. The `Retry-After` on an allowance-exhausted refusal
-  now advises the time left in the hourly allowance window instead of
-  `OBAN_INGEST_BACKLOG_RETRY_AFTER` (~60s), which had a compliant client re-running the
-  backlog count ~60 times per window against the pool the gate is protecting. The fail-open
+  on them is now window-scaled but capped (#565, #566).** `429 ingestion_backlog_exceeded` is
+  now reserved for a fault that is demonstrable pool pressure: the SQLSTATE/exception classes
+  `connection`, `timeout`, `db_pressure`, `guc_capture_abort`, plus any EXIT the driver's own
+  pool raised. Pool-ness of an exit is decided from the raw exit reason
+  (`ExitClass.pool_exit?/1`), not from its metric label, so a foreign `{:timeout, {GenServer,
+  :call, _}}` escaping the counter takes the `503 ingestion_gate_unavailable` while a
+  `{:noproc, {DBConnection, :execute, []}}` keeps the 429 — the label alone cannot tell them
+  apart. A `throw:*` and every exit the gate cannot place at the pool answer the 503, like
+  `db_error` and `driver_fault` already did, because none of them is evidence that the refused
+  tenant has a backlog. In the other direction, the CONTENTION SQLSTATEs (40001, 40P01
+  deadlock_detected, 55P03 lock_not_available) now classify as `db_pressure` rather than
+  `db_error`, so heavy `oban_jobs` churn reads as load on the dashboard instead of as a defect
+  in the counting query; the rest of classes 40 and 55 (55P02 cant_change_runtime_param and
+  friends) stay `db_error`, since a deterministic config fault never drains. The `Retry-After`
+  on an allowance-exhausted refusal now advises the time left in the hourly allowance window
+  instead of `OBAN_INGEST_BACKLOG_RETRY_AFTER` (~60s) — which had a compliant client re-running
+  the backlog count ~60 times per window against the pool the gate is protecting — capped at 5x
+  that variable so a cleared blip cannot stall a client for a whole window. The fail-open
   allowance is also now metered in two per-tenant lanes (pressure vs non-pressure), so a
-  counting-code defect can no longer spend the tokens a genuine pool fault is then refused on.
+  counting-code defect can no longer spend the tokens a genuine pool fault is then refused on;
+  size `OBAN_INGEST_BACKLOG_MAX` against **2x** the per-lane allowance, as
+  `deploy/FLY_SECRETS.md` now states.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,9 +89,12 @@ Operator-facing changes for deployments outside the hosted instance.
   the backlog count ~60 times per window against the pool the gate is protecting — capped at 5x
   that variable so a cleared blip cannot stall a client for a whole window. The fail-open
   allowance is also now metered in two per-tenant lanes (pressure vs non-pressure), so a
-  counting-code defect can no longer spend the tokens a genuine pool fault is then refused on;
-  size `OBAN_INGEST_BACKLOG_MAX` against **2x** the per-lane allowance, as
-  `deploy/FLY_SECRETS.md` now states.
+  counting-code defect can no longer spend the tokens a genuine pool fault is then refused on.
+  The lanes SPLIT one threshold's worth rather than each getting one — the per-lane allowance
+  is `max(1, OBAN_INGEST_BACKLOG_MAX / 20)` per web node (10 nodes x 2 lanes), so the total a
+  tenant can have admitted while unmeasured stays at one `OBAN_INGEST_BACKLOG_MAX` per hour and
+  there is **no multiplier to apply on top**. At the default of 500 the per-lane allowance is
+  25/node.
 
 ### Added
 

--- a/deploy/FLY_SECRETS.md
+++ b/deploy/FLY_SECRETS.md
@@ -94,14 +94,15 @@ during an incident with `fly secrets set … && fly apps restart` — no deploy.
 > **When the gate cannot MEASURE the backlog** (wedged/saturated `AdminRepo` pool, driver
 > fault, or a defect in the counting query) it fails OPEN — an innocent tenant must not be
 > refused because the count path is degraded — but only for a bounded number of jobs per
-> tenant per hour: `max(1, OBAN_INGEST_BACKLOG_MAX / 10)` per web node, **per fault lane**.
-> The `/ 10` holds the FLEET allowance to one `OBAN_INGEST_BACKLOG_MAX` per hour per lane for a
-> fleet up to 10 web nodes, because the default limiter is node-local ETS. **Size against 2x
-> that**: pressure faults and non-pressure faults are metered in SEPARATE buckets (so a defect
-> in the counting query cannot spend the allowance a genuine pool fault is then refused on), and
-> a tenant hitting both families inside one window admits from both. Second residual, below a
-> threshold of **10**: the per-node allowance floors at 1 rather than 0, so a 10-node fleet can
-> admit up to 10 jobs/hour/lane against a smaller threshold. A request asking for MORE items
+> tenant per hour: `max(1, OBAN_INGEST_BACKLOG_MAX / 20)` per web node **per fault lane**,
+> which totals one `OBAN_INGEST_BACKLOG_MAX` per hour per tenant across a fleet of up to 10 web
+> nodes. **That total is the number to size against — there is no multiplier to apply on top.**
+> The divisor is 10 nodes x 2 lanes: pressure faults and non-pressure faults are metered in
+> SEPARATE buckets (so a defect in the counting query cannot spend the allowance a genuine pool
+> fault is then refused on), and the two lanes SPLIT one threshold's worth rather than each
+> getting one. Residual, below a threshold of **20**: the per-lane allowance floors at 1 rather
+> than 0 — so the valve cannot fail closed on the first transient blip — and a 10-node fleet can
+> then admit up to 20 jobs/hour against a smaller threshold. A request asking for MORE items
 > than one window's allowance can never fit it and is refused after a single token. Past that
 > allowance the request is refused — `429 ingestion_backlog_exceeded` only when the fault is
 > DEMONSTRABLE pool pressure (a wedged/saturated pool, an exit the driver's own pool raised, a

--- a/deploy/FLY_SECRETS.md
+++ b/deploy/FLY_SECRETS.md
@@ -89,16 +89,21 @@ during an incident with `fly secrets set … && fly apps restart` — no deploy.
 | Variable                          | Default | Description |
 |-----------------------------------|---------|-------------|
 | `OBAN_INGEST_BACKLOG_MAX`         | `500`   | In-flight `:ingestion` jobs at/above which a tenant's ingest requests get `429 ingestion_backlog_exceeded`. A SOFT admission floor, not a hard cap — the check is a lock-free read-then-enqueue, so concurrent requests can overshoot it by the in-flight request concurrency. Read it as "start shedding around here". **It also derives the fail-open allowance** (see below), so tightening it tightens both |
-| `OBAN_INGEST_BACKLOG_RETRY_AFTER` | `60`    | Seconds advised in `Retry-After` on a backlog refusal. Scaled to the queue's DRAIN cadence (jobs are multi-minute LLM calls on a width-2 queue), not to a request cadence — a few-second hint just hot-loops a compliant client into a stream of 429s |
+| `OBAN_INGEST_BACKLOG_RETRY_AFTER` | `60`    | Seconds advised in `Retry-After` on an OVER-THRESHOLD backlog refusal. Scaled to the queue's DRAIN cadence (jobs are multi-minute LLM calls on a width-2 queue), not to a request cadence — a few-second hint just hot-loops a compliant client into a stream of 429s. A refusal for a spent FAIL-OPEN allowance (below) ignores this and advises the time left in the hourly allowance window instead, which is the clock that one waits on |
 
 > **When the gate cannot MEASURE the backlog** (wedged/saturated `AdminRepo` pool, driver
 > fault, or a defect in the counting query) it fails OPEN — an innocent tenant must not be
 > refused because the count path is degraded — but only for a bounded number of jobs per
 > tenant per hour: `max(1, OBAN_INGEST_BACKLOG_MAX / 10)` per web node. The `/ 10` holds the
 > FLEET allowance at or under one `OBAN_INGEST_BACKLOG_MAX` per hour for a fleet up to 10 web
-> nodes, because the default limiter is node-local ETS. Past that allowance the request is
-> refused — `429 ingestion_backlog_exceeded` when the fault IS pool pressure, otherwise
-> `503 ingestion_gate_unavailable`, which asserts nothing about the tenant's backlog. Watch
+> nodes, because the default limiter is node-local ETS — with one residual below a threshold
+> of **10**, where the per-node allowance floors at 1 rather than 0, so a 10-node fleet can
+> admit up to 10 jobs/hour against a smaller threshold. A request asking for MORE items than
+> one window's allowance can never fit it and is refused without spending it. Past that
+> allowance the request is refused — `429 ingestion_backlog_exceeded` only when the fault is
+> DEMONSTRABLE pool pressure (a wedged/saturated pool, a contention or resource-exhaustion
+> SQLSTATE), otherwise `503 ingestion_gate_unavailable`, which asserts nothing about the
+> tenant's backlog. Watch
 > `loopctl.ingestion.backlog_gate.failed_open.*` sliced by `outcome` and `error_class`; a
 > sustained non-zero rate means the valve is admitting or refusing blind.
 

--- a/deploy/FLY_SECRETS.md
+++ b/deploy/FLY_SECRETS.md
@@ -80,6 +80,32 @@ fly secrets set CLOAK_KEY="GENERATED_BASE64_KEY"
 > boot — a deliberate choice after the `STH_SWEEP_CRON` incident, so a bad
 > placeholder can never take the app down at startup.
 
+#### Ingestion backlog gate
+
+Per-tenant backpressure on `POST /api/v1/knowledge/ingest` and `/ingest/batch`, so one
+tenant cannot monopolise the `:ingestion` queue. Read at call time, so both are tunable
+during an incident with `fly secrets set … && fly apps restart` — no deploy.
+
+| Variable                          | Default | Description |
+|-----------------------------------|---------|-------------|
+| `OBAN_INGEST_BACKLOG_MAX`         | `500`   | In-flight `:ingestion` jobs at/above which a tenant's ingest requests get `429 ingestion_backlog_exceeded`. A SOFT admission floor, not a hard cap — the check is a lock-free read-then-enqueue, so concurrent requests can overshoot it by the in-flight request concurrency. Read it as "start shedding around here". **It also derives the fail-open allowance** (see below), so tightening it tightens both |
+| `OBAN_INGEST_BACKLOG_RETRY_AFTER` | `60`    | Seconds advised in `Retry-After` on a backlog refusal. Scaled to the queue's DRAIN cadence (jobs are multi-minute LLM calls on a width-2 queue), not to a request cadence — a few-second hint just hot-loops a compliant client into a stream of 429s |
+
+> **When the gate cannot MEASURE the backlog** (wedged/saturated `AdminRepo` pool, driver
+> fault, or a defect in the counting query) it fails OPEN — an innocent tenant must not be
+> refused because the count path is degraded — but only for a bounded number of jobs per
+> tenant per hour: `max(1, OBAN_INGEST_BACKLOG_MAX / 10)` per web node. The `/ 10` holds the
+> FLEET allowance at or under one `OBAN_INGEST_BACKLOG_MAX` per hour for a fleet up to 10 web
+> nodes, because the default limiter is node-local ETS. Past that allowance the request is
+> refused — `429 ingestion_backlog_exceeded` when the fault IS pool pressure, otherwise
+> `503 ingestion_gate_unavailable`, which asserts nothing about the tenant's backlog. Watch
+> `loopctl.ingestion.backlog_gate.failed_open.*` sliced by `outcome` and `error_class`; a
+> sustained non-zero rate means the valve is admitting or refusing blind.
+
+> Both accept only a **positive integer**, and unlike the rate-limit knobs above they are
+> validated at BOOT (`config/runtime.exs` evaluates them), so a malformed value aborts the
+> node LOUD at startup rather than surfacing as per-request 500s on the ingest endpoints.
+
 #### Metrics and scale alerting
 
 | Variable                    | Default | Description |

--- a/deploy/FLY_SECRETS.md
+++ b/deploy/FLY_SECRETS.md
@@ -89,21 +89,24 @@ during an incident with `fly secrets set … && fly apps restart` — no deploy.
 | Variable                          | Default | Description |
 |-----------------------------------|---------|-------------|
 | `OBAN_INGEST_BACKLOG_MAX`         | `500`   | In-flight `:ingestion` jobs at/above which a tenant's ingest requests get `429 ingestion_backlog_exceeded`. A SOFT admission floor, not a hard cap — the check is a lock-free read-then-enqueue, so concurrent requests can overshoot it by the in-flight request concurrency. Read it as "start shedding around here". **It also derives the fail-open allowance** (see below), so tightening it tightens both |
-| `OBAN_INGEST_BACKLOG_RETRY_AFTER` | `60`    | Seconds advised in `Retry-After` on an OVER-THRESHOLD backlog refusal. Scaled to the queue's DRAIN cadence (jobs are multi-minute LLM calls on a width-2 queue), not to a request cadence — a few-second hint just hot-loops a compliant client into a stream of 429s. A refusal for a spent FAIL-OPEN allowance (below) ignores this and advises the time left in the hourly allowance window instead, which is the clock that one waits on |
+| `OBAN_INGEST_BACKLOG_RETRY_AFTER` | `60`    | Seconds advised in `Retry-After` on an OVER-THRESHOLD backlog refusal. Scaled to the queue's DRAIN cadence (jobs are multi-minute LLM calls on a width-2 queue), not to a request cadence — a few-second hint just hot-loops a compliant client into a stream of 429s. A refusal for a spent FAIL-OPEN allowance (below) advises the time left in the hourly allowance window instead, CAPPED at 5x this value — the allowance binds only while the count is unmeasurable, so a cleared blip must not cost a compliant client a whole window |
 
 > **When the gate cannot MEASURE the backlog** (wedged/saturated `AdminRepo` pool, driver
 > fault, or a defect in the counting query) it fails OPEN — an innocent tenant must not be
 > refused because the count path is degraded — but only for a bounded number of jobs per
-> tenant per hour: `max(1, OBAN_INGEST_BACKLOG_MAX / 10)` per web node. The `/ 10` holds the
-> FLEET allowance at or under one `OBAN_INGEST_BACKLOG_MAX` per hour for a fleet up to 10 web
-> nodes, because the default limiter is node-local ETS — with one residual below a threshold
-> of **10**, where the per-node allowance floors at 1 rather than 0, so a 10-node fleet can
-> admit up to 10 jobs/hour against a smaller threshold. A request asking for MORE items than
-> one window's allowance can never fit it and is refused without spending it. Past that
+> tenant per hour: `max(1, OBAN_INGEST_BACKLOG_MAX / 10)` per web node, **per fault lane**.
+> The `/ 10` holds the FLEET allowance to one `OBAN_INGEST_BACKLOG_MAX` per hour per lane for a
+> fleet up to 10 web nodes, because the default limiter is node-local ETS. **Size against 2x
+> that**: pressure faults and non-pressure faults are metered in SEPARATE buckets (so a defect
+> in the counting query cannot spend the allowance a genuine pool fault is then refused on), and
+> a tenant hitting both families inside one window admits from both. Second residual, below a
+> threshold of **10**: the per-node allowance floors at 1 rather than 0, so a 10-node fleet can
+> admit up to 10 jobs/hour/lane against a smaller threshold. A request asking for MORE items
+> than one window's allowance can never fit it and is refused after a single token. Past that
 > allowance the request is refused — `429 ingestion_backlog_exceeded` only when the fault is
-> DEMONSTRABLE pool pressure (a wedged/saturated pool, a contention or resource-exhaustion
-> SQLSTATE), otherwise `503 ingestion_gate_unavailable`, which asserts nothing about the
-> tenant's backlog. Watch
+> DEMONSTRABLE pool pressure (a wedged/saturated pool, an exit the driver's own pool raised, a
+> contention or resource-exhaustion SQLSTATE), otherwise `503 ingestion_gate_unavailable`, which
+> asserts nothing about the tenant's backlog. Watch
 > `loopctl.ingestion.backlog_gate.failed_open.*` sliced by `outcome` and `error_class`; a
 > sustained non-zero rate means the valve is admitting or refusing blind.
 

--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -79,6 +79,7 @@ defmodule Loopctl.Application do
       # (and never writes client IPs into the logs). Node-local; pure ETS owner
       # with no other dependency.
       Loopctl.RateLimiter.FailOpenLog,
+      Loopctl.RateLimiter.FailOpenBackstop,
       {Oban, Application.fetch_env!(:loopctl, Oban)},
       # US-35.2 / US-38.3: supervised, CLUSTER-WIDE singleton (leadership via
       # :global, negotiated in init) that subscribes to the fixed audit-chain

--- a/lib/loopctl/oban/backlog_counter_behaviour.ex
+++ b/lib/loopctl/oban/backlog_counter_behaviour.ex
@@ -11,18 +11,27 @@ defmodule Loopctl.Oban.BacklogCounterBehaviour do
   `Mox.expect/3` to RAISE a DB error, or to EXIT the way a wedged pool checkout really
   does — deterministically driving the gate's fail-open path.
 
-  What "fail open" means here depends on the fault, not on the tenant:
+  "Fail open" means BOUNDED admission, for every fault without exception (#564). Whatever
+  the shape, the count is unmeasurable, and an unmeasurable count is not evidence that the
+  tenant is under threshold — so every class admits only up to a bounded per-tenant JOB
+  allowance and is then refused. What the fault decides is the refusal CODE, not whether the
+  admissions are bounded:
 
-    * not backlog pressure — a query-shape SQLSTATE (`db_error`, incl. 08P01
-      protocol_violation) — ADMITS unconditionally;
-    * POOL pressure (`connection`, `timeout`, `exit:*`, `throw:*`, `guc_capture_abort`
-      — raised only once the connection is already wedged — and `db_pressure`, the
-      exhaustion/connection SQLSTATEs a saturated pool raises behind pgbouncer) admits
-      up to a bounded per-tenant JOB allowance, then returns the ordinary backlog 429:
-      unbounded admission here made "no backpressure at all" the steady state;
+    * DEMONSTRABLE pool pressure — `connection`, `timeout`, `guc_capture_abort` (raised
+      only once the connection is already wedged), `db_pressure` (the
+      exhaustion/connection/contention SQLSTATEs a saturated pool raises behind pgbouncer),
+      and any exit the gate can place at the DB pool (`ExitClass.pool_exit?/1` on the raw
+      reason, not on its metric label) — is refused with the ordinary backlog 429;
+    * everything else — a query-shape SQLSTATE (`db_error`, incl. 08P01 protocol_violation),
+      a `driver_fault`, a counting-code `throw:*`, and any exit that CANNOT be placed at the
+      pool — is refused with a 503 `ingestion_gate_unavailable`, which claims no backlog. A
+      deterministic defect in our own counting code must not be reported to a tenant as its
+      backlog being too big;
     * the METER itself unreachable (under `RATE_LIMITER=postgres` its store is the same
-      `AdminRepo` pool) admits as `:unmetered` — 429-ing a tenant whose backlog was
-      neither measured nor metered is a code it has not earned — and says so.
+      `AdminRepo` pool; on the node-local path, its poolboy pool saturating) admits as
+      `:unmetered` — 429-ing a tenant whose backlog was neither measured nor metered is a
+      code it has not earned — and says so. Those admissions are still bounded, by
+      `Loopctl.RateLimiter.FailOpenBackstop`, which shares no pool with either.
 
   No outcome may ever return a generic 500, and EVERY unmeasurable count stays
   telemetry-visible — admitted, unmetered or refused — so the alert cannot go silent.

--- a/lib/loopctl/rate_limiter/fail_open_backstop.ex
+++ b/lib/loopctl/rate_limiter/fail_open_backstop.ex
@@ -1,0 +1,128 @@
+defmodule Loopctl.RateLimiter.FailOpenBackstop do
+  @moduledoc """
+  A pool-free, node-local counter that bounds admissions while the PRIMARY rate
+  limiter is unconsultable (#564 review).
+
+  ## Why this exists
+
+  A capacity gate that meters its admissions is only bounded while its meter
+  answers. `Loopctl.RateLimiter.Hammer` is node-local ETS, but every check goes
+  through a **poolboy pool** — and `config/config.exs` documents, in its own
+  comment, that a single-source flood can saturate that pool until a checkout
+  times out and exits. The caller normalises that to "unconsultable" and, on a
+  fail-OPEN gate, admits.
+
+  That is the failure mode the ingest backlog gate exists to prevent, arriving by
+  a second route: under a flood large enough to saturate `AdminRepo` (making the
+  backlog UNMEASURABLE) *and* the limiter's own pool (making the allowance
+  UNCONSULTABLE), admissions were bounded per request but unbounded across them —
+  for exactly as long as the flood lasted.
+
+  The gate already refuses to let its meter share a failure domain with the thing
+  it measures (`fail_open_meter/1` pins away from the Postgres limiter for the
+  same reason). This closes the remaining one: `:ets.update_counter/4` against a
+  table this process owns takes no lock, no checkout, and no pool.
+
+  ## What it is NOT
+
+  A replacement for the primary limiter. It is consulted **only** when the
+  primary could not answer, so it counts the unmetered period alone — a meter
+  that fails mid-window starts the backstop from zero. That is deliberate: the
+  job is to bound an outage, not to be exact across one. Being approximate in the
+  admitting direction by less than one window is the acceptable error; being
+  unbounded is not.
+
+  Fixed windows are epoch-aligned, matching Hammer's bucketing, so a client
+  advised to retry at the window boundary lands in a refilled window under either
+  counter.
+
+  If the table is unavailable (a caller running before the app tree is up), every
+  function returns as if there were headroom rather than crashing a fail-open
+  path — the same fallback posture as `Loopctl.RateLimiter.FailOpenLog`.
+  """
+
+  use GenServer
+
+  @table :rate_limiter_fail_open_backstop
+
+  # Sweep cadence for expired window rows. Generous: rows are tiny
+  # ({bucket, window} -> integer) and a missed sweep costs memory, never
+  # correctness, since the window is part of the key.
+  @sweep_interval_ms 600_000
+
+  @doc false
+  def start_link(_opts), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+
+  @impl true
+  def init(:ok) do
+    :ets.new(@table, [
+      :named_table,
+      :public,
+      :set,
+      read_concurrency: true,
+      write_concurrency: true
+    ])
+
+    schedule_sweep()
+    {:ok, %{}}
+  end
+
+  @doc """
+  Charge one token against `bucket` for the current `window_ms` window.
+
+  Returns `:admitted` while the bucket is at or under `limit` for this window,
+  `:exhausted` once it is over. Never raises, never exits.
+  """
+  @spec charge(String.t(), pos_integer(), pos_integer()) :: :admitted | :exhausted
+  def charge(bucket, window_ms, limit), do: charge(bucket, window_ms, limit, @table)
+
+  @doc """
+  `charge/3` against an explicit table. Exists so the missing-table fallback is
+  reachable from a test: the table is supervised, so in a running system there is
+  no way to observe that branch, and an untested fallback on a fail-open path is
+  how a "never crashes the caller" claim goes stale.
+  """
+  @spec charge(String.t(), pos_integer(), pos_integer(), atom()) :: :admitted | :exhausted
+  def charge(bucket, window_ms, limit, table) do
+    index = window_index(window_ms)
+    key = {bucket, index}
+    # The row carries its own ABSOLUTE expiry so the sweep never has to compare
+    # window indices, which are only comparable between callers using the SAME
+    # window width. `update_counter/4` touches position 2 only, so the expiry
+    # keeps the value it was created with.
+    expires_at = (index + 1) * window_ms
+
+    case :ets.update_counter(table, key, {2, 1}, {key, 0, expires_at}) do
+      count when count > limit -> :exhausted
+      _count -> :admitted
+    end
+  rescue
+    # ArgumentError when the table does not exist yet.
+    ArgumentError -> :admitted
+  end
+
+  @doc """
+  Drop every counter for `bucket`, across all windows. Test support.
+  """
+  @spec reset(String.t()) :: :ok
+  def reset(bucket) do
+    :ets.match_delete(@table, {{bucket, :_}, :_, :_})
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  @impl true
+  def handle_info(:sweep, state) do
+    :ets.select_delete(@table, [
+      {{:_, :_, :"$1"}, [{:<, :"$1", System.system_time(:millisecond)}], [true]}
+    ])
+
+    schedule_sweep()
+    {:noreply, state}
+  end
+
+  defp schedule_sweep, do: Process.send_after(self(), :sweep, @sweep_interval_ms)
+
+  defp window_index(window_ms), do: div(System.system_time(:millisecond), window_ms)
+end

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -242,17 +242,21 @@ defmodule Loopctl.TelemetryEvents do
       from a trickle of single ingests.
     * `metadata`: `%{tenant_id, error_class, outcome}`.
 
-      `outcome` is a BOUNDED 3-value atom: `:admitted` (unmetered fault class, or within
-      allowance), `:unmetered` (the METER was unconsultable — this ONE bucket is metered on
-      the node-local ETS limiter whatever `RATE_LIMITER` says, precisely so the meter does not
-      share a failure domain with the count it bounds, so `:unmetered` means an ETS/Hammer
-      fault, NOT a DB-pool one — the request was admitted rather than refusing a tenant whose
-      backlog was neither measured nor metered), `:exhausted` (allowance spent; the request was
-      refused — the backlog 429 for a pressure class, otherwise a 503 that claims no backlog).
+      `outcome` is a BOUNDED 3-value atom: `:admitted` (within allowance), `:unmetered` (the
+      METER was unconsultable — this ONE bucket is metered on the node-local ETS limiter
+      whatever `RATE_LIMITER` says, precisely so the meter does not share a failure domain with
+      the count it bounds, so `:unmetered` means an ETS/Hammer fault, NOT a DB-pool one — the
+      request was admitted, bounded by `RateLimiter.FailOpenBackstop` rather than refusing a
+      tenant whose backlog was neither measured nor metered), `:exhausted` (the meter was
+      consulted and the remaining allowance could not cover this request — either spent, or
+      smaller than the items asked for; the request was refused — the backlog 429 for a
+      pressure class, otherwise a 503 that claims no backlog).
 
       `error_class` is a BOUNDED tag: `"timeout"` (57014 query_canceled — the
-      count's own statement_timeout), `"db_pressure"` (SQLSTATE class 53/57/08 — the
-      exhaustion/connection classes a saturated pool raises behind pgbouncer),
+      count's own statement_timeout), `"db_pressure"` (SQLSTATE classes 53/57/08 — the
+      exhaustion/connection classes a saturated pool raises behind pgbouncer — plus the
+      CONTENTION codes 40001, 40P01 deadlock_detected and 55P03 lock_not_available, which are
+      load on `oban_jobs` rather than a defect in the counting query),
       `"driver_fault"` (a `Postgrex.Error` carrying NO server SQLSTATE — a client-side
       protocol/decode fault, or a PERMANENT ssl/config one; metered, but never attributed to
       backlog), `"db_error"` (any OTHER SERVER SQLSTATE — a query bug in the
@@ -263,16 +267,21 @@ defmodule Loopctl.TelemetryEvents do
       once the connection is ALREADY wedged, hence metered), plus the `exit:<t>` / `throw:<t>`
       families from `Loopctl.ExitClass`.
 
-      METERED classes (bounded allowance, then a refusal): `connection`, `timeout`,
-      `db_pressure`, `driver_fault`, `guc_capture_abort`, `exit:*`, `throw:*`. Of those,
-      `driver_fault` and `throw:*` are refused as a 503 `ingestion_gate_unavailable` rather
-      than the backlog 429 — metered so admissions stay bounded, but not backlog-attributable,
-      so a deterministic fault never tells an under-threshold tenant its backlog is full.
-      UNMETERED (always admits): `db_error` ONLY —
-      a query-shape bug in the count path is not backlog pressure, and capping it would 429 an
-      under-threshold tenant with a code it has not earned. Every other class leaves the
-      backlog UNMEASURED, and an unmeasured backlog is not evidence of an under-threshold
-      tenant, so its admissions stay bounded.
+      EVERY class is METERED (bounded allowance, then a refusal) — there is no unmetered
+      class. An unmeasured backlog is not evidence of an under-threshold tenant, whatever
+      shape the fault arrived in, so no class earns free admission (#564).
+
+      What DOES vary is the refusal CODE, and it is an allowlist: the backlog 429 is reserved
+      for `connection`, `timeout`, `db_pressure`, `guc_capture_abort`, plus any `exit:*` the
+      gate can place at the DB pool. Everything else — `driver_fault`, `db_error`, `throw:*`,
+      and any exit it CANNOT place at the pool — is refused as a 503
+      `ingestion_gate_unavailable`, which asserts nothing about a backlog: a deterministic
+      fault must never tell an under-threshold tenant its backlog is full.
+
+      An `exit:*` class alone therefore implies NEITHER code. The tag is derived from the exit
+      reason and cannot name which process died, so pool-ness is decided at the catch site
+      with `ExitClass.pool_exit?/1` while the raw reason is still in scope. Source of truth for
+      the split: `@backlog_attributable_classes` in `LoopctlWeb.KnowledgeIngestionController`.
 
       `tenant_id` is an id, cap-gated to a sentinel in the metric's `tag_values`
       (`ScaleMetrics.backlog_gate_tags/1`) so label cardinality stays bounded.

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -64,8 +64,12 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # less than a batch, so TIGHTENING `OBAN_INGEST_BACKLOG_MAX` stopped tightening the
   # allowance and pinned it at 50/node — a 10-node fleet admitting 500 jobs/hour against a
   # threshold of 100 — quietly, and in exactly the direction an operator assumes is the safe
-  # one. The floor exists only to stop integer division producing 0, which would make the
-  # valve fail CLOSED and refuse an innocent tenant on the first transient blip. Residual and
+  # one. The floor exists only to stop integer division producing 0, which would refuse EVERY
+  # request on the first transient blip. It is NOT the stronger guarantee that NO request is
+  # refused there: the allowance is charged per ITEM, so a request of more than
+  # `fail_open_jobs_per_window/0` items can never fit one window and is refused on the first
+  # blip whatever the floor is (`consume_fail_open_allowance/3` refuses it WITHOUT charging).
+  # A request at or under the allowance is the one carried through the blip. Residual and
   # accepted: for a threshold below @fail_open_fleet_nodes the fleet may admit up to
   # @fail_open_fleet_nodes jobs/hour against a smaller threshold. That is unavoidable without
   # shared (non-node-local) limiter state, and it is the bound documented for every
@@ -77,9 +81,10 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # documented status set matches `backlog_fail_open_verdict/3` (CLAUDE.md: a new API
   # constraint is documented in the `operation/2` spec, not just enforced in the controller).
   @gate_unavailable_description "Service Unavailable — the ingest admission gate could not " <>
-                                  "MEASURE your in-flight backlog, the fault is not pool " <>
-                                  "pressure (a driver/config fault, or a defect in the " <>
-                                  "counting code), and the bounded allowance for admitting " <>
+                                  "MEASURE your in-flight backlog, the fault is not " <>
+                                  "DEMONSTRABLE pool pressure (a driver/config fault, a " <>
+                                  "defect in the counting code, or an exit the gate cannot " <>
+                                  "place as pressure), and the allowance for admitting " <>
                                   "unmeasured work is spent. `error.code: " <>
                                   "\"ingestion_gate_unavailable\"`, sets `Retry-After`. Zero " <>
                                   "jobs are enqueued. Distinct from the 429s: this one does " <>
@@ -394,10 +399,10 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # EVERY outcome emits `fail_open_event/4`: the only signal that the backlog is UNMEASURABLE
   # must not go silent at the moment the fault stops being a blip and becomes the wedge.
   defp backlog_fail_open_verdict(tenant_id, error_class, jobs) do
-    outcome = consume_fail_open_allowance(tenant_id, jobs)
+    outcome = consume_fail_open_allowance(tenant_id, error_class, jobs)
 
     fail_open_event(tenant_id, error_class, outcome, jobs)
-    retry_after = backlog_retry_after_seconds()
+    retry_after = fail_open_retry_after_seconds()
 
     cond do
       outcome != :exhausted -> :ok
@@ -406,23 +411,27 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     end
   end
 
-  # WHAT A REFUSAL MAY CLAIM — a different question from whether admissions are BOUNDED. A
-  # class that is not demonstrable pool pressure — a counting-code `throw:*`, or a
-  # `Postgrex.Error` carrying no server SQLSTATE (`driver_fault`, which covers the PERMANENT
-  # ssl/protocol/status faults as well as a decode fault on a degrading connection) — still
-  # leaves the backlog UNMEASURED, so its admissions stay metered. But answering
-  # `429 ingestion_backlog_exceeded` there asserts a backlog nobody counted and advertises a
-  # remedy (wait for the drain) that a deterministic fault never reaches: the tenant may be at
-  # zero backlog and is refused for the whole window. Those get the server-side 503 instead.
-  # `db_error` joins them. It is the class for a fault carrying a server SQLSTATE that is
-  # neither saturation (53/57/08) nor a timeout — i.e. a query-shape bug in OUR counting code
-  # (42703 after a `FairShare` change, 08P01 protocol_violation). The tenant's backlog is
-  # unknown and unrelated, so a 429 would name a backlog nobody counted and advertise a remedy
-  # — wait for the drain — that a deterministic defect never reaches.
-  defp backlog_attributable?("throw:" <> _tag), do: false
-  defp backlog_attributable?("driver_fault"), do: false
-  defp backlog_attributable?("db_error"), do: false
-  defp backlog_attributable?(_class), do: true
+  # WHAT A REFUSAL MAY CLAIM — a different question from whether admissions are BOUNDED. An
+  # ALLOWLIST, deliberately: `429 ingestion_backlog_exceeded` asserts a backlog nobody counted
+  # and advertises a remedy (wait for the drain) that a non-pressure fault never reaches — the
+  # tenant may be at zero backlog and is refused for the whole window — so only a class that is
+  # DEMONSTRABLE pool pressure may be answered with it. Everything else takes the server-side
+  # 503, which asserts nothing about a backlog: `driver_fault` (a `Postgrex.Error` with no
+  # server SQLSTATE, the shape that also carries the PERMANENT ssl/protocol/status faults),
+  # `db_error` (a SQLSTATE that is a query-shape bug in OUR counting code — 42703 after a
+  # `FairShare` change, 08P01 protocol_violation), a counting-code `throw:*`, and every exit
+  # this gate cannot place as pressure. A catch-all `true` was the wrong default: it swept in
+  # every string `ExitClass.bounded/2` can produce — `exit:noproc` (an ABSENT pool),
+  # `exit:shutdown`, `exit:killed`, `exit:other` (unclassified BY DEFINITION) and
+  # `exit:Postgrex.Error` (a propagated query-shape crash) — none of them evidence of pressure,
+  # and it made "claims a backlog" the default for any class a later edit introduces. Every
+  # class is METERED either way (`consume_fail_open_allowance/3`); this decides only the CODE.
+  @backlog_attributable_classes ~w(
+    connection timeout db_pressure guc_capture_abort
+    exit:timeout exit:DBConnection.ConnectionError
+  )
+
+  defp backlog_attributable?(error_class), do: error_class in @backlog_attributable_classes
 
   # ONE token per SUBMITTED ITEM (an upper bound on the jobs this request would enqueue),
   # halting on a REFUSAL so a doomed request does not queue up to @batch_max more checks. An
@@ -431,29 +440,62 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # halting on it converted ONE transient soft-error into a whole batch admitted with ZERO
   # tokens charged, so an ALREADY-SPENT allowance stopped refusing. The `:unmetered` verdict is
   # carried forward instead (it is what keeps the unconsultable meter alertable), and a later
-  # `{:deny, _}` still refuses. Tokens charged before the halt are NOT refunded (the limiter
-  # has no reservation), so a batch bigger than the remaining allowance burns what is left and
-  # is refused anyway — bounded waste, on the safe side of a valve that is already admitting
-  # blind. The allowance is deliberately NOT inflated to one full batch to compensate: that
-  # floor is what broke the fleet bound `fail_open_jobs_per_window/0` derives.
+  # `{:deny, _}` still refuses.
+  #
+  # A request that CANNOT FIT is refused WITHOUT charging. The limiter has no reservation and
+  # no refund, so charging item-by-item until the deny meant a batch too big for the remaining
+  # allowance burned every token it had for ZERO enqueued jobs — starving the single-item path
+  # that WOULD have been admitted for the rest of the window, and guaranteed for any
+  # `OBAN_INGEST_BACKLOG_MAX` under 500 (where the allowance is smaller than @batch_max). Two
+  # guards, no new state: a request bigger than a whole window's allowance never charges a
+  # token, and each `{:admitted, spent}` reports the spend so far, so the loop halts the moment
+  # what REMAINS cannot cover the items still to charge. The allowance is deliberately NOT
+  # inflated to one full batch to compensate: that floor is what broke the fleet bound
+  # `fail_open_jobs_per_window/0` derives.
   #
   # TRI-STATE, because a limiter FAULT is not a spent allowance and neither
   # `RateLimiter.within_limit?/3` (fail-OPEN) nor `gate_ok?/3` (fail-CLOSED) can tell them
   # apart. An unconsultable meter ADMITS (availability wins on a capacity gate) and reports
   # `:unmetered`, which keeps "the valve is admitting because its METER is unreachable"
   # alertable rather than silent; fail-CLOSED would 429 an innocent tenant on the FIRST
-  # transient blip with a backlog code it has not earned.
-  defp consume_fail_open_allowance(tenant_id, jobs) do
-    bucket = "ingest_backlog_fail_open:#{tenant_id}"
+  # transient blip with a backlog code it has not earned. KNOWN RESIDUAL, not a property the
+  # gate has: while the meter itself is unconsultable, admissions are bounded PER REQUEST (by
+  # the fit guard above) but not across requests, so a flood that saturates the limiter's own
+  # pool as well as `AdminRepo` admits for as long as it lasts. `outcome: :unmetered` is the
+  # only signal — alert on it; a cross-request bound there needs limiter state this gate does
+  # not own.
+  defp consume_fail_open_allowance(tenant_id, error_class, jobs) do
     limit = fail_open_jobs_per_window()
 
-    Enum.reduce_while(1..jobs//1, :admitted, fn _item, outcome ->
+    if jobs > limit do
+      :exhausted
+    else
+      charge_fail_open_allowance(fail_open_bucket(tenant_id, error_class), limit, jobs)
+    end
+  end
+
+  defp charge_fail_open_allowance(bucket, limit, jobs) do
+    Enum.reduce_while(1..jobs//1, :admitted, fn item, outcome ->
       case allowance_token(bucket, limit) do
         :exhausted -> {:halt, :exhausted}
         :unmetered -> {:cont, :unmetered}
-        :admitted -> {:cont, outcome}
+        {:admitted, spent} when limit - spent < jobs - item -> {:halt, :exhausted}
+        {:admitted, _spent} -> {:cont, outcome}
       end
     end)
+  end
+
+  # TWO LANES per tenant, split on the SAME predicate that picks the refusal code. One bucket
+  # per tenant let a class the code explicitly declares NOT backlog-attributable spend the
+  # allowance a later, pressure-classed request was then refused on — so the careful per-class
+  # code split above was decided by tokens a different class burned, and an at-zero-backlog
+  # tenant got a `429 ingestion_backlog_exceeded` paid for by a counting-code defect. Residual:
+  # a tenant hitting BOTH fault families inside one window may admit up to 2x
+  # `fail_open_jobs_per_window/0`; a bounded over-admission is the cheaper error than a
+  # refusal that names the wrong cause.
+  defp fail_open_bucket(tenant_id, error_class) do
+    lane = if backlog_attributable?(error_class), do: "pressure", else: "fault"
+    "ingest_backlog_fail_open:#{lane}:#{tenant_id}"
   end
 
   # The METER must not share a FAILURE DOMAIN with the count it bounds. `RateLimiter.impl/0`
@@ -477,7 +519,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # soft-error: both mean UNCONSULTABLE, never "denied". Raise/exit/throw likewise.
   defp allowance_token(bucket, limit) do
     case fail_open_meter().check_rate(bucket, @fail_open_window_ms, limit) do
-      {:allow, count} when is_integer(count) and count > 0 -> :admitted
+      {:allow, count} when is_integer(count) and count > 0 -> {:admitted, count}
       {:deny, _limit} -> :exhausted
       _other -> :unmetered
     end
@@ -567,7 +609,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   defp fail_open_event(tenant_id, error_class, outcome, jobs) do
     FailOpenLog.warn(
       :ingest_backlog,
-      "ingest_backlog_fail_open:#{tenant_id}",
+      fail_open_bucket(tenant_id, error_class),
       "backlog unmeasurable (#{error_class}, outcome=#{outcome}, jobs=#{jobs})"
     )
 
@@ -596,14 +638,17 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   defp fail_open_class(%Postgrex.Error{postgres: %{pg_code: "08P01"}}), do: "db_error"
 
   # Resource exhaustion (SQLSTATE class 53, e.g. 53300 too_many_connections), operator
-  # intervention (57, e.g. 57P03 cannot_connect_now) and connection exceptions (08) arrive as
-  # a server ERROR, not a `DBConnection` exit — the NORMAL presentation of pool saturation
-  # behind pgbouncer. They ARE backlog pressure, and a tenant refused over them has genuinely
-  # earned `429 ingestion_backlog_exceeded` — so they must not slip into the `db_error` bucket
-  # (refused as a 503 that asserts nothing about a backlog) merely because of the struct they
-  # travel in. Only a genuine query-shape error (42xxx et al) stays `db_error`.
+  # intervention (57, e.g. 57P03 cannot_connect_now), connection exceptions (08) and the
+  # CONTENTION classes (40, e.g. 40P01 deadlock_detected / 40001 serialization_failure, and
+  # 55, e.g. 55P03 lock_not_available) arrive as a server ERROR, not a `DBConnection` exit —
+  # the NORMAL presentation of pool saturation behind pgbouncer and of queue churn on
+  # `oban_jobs`. They ARE pressure, and a tenant refused over them has genuinely earned
+  # `429 ingestion_backlog_exceeded` — so they must not slip into the `db_error` bucket
+  # (refused as a 503 labelled "a defect in the counting code", which sends a triaging operator
+  # at the query instead of at load) merely because of the struct they travel in. Only a
+  # genuine query-shape error (42xxx, 22xxx et al) stays `db_error`.
   defp fail_open_class(%Postgrex.Error{postgres: %{pg_code: <<class::binary-2, _::binary>>}})
-       when class in ~w(53 57 08),
+       when class in ~w(53 57 08 40 55),
        do: "db_pressure"
 
   # `db_error` is restricted to an error that actually carries a server SQLSTATE — i.e. a
@@ -642,6 +687,18 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # between real drains. Deploy-free-tunable like the threshold itself.
   defp backlog_retry_after_seconds do
     ObanConfig.ingest_backlog_retry_after_seconds()
+  end
+
+  # ...but an ALLOWANCE-exhausted refusal waits on a different clock, so it advises a different
+  # hint. What the client is waiting for there is `@fail_open_window_ms` rolling over, not the
+  # queue draining: advising the drain cadence (~60s) against an hour-long window invited ~60
+  # refusals per window from a compliant client — each one re-running the backlog count against
+  # the very pool the gate is protecting, which is the hot loop the hint exists to prevent.
+  # The limiter's windows are fixed and epoch-aligned, so the remainder needs no per-tenant
+  # state; +1s so a client retrying exactly on the boundary lands INSIDE the refilled window.
+  defp fail_open_retry_after_seconds do
+    elapsed_ms = rem(System.system_time(:millisecond), @fail_open_window_ms)
+    div(@fail_open_window_ms - elapsed_ms, 1000) + 1
   end
 
   # Mandatory BYO gate shared by single + batch ingest. On a miss, record the block

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -23,6 +23,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   alias Loopctl.Oban.FairShare
   alias Loopctl.ObanConfig
   alias Loopctl.RateLimiter
+  alias Loopctl.RateLimiter.FailOpenBackstop
   alias Loopctl.RateLimiter.FailOpenLog
   alias Loopctl.TelemetryEvents
   alias Loopctl.Workers.ContentIngestionWorker
@@ -56,11 +57,17 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # default limiter (`Loopctl.RateLimiter.Hammer`) is node-local ETS and the FLEET allowance
   # is therefore per-node x web-node count — at a flat 100 that silently multiplied PAST the
   # threshold from ~5 nodes up. Dividing the threshold by @fail_open_fleet_nodes holds the
-  # FLEET allowance to one `OBAN_INGEST_BACKLOG_MAX` per hour per tenant PER LANE for any
-  # fleet up to that many web nodes, and retuning the threshold retunes this with it. LANE,
-  # not total: `fail_open_bucket/2` meters the pressure and fault families separately, so a
-  # tenant hitting BOTH inside one window admits up to 2x that (stated in full there, and in
-  # `deploy/FLY_SECRETS.md` — an operator sizing the threshold must read the 2x, not the 1x).
+  # FLEET allowance at or under one `OBAN_INGEST_BACKLOG_MAX` per hour per tenant for any
+  # fleet up to that many web nodes, and retuning the threshold retunes this with it.
+  #
+  # The divisor counts LANES as well as nodes. `fail_open_bucket/2` meters the pressure and
+  # fault families in separate buckets (for a real reason — see there), and a per-LANE
+  # allowance sized as if it were the only one puts a tenant hitting both families inside one
+  # window at 2x the threshold it is derived from. Dividing by @fail_open_fleet_nodes x
+  # @fail_open_lanes keeps the TOTAL at the stated 1x, which is the only number an operator
+  # should ever have to size against: a bound that holds only per-lane, with a 2x footnote, is
+  # the same defect as the @batch_max floor below — an effective allowance larger than the
+  # derivation advertises. Adding a third lane must extend @fail_open_lanes with it.
   #
   # FLOORED at 1, NOT at one full batch. A @batch_max floor was the one thing that could
   # break the fleet bound stated just above: it took over whenever the threshold divided to
@@ -79,6 +86,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # node-local limit divided by node count — over-admission when node_count > limit.
   @fail_open_window_ms 3_600_000
   @fail_open_fleet_nodes 10
+  @fail_open_lanes 2
 
   # The OTHER refusal the same admission gate can return, shared by both routes' specs so the
   # documented status set matches `backlog_fail_open_verdict/3` (CLAUDE.md: a new API
@@ -467,12 +475,11 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # apart. An unconsultable meter ADMITS (availability wins on a capacity gate) and reports
   # `:unmetered`, which keeps "the valve is admitting because its METER is unreachable"
   # alertable rather than silent; fail-CLOSED would 429 an innocent tenant on the FIRST
-  # transient blip with a backlog code it has not earned. KNOWN RESIDUAL, not a property the
-  # gate has: while the meter itself is unconsultable, admissions are bounded PER REQUEST (by
-  # the fit guard above) but not across requests, so a flood that saturates the limiter's own
-  # pool as well as `AdminRepo` admits for as long as it lasts. `outcome: :unmetered` is the
-  # only signal — alert on it; a cross-request bound there needs limiter state this gate does
-  # not own.
+  # transient blip with a backlog code it has not earned. The admission it grants is bounded
+  # ACROSS requests too, by `FailOpenBackstop` (see `allowance_token/2`) — without it, a flood
+  # that saturated the limiter's own pool as well as `AdminRepo` admitted freely for as long as
+  # it lasted, which made "admissions are bounded" true only per request. `:unmetered` remains
+  # the outcome on that path precisely so the degraded meter stays alertable.
   defp consume_fail_open_allowance(tenant_id, fault, jobs) do
     charge_fail_open_allowance(
       fail_open_bucket(tenant_id, fault),
@@ -502,11 +509,16 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # per tenant let a fault the code explicitly declares NOT backlog-attributable spend the
   # allowance a later, pressure-classed request was then refused on — so the careful code split
   # above was decided by tokens a different fault burned, and an at-zero-backlog tenant got a
-  # `429 ingestion_backlog_exceeded` paid for by a counting-code defect. Residual, and the
-  # ACTUAL bound an operator sizes against: a tenant hitting BOTH fault families inside one
-  # window may admit up to 2x `fail_open_jobs_per_window/0` per node — stated at the top of
-  # this module and in `deploy/FLY_SECRETS.md` so the one bound is documented once. A bounded
-  # over-admission is the cheaper error than a refusal that names the wrong cause.
+  # `429 ingestion_backlog_exceeded` paid for by a counting-code defect.
+  #
+  # The lanes are PAID FOR, not added on top: @fail_open_lanes is part of the divisor in
+  # `fail_open_jobs_per_window/1`, so the two lanes SPLIT one threshold's worth of allowance
+  # instead of each getting one. Sizing each lane as if it were the only one would leave a
+  # tenant that hits both families in a window admitting 2x the threshold the allowance is
+  # derived from — an effective bound larger than the advertised one, which is precisely the
+  # `@batch_max`-floor defect this PR exists to remove, re-introduced from the other side. The
+  # isolation is worth having; doubling the bound to buy it is not, and an operator should
+  # never have to read a footnote to learn the real number.
   defp fail_open_bucket(tenant_id, {_class, pressure?}) do
     lane = if pressure?, do: "pressure", else: "fault"
     "ingest_backlog_fail_open:#{lane}:#{tenant_id}"
@@ -531,16 +543,41 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
 
   # `{:allow, 0}` is the Postgres impl's own fail-open sentinel and `{:error, _}` is a Hammer
   # soft-error: both mean UNCONSULTABLE, never "denied". Raise/exit/throw likewise.
+  #
+  # An unconsultable meter falls through to `FailOpenBackstop`, which is the difference between
+  # "bounded per request" and "bounded". Pinning away from the Postgres limiter removed ONE
+  # shared failure domain; the default Hammer path has another, and `config/config.exs` names
+  # it in its own comment — every check goes through a poolboy pool that a single-source flood
+  # can saturate until a checkout times out. Under a flood big enough to take BOTH `AdminRepo`
+  # (count unmeasurable) and that pool (allowance unconsultable), the valve admitted without
+  # limit for as long as the flood lasted — the exact state this gate exists to prevent,
+  # arriving by the meter instead of by the count. The backstop is a bare
+  # `:ets.update_counter/4` against a table its own GenServer owns: no pool, no checkout, so it
+  # cannot be taken out by the traffic it is counting.
+  #
+  # It is a BACKSTOP, not a second meter — consulted only when the primary could not answer, so
+  # it counts the unmetered period alone and a meter that dies mid-window restarts it from
+  # zero. Approximate in the admitting direction by less than one window is the acceptable
+  # error here; unbounded is not. `:unmetered` is still the reported outcome when the backstop
+  # admits, so "the valve is admitting because its METER is unreachable" stays the alertable
+  # signal it was.
   defp allowance_token(bucket, limit) do
     case fail_open_meter().check_rate(bucket, @fail_open_window_ms, limit) do
       {:allow, count} when is_integer(count) and count > 0 -> {:admitted, count}
       {:deny, _limit} -> :exhausted
-      _other -> :unmetered
+      _other -> unmetered_token(bucket, limit)
     end
   rescue
-    _e -> :unmetered
+    _e -> unmetered_token(bucket, limit)
   catch
-    kind, _reason when kind in [:exit, :throw] -> :unmetered
+    kind, _reason when kind in [:exit, :throw] -> unmetered_token(bucket, limit)
+  end
+
+  defp unmetered_token(bucket, limit) do
+    case FailOpenBackstop.charge(bucket, @fail_open_window_ms, limit) do
+      :exhausted -> :exhausted
+      :admitted -> :unmetered
+    end
   end
 
   # PUBLIC as a pure function of the threshold, for the same reason `fail_open_meter/1` is:
@@ -551,7 +588,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   @doc false
   @spec fail_open_jobs_per_window(pos_integer()) :: pos_integer()
   def fail_open_jobs_per_window(max_backlog) when is_integer(max_backlog) and max_backlog > 0 do
-    max(1, div(max_backlog, @fail_open_fleet_nodes))
+    max(1, div(max_backlog, @fail_open_fleet_nodes * @fail_open_lanes))
   end
 
   defp fail_open_jobs_per_window, do: fail_open_jobs_per_window(ObanConfig.ingest_backlog_max())

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -56,8 +56,11 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # default limiter (`Loopctl.RateLimiter.Hammer`) is node-local ETS and the FLEET allowance
   # is therefore per-node x web-node count — at a flat 100 that silently multiplied PAST the
   # threshold from ~5 nodes up. Dividing the threshold by @fail_open_fleet_nodes holds the
-  # FLEET allowance at or under one `OBAN_INGEST_BACKLOG_MAX` per hour per tenant for any
-  # fleet up to that many web nodes, and retuning the threshold retunes this with it.
+  # FLEET allowance to one `OBAN_INGEST_BACKLOG_MAX` per hour per tenant PER LANE for any
+  # fleet up to that many web nodes, and retuning the threshold retunes this with it. LANE,
+  # not total: `fail_open_bucket/2` meters the pressure and fault families separately, so a
+  # tenant hitting BOTH inside one window admits up to 2x that (stated in full there, and in
+  # `deploy/FLY_SECRETS.md` — an operator sizing the threshold must read the 2x, not the 1x).
   #
   # FLOORED at 1, NOT at one full batch. A @batch_max floor was the one thing that could
   # break the fleet bound stated just above: it took over whenever the threshold divided to
@@ -68,7 +71,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # request on the first transient blip. It is NOT the stronger guarantee that NO request is
   # refused there: the allowance is charged per ITEM, so a request of more than
   # `fail_open_jobs_per_window/0` items can never fit one window and is refused on the first
-  # blip whatever the floor is (`consume_fail_open_allowance/3` refuses it WITHOUT charging).
+  # blip whatever the floor is (`charge_fail_open_allowance/3` halts it after ONE token).
   # A request at or under the allowance is the one carried through the blip. Residual and
   # accepted: for a threshold below @fail_open_fleet_nodes the fleet may admit up to
   # @fail_open_fleet_nodes jobs/hour against a smaller threshold. That is unavoidable without
@@ -358,8 +361,8 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     max = ObanConfig.ingest_backlog_max()
 
     case in_flight_ingestion_backlog(tenant_id) do
-      {:unmeasurable, error_class} ->
-        backlog_fail_open_verdict(tenant_id, error_class, jobs)
+      {:unmeasurable, fault} ->
+        backlog_fail_open_verdict(tenant_id, fault, jobs)
 
       count when count >= max ->
         {:error, :ingestion_backlog_exceeded, backlog_retry_after_seconds()}
@@ -398,15 +401,15 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   #
   # EVERY outcome emits `fail_open_event/4`: the only signal that the backlog is UNMEASURABLE
   # must not go silent at the moment the fault stops being a blip and becomes the wedge.
-  defp backlog_fail_open_verdict(tenant_id, error_class, jobs) do
-    outcome = consume_fail_open_allowance(tenant_id, error_class, jobs)
+  defp backlog_fail_open_verdict(tenant_id, {_class, pressure?} = fault, jobs) do
+    outcome = consume_fail_open_allowance(tenant_id, fault, jobs)
 
-    fail_open_event(tenant_id, error_class, outcome, jobs)
+    fail_open_event(tenant_id, fault, outcome, jobs)
     retry_after = fail_open_retry_after_seconds()
 
     cond do
       outcome != :exhausted -> :ok
-      backlog_attributable?(error_class) -> {:error, :ingestion_backlog_exceeded, retry_after}
+      pressure? -> {:error, :ingestion_backlog_exceeded, retry_after}
       true -> {:error, :ingestion_gate_unavailable, retry_after}
     end
   end
@@ -420,16 +423,19 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # server SQLSTATE, the shape that also carries the PERMANENT ssl/protocol/status faults),
   # `db_error` (a SQLSTATE that is a query-shape bug in OUR counting code — 42703 after a
   # `FairShare` change, 08P01 protocol_violation), a counting-code `throw:*`, and every exit
-  # this gate cannot place as pressure. A catch-all `true` was the wrong default: it swept in
-  # every string `ExitClass.bounded/2` can produce — `exit:noproc` (an ABSENT pool),
-  # `exit:shutdown`, `exit:killed`, `exit:other` (unclassified BY DEFINITION) and
-  # `exit:Postgrex.Error` (a propagated query-shape crash) — none of them evidence of pressure,
-  # and it made "claims a backlog" the default for any class a later edit introduces. Every
-  # class is METERED either way (`consume_fail_open_allowance/3`); this decides only the CODE.
-  @backlog_attributable_classes ~w(
-    connection timeout db_pressure guc_capture_abort
-    exit:timeout exit:DBConnection.ConnectionError
-  )
+  # this gate cannot place at the pool. A catch-all `true` was the wrong default: it made
+  # "claims a backlog" the default for any class a later edit introduces. Every class is
+  # METERED either way (`charge_fail_open_allowance/3`); this decides only the CODE.
+  #
+  # Exits are NOT judged from this list, because the class STRING cannot answer the question.
+  # `ExitClass` is a metrics vocabulary derived from the exit REASON alone and says so
+  # (`exit_class.ex` moduledoc): it cannot name WHICH process died, so an allowlisted
+  # `exit:timeout` also covers a foreign `{:timeout, {GenServer, :call, _}}` from any hop
+  # inside the counter, while a demonstrably-pool `{:noproc, {DBConnection, :execute, []}}`
+  # collapses to a label the list excludes. The discriminating fact is at the CATCH SITE, where
+  # the raw reason is still in scope, so pool-ness is decided there with `ExitClass.pool_exit?/1`
+  # and carried alongside the class (`in_flight_ingestion_backlog/1`).
+  @backlog_attributable_classes ~w(connection timeout db_pressure guc_capture_abort)
 
   defp backlog_attributable?(error_class), do: error_class in @backlog_attributable_classes
 
@@ -442,16 +448,19 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # carried forward instead (it is what keeps the unconsultable meter alertable), and a later
   # `{:deny, _}` still refuses.
   #
-  # A request that CANNOT FIT is refused WITHOUT charging. The limiter has no reservation and
-  # no refund, so charging item-by-item until the deny meant a batch too big for the remaining
-  # allowance burned every token it had for ZERO enqueued jobs — starving the single-item path
-  # that WOULD have been admitted for the rest of the window, and guaranteed for any
-  # `OBAN_INGEST_BACKLOG_MAX` under 500 (where the allowance is smaller than @batch_max). Two
-  # guards, no new state: a request bigger than a whole window's allowance never charges a
-  # token, and each `{:admitted, spent}` reports the spend so far, so the loop halts the moment
-  # what REMAINS cannot cover the items still to charge. The allowance is deliberately NOT
-  # inflated to one full batch to compensate: that floor is what broke the fleet bound
-  # `fail_open_jobs_per_window/0` derives.
+  # A request that CANNOT FIT is refused after ONE token, not after burning the remainder. The
+  # limiter has no reservation and no refund, so charging item-by-item until the deny meant a
+  # batch too big for the remaining allowance burned every token it had for ZERO enqueued jobs —
+  # starving the single-item path that WOULD have been admitted for the rest of the window, and
+  # guaranteed for any `OBAN_INGEST_BACKLOG_MAX` under 500 (where the allowance is smaller than
+  # @batch_max). ONE guard, no new state: each `{:admitted, spent}` reports the spend so far, so
+  # the loop halts the moment what REMAINS cannot cover the items still to charge — which at
+  # item 1 is exactly "bigger than a whole window's allowance". A `jobs > limit` PRE-check that
+  # skipped the meter entirely was the tempting extra guard and it broke the tri-state below: it
+  # answered `:exhausted` for a request the meter was never asked about, so an UNCONSULTABLE
+  # meter refused instead of admitting, and the `:unmetered` alert went silent. The allowance is
+  # deliberately NOT inflated to one full batch to compensate: that floor is what broke the
+  # fleet bound `fail_open_jobs_per_window/0` derives.
   #
   # TRI-STATE, because a limiter FAULT is not a spent allowance and neither
   # `RateLimiter.within_limit?/3` (fail-OPEN) nor `gate_ok?/3` (fail-CLOSED) can tell them
@@ -464,37 +473,42 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # pool as well as `AdminRepo` admits for as long as it lasts. `outcome: :unmetered` is the
   # only signal — alert on it; a cross-request bound there needs limiter state this gate does
   # not own.
-  defp consume_fail_open_allowance(tenant_id, error_class, jobs) do
-    limit = fail_open_jobs_per_window()
-
-    if jobs > limit do
-      :exhausted
-    else
-      charge_fail_open_allowance(fail_open_bucket(tenant_id, error_class), limit, jobs)
-    end
+  defp consume_fail_open_allowance(tenant_id, fault, jobs) do
+    charge_fail_open_allowance(
+      fail_open_bucket(tenant_id, fault),
+      fail_open_jobs_per_window(),
+      jobs
+    )
   end
 
+  # The fit halt PRESERVES a carried `:unmetered`: a partially unconsultable meter reported as a
+  # spent allowance is the one signal this tri-state exists to keep alertable, and admitting is
+  # what "availability wins on a capacity gate" means when the meter cannot be trusted to say no.
   defp charge_fail_open_allowance(bucket, limit, jobs) do
     Enum.reduce_while(1..jobs//1, :admitted, fn item, outcome ->
       case allowance_token(bucket, limit) do
         :exhausted -> {:halt, :exhausted}
         :unmetered -> {:cont, :unmetered}
-        {:admitted, spent} when limit - spent < jobs - item -> {:halt, :exhausted}
+        {:admitted, spent} when limit - spent < jobs - item -> {:halt, outcome_when_full(outcome)}
         {:admitted, _spent} -> {:cont, outcome}
       end
     end)
   end
 
-  # TWO LANES per tenant, split on the SAME predicate that picks the refusal code. One bucket
-  # per tenant let a class the code explicitly declares NOT backlog-attributable spend the
-  # allowance a later, pressure-classed request was then refused on — so the careful per-class
-  # code split above was decided by tokens a different class burned, and an at-zero-backlog
-  # tenant got a `429 ingestion_backlog_exceeded` paid for by a counting-code defect. Residual:
-  # a tenant hitting BOTH fault families inside one window may admit up to 2x
-  # `fail_open_jobs_per_window/0`; a bounded over-admission is the cheaper error than a
-  # refusal that names the wrong cause.
-  defp fail_open_bucket(tenant_id, error_class) do
-    lane = if backlog_attributable?(error_class), do: "pressure", else: "fault"
+  defp outcome_when_full(:unmetered), do: :unmetered
+  defp outcome_when_full(_outcome), do: :exhausted
+
+  # TWO LANES per tenant, split on the SAME verdict that picks the refusal code. One bucket
+  # per tenant let a fault the code explicitly declares NOT backlog-attributable spend the
+  # allowance a later, pressure-classed request was then refused on — so the careful code split
+  # above was decided by tokens a different fault burned, and an at-zero-backlog tenant got a
+  # `429 ingestion_backlog_exceeded` paid for by a counting-code defect. Residual, and the
+  # ACTUAL bound an operator sizes against: a tenant hitting BOTH fault families inside one
+  # window may admit up to 2x `fail_open_jobs_per_window/0` per node — stated at the top of
+  # this module and in `deploy/FLY_SECRETS.md` so the one bound is documented once. A bounded
+  # over-admission is the cheaper error than a refusal that names the wrong cause.
+  defp fail_open_bucket(tenant_id, {_class, pressure?}) do
+    lane = if pressure?, do: "pressure", else: "fault"
     "ingest_backlog_fail_open:#{lane}:#{tenant_id}"
   end
 
@@ -570,7 +584,8 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     # other pool faults, since it is raised only once the connection is already wedged. See
     # `Loopctl.LocalGuc.capture_abort?/1`.
     e in [DBConnection.ConnectionError, Postgrex.Error] ->
-      {:unmeasurable, fail_open_class(e)}
+      class = fail_open_class(e)
+      {:unmeasurable, {class, backlog_attributable?(class)}}
   catch
     # The rescue above covers only the RAISE shape, and a DBConnection checkout against a
     # wedged, saturated or unstarted pool EXITS instead. So the one failure this gate exists
@@ -581,8 +596,16 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     # NOT `0` ("an empty backlog"), which admitted unconditionally and forever. The count is
     # UNMEASURABLE, and `backlog_fail_open_verdict/3` decides how many such admissions a
     # tenant gets before the valve closes again.
+    #
+    # PRESSURE is decided HERE, on the RAW reason, and carried with the class: this is the only
+    # place that still knows WHICH process died. `ExitClass.pool_exit?/1` is conservative (what
+    # it cannot place at the pool is not a pool exit), so a foreign `{:timeout, {GenServer,
+    # :call, _}}` never earns the backlog 429 and a `{:noproc, {DBConnection, :execute, []}}`
+    # does not lose it to a label. A `:throw` is never pool pressure — it escaped OUR code.
     kind, reason when kind in [:exit, :throw] ->
-      {:unmeasurable, fail_open_class({kind, ExitTag.tag(reason)})}
+      {:unmeasurable,
+       {fail_open_class({kind, ExitTag.tag(reason)}),
+        kind == :exit and ExitClass.pool_exit?(reason)}}
   end
 
   # EVERY outcome (`:admitted` | `:unmetered` | `:exhausted`). The event means "the gate could
@@ -606,10 +629,10 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # `DBConnection.ConnectionError` message names the backend host, database and role
   # ("tcp connect (host:port): ..."), and this line is reachable from any wedged-pool
   # moment on an ordinary ingest. Same policy as `Loopctl.LocalGuc`'s own failure log.
-  defp fail_open_event(tenant_id, error_class, outcome, jobs) do
+  defp fail_open_event(tenant_id, {error_class, _pressure?} = fault, outcome, jobs) do
     FailOpenLog.warn(
       :ingest_backlog,
-      fail_open_bucket(tenant_id, error_class),
+      fail_open_bucket(tenant_id, fault),
       "backlog unmeasurable (#{error_class}, outcome=#{outcome}, jobs=#{jobs})"
     )
 
@@ -639,16 +662,23 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
 
   # Resource exhaustion (SQLSTATE class 53, e.g. 53300 too_many_connections), operator
   # intervention (57, e.g. 57P03 cannot_connect_now), connection exceptions (08) and the
-  # CONTENTION classes (40, e.g. 40P01 deadlock_detected / 40001 serialization_failure, and
-  # 55, e.g. 55P03 lock_not_available) arrive as a server ERROR, not a `DBConnection` exit —
-  # the NORMAL presentation of pool saturation behind pgbouncer and of queue churn on
-  # `oban_jobs`. They ARE pressure, and a tenant refused over them has genuinely earned
-  # `429 ingestion_backlog_exceeded` — so they must not slip into the `db_error` bucket
-  # (refused as a 503 labelled "a defect in the counting code", which sends a triaging operator
-  # at the query instead of at load) merely because of the struct they travel in. Only a
-  # genuine query-shape error (42xxx, 22xxx et al) stays `db_error`.
-  defp fail_open_class(%Postgrex.Error{postgres: %{pg_code: <<class::binary-2, _::binary>>}})
-       when class in ~w(53 57 08 40 55),
+  # individual CONTENTION codes (40001 serialization_failure, 40P01 deadlock_detected,
+  # 55P03 lock_not_available) arrive as a server ERROR, not a `DBConnection` exit — the NORMAL
+  # presentation of pool saturation behind pgbouncer and of queue churn on `oban_jobs`. They ARE
+  # pressure, and a tenant refused over them has genuinely earned `429 ingestion_backlog_exceeded`
+  # — so they must not slip into the `db_error` bucket (refused as a 503 labelled "a defect in
+  # the counting code", which sends a triaging operator at the query instead of at load) merely
+  # because of the struct they travel in. Only a genuine query-shape error (42xxx, 22xxx et al)
+  # stays `db_error`. The CONTENTION codes are matched INDIVIDUALLY, not as whole classes 40/55:
+  # those classes also carry deterministic config/state faults — 55P02 cant_change_runtime_param
+  # (the count's own `SET LOCAL statement_timeout` refused under a restricted role or a pgbouncer
+  # pooling mode), 55000, 55006 — and classing THOSE as pressure answers an at-zero-backlog
+  # tenant with a backlog 429 for the whole window over a fault that never drains. Same carve-out
+  # the 08P01 clause above makes, for the same reason.
+  defp fail_open_class(%Postgrex.Error{
+         postgres: %{pg_code: <<class::binary-2, _::binary>> = code}
+       })
+       when class in ~w(53 57 08) or code in ~w(40001 40P01 55P03),
        do: "db_pressure"
 
   # `db_error` is restricted to an error that actually carries a server SQLSTATE — i.e. a
@@ -696,9 +726,20 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # the very pool the gate is protecting, which is the hot loop the hint exists to prevent.
   # The limiter's windows are fixed and epoch-aligned, so the remainder needs no per-tenant
   # state; +1s so a client retrying exactly on the boundary lands INSIDE the refilled window.
+  #
+  # CAPPED at a few drain cadences, because the window is not really the clock either: the
+  # allowance binds ONLY while the count is UNMEASURABLE, so the moment the pool recovers the
+  # next request never reaches this path at all. Uncapped, a 200ms blip that spent the last
+  # token advertised up to an hour of backoff for a fault that cleared a second later — for a
+  # small tenant (allowance 1) that is a whole window of stalled ingestion bought to suppress a
+  # retry storm. The cap keeps the hint far above the ~60s hot loop (a dozen refusals per window
+  # at worst, not ~60) while bounding what a transient fault can cost a compliant client.
+  @fail_open_retry_after_drains 5
+
   defp fail_open_retry_after_seconds do
     elapsed_ms = rem(System.system_time(:millisecond), @fail_open_window_ms)
-    div(@fail_open_window_ms - elapsed_ms, 1000) + 1
+    window_remaining = div(@fail_open_window_ms - elapsed_ms, 1000) + 1
+    min(window_remaining, backlog_retry_after_seconds() * @fail_open_retry_after_drains)
   end
 
   # Mandatory BYO gate shared by single + batch ingest. On a miss, record the block

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -57,11 +57,19 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # is therefore per-node x web-node count — at a flat 100 that silently multiplied PAST the
   # threshold from ~5 nodes up. Dividing the threshold by @fail_open_fleet_nodes holds the
   # FLEET allowance at or under one `OBAN_INGEST_BACKLOG_MAX` per hour per tenant for any
-  # fleet up to that many web nodes, and retuning the threshold retunes this with it. It is
-  # FLOORED at @batch_max because charging is incremental with no reservation or refund: an
-  # allowance smaller than one batch converts the whole window into nothing the first time a
-  # batch is refused mid-charge, and integer division floors to 0 (clamping to a useless 1
-  # job/hour) for any OBAN_INGEST_BACKLOG_MAX under @fail_open_fleet_nodes.
+  # fleet up to that many web nodes, and retuning the threshold retunes this with it.
+  #
+  # FLOORED at 1, NOT at one full batch. A @batch_max floor was the one thing that could
+  # break the fleet bound stated just above: it took over whenever the threshold divided to
+  # less than a batch, so TIGHTENING `OBAN_INGEST_BACKLOG_MAX` stopped tightening the
+  # allowance and pinned it at 50/node — a 10-node fleet admitting 500 jobs/hour against a
+  # threshold of 100 — quietly, and in exactly the direction an operator assumes is the safe
+  # one. The floor exists only to stop integer division producing 0, which would make the
+  # valve fail CLOSED and refuse an innocent tenant on the first transient blip. Residual and
+  # accepted: for a threshold below @fail_open_fleet_nodes the fleet may admit up to
+  # @fail_open_fleet_nodes jobs/hour against a smaller threshold. That is unavoidable without
+  # shared (non-node-local) limiter state, and it is the bound documented for every
+  # node-local limit divided by node count — over-admission when node_count > limit.
   @fail_open_window_ms 3_600_000
   @fail_open_fleet_nodes 10
 
@@ -77,8 +85,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
                                   "jobs are enqueued. Distinct from the 429s: this one does " <>
                                   "NOT assert anything about your backlog."
 
-  # Max batch size for POST /knowledge/ingest/batch. Declared HERE, above
-  # `fail_open_jobs_per_window/0`, which floors the fail-open allowance at one full batch.
+  # Max batch size for POST /knowledge/ingest/batch.
   @batch_max 50
   alias LoopctlWeb.Helpers.Pagination
   alias LoopctlWeb.Helpers.ProjectId
@@ -363,16 +370,31 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # SUSTAINED, so an unconditional admit makes "no backpressure at all" the steady state
   # during exactly the overload the valve exists to bound. (Before the exit shape was caught
   # at all, the 500 at least shed the flood incidentally.) So those admissions are metered
-  # (`fail_open_jobs_per_window/0` per tenant per `@fail_open_window_ms`), and the rest are
-  # refused — as the backlog 429 where the fault IS pool pressure, otherwise as the
-  # server-side 503 (`backlog_attributable?/1`).
+  # (`fail_open_jobs_per_window/0` per tenant per `@fail_open_window_ms`), and past the
+  # allowance the request is refused — as the backlog 429 where the fault IS pool pressure,
+  # otherwise as the server-side 503 (`backlog_attributable?/1`).
+  #
+  # EVERY class is metered, unconditionally. There used to be a `metered_fail_open?/1`
+  # predicate carving out the classes believed to be capacity-INDEPENDENT (a counting-code
+  # defect rather than backlog pressure), so those admitted for free. It was whittled down one
+  # finding at a time — `db_pressure`, `driver_fault`, `guc_capture_abort`, `throw:*` — until
+  # `db_error` was the last class still exempt, and exempt is precisely "unbounded fail-open,
+  # forever": a deterministic query-shape fault (42703 after a `FairShare` change) recurs on
+  # every single request, so the valve is simply OFF for as long as the bug exists.
+  #
+  # The predicate is gone rather than extended, because the exemption cannot be right for ANY
+  # class. It always rested on two claims, and the second never holds here: that the fault is
+  # not capacity-related, AND that the tenant is under threshold — which is unknowable exactly
+  # when the count is UNMEASURABLE. The objection the carve-out actually encoded (do not tell
+  # an under-threshold tenant its backlog is too big over a defect in our counting code) is a
+  # question about the error CODE, and it is answered in `backlog_attributable?/1`: metered
+  # here, refused as a 503 there. Removing the branch makes "admissions are bounded" a
+  # property of the gate instead of a per-class opinion a later edit can quietly invert.
+  #
   # EVERY outcome emits `fail_open_event/4`: the only signal that the backlog is UNMEASURABLE
   # must not go silent at the moment the fault stops being a blip and becomes the wedge.
   defp backlog_fail_open_verdict(tenant_id, error_class, jobs) do
-    outcome =
-      if metered_fail_open?(error_class),
-        do: consume_fail_open_allowance(tenant_id, jobs),
-        else: :admitted
+    outcome = consume_fail_open_allowance(tenant_id, jobs)
 
     fail_open_event(tenant_id, error_class, outcome, jobs)
     retry_after = backlog_retry_after_seconds()
@@ -392,37 +414,15 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # `429 ingestion_backlog_exceeded` there asserts a backlog nobody counted and advertises a
   # remedy (wait for the drain) that a deterministic fault never reaches: the tenant may be at
   # zero backlog and is refused for the whole window. Those get the server-side 503 instead.
+  # `db_error` joins them. It is the class for a fault carrying a server SQLSTATE that is
+  # neither saturation (53/57/08) nor a timeout — i.e. a query-shape bug in OUR counting code
+  # (42703 after a `FairShare` change, 08P01 protocol_violation). The tenant's backlog is
+  # unknown and unrelated, so a 429 would name a backlog nobody counted and advertise a remedy
+  # — wait for the drain — that a deterministic defect never reaches.
   defp backlog_attributable?("throw:" <> _tag), do: false
   defp backlog_attributable?("driver_fault"), do: false
+  defp backlog_attributable?("db_error"), do: false
   defp backlog_attributable?(_class), do: true
-
-  # Meter every class that means the POOL is under pressure, including `guc_capture_abort`:
-  # `LocalGuc` raises that abort only after the capture round-trip ITSELF failed, i.e. the
-  # connection is already wedged, which is exactly the sustained pressure this bound exists
-  # for — leaving it unmetered let the wedge keep its unconditional admit under any nested
-  # scope. Only a broken count QUERY (`db_error`, e.g. 42703 after a `FairShare` change)
-  # stays unmetered: it is not backlog pressure at all, and capping it would 429 an
-  # under-threshold tenant with a backlog error code it has not earned.
-  defp metered_fail_open?("connection"), do: true
-  defp metered_fail_open?("db_pressure"), do: true
-  defp metered_fail_open?("driver_fault"), do: true
-  defp metered_fail_open?("timeout"), do: true
-  defp metered_fail_open?("guc_capture_abort"), do: true
-  defp metered_fail_open?("exit:" <> _tag), do: true
-
-  # A THROW is metered, SYMMETRIC with `exit:`. Un-metering it on the premise that a throw is
-  # always a deterministic counting-code defect restored, for that class, precisely the
-  # unbounded fail-open this allowance exists to close: an admit with no bound, forever. The
-  # premise does not hold either — Ecto/DBConnection re-raise a throw out of a transaction
-  # fun, so a throw is not structurally capacity-independent. And when the count is
-  # unmeasurable the server does not know the tenant IS under threshold, which is the whole
-  # reason admissions are bounded rather than free. The counter (`fail_open_event/4`) is what
-  # keeps a deterministic defect alertable; the allowance is not the alerting mechanism.
-  # What the round-tripping of this decision was actually about — a client told "your backlog
-  # is too big, wait" for a counting-code defect — is settled in `backlog_attributable?/1`:
-  # metered here, refused as a 503 there. Metering and the error CODE are separate questions.
-  defp metered_fail_open?("throw:" <> _tag), do: true
-  defp metered_fail_open?(_class), do: false
 
   # ONE token per SUBMITTED ITEM (an upper bound on the jobs this request would enqueue),
   # halting on a REFUSAL so a doomed request does not queue up to @batch_max more checks. An
@@ -431,9 +431,11 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # halting on it converted ONE transient soft-error into a whole batch admitted with ZERO
   # tokens charged, so an ALREADY-SPENT allowance stopped refusing. The `:unmetered` verdict is
   # carried forward instead (it is what keeps the unconsultable meter alertable), and a later
-  # `{:deny, _}` still refuses. Tokens charged before the halt are not refunded
-  # (the limiter has no reservation), which is why `fail_open_jobs_per_window/0` is floored
-  # at one full batch: an allowance smaller than a batch would be converted into nothing.
+  # `{:deny, _}` still refuses. Tokens charged before the halt are NOT refunded (the limiter
+  # has no reservation), so a batch bigger than the remaining allowance burns what is left and
+  # is refused anyway — bounded waste, on the safe side of a valve that is already admitting
+  # blind. The allowance is deliberately NOT inflated to one full batch to compensate: that
+  # floor is what broke the fleet bound `fail_open_jobs_per_window/0` derives.
   #
   # TRI-STATE, because a limiter FAULT is not a spent allowance and neither
   # `RateLimiter.within_limit?/3` (fail-OPEN) nor `gate_ok?/3` (fail-CLOSED) can tell them
@@ -485,9 +487,18 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     kind, _reason when kind in [:exit, :throw] -> :unmetered
   end
 
-  defp fail_open_jobs_per_window do
-    max(@batch_max, div(ObanConfig.ingest_backlog_max(), @fail_open_fleet_nodes))
+  # PUBLIC as a pure function of the threshold, for the same reason `fail_open_meter/1` is:
+  # the property that matters — TIGHTENING `OBAN_INGEST_BACKLOG_MAX` tightens the allowance —
+  # is invisible at the one threshold a test run happens to have configured (the default 500
+  # divides to exactly @batch_max, which is why the old floor could sit there breaking the
+  # fleet bound at every OTHER value with a green suite).
+  @doc false
+  @spec fail_open_jobs_per_window(pos_integer()) :: pos_integer()
+  def fail_open_jobs_per_window(max_backlog) when is_integer(max_backlog) and max_backlog > 0 do
+    max(1, div(max_backlog, @fail_open_fleet_nodes))
   end
+
+  defp fail_open_jobs_per_window, do: fail_open_jobs_per_window(ObanConfig.ingest_backlog_max())
 
   # FAIL OPEN on an UNMEASURABLE count only: an unreachable/timed-out backlog count must
   # never block work (an innocent, under-threshold tenant must never eat a generic 500
@@ -578,30 +589,31 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   defp fail_open_class(%Postgrex.Error{postgres: %{code: :query_canceled}}), do: "timeout"
 
   # 08P01 protocol_violation is a driver / query-shape bug that happens to live in the
-  # connection-exception class — not saturation. Metering it would cap an under-threshold
-  # tenant over a fault that is not its backlog, so it is excluded from `db_pressure` BEFORE
-  # the class match below.
+  # connection-exception class — not saturation. Classing it as `db_pressure` would answer an
+  # under-threshold tenant with a backlog 429 over a fault that is not its backlog, so it is
+  # excluded BEFORE the class match below. Every class is metered either way; what this
+  # split decides is the error CODE (`backlog_attributable?/1`) and what an operator triages.
   defp fail_open_class(%Postgrex.Error{postgres: %{pg_code: "08P01"}}), do: "db_error"
 
   # Resource exhaustion (SQLSTATE class 53, e.g. 53300 too_many_connections), operator
   # intervention (57, e.g. 57P03 cannot_connect_now) and connection exceptions (08) arrive as
   # a server ERROR, not a `DBConnection` exit — the NORMAL presentation of pool saturation
-  # behind pgbouncer. They ARE the sustained pressure the meter bounds, so they must not slip
-  # into the unmetered `db_error` bucket (and escape it unconditionally) merely because of the
-  # struct they travel in. Only a genuine query-shape error (42xxx et al) stays `db_error`.
+  # behind pgbouncer. They ARE backlog pressure, and a tenant refused over them has genuinely
+  # earned `429 ingestion_backlog_exceeded` — so they must not slip into the `db_error` bucket
+  # (refused as a 503 that asserts nothing about a backlog) merely because of the struct they
+  # travel in. Only a genuine query-shape error (42xxx et al) stays `db_error`.
   defp fail_open_class(%Postgrex.Error{postgres: %{pg_code: <<class::binary-2, _::binary>>}})
        when class in ~w(53 57 08),
        do: "db_pressure"
 
-  # UNMETERED `db_error` is restricted to an error that actually carries a server SQLSTATE —
-  # i.e. a query-shape bug, which is not backlog pressure. A `Postgrex.Error` with NO
-  # `postgres` map is a CLIENT-side driver fault (protocol/decode failure on a degrading
-  # connection); letting it fall into the catch-all admitted it unconditionally and forever,
-  # charging nothing. It gets its OWN class rather than `db_pressure`, because the same shape
-  # also carries PERMANENT config faults ("ssl not available", "unexpected postgres status"):
-  # metered, so admissions stay bounded, but NOT backlog-attributable, so exhausting the
-  # allowance on one never answers an under-threshold tenant with a backlog code
-  # (`backlog_attributable?/1`).
+  # `db_error` is restricted to an error that actually carries a server SQLSTATE — i.e. a
+  # query-shape bug, which is not backlog pressure. A `Postgrex.Error` with NO `postgres` map
+  # is a CLIENT-side driver fault (protocol/decode failure on a degrading connection). It gets
+  # its OWN class rather than `db_pressure`, because the same shape also carries PERMANENT
+  # config faults ("ssl not available", "unexpected postgres status"), so exhausting the
+  # allowance on one must not answer an under-threshold tenant with a backlog code. Both land
+  # on the same side of `backlog_attributable?/1`; they stay separate classes because the
+  # telemetry label is what sends a triaging operator at the query or at the driver.
   defp fail_open_class(%Postgrex.Error{postgres: %{pg_code: pg_code}}) when is_binary(pg_code),
     do: "db_error"
 

--- a/test/loopctl/rate_limiter/fail_open_backstop_test.exs
+++ b/test/loopctl/rate_limiter/fail_open_backstop_test.exs
@@ -1,0 +1,83 @@
+defmodule Loopctl.RateLimiter.FailOpenBackstopTest do
+  use ExUnit.Case, async: true
+
+  alias Loopctl.RateLimiter.FailOpenBackstop
+
+  @window_ms 3_600_000
+
+  # Each test owns its bucket, so the shared node-local table cannot couple them.
+  setup context do
+    bucket = "backstop_test:#{inspect(context.test)}"
+    on_exit(fn -> FailOpenBackstop.reset(bucket) end)
+    {:ok, bucket: bucket}
+  end
+
+  describe "charge/3" do
+    test "admits up to the limit, then refuses", %{bucket: bucket} do
+      for _ <- 1..3 do
+        assert FailOpenBackstop.charge(bucket, @window_ms, 3) == :admitted
+      end
+
+      assert FailOpenBackstop.charge(bucket, @window_ms, 3) == :exhausted
+    end
+
+    test "stays refused for the rest of the window", %{bucket: bucket} do
+      # The bound this exists for is SUSTAINED, not per-request: a flood that takes out the
+      # primary meter keeps calling, and a backstop that refilled per request would be no
+      # bound at all.
+      assert FailOpenBackstop.charge(bucket, @window_ms, 1) == :admitted
+
+      for _ <- 1..25 do
+        assert FailOpenBackstop.charge(bucket, @window_ms, 1) == :exhausted
+      end
+    end
+
+    test "buckets are independent", %{bucket: bucket} do
+      other = bucket <> ":other"
+      on_exit(fn -> FailOpenBackstop.reset(other) end)
+
+      assert FailOpenBackstop.charge(bucket, @window_ms, 1) == :admitted
+      assert FailOpenBackstop.charge(bucket, @window_ms, 1) == :exhausted
+
+      # One tenant (or lane) spending its allowance must not close the valve on another.
+      assert FailOpenBackstop.charge(other, @window_ms, 1) == :admitted
+    end
+
+    test "a limit of 1 admits exactly once — the floor case", %{bucket: bucket} do
+      # `fail_open_jobs_per_window/1` floors at 1, so this is the live configuration for any
+      # OBAN_INGEST_BACKLOG_MAX below nodes x lanes. Off-by-one here would either refuse
+      # everything (valve fail-closed) or never refuse (no bound).
+      assert FailOpenBackstop.charge(bucket, @window_ms, 1) == :admitted
+      assert FailOpenBackstop.charge(bucket, @window_ms, 1) == :exhausted
+    end
+
+    test "a shorter window is counted separately from a longer one", %{bucket: bucket} do
+      # Window width is part of the key's index, so two callers using different widths cannot
+      # silently share a counter.
+      assert FailOpenBackstop.charge(bucket, 1_000, 1) == :admitted
+      assert FailOpenBackstop.charge(bucket, @window_ms, 1) == :admitted
+    end
+  end
+
+  describe "availability posture" do
+    test "an unavailable table admits rather than crashing the caller" do
+      # This sits on a FAIL-OPEN path: a caller reaching it before the app tree is up must not
+      # take a crash from the thing that exists to keep it available. The real table is
+      # supervised, so the branch is only reachable through the explicit-table arity.
+      absent = :rate_limiter_fail_open_backstop_absent
+      assert :ets.info(absent) == :undefined
+
+      # Repeatedly, and past any plausible limit — a fallback that admitted once and then
+      # raised would be worse than one that never worked.
+      for _ <- 1..5 do
+        assert FailOpenBackstop.charge("no-table", @window_ms, 1, absent) == :admitted
+      end
+    end
+
+    test "the supervised table IS present, so the tests above are not all hitting the fallback" do
+      # Vacuity guard: every assertion in this file would also pass against a missing table,
+      # since the fallback admits. Pin that the real table exists and actually counts.
+      assert :ets.info(:rate_limiter_fail_open_backstop) != :undefined
+    end
+  end
+end

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -1109,10 +1109,10 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
           items: [%{content: "Beyond the fail-open allowance", source_type: "newsletter"}]
         })
 
-      # ...and the refusal is the 503: an ABSENT pool (`exit:noproc`) is not DEMONSTRABLE
-      # pressure, so nothing may claim this tenant's backlog is too big. The bound is what this
-      # test pins — zero jobs enqueued once the allowance is spent — not the code.
-      assert json_response(conn, 503)["error"]["code"] == "ingestion_gate_unavailable"
+      # The bound is what this test pins — zero jobs enqueued once the allowance is spent — not
+      # the code (`{:noproc, {DBConnection, ...}}` is a pool exit, so it earns the backlog 429;
+      # the code split itself is pinned by the pool-ness test below).
+      assert json_response(conn, 429)["error"]["code"] == "ingestion_backlog_exceeded"
 
       # Per-TENANT: one flooding tenant spending its allowance must not close the valve on
       # everyone else.
@@ -1211,13 +1211,17 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert body["error"]["code"] == "ingestion_gate_unavailable"
       refute body["error"]["message"] =~ "at or over the"
 
-      # ...and the hint is scaled to the ALLOWANCE window, not the queue's DRAIN cadence: what
-      # this client waits for is the hourly allowance refilling, so advising ~60s invited ~60
-      # refusals per window from a compliant client, each re-running the backlog count against
-      # the very pool the gate is protecting.
+      # ...and the hint is scaled to the ALLOWANCE window rather than the queue's DRAIN cadence
+      # (advising ~60s against an hour-long window invited ~60 refusals per window from a
+      # compliant client, each re-running the backlog count against the very pool the gate is
+      # protecting) — but CAPPED at a few drain cadences, because the allowance binds only while
+      # the count is unmeasurable: a cleared blip must not cost a compliant client a whole hour
+      # of stalled ingestion.
       assert [retry_after] = get_resp_header(conn, "retry-after")
       window_remaining_s = div(3_600_000 - rem(System.system_time(:millisecond), 3_600_000), 1000)
-      assert_in_delta String.to_integer(retry_after), window_remaining_s + 1, 2
+      cap = ObanConfig.ingest_backlog_retry_after_seconds() * 5
+      assert String.to_integer(retry_after) <= cap
+      assert_in_delta String.to_integer(retry_after), min(window_remaining_s + 1, cap), 2
 
       # Still ALERTABLE — a deterministic defect must not go silent either way.
       assert_receive {:backlog_failed_open, _measurements, metadata}
@@ -1269,7 +1273,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
       # One blip does NOT buy the whole batch a free pass: the loop keeps asking and the
       # spent allowance still closes the valve.
-      assert json_response(conn, 503)["error"]["code"] == "ingestion_gate_unavailable"
+      assert json_response(conn, 429)["error"]["code"] == "ingestion_backlog_exceeded"
 
       assert_receive :fail_open_token
       assert_receive :fail_open_token
@@ -1392,6 +1396,82 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert metadata.outcome == :exhausted
     end
 
+    test "#566: a FOREIGN exit sharing that class label does NOT earn the backlog 429",
+         %{conn: conn} do
+      # The discriminating pair. This exit collapses to the SAME `exit:timeout` class as the
+      # wedged pool above, because `ExitClass` is derived from the exit REASON alone and cannot
+      # say WHICH process died — so a code decided from the class STRING dressed up any
+      # GenServer hop inside the counter as pool pressure. Pool-ness is decided at the catch
+      # site (`ExitClass.pool_exit?/1`), where the raw reason still names the callee.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        exit({:timeout, {GenServer, :call, [:counter_helper, :count, 5000]}})
+      end)
+
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
+          do: {:deny, limit},
+          else: {:allow, 1}
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Foreign timeout item", source_type: "newsletter"}]
+        })
+
+      assert json_response(conn, 503)["error"]["code"] == "ingestion_gate_unavailable"
+
+      assert_receive {:backlog_failed_open, %{count: 1}, metadata}
+      assert metadata.error_class == "exit:timeout"
+    end
+
+    test "#566: a 55P02 config fault is not pressure, though it shares SQLSTATE class 55",
+         %{conn: conn} do
+      # `SET LOCAL statement_timeout` — which the count itself runs under — is refused with
+      # 55P02 under a restricted role or a pgbouncer pooling mode that disallows it. Matching
+      # the WHOLE class 55 to catch 55P03 lock_not_available swept that in, and answered an
+      # at-zero-backlog tenant with a 429 advertising a drain a deterministic config fault
+      # never reaches. The contention codes are matched individually instead.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        raise %Postgrex.Error{
+          postgres: %{
+            code: :cant_change_runtime_param,
+            pg_code: "55P02",
+            message: "cannot set parameter during a parallel operation"
+          }
+        }
+      end)
+
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
+          do: {:deny, limit},
+          else: {:allow, 1}
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Config fault item", source_type: "newsletter"}]
+        })
+
+      assert json_response(conn, 503)["error"]["code"] == "ingestion_gate_unavailable"
+
+      assert_receive {:backlog_failed_open, %{count: 1}, metadata}
+      assert metadata.error_class == "db_error"
+    end
+
     test "#565: a CONTENTION SQLSTATE is pool pressure, not a counting-code defect",
          %{conn: conn} do
       # 40P01 deadlock_detected (and 40001 serialization_failure, 55P03 lock_not_available)
@@ -1471,7 +1551,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
           ]
         })
 
-      assert json_response(conn, 503)["error"]["code"] == "ingestion_gate_unavailable"
+      assert json_response(conn, 429)["error"]["code"] == "ingestion_backlog_exceeded"
 
       # ONE token, not three: the remainder the window still has is left for the requests that
       # can actually be admitted with it.
@@ -1480,6 +1560,53 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
       assert_receive {:backlog_failed_open, %{count: 1, jobs: 3}, metadata}
       assert metadata.outcome == :exhausted
+    end
+
+    test "#566: the fit halt does not report an UNCONSULTABLE meter as a spent allowance",
+         %{conn: conn} do
+      # A limiter FAULT is not a spent allowance — availability wins on a capacity gate, and
+      # `:unmetered` is the only signal that the valve is admitting because its METER is
+      # unreachable. Halting the fit guard on a hard `:exhausted` discarded that carried
+      # verdict, so a partially unconsultable meter refused an innocent tenant with a code it
+      # had not earned AND went silent in the metrics. (The same discard, as a `jobs > limit`
+      # pre-check that skipped the meter entirely, refused EVERY over-allowance request.)
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        exit({:noproc, {DBConnection, :execute, []}})
+      end)
+
+      # Unconsultable on the FIRST token; the second reports a FULL allowance, which is what
+      # trips the "what remains cannot cover the rest" halt.
+      counter = :counters.new(1, [])
+
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:") do
+          :counters.add(counter, 1, 1)
+          if :counters.get(counter, 1) == 1, do: {:allow, 0}, else: {:allow, limit}
+        else
+          {:allow, 1}
+        end
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [
+            %{content: "Unmetered fit item one", source_type: "newsletter"},
+            %{content: "Unmetered fit item two", source_type: "newsletter"},
+            %{content: "Unmetered fit item three", source_type: "newsletter"}
+          ]
+        })
+
+      assert length(json_response(conn, 200)["data"]) == 3
+
+      assert_receive {:backlog_failed_open, %{count: 1, jobs: 3}, metadata}
+      assert metadata.outcome == :unmetered
     end
 
     test "#565: a non-pressure fault cannot spend the allowance a backlog 429 is charged to",

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -1160,10 +1160,10 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
       # ...over the :ingestion queue's DRAIN cadence (an hour — a 60s window refills to ~60x
       # the threshold against a ~20/hour drain), against a limit DERIVED from
-      # OBAN_INGEST_BACKLOG_MAX and floored at one full batch: integer division floors to 0
-      # for a small threshold, and charging is incremental with no refund.
+      # OBAN_INGEST_BACKLOG_MAX and floored only at 1, so integer division cannot produce a
+      # 0 that would make the valve fail CLOSED (#564).
       assert_receive {:fail_open_token, 3_600_000, limit}
-      assert limit == max(50, div(ObanConfig.ingest_backlog_max(), 10))
+      assert limit == max(1, div(ObanConfig.ingest_backlog_max(), 10))
       assert_receive {:fail_open_token, _, _}
       assert_receive {:fail_open_token, _, _}
       refute_receive {:fail_open_token, _, _}, 20
@@ -1316,6 +1316,39 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert Ctl.fail_open_meter(Loopctl.MockRateLimiter) == Loopctl.MockRateLimiter
     end
 
+    test "#564: tightening OBAN_INGEST_BACKLOG_MAX tightens the fail-open allowance with it" do
+      alias LoopctlWeb.KnowledgeIngestionController, as: Ctl
+
+      # The limiter is node-local ETS, so the FLEET allowance is per-node x web nodes. The
+      # derivation exists to hold that at or under ONE OBAN_INGEST_BACKLOG_MAX per hour per
+      # tenant for a fleet up to @fail_open_fleet_nodes (10).
+      fleet_nodes = 10
+
+      for threshold <- [10, 50, 100, 250, 500, 1000, 5000] do
+        allowance = Ctl.fail_open_jobs_per_window(threshold)
+
+        assert allowance * fleet_nodes <= threshold,
+               "fleet allowance #{allowance * fleet_nodes} exceeds threshold #{threshold}"
+      end
+
+      # The specific regression: a @batch_max (50) floor pinned the allowance there for every
+      # threshold under 500, so TIGHTENING the knob stopped tightening the allowance — a
+      # 10-node fleet still admitting 500/hour against a threshold of 100, quietly, and in the
+      # direction an operator assumes is the safer one.
+      assert Ctl.fail_open_jobs_per_window(100) == 10
+      assert Ctl.fail_open_jobs_per_window(500) == 50
+
+      # Monotonic: a smaller threshold never buys a larger allowance.
+      assert Ctl.fail_open_jobs_per_window(100) < Ctl.fail_open_jobs_per_window(500)
+
+      # Floored at 1, never 0: integer division below the fleet-node count would otherwise
+      # make the valve fail CLOSED and refuse an innocent tenant on the first transient blip.
+      # This is where the bound is knowingly given up — documented residual, since a
+      # node-local limiter has no fleet-wide counter.
+      assert Ctl.fail_open_jobs_per_window(1) == 1
+      assert Ctl.fail_open_jobs_per_window(9) == 1
+    end
+
     test "a NON-timeout SQLSTATE is not reported as a timeout", %{conn: conn} do
       # The rescue catches EVERY `Postgrex.Error`, not only 57014, so a query bug in the
       # count path (a column renamed out from under `FairShare`) also fails open. It must
@@ -1336,14 +1369,9 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
         }
       end)
 
-      # ...and it is NOT metered: a broken count QUERY is not backlog pressure, so capping it
-      # would 429 an under-threshold tenant with a backlog code it has not earned. Even with
-      # the fail-open allowance fully spent, this class still admits.
-      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
-        if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
-          do: {:deny, limit},
-          else: {:allow, 1}
-      end)
+      # Allowance available, so this is about the CLASS LABEL alone: it admits, tagged
+      # `db_error` rather than `timeout`.
+      stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit -> {:allow, 1} end)
 
       conn =
         conn
@@ -1356,6 +1384,66 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
       assert_receive {:backlog_failed_open, %{count: 1}, metadata}
       assert metadata.error_class == "db_error"
+      assert metadata.outcome == :admitted
+    end
+
+    test "#564: `db_error` is METERED — the last unbounded fail-open class", %{conn: conn} do
+      # It was the only class left admitting unconditionally, on the premise that a broken
+      # count QUERY is not backlog pressure so capping it would 429 a tenant over our defect.
+      # The premise about the CODE was right and is kept (`backlog_attributable?/1` answers
+      # the 503, not a backlog 429); the conclusion about the BOUND was wrong. A deterministic
+      # query-shape fault recurs on every request at the same rate, so "admit unconditionally"
+      # means the valve is simply OFF for as long as the bug exists — the exact unbounded
+      # fail-open this allowance was built to close.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        raise %Postgrex.Error{
+          postgres: %{
+            code: :undefined_column,
+            pg_code: "42703",
+            message: "column j.args does not exist"
+          }
+        }
+      end)
+
+      test_pid = self()
+
+      # The allowance is spent. Scoped to the fail-open bucket alone: the auth pipeline shares
+      # this limiter, and denying THAT would refuse the request for an unrelated reason.
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:") do
+          send(test_pid, {:fail_open_bucket, bucket})
+          {:deny, limit}
+        else
+          {:allow, 1}
+        end
+      end)
+
+      expect(Loopctl.MockContentExtractor, :extract_from_content, 0, fn _t, _c, _o ->
+        flunk("nothing may be enqueued once the fail-open allowance is spent")
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Query-bug beyond the allowance", source_type: "newsletter"}]
+        })
+
+      # The 503, NOT the backlog 429: the count was never taken, so nothing may claim the
+      # tenant's backlog is too big over a defect in our own counting code.
+      assert json_response(conn, 503)["error"]["code"] == "ingestion_gate_unavailable"
+
+      assert_receive {:fail_open_bucket, bucket}
+      assert bucket =~ tenant.id
+
+      assert_receive {:backlog_failed_open, %{count: 1, jobs: 1}, metadata}
+      assert metadata.error_class == "db_error"
+      assert metadata.outcome == :exhausted
     end
 
     test "a resource-exhaustion SQLSTATE is METERED, not waved through as a query bug",
@@ -1412,10 +1500,12 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert metadata.outcome == :exhausted
     end
 
-    test "08P01 protocol_violation is a query bug, not pool pressure (unmetered)",
+    test "08P01 protocol_violation is a query bug, not pool pressure (503, not a backlog 429)",
          %{conn: conn} do
       # SQLSTATE class 08 is matched as pool pressure, but 08P01 is a driver/query-shape bug.
-      # Metering it would 429 an under-threshold tenant over a fault that is not its backlog.
+      # Classing it as `db_pressure` would 429 an under-threshold tenant over a fault that is
+      # not its backlog. It is metered like every other class; what the split decides is the
+      # error CODE.
       tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
@@ -1427,7 +1517,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
         }
       end)
 
-      # Allowance fully spent: an unmetered class must still admit.
+      # Allowance fully spent, so the refusal CODE is what this asserts.
       stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
         if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
           do: {:deny, limit},
@@ -1441,11 +1531,11 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
           items: [%{content: "Protocol violation item", source_type: "newsletter"}]
         })
 
-      assert length(json_response(conn, 200)["data"]) == 1
+      assert json_response(conn, 503)["error"]["code"] == "ingestion_gate_unavailable"
 
       assert_receive {:backlog_failed_open, %{count: 1}, metadata}
       assert metadata.error_class == "db_error"
-      assert metadata.outcome == :admitted
+      assert metadata.outcome == :exhausted
     end
 
     test "a Postgrex error with NO server SQLSTATE is METERED, but never claims a backlog",

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -1166,7 +1166,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       # OBAN_INGEST_BACKLOG_MAX and floored only at 1, so integer division cannot produce a
       # 0 that would make the valve fail CLOSED (#564).
       assert_receive {:fail_open_token, 3_600_000, limit}
-      assert limit == max(1, div(ObanConfig.ingest_backlog_max(), 10))
+      assert limit == max(1, div(ObanConfig.ingest_backlog_max(), 10 * 2))
       assert_receive {:fail_open_token, _, _}
       assert_receive {:fail_open_token, _, _}
       refute_receive {:fail_open_token, _, _}, 20
@@ -1314,6 +1314,61 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert metadata.outcome == :unmetered
     end
 
+    test "#564: an unconsultable meter is still BOUNDED across requests, not just within one",
+         %{conn: conn} do
+      # The bound the PR claims was true per-request only. Under a flood big enough to take
+      # AdminRepo (count unmeasurable) AND the limiter's own poolboy pool (allowance
+      # unconsultable — `config/config.exs` documents that saturation), every request took the
+      # `:unmetered` admit and the valve was open for as long as the flood lasted. That is the
+      # state this gate exists to prevent, arriving via the meter instead of via the count.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
+
+      # A sustained fault: every request, count unmeasurable, meter unconsultable.
+      stub(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        exit({:noproc, {DBConnection, :execute, []}})
+      end)
+
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, _limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
+          do: {:error, :pool_timeout},
+          else: {:allow, 1}
+      end)
+
+      # The backstop is node-local and this tenant is fresh, so its allowance starts full.
+      allowance =
+        LoopctlWeb.KnowledgeIngestionController.fail_open_jobs_per_window(
+          ObanConfig.ingest_backlog_max()
+        )
+
+      statuses =
+        for _ <- 1..(allowance + 5) do
+          conn
+          |> auth_conn(raw_key)
+          |> post(~p"/api/v1/knowledge/ingest", %{
+            content: "Flood item",
+            source_type: "newsletter"
+          })
+          |> Map.fetch!(:status)
+        end
+
+      # It admits while the backstop has headroom, then closes — the point is that it CLOSES.
+      # Exactly the allowance is admitted, then it closes — not "eventually closes".
+      assert Enum.count(statuses, &(&1 == 202)) == allowance
+      assert 429 in statuses, "an unconsultable meter must not admit without limit"
+
+      # Once closed it STAYS closed for the window: a bound that refilled per request would be
+      # no bound at all under exactly the sustained flood it exists for.
+      assert List.last(statuses) == 429
+
+      # Still reported as `:unmetered` while admitting, so "the valve is admitting because its
+      # METER is unreachable" remains the alertable signal rather than looking like a healthy
+      # metered admit.
+      assert_receive {:backlog_failed_open, _measurements, %{outcome: :unmetered}}
+    end
+
     test "the fail-open meter is pinned to the node-local ETS limiter under RATE_LIMITER=postgres",
          %{conn: _conn} do
       # The meter must not share a FAILURE DOMAIN with the count it bounds: the Postgres
@@ -1333,34 +1388,41 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     test "#564: tightening OBAN_INGEST_BACKLOG_MAX tightens the fail-open allowance with it" do
       alias LoopctlWeb.KnowledgeIngestionController, as: Ctl
 
-      # The limiter is node-local ETS, so the FLEET allowance is per-node x web nodes. The
-      # derivation exists to hold that at or under ONE OBAN_INGEST_BACKLOG_MAX per hour per
-      # tenant for a fleet up to @fail_open_fleet_nodes (10).
+      # The limiter is node-local ETS, so the WORST-CASE fleet exposure is
+      # per-node x web nodes x LANES — `fail_open_bucket/2` meters the pressure and fault
+      # families in separate buckets, and a tenant can hit both inside one window. The
+      # derivation exists to hold that TOTAL at or under ONE OBAN_INGEST_BACKLOG_MAX per hour
+      # per tenant. Asserting it per-lane instead is how the 2x got in: the old form of this
+      # loop multiplied by nodes ALONE, so it kept passing while the real exposure doubled.
       fleet_nodes = 10
+      lanes = 2
 
-      for threshold <- [10, 50, 100, 250, 500, 1000, 5000] do
+      for threshold <- [20, 50, 100, 250, 500, 1000, 5000] do
         allowance = Ctl.fail_open_jobs_per_window(threshold)
+        fleet_total = allowance * fleet_nodes * lanes
 
-        assert allowance * fleet_nodes <= threshold,
-               "fleet allowance #{allowance * fleet_nodes} exceeds threshold #{threshold}"
+        assert fleet_total <= threshold,
+               "fleet allowance #{fleet_total} (#{allowance}/node x #{fleet_nodes} nodes x " <>
+                 "#{lanes} lanes) exceeds threshold #{threshold}"
       end
 
-      # The specific regression: a @batch_max (50) floor pinned the allowance there for every
+      # The original regression: a @batch_max (50) floor pinned the allowance there for every
       # threshold under 500, so TIGHTENING the knob stopped tightening the allowance — a
       # 10-node fleet still admitting 500/hour against a threshold of 100, quietly, and in the
       # direction an operator assumes is the safer one.
-      assert Ctl.fail_open_jobs_per_window(100) == 10
-      assert Ctl.fail_open_jobs_per_window(500) == 50
+      assert Ctl.fail_open_jobs_per_window(100) == 5
+      assert Ctl.fail_open_jobs_per_window(500) == 25
 
       # Monotonic: a smaller threshold never buys a larger allowance.
       assert Ctl.fail_open_jobs_per_window(100) < Ctl.fail_open_jobs_per_window(500)
 
-      # Floored at 1, never 0: integer division below the fleet-node count would otherwise
-      # make the valve fail CLOSED and refuse an innocent tenant on the first transient blip.
-      # This is where the bound is knowingly given up — documented residual, since a
-      # node-local limiter has no fleet-wide counter.
+      # Floored at 1, never 0: integer division below nodes x lanes would otherwise make the
+      # valve fail CLOSED and refuse an innocent tenant on the first transient blip. This is
+      # the one place the bound is knowingly given up — a node-local limiter has no fleet-wide
+      # counter — so it is asserted rather than left to be rediscovered.
       assert Ctl.fail_open_jobs_per_window(1) == 1
-      assert Ctl.fail_open_jobs_per_window(9) == 1
+      assert Ctl.fail_open_jobs_per_window(19) == 1
+      assert Ctl.fail_open_jobs_per_window(19) * fleet_nodes * lanes > 19
     end
 
     test "#565: a WEDGED-pool exit still earns the backlog 429", %{conn: conn} do

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -1109,7 +1109,10 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
           items: [%{content: "Beyond the fail-open allowance", source_type: "newsletter"}]
         })
 
-      assert json_response(conn, 429)["error"]["code"] == "ingestion_backlog_exceeded"
+      # ...and the refusal is the 503: an ABSENT pool (`exit:noproc`) is not DEMONSTRABLE
+      # pressure, so nothing may claim this tenant's backlog is too big. The bound is what this
+      # test pins — zero jobs enqueued once the allowance is spent — not the code.
+      assert json_response(conn, 503)["error"]["code"] == "ingestion_gate_unavailable"
 
       # Per-TENANT: one flooding tenant spending its allowance must not close the valve on
       # everyone else.
@@ -1207,7 +1210,14 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       body = json_response(conn, 503)
       assert body["error"]["code"] == "ingestion_gate_unavailable"
       refute body["error"]["message"] =~ "at or over the"
-      assert [_retry_after] = get_resp_header(conn, "retry-after")
+
+      # ...and the hint is scaled to the ALLOWANCE window, not the queue's DRAIN cadence: what
+      # this client waits for is the hourly allowance refilling, so advising ~60s invited ~60
+      # refusals per window from a compliant client, each re-running the backlog count against
+      # the very pool the gate is protecting.
+      assert [retry_after] = get_resp_header(conn, "retry-after")
+      window_remaining_s = div(3_600_000 - rem(System.system_time(:millisecond), 3_600_000), 1000)
+      assert_in_delta String.to_integer(retry_after), window_remaining_s + 1, 2
 
       # Still ALERTABLE — a deterministic defect must not go silent either way.
       assert_receive {:backlog_failed_open, _measurements, metadata}
@@ -1259,7 +1269,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
       # One blip does NOT buy the whole batch a free pass: the loop keeps asking and the
       # spent allowance still closes the valve.
-      assert json_response(conn, 429)["error"]["code"] == "ingestion_backlog_exceeded"
+      assert json_response(conn, 503)["error"]["code"] == "ingestion_gate_unavailable"
 
       assert_receive :fail_open_token
       assert_receive :fail_open_token
@@ -1347,6 +1357,176 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       # node-local limiter has no fleet-wide counter.
       assert Ctl.fail_open_jobs_per_window(1) == 1
       assert Ctl.fail_open_jobs_per_window(9) == 1
+    end
+
+    test "#565: a WEDGED-pool exit still earns the backlog 429", %{conn: conn} do
+      # The counterpart to the `exit:noproc` 503 above, and what keeps the attributable set
+      # from going vacuous: `exit:timeout` IS demonstrable pool pressure, so the tenant has
+      # earned the backlog code and the drain is a remedy it actually reaches.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        exit({:timeout, {DBConnection, :execute, []}})
+      end)
+
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
+          do: {:deny, limit},
+          else: {:allow, 1}
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Wedged pool item", source_type: "newsletter"}]
+        })
+
+      assert json_response(conn, 429)["error"]["code"] == "ingestion_backlog_exceeded"
+
+      assert_receive {:backlog_failed_open, %{count: 1}, metadata}
+      assert metadata.error_class == "exit:timeout"
+      assert metadata.outcome == :exhausted
+    end
+
+    test "#565: a CONTENTION SQLSTATE is pool pressure, not a counting-code defect",
+         %{conn: conn} do
+      # 40P01 deadlock_detected (and 40001 serialization_failure, 55P03 lock_not_available)
+      # under heavy `oban_jobs` churn is LOAD. Falling to `db_error` refused it with a 503 that
+      # explicitly denies pressure, under a telemetry label that sends a triaging operator at
+      # the counting query instead of at the load that actually caused it.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        raise %Postgrex.Error{
+          postgres: %{code: :deadlock_detected, pg_code: "40P01", message: "deadlock detected"}
+        }
+      end)
+
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
+          do: {:deny, limit},
+          else: {:allow, 1}
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Deadlocked count item", source_type: "newsletter"}]
+        })
+
+      assert json_response(conn, 429)["error"]["code"] == "ingestion_backlog_exceeded"
+
+      assert_receive {:backlog_failed_open, %{count: 1}, metadata}
+      assert metadata.error_class == "db_pressure"
+      assert metadata.outcome == :exhausted
+    end
+
+    test "#565: a request bigger than what REMAINS is refused without burning the remainder",
+         %{conn: conn} do
+      # The limiter has no reservation and no refund, so charging item-by-item until the deny
+      # spent every token the tenant had left for ZERO enqueued jobs — and starved the
+      # single-item path that WOULD have been admitted for the rest of the window. The loop
+      # must stop at the first token that proves the request cannot fit.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      attach_failed_open(tenant.id)
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        exit({:noproc, {DBConnection, :execute, []}})
+      end)
+
+      test_pid = self()
+
+      # One token left in the window, and a 3-item request asking for three.
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:") do
+          send(test_pid, :fail_open_token)
+          {:allow, max(1, limit - 1)}
+        else
+          {:allow, 1}
+        end
+      end)
+
+      expect(Loopctl.MockContentExtractor, :extract_from_content, 0, fn _t, _c, _o ->
+        flunk("a request that cannot fit the allowance must enqueue nothing")
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [
+            %{content: "Overflowing item one", source_type: "newsletter"},
+            %{content: "Overflowing item two", source_type: "newsletter"},
+            %{content: "Overflowing item three", source_type: "newsletter"}
+          ]
+        })
+
+      assert json_response(conn, 503)["error"]["code"] == "ingestion_gate_unavailable"
+
+      # ONE token, not three: the remainder the window still has is left for the requests that
+      # can actually be admitted with it.
+      assert_receive :fail_open_token
+      refute_receive :fail_open_token, 20
+
+      assert_receive {:backlog_failed_open, %{count: 1, jobs: 3}, metadata}
+      assert metadata.outcome == :exhausted
+    end
+
+    test "#565: a non-pressure fault cannot spend the allowance a backlog 429 is charged to",
+         %{conn: conn} do
+      # ONE bucket per tenant let a `db_error` — our own counting-code defect, which the code
+      # explicitly declares NOT backlog-attributable — burn the tokens a later connection fault
+      # was then refused on. The 429 then named a backlog nobody counted, paid for by a
+      # different class. The bucket is laned on the same predicate that picks the code.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      test_pid = self()
+
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, _limit ->
+        if String.starts_with?(bucket, "ingest_backlog_fail_open:"),
+          do: send(test_pid, {:fail_open_bucket, bucket})
+
+        {:allow, 1}
+      end)
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        raise %Postgrex.Error{
+          postgres: %{code: :undefined_column, pg_code: "42703", message: "no such column"}
+        }
+      end)
+
+      conn
+      |> auth_conn(raw_key)
+      |> post(~p"/api/v1/knowledge/ingest", %{content: "Fault lane", source_type: "newsletter"})
+      |> json_response(202)
+
+      assert_receive {:fail_open_bucket, fault_bucket}
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        raise DBConnection.ConnectionError, "pool timeout"
+      end)
+
+      conn
+      |> auth_conn(raw_key)
+      |> post(~p"/api/v1/knowledge/ingest", %{content: "Pressure lane", source_type: "newsletter"})
+      |> json_response(202)
+
+      assert_receive {:fail_open_bucket, pressure_bucket}
+
+      assert fault_bucket =~ tenant.id
+      assert pressure_bucket =~ tenant.id
+      refute fault_bucket == pressure_bucket
     end
 
     test "a NON-timeout SQLSTATE is not reported as a timeout", %{conn: conn} do


### PR DESCRIPTION
Closes #564.

Two findings in the ingest admission gate, carried forward from #563's review. Both are about the **bound** rather than the guard — the fail-open path is right, its limits were not. Review then found a third, larger one underneath.

## 1. `db_error` was the last unbounded fail-open class

Every other unmeasurable-count class had been metered one finding at a time (`db_pressure`, `driver_fault`, `guc_capture_abort`, `throw:*`). `db_error` still admitted **unconditionally, forever**.

The reasoning behind the exemption — a broken count query is *our* defect, not the tenant's backlog, so do not answer it with a backlog 429 — is a correct argument about the error **code**, and it is kept: the refusal is a 503 that asserts nothing about a backlog. As a **bound** it was wrong: a deterministic query-shape fault recurs on every request, so unconditional admission means the valve is **off** for as long as the bug exists.

`metered_fail_open?/1` is removed, not extended. The exemption cannot be right for any class — it always rested on the claim that the tenant is under threshold, which is unknowable exactly when the count is *unmeasurable*.

## 2. The allowance floor broke the fleet bound it sat under

`max(@batch_max, threshold/10)`. The `/10` holds the fleet allowance at one `OBAN_INGEST_BACKLOG_MAX`/hour, but the 50-floor took over for any threshold below 500 — so **tightening** the knob to 100 left a 10-node fleet admitting 500/hour against a threshold of 100.

Effect at the default of 500 is unchanged (500/10 = 50 = the old floor). That is precisely why it survived: the one value a test run configures is the one value where the floor is invisible. So `fail_open_jobs_per_window/1` is exposed as a pure function of the threshold and the test sweeps values.

---

## What review changed

**27 confirmed findings, 15 fixed across two rounds.** The substantial ones:

- **Attributability is decided from the raw exit reason, not its metric label.** `ExitClass` is a metrics vocabulary — it cannot name *which* process died, so an `exit:timeout` label covers both a pool fault and a foreign `{:timeout, {GenServer, :call, _}}`. Pool-ness is now decided at the catch site with `ExitClass.pool_exit?/1`, where the reason is still in scope, and carried alongside the class. `backlog_attributable?/1` became an allowlist: a catch-all `true` made "claims a backlog" the default for any class a later edit introduces.
- **A request that cannot fit is refused after one token**, not after burning the remainder of the window on zero admitted jobs.
- **Contention SQLSTATEs** (40001, 40P01, 55P03) classify as `db_pressure` — load, not a defect in the counting query.
- **`Retry-After` is window-scaled and capped**, instead of advising a 60s drain cadence against an hour-long allowance window (~60 re-counts per window against the pool the gate protects).

## What I changed back

**The lane split was right about the defect and wrong about the price.** Metering pressure and non-pressure faults in separate buckets does stop a counting-code defect from spending the tokens a genuine pool fault is then refused on. But each lane was sized as if it were the only one, so a tenant hitting both families in a window admitted **2x** the threshold — and that was shipped by documenting "size against 2x". That is this branch's own defect arriving from the other side: an effective bound larger than the derivation advertises.

The lanes now split one threshold's worth (divisor = nodes × lanes), so the total stays at the advertised 1x. The fleet-bound test multiplied by nodes alone, which is why it kept passing while real exposure doubled; it now asserts the total.

## The finding the review skipped

Round 1 deferred one confirmed finding for scope, and the pipeline itself classified that as an **invalid deferral**. It was real: every check against the default limiter goes through a poolboy pool that `config/config.exs` documents as saturating under a single-source flood. A flood large enough to take `AdminRepo` *and* that pool left the valve admitting for as long as it lasted — admissions bounded per request, but not across them. Making every class metered is what made this load-bearing, so it belongs here rather than in a follow-up.

`Loopctl.RateLimiter.FailOpenBackstop` is a bare ETS counter owned by its own GenServer — no pool, no checkout, so the traffic it counts cannot take it out. It is consulted only when the primary meter could not answer, and the outcome stays `:unmetered` so a degraded meter is still alertable rather than looking like a healthy admit.

## Verification

- `mix precommit` green: **6643 tests, 0 failures**, dialyzer and credo --strict clean.
- **Mutation-verified at the guard site**, five guards: restoring the `@batch_max` floor fails the fleet-bound test; exempting `db_error` from metering fails two; dropping lanes from the divisor fails the fleet bound; removing the backstop fails the flood test; and the backstop suite pins that the real ETS table exists, so its assertions are not all passing through the admitting fallback.

## Docs

`OBAN_INGEST_BACKLOG_MAX` and `OBAN_INGEST_BACKLOG_RETRY_AFTER` are now in `deploy/FLY_SECRETS.md` — undocumented because `mix loopctl.check_env_docs` scans only `config/runtime.exs` and these are read from `lib/` via `ObanConfig`. That blind spot hides six more variables: **#566**.

Two moduledocs (`telemetry_events.ex`, `oban/backlog_counter_behaviour.ex`) stated the inverse of enforced behaviour — this branch falsified them, so they are resynced here rather than routed out.

The remaining eight confirmed out-of-scope findings all land on the already-merged #563 heat-index surface: **#567**. The first of them is worth reading — it is the same defect class #563's review caught once already, one layer deeper.
