### PR TITLE
Scan lib/ for operator env vars, and stop counting a mention as a doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,21 +146,24 @@ Operator-facing changes for deployments outside the hosted instance.
 
 ### Added
 
-- **Six operator knobs that were live but undiscoverable are now documented (#566):**
-  `EXPECTED_APP_NODES`, `STH_SWEEP_CRON`, `OBAN_TENANT_FAIRSHARE_SNOOZE_SECONDS`,
-  `OBAN_TENANT_FAIRSHARE_SNOOZE_JITTER`, `GITHUB_TOKEN`, and the Fly secrets-adapter pair
-  `FLY_APP_NAME` / `FLY_API_TOKEN`. Nothing about their behaviour changed — they simply
-  could not be found without reading our source. The two that most affect a self-hosted
-  install: **`FLY_API_TOKEN` is not injected by anything**, and without it (or off Fly
-  entirely) the default secrets adapter refuses every write, which fails tenant signup —
-  use `SECRETS_ADAPTER=local_file`; and `GITHUB_TOKEN` left unset caps CI-status lookups
-  at GitHub's 60/hour anonymous limit, past which story verification reports an API error
-  rather than a CI verdict.
+- **Operator knobs that were live but undiscoverable are now documented (#566):**
+  `EXPECTED_APP_NODES`, `STH_SWEEP_CRON`, the fair-share snooze pair
+  (`OBAN_TENANT_FAIRSHARE_SNOOZE_SECONDS` / `_JITTER`), the per-queue families
+  `OBAN_QUEUE_<QUEUE>` and `OBAN_TENANT_FAIRSHARE_<QUEUE>`, `GITHUB_TOKEN`, and the Fly
+  secrets-adapter pair `FLY_APP_NAME` / `FLY_API_TOKEN`. Nothing about their behaviour
+  changed — they simply could not be found without reading our source. The two that most
+  affect a self-hosted install: **`FLY_API_TOKEN` is not injected by anything**, and
+  without it (or off Fly entirely) the default secrets adapter refuses every write, which
+  fails tenant signup — use `SECRETS_ADAPTER=local_file`; and `GITHUB_TOKEN` left unset
+  caps CI-status lookups at GitHub's 60/hour anonymous limit, past which story
+  verification reports an API error rather than a CI verdict (set it, or leave it unset —
+  a BLANK value 401s every lookup).
 
   `mix loopctl.check_env_docs` now scans `lib/**/*.ex` alongside `config/runtime.exs` and
   requires a documentation table ROW rather than any mention, so the next such knob cannot
-  ship undiscoverable. It had reported "42 runtime env var(s) documented" while never
-  looking at these.
+  ship undiscoverable. A name the code BUILDS at runtime still cannot be resolved by a
+  textual scan, so the guard now fails on an undeclared dynamic read instead of passing
+  over it: those families are documented by hand.
 
 - **A retirement trigger for the US-41.1 legacy embedding columns (#551).** New migration
   (`embedding_retirement_observations`, a global non-tenant table) and a new daily job at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,22 @@ Operator-facing changes for deployments outside the hosted instance.
 
 ### Added
 
+- **Six operator knobs that were live but undiscoverable are now documented (#566):**
+  `EXPECTED_APP_NODES`, `STH_SWEEP_CRON`, `OBAN_TENANT_FAIRSHARE_SNOOZE_SECONDS`,
+  `OBAN_TENANT_FAIRSHARE_SNOOZE_JITTER`, `GITHUB_TOKEN`, and the Fly secrets-adapter pair
+  `FLY_APP_NAME` / `FLY_API_TOKEN`. Nothing about their behaviour changed — they simply
+  could not be found without reading our source. The two that most affect a self-hosted
+  install: **`FLY_API_TOKEN` is not injected by anything**, and without it (or off Fly
+  entirely) the default secrets adapter refuses every write, which fails tenant signup —
+  use `SECRETS_ADAPTER=local_file`; and `GITHUB_TOKEN` left unset caps CI-status lookups
+  at GitHub's 60/hour anonymous limit, past which story verification reports an API error
+  rather than a CI verdict.
+
+  `mix loopctl.check_env_docs` now scans `lib/**/*.ex` alongside `config/runtime.exs` and
+  requires a documentation table ROW rather than any mention, so the next such knob cannot
+  ship undiscoverable. It had reported "42 runtime env var(s) documented" while never
+  looking at these.
+
 - **A retirement trigger for the US-41.1 legacy embedding columns (#551).** New migration
   (`embedding_retirement_observations`, a global non-tenant table) and a new daily job at
   03:40 UTC. It records one observation per UTC day — the read flag, which legacy columns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,9 +325,10 @@ re-checked.
 The inverse rule, and the one that actually bit us. Two things are easy to ship
 and impossible for a user to discover — both are required in the SAME PR:
 
-1. **A new environment variable** → document it in `deploy/FLY_SECRETS.md` with
-   its DEFAULT and what breaks if it is wrong. `mix loopctl.check_env_docs`
-   (in `mix precommit`) fails the build otherwise.
+1. **A new environment variable** → give it a table ROW in `deploy/FLY_SECRETS.md`
+   with its DEFAULT and what breaks if it is wrong. `mix loopctl.check_env_docs`
+   (in `mix precommit`) fails the build otherwise — it scans `config/runtime.exs`
+   AND `lib/**/*.ex`, and a passing mention in prose does not satisfy it (#566).
 2. **A new/changed API constraint** — a size cap, a new 4xx, changed field
    semantics, what is or is not encrypted at rest → the endpoint's `operation/2`
    OpenAPI spec, not just the controller guard. When a limit is both enforced and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,16 @@ An operator cannot read our source tree; a knob that lives only in our source
 effectively does not exist for them.
 
 The guard scans `config/runtime.exs` **and** `lib/**/*.ex`, and it wants a table
-**row** — not a passing mention. Both bounds were bought the hard way: the whole
-`OBAN_*` family stayed invisible for months because `runtime.exs` reads it through
-`Loopctl.ObanConfig` rather than by literal name, and `STH_SWEEP_CRON` counted as
-documented on the strength of one aside about a different decision (#566).
+**row** with a real default and description — not a passing mention. Both bounds were
+bought the hard way: the whole `OBAN_*` family stayed invisible for months because
+`runtime.exs` reads it through `Loopctl.ObanConfig` rather than by literal name, and
+`STH_SWEEP_CRON` counted as documented on the strength of one aside about a different
+decision (#566).
+
+A name the code BUILDS at runtime (`"OBAN_QUEUE_" <> queue`) is not resolvable by a
+textual scan, and is still an operator knob. So the guard FAILS on a dynamic read
+unless its file is listed in the task's `@dynamic_read_sources` with a reason — and
+then you document the family (`OBAN_QUEUE_<QUEUE>`) by hand.
 
 **2. A new or changed API constraint.** Size caps, new `4xx` conditions, changed
 field semantics, and what is or is not encrypted at rest all belong in the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ All contributions must pass:
 - `mix credo --strict` -- Static analysis
 - `mix dialyzer` -- Type checking
 - `mix test` -- Full test suite with 100% pass rate
-- `mix loopctl.check_env_docs` -- Every `runtime.exs` env var is documented for operators
+- `mix loopctl.check_env_docs` -- Every env var read in `runtime.exs` or `lib/` has a doc table row
 - `mix loopctl.check_skill_citations` -- `file:line` citations in skills/CLAUDE.md still resolve
 
 The last two run inside `mix precommit`. They exist because both failures are
@@ -30,11 +30,17 @@ that rotted after a refactor.
 Two things are easy to ship and impossible for a user to discover, so both are
 required in the same PR that introduces them:
 
-**1. A new environment variable.** Document it in the appropriate table in
+**1. A new environment variable.** Give it a row in the appropriate table in
 [`deploy/FLY_SECRETS.md`](deploy/FLY_SECRETS.md) with its **default** and **what
 breaks if it is wrong**. `mix loopctl.check_env_docs` fails the build otherwise.
-An operator cannot read our source tree; a knob that lives only in
-`config/runtime.exs` effectively does not exist for them.
+An operator cannot read our source tree; a knob that lives only in our source
+effectively does not exist for them.
+
+The guard scans `config/runtime.exs` **and** `lib/**/*.ex`, and it wants a table
+**row** — not a passing mention. Both bounds were bought the hard way: the whole
+`OBAN_*` family stayed invisible for months because `runtime.exs` reads it through
+`Loopctl.ObanConfig` rather than by literal name, and `STH_SWEEP_CRON` counted as
+documented on the strength of one aside about a different decision (#566).
 
 **2. A new or changed API constraint.** Size caps, new `4xx` conditions, changed
 field semantics, and what is or is not encrypted at rest all belong in the

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -414,9 +414,10 @@ if config_env() == :prod do
   # mistyped value must never be silently-no-alerting. That asymmetry is pinned by
   # test/loopctl/config_test.exs, since this prod-only file is never evaluated by the
   # suite (same in-lib-so-it-is-testable shape as Loopctl.ObanConfig above). The
-  # System.get_env/1 read stays HERE and the helper takes the VALUE: mix
-  # loopctl.check_env_docs scans this file textually for System.get_env("NAME"), so a
-  # name passed into lib/ would drop the variable out of the undocumented-var guard.
+  # System.get_env/1 read stays HERE and the helper takes the VALUE — a shape that was
+  # once load-bearing (mix loopctl.check_env_docs scanned this file alone, so a name
+  # passed into lib/ fell out of the undocumented-var guard) and since #566 is merely
+  # tidy: the guard scans lib/ too, so either placement stays guarded.
   config :loopctl,
          :scale_alerts_enabled,
          Loopctl.Config.opt_out_enabled?(System.get_env("SCALE_ALERTS_ENABLED"))

--- a/deploy/FLY_SECRETS.md
+++ b/deploy/FLY_SECRETS.md
@@ -66,7 +66,7 @@ fly secrets set CLOAK_KEY="GENERATED_BASE64_KEY"
 | `HEAVY_READ_POOL_SIZE`            | `8`     | `HeavyReadRepo` pool size. This pool exists so a heavy analytical/vector read cannot starve the 3-connection AdminRepo pool |
 | `HEAVY_READ_STATEMENT_TIMEOUT_MS` | `10000` | Per-statement timeout on the heavy-read pool — the backstop that keeps one pathological vector scan from pinning a connection |
 | `SLOW_QUERY_THRESHOLD_MS`         | `1000`  | Queries slower than this are logged for diagnosis |
-| `EXPECTED_APP_NODES`              | `2`     | How many app nodes the boot-time connection-budget check assumes when it multiplies the per-node pools out against Postgres `max_connections`. Advisory — it only logs, and never blocks boot — but it is the one place that notices a pool sizing that works on one node and exhausts the server on a scaled-out fleet, so **set it to the real machine count** when you scale past two. A non-integer value raises at boot; `0` or a negative parses cleanly and then DISABLES the check (it is logged as `DbCapacity boot check skipped`), so never template it from a scale-to-zero machine count |
+| `EXPECTED_APP_NODES`              | `2`     | How many app nodes the boot-time connection-budget check assumes when it multiplies the per-node pools out against Postgres `max_connections`. Advisory — it only logs, and never blocks boot — but it is the one place that notices a pool sizing that works on one node and exhausts the server on a scaled-out fleet, so **set it to the real machine count** when you scale past two. Must be a POSITIVE integer: a non-integer raises at boot, and `0` or a negative degrades to a skipped check on the primary but crashes boot on the replica half (`warn_if_replica_over_budget/1` has no fallback) whenever a distinct `REPLICA_DATABASE_URL` is set — so never template it from a scale-to-zero machine count |
 
 #### Rate limiting and auth-path throttle
 
@@ -160,6 +160,18 @@ during an incident with `fly secrets set … && fly apps restart` — no deploy.
 | Variable       | Default | Description |
 |----------------|---------|-------------|
 | `GITHUB_TOKEN` | -       | Bearer token for the CI status/test-result lookups that back independent story verification. Optional: unset, the calls go out unauthenticated, which works for PUBLIC repos until GitHub's 60-requests/hour/IP anonymous limit bites — after that verification reports a `github_api_error` rather than a real CI verdict. Required for a private repo, where unauthenticated lookups 404. Needs only read access to checks. **Leave it UNSET rather than blank** — an empty string is truthy in Elixir, so a blanked value sends `Bearer ` with nothing after it and GitHub 401s every lookup, which is strictly worse than the anonymous path |
+
+#### CLI client (`loopctl` command, not the server)
+
+Read by `Loopctl.CLI.Config` through an injected `&System.get_env/1`, so each overrides the
+matching key in `~/.loopctl/config.json` for that shell only. A blank value is ignored (the
+file value stands) rather than blanking the setting.
+
+| Variable          | Default | Description |
+|-------------------|---------|-------------|
+| `LOOPCTL_SERVER`  | config file, else the CLI's built-in default | Base URL the CLI talks to — point it at a self-hosted deployment |
+| `LOOPCTL_API_KEY` | config file value | API key the CLI authenticates with. Prefer this over `loopctl config set api_key` in CI, so the key never lands on disk |
+| `LOOPCTL_FORMAT`  | `json`  | Default output format: `json`, `human`, or `csv` |
 
 #### Feature flags
 

--- a/deploy/FLY_SECRETS.md
+++ b/deploy/FLY_SECRETS.md
@@ -55,7 +55,7 @@ fly secrets set CLOAK_KEY="GENERATED_BASE64_KEY"
 | `SECRETS_ADAPTER`   | Fly GraphQL | Set to `local_file` to store the per-tenant audit keypairs on disk instead of in Fly secrets — REQUIRED when self-hosting off Fly (see below) |
 | `SECRETS_FILE`      | `/data/loopctl/secrets.json` | Path for the `local_file` adapter. Put it on a PERSISTENT volume |
 | `FLY_APP_NAME`      | injected by Fly | The app the DEFAULT (Fly GraphQL) secrets adapter writes tenant audit keys to. Fly Machines set this for you, so it only needs setting when running the Fly adapter off Fly — a case better served by `SECRETS_ADAPTER=local_file` |
-| `FLY_API_TOKEN`     | -       | API token the Fly secrets adapter authenticates with (`fly tokens create deploy`). **Not injected** — with it or `FLY_APP_NAME` missing the adapter refuses every write with `fly_not_configured`, and since tenant signup mints and stores a per-tenant Ed25519 audit keypair, no tenant can be created. Unset it and use `local_file` when self-hosting |
+| `FLY_API_TOKEN`     | -       | API token the Fly secrets adapter authenticates with (`fly tokens create deploy`). **Not injected** — with either it or `FLY_APP_NAME` missing, the adapter refuses every write with `fly_not_configured`, and since tenant signup mints and stores a per-tenant Ed25519 audit keypair, no tenant can be created. Unset it and use `local_file` when self-hosting |
 | `FTS_REGCONFIG`     | `english` | Postgres text-search config for keyword FTS (see below) |
 
 #### Connection pools and query budgets
@@ -66,7 +66,7 @@ fly secrets set CLOAK_KEY="GENERATED_BASE64_KEY"
 | `HEAVY_READ_POOL_SIZE`            | `8`     | `HeavyReadRepo` pool size. This pool exists so a heavy analytical/vector read cannot starve the 3-connection AdminRepo pool |
 | `HEAVY_READ_STATEMENT_TIMEOUT_MS` | `10000` | Per-statement timeout on the heavy-read pool — the backstop that keeps one pathological vector scan from pinning a connection |
 | `SLOW_QUERY_THRESHOLD_MS`         | `1000`  | Queries slower than this are logged for diagnosis |
-| `EXPECTED_APP_NODES`              | `2`     | How many app nodes the boot-time connection-budget check assumes when it multiplies the per-node pools out against Postgres `max_connections`. Advisory — it only logs, and never blocks boot — but it is the one place that notices a pool sizing that works on one node and exhausts the server on a scaled-out fleet, so **set it to the real machine count** when you scale past two. A non-integer value raises at boot |
+| `EXPECTED_APP_NODES`              | `2`     | How many app nodes the boot-time connection-budget check assumes when it multiplies the per-node pools out against Postgres `max_connections`. Advisory — it only logs, and never blocks boot — but it is the one place that notices a pool sizing that works on one node and exhausts the server on a scaled-out fleet, so **set it to the real machine count** when you scale past two. A non-integer value raises at boot; `0` or a negative parses cleanly and then DISABLES the check (it is logged as `DbCapacity boot check skipped`), so never template it from a scale-to-zero machine count |
 
 #### Rate limiting and auth-path throttle
 
@@ -78,10 +78,12 @@ fly secrets set CLOAK_KEY="GENERATED_BASE64_KEY"
 | `HAMMER_POOL_SIZE`                  | `20`    | Poolboy worker pool fronting every rate-limit check. Sized above Hammer's default of 4 so the fail-CLOSED auth throttle cannot saturate the pool under a single-IP flood |
 | `HAMMER_POOL_MAX_OVERFLOW`          | `10`    | Overflow workers for that pool |
 
-> All five accept only a **positive integer** (where numeric). An unset, blank, or
-> malformed value leaves the compiled default in place rather than crashing release
-> boot — a deliberate choice after the `STH_SWEEP_CRON` incident, so a bad
-> placeholder can never take the app down at startup.
+> The four numeric knobs in the table directly above (`AUTH_THROTTLE_MAX_REQUESTS_PER_IP`,
+> `AUTH_THROTTLE_WINDOW_MS`, `HAMMER_POOL_SIZE`, `HAMMER_POOL_MAX_OVERFLOW`) accept only a
+> **positive integer**. An unset, blank, or malformed value leaves the compiled default in
+> place rather than crashing release boot — a deliberate choice after the `STH_SWEEP_CRON`
+> incident, so a bad placeholder can never take *those* down at startup. The Oban knobs
+> below do NOT share that behaviour: each raises on a malformed value.
 
 #### Oban scheduling and fair-share yield
 
@@ -90,6 +92,8 @@ fly secrets set CLOAK_KEY="GENERATED_BASE64_KEY"
 | `STH_SWEEP_CRON`                       | `*/5 * * * *` | Cron for the all-tenants Signed-Tree-Head safety sweep. A load/latency knob only: every job it fans out self-gates on whether an STH is actually needed, so slowing it delays (never corrupts) an STH for a tenant the event path also missed, by at most one interval. Accepts anything Oban's own Cron parser accepts, `@`-nicknames included. Unlike the knobs above, a present-but-malformed value **raises at boot** rather than falling back — the fallback is what made the original incident silent |
 | `OBAN_TENANT_FAIRSHARE_SNOOZE_SECONDS` | `5`           | Base snooze, in seconds, for a job that yields its slot to a tenant with less work executing. Positive integer, else raises. Raise it to cut re-check churn on a busy queue; too high starves the yielding tenant, since a snoozed job re-competes only after it elapses |
 | `OBAN_TENANT_FAIRSHARE_SNOOZE_JITTER`  | `5`           | Span added on top as `base + rand(0..jitter)`, so a batch of jobs snoozed together does not re-check in lockstep. Non-negative integer — `0` disables jitter and is the thundering-herd shape; else raises |
+| `OBAN_QUEUE_<QUEUE>`                   | per queue     | Width (concurrency) of one Oban queue, one variable per queue — `OBAN_QUEUE_EMBEDDINGS=8` and restart, no deploy. Defaults: `DEFAULT` 9, `WEBHOOKS` 5, `EMBEDDINGS` 5, `ANALYTICS`/`KNOWLEDGE`/`MEMORY`/`AUDIT` 3, `CLEANUP`/`MAINTENANCE`/`INGESTION` 2, `VERIFICATION` 1. Positive integer, else raises at boot — a `0` would starve the queue silently |
+| `OBAN_TENANT_FAIRSHARE_<QUEUE>`        | `ceil(width/2)` | Per-tenant cap on a queue's EXECUTING slots before that tenant's next job snoozes, one variable per queue (same names as above), so one tenant cannot monopolise a contended queue. DERIVED from the current width, so retuning `OBAN_QUEUE_<QUEUE>` rescales it — set this only to loosen fairness mid-incident. Positive integer, else raises at boot; the effective value is never below 1, or the gate could wedge the queue |
 
 #### Ingestion backlog gate
 
@@ -155,7 +159,7 @@ during an incident with `fly secrets set … && fly apps restart` — no deploy.
 
 | Variable       | Default | Description |
 |----------------|---------|-------------|
-| `GITHUB_TOKEN` | -       | Bearer token for the CI status/test-result lookups that back independent story verification. Optional: unset, the calls go out unauthenticated, which works for PUBLIC repos until GitHub's 60-requests/hour/IP anonymous limit bites — after that verification reports a `github_api_error` rather than a real CI verdict. Required for a private repo, where unauthenticated lookups 404. Needs only read access to checks |
+| `GITHUB_TOKEN` | -       | Bearer token for the CI status/test-result lookups that back independent story verification. Optional: unset, the calls go out unauthenticated, which works for PUBLIC repos until GitHub's 60-requests/hour/IP anonymous limit bites — after that verification reports a `github_api_error` rather than a real CI verdict. Required for a private repo, where unauthenticated lookups 404. Needs only read access to checks. **Leave it UNSET rather than blank** — an empty string is truthy in Elixir, so a blanked value sends `Bearer ` with nothing after it and GitHub 401s every lookup, which is strictly worse than the anonymous path |
 
 #### Feature flags
 

--- a/deploy/FLY_SECRETS.md
+++ b/deploy/FLY_SECRETS.md
@@ -66,7 +66,7 @@ fly secrets set CLOAK_KEY="GENERATED_BASE64_KEY"
 | `HEAVY_READ_POOL_SIZE`            | `8`     | `HeavyReadRepo` pool size. This pool exists so a heavy analytical/vector read cannot starve the 3-connection AdminRepo pool |
 | `HEAVY_READ_STATEMENT_TIMEOUT_MS` | `10000` | Per-statement timeout on the heavy-read pool — the backstop that keeps one pathological vector scan from pinning a connection |
 | `SLOW_QUERY_THRESHOLD_MS`         | `1000`  | Queries slower than this are logged for diagnosis |
-| `EXPECTED_APP_NODES`              | `2`     | How many app nodes the boot-time connection-budget check assumes when it multiplies the per-node pools out against Postgres `max_connections`. Advisory — it only logs, and never blocks boot — but it is the one place that notices a pool sizing that works on one node and exhausts the server on a scaled-out fleet, so **set it to the real machine count** when you scale past two. Must be a POSITIVE integer: a non-integer raises at boot, and `0` or a negative degrades to a skipped check on the primary but crashes boot on the replica half (`warn_if_replica_over_budget/1` has no fallback) whenever a distinct `REPLICA_DATABASE_URL` is set — so never template it from a scale-to-zero machine count |
+| `EXPECTED_APP_NODES`              | `2`     | How many app nodes the boot-time connection-budget check assumes when it multiplies the per-node pools out against Postgres `max_connections`. Advisory — it only logs, and never blocks boot — but it is the one place that notices a pool sizing that works on one node and exhausts the server on a scaled-out fleet, so **set it to the real machine count** when you scale past two. Anything that is not a positive integer — including a `0` templated from a scale-to-zero machine count — is named in the boot log and falls back to the default, which costs you the accuracy of the check but never the boot |
 
 #### Rate limiting and auth-path throttle
 
@@ -159,7 +159,7 @@ during an incident with `fly secrets set … && fly apps restart` — no deploy.
 
 | Variable       | Default | Description |
 |----------------|---------|-------------|
-| `GITHUB_TOKEN` | -       | Bearer token for the CI status/test-result lookups that back independent story verification. Optional: unset, the calls go out unauthenticated, which works for PUBLIC repos until GitHub's 60-requests/hour/IP anonymous limit bites — after that verification reports a `github_api_error` rather than a real CI verdict. Required for a private repo, where unauthenticated lookups 404. Needs only read access to checks. **Leave it UNSET rather than blank** — an empty string is truthy in Elixir, so a blanked value sends `Bearer ` with nothing after it and GitHub 401s every lookup, which is strictly worse than the anonymous path |
+| `GITHUB_TOKEN` | -       | Bearer token for the CI status/test-result lookups that back independent story verification. Optional: unset, the calls go out unauthenticated, which works for PUBLIC repos until GitHub's 60-requests/hour/IP anonymous limit bites — after that verification reports a `github_api_error` rather than a real CI verdict. Required for a private repo, where unauthenticated lookups 404. Needs only read access to checks. A blank value is treated as unset (it is trimmed), so a templated-but-empty secret degrades to the anonymous path rather than sending an empty bearer that GitHub 401s |
 
 #### CLI client (`loopctl` command, not the server)
 

--- a/deploy/FLY_SECRETS.md
+++ b/deploy/FLY_SECRETS.md
@@ -54,6 +54,8 @@ fly secrets set CLOAK_KEY="GENERATED_BASE64_KEY"
 | `WEBAUTHN_RP_NAME`  | `loopctl`   | Display name the authenticator shows during enrollment. Cosmetic |
 | `SECRETS_ADAPTER`   | Fly GraphQL | Set to `local_file` to store the per-tenant audit keypairs on disk instead of in Fly secrets — REQUIRED when self-hosting off Fly (see below) |
 | `SECRETS_FILE`      | `/data/loopctl/secrets.json` | Path for the `local_file` adapter. Put it on a PERSISTENT volume |
+| `FLY_APP_NAME`      | injected by Fly | The app the DEFAULT (Fly GraphQL) secrets adapter writes tenant audit keys to. Fly Machines set this for you, so it only needs setting when running the Fly adapter off Fly — a case better served by `SECRETS_ADAPTER=local_file` |
+| `FLY_API_TOKEN`     | -       | API token the Fly secrets adapter authenticates with (`fly tokens create deploy`). **Not injected** — with it or `FLY_APP_NAME` missing the adapter refuses every write with `fly_not_configured`, and since tenant signup mints and stores a per-tenant Ed25519 audit keypair, no tenant can be created. Unset it and use `local_file` when self-hosting |
 | `FTS_REGCONFIG`     | `english` | Postgres text-search config for keyword FTS (see below) |
 
 #### Connection pools and query budgets
@@ -64,6 +66,7 @@ fly secrets set CLOAK_KEY="GENERATED_BASE64_KEY"
 | `HEAVY_READ_POOL_SIZE`            | `8`     | `HeavyReadRepo` pool size. This pool exists so a heavy analytical/vector read cannot starve the 3-connection AdminRepo pool |
 | `HEAVY_READ_STATEMENT_TIMEOUT_MS` | `10000` | Per-statement timeout on the heavy-read pool — the backstop that keeps one pathological vector scan from pinning a connection |
 | `SLOW_QUERY_THRESHOLD_MS`         | `1000`  | Queries slower than this are logged for diagnosis |
+| `EXPECTED_APP_NODES`              | `2`     | How many app nodes the boot-time connection-budget check assumes when it multiplies the per-node pools out against Postgres `max_connections`. Advisory — it only logs, and never blocks boot — but it is the one place that notices a pool sizing that works on one node and exhausts the server on a scaled-out fleet, so **set it to the real machine count** when you scale past two. A non-integer value raises at boot |
 
 #### Rate limiting and auth-path throttle
 
@@ -79,6 +82,14 @@ fly secrets set CLOAK_KEY="GENERATED_BASE64_KEY"
 > malformed value leaves the compiled default in place rather than crashing release
 > boot — a deliberate choice after the `STH_SWEEP_CRON` incident, so a bad
 > placeholder can never take the app down at startup.
+
+#### Oban scheduling and fair-share yield
+
+| Variable                               | Default       | Description |
+|----------------------------------------|---------------|-------------|
+| `STH_SWEEP_CRON`                       | `*/5 * * * *` | Cron for the all-tenants Signed-Tree-Head safety sweep. A load/latency knob only: every job it fans out self-gates on whether an STH is actually needed, so slowing it delays (never corrupts) an STH for a tenant the event path also missed, by at most one interval. Accepts anything Oban's own Cron parser accepts, `@`-nicknames included. Unlike the knobs above, a present-but-malformed value **raises at boot** rather than falling back — the fallback is what made the original incident silent |
+| `OBAN_TENANT_FAIRSHARE_SNOOZE_SECONDS` | `5`           | Base snooze, in seconds, for a job that yields its slot to a tenant with less work executing. Positive integer, else raises. Raise it to cut re-check churn on a busy queue; too high starves the yielding tenant, since a snoozed job re-competes only after it elapses |
+| `OBAN_TENANT_FAIRSHARE_SNOOZE_JITTER`  | `5`           | Span added on top as `base + rand(0..jitter)`, so a batch of jobs snoozed together does not re-check in lockstep. Non-negative integer — `0` disables jitter and is the thundering-herd shape; else raises |
 
 #### Ingestion backlog gate
 
@@ -139,6 +150,12 @@ during an incident with `fly secrets set … && fly apps restart` — no deploy.
 | `OPENAI_BASE_URL`         | `https://api.openai.com/v1` | Override to point embeddings at an OpenAI-compatible endpoint (e.g. a local Ollama / vLLM server) |
 | `OPENAI_EMBEDDING_MODEL`  | `text-embedding-3-small` | Embedding model name |
 | `LOCAL_ENDPOINT_ALLOWLIST` | -      | Comma-separated hosts/CIDRs that the egress guard may reach despite being private/loopback — e.g. `127.0.0.1,localhost,ollama.internal,10.1.0.0/16`. Required to use a LOCAL model endpoint, since the SSRF denylist otherwise refuses private addresses |
+
+#### Story verification (GitHub Actions)
+
+| Variable       | Default | Description |
+|----------------|---------|-------------|
+| `GITHUB_TOKEN` | -       | Bearer token for the CI status/test-result lookups that back independent story verification. Optional: unset, the calls go out unauthenticated, which works for PUBLIC repos until GitHub's 60-requests/hour/IP anonymous limit bites — after that verification reports a `github_api_error` rather than a real CI verdict. Required for a private repo, where unauthenticated lookups 404. Needs only read access to checks |
 
 #### Feature flags
 

--- a/lib/loopctl/config.ex
+++ b/lib/loopctl/config.ex
@@ -14,8 +14,10 @@ defmodule Loopctl.Config do
   Parses an opt-OUT boolean env VALUE: `true` unless the value is `false` or `0`
   (surrounding whitespace trimmed, case-insensitive). `nil` (unset) is `true`.
 
-  Takes the VALUE, not the variable NAME: `mix loopctl.check_env_docs` scans `runtime.exs`
-  textually for `System.get_env("NAME")`, so the read must stay there to stay guarded.
+  Takes the VALUE, not the variable name — the caller keeps the `System.get_env/1` read.
+  That used to be load-bearing (`mix loopctl.check_env_docs` scanned only `runtime.exs`,
+  so a read moved in here fell out of the guard); since #566 the guard scans `lib/` too,
+  and either placement stays guarded.
 
   Deliberately ASYMMETRIC with the `in ~w(true 1)` opt-IN vars in `runtime.exs`. It is
   for switches whose safe failure mode is ON (`SCALE_ALERTS_ENABLED`, #376): an unset,

--- a/lib/loopctl/db_capacity.ex
+++ b/lib/loopctl/db_capacity.ex
@@ -80,6 +80,10 @@ defmodule Loopctl.DbCapacity do
   @notifier_per_node 1
   @fixed_ops 2
 
+  # Fallback node count when EXPECTED_APP_NODES is unset or unusable — see
+  # `parse_expected_app_nodes/1` for why an unusable value must not raise.
+  @default_expected_app_nodes 2
+
   # Verified live against fly mpg on 2026-06-24: `SHOW max_connections` = 100.
   # Re-verify post-deploy per docs/runbooks/knowledge-scale.md.
   @verified_live_max_connections 100
@@ -412,16 +416,49 @@ defmodule Loopctl.DbCapacity do
   defp log_replica_budget({:over, message}, _live_max, _nodes), do: Logger.warning(message)
 
   @doc """
-  The expected app node count (env `EXPECTED_APP_NODES`, default 2) used as the
-  default `nodes` argument to `warn_if_over_budget/1`. Public so tests (and any
-  other caller wanting the SAME env-derived node count) don't have to
-  hand-duplicate the parsing/default.
+  The expected app node count (env `EXPECTED_APP_NODES`, default
+  #{@default_expected_app_nodes}) used as the default `nodes` argument to
+  `warn_if_over_budget/1`. Public so tests (and any other caller wanting the SAME
+  env-derived node count) don't have to hand-duplicate the parsing/default.
   """
   @spec expected_app_nodes() :: pos_integer()
-  def expected_app_nodes do
-    case System.get_env("EXPECTED_APP_NODES") do
-      nil -> 2
-      v -> String.to_integer(v)
+  def expected_app_nodes, do: parse_expected_app_nodes(System.get_env("EXPECTED_APP_NODES"))
+
+  @doc """
+  Parses an `EXPECTED_APP_NODES` VALUE to a positive node count, falling back to
+  #{@default_expected_app_nodes} with a warning for anything else.
+
+  Takes the VALUE, not the variable name (the `Loopctl.Config` precedent), so the parsing
+  rules are unit-testable — this module's callers run only at prod boot.
+
+  **A bad value must never crash boot**, which is what it used to do. Both callers take
+  this as a DEFAULT ARGUMENT, and a default argument is evaluated in the generated
+  zero-arity clause — outside the `rescue` in `warn_if_over_budget/1`'s body — so a
+  non-integer raised straight out of `Application.start/2`. `0` or a negative parsed
+  fine and then hit `replica_budget_status/2`'s `nodes > 0` guard with a
+  `FunctionClauseError`, in `warn_if_replica_over_budget/1`, which has no rescue at all.
+  Both are advisory log-only checks; neither is worth a boot failure, least of all one
+  reachable by templating this from a scale-to-zero machine count.
+  """
+  @spec parse_expected_app_nodes(String.t() | nil) :: pos_integer()
+  def parse_expected_app_nodes(value)
+
+  def parse_expected_app_nodes(nil), do: @default_expected_app_nodes
+
+  def parse_expected_app_nodes(value) when is_binary(value) do
+    case Integer.parse(String.trim(value)) do
+      {nodes, ""} when nodes > 0 ->
+        nodes
+
+      _ ->
+        Logger.warning(
+          "EXPECTED_APP_NODES=#{inspect(value)} is not a positive integer — using " <>
+            "#{@default_expected_app_nodes}. The connection-budget check is advisory, " <>
+            "so this degrades its accuracy rather than blocking boot; set it to the " <>
+            "real machine count."
+        )
+
+        @default_expected_app_nodes
     end
   end
 end

--- a/lib/loopctl/verification/github_actions.ex
+++ b/lib/loopctl/verification/github_actions.ex
@@ -42,14 +42,28 @@ defmodule Loopctl.Verification.GitHubActions do
   end
 
   defp github_headers do
-    token = System.get_env("GITHUB_TOKEN")
+    auth_headers(System.get_env("GITHUB_TOKEN")) ++
+      [{"accept", "application/vnd.github+json"}, {"user-agent", "loopctl-verification"}]
+  end
 
-    headers = [{"accept", "application/vnd.github+json"}, {"user-agent", "loopctl-verification"}]
+  @doc """
+  The `Authorization` header for `token`, or none when there is no usable token.
 
-    if token do
-      [{"authorization", "Bearer #{token}"} | headers]
-    else
-      headers
+  Takes the VALUE so the rule is unit-testable. A BLANK value is not a token, and used to
+  be treated as one: `if token do` is truthy for `""`, so a variable set-but-empty (the
+  shape a templated deploy config produces) sent `Authorization: Bearer ` and GitHub 401'd
+  every lookup. Verification then reported `github_api_error` instead of a CI verdict —
+  strictly WORSE than sending nothing, which at least works for a public repo.
+  """
+  @spec auth_headers(String.t() | nil) :: [{String.t(), String.t()}]
+  def auth_headers(token)
+
+  def auth_headers(nil), do: []
+
+  def auth_headers(token) when is_binary(token) do
+    case String.trim(token) do
+      "" -> []
+      trimmed -> [{"authorization", "Bearer #{trimmed}"}]
     end
   end
 

--- a/lib/mix/tasks/loopctl.check_env_docs.ex
+++ b/lib/mix/tasks/loopctl.check_env_docs.ex
@@ -31,15 +31,15 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocs do
   ### Limits of a textual scan
 
   The scan is textual, not an AST walk, so a name BUILT at runtime
-  (`"OBAN_QUEUE_" <> queue`) cannot be resolved. Such a name is still an operator knob —
-  `OBAN_QUEUE_<QUEUE>` and `OBAN_TENANT_FAIRSHARE_<QUEUE>` are retuned mid-incident — so a
-  dynamic read is not ignored: its file must be listed in `@dynamic_read_sources` with a
-  reason, and the family documented by hand.
+  (`"OBAN_QUEUE_" <> queue`), or read through a captured getter, cannot be resolved. Such a
+  name is still an operator knob, so a dynamic read is not ignored: its file must be listed
+  in `@dynamic_read_sources` NAMING the knobs it reads, and those names go through the same
+  doc check as a literal — a whitelist carrying only a prose promise is #566 again.
 
   A literal read inside a `@moduledoc` IS detected (a docstring is not a comment), so name
-  variables in prose or as `System.get_env/1` rather than writing a fake call with a
-  placeholder name. Comments — whole-line and trailing alike — are stripped first, so the
-  commented-out `phx.new` TLS boilerplate is not demanded.
+  variables in prose as `System.get_env/1`, not as a fake call; the DYNAMIC check skips
+  heredocs. Comments are stripped first — whole-line and trailing alike — but a `#` inside
+  a string literal is NOT one, or the rest of that line would go unscanned.
 
   ## Adding a variable
 
@@ -79,14 +79,18 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocs do
   # (Empty today — every scanned variable is documented.)
   @exempt %{}
 
-  # Files that read env by a name built at RUNTIME, which no textual scan can resolve. Not
-  # a free pass: a built name is still an operator knob, so each entry says where the
-  # FAMILY is documented. Any OTHER file's dynamic read FAILS the guard — #566, one down.
+  # Files that read env by a name built at RUNTIME (or through a captured getter), which no
+  # textual scan can resolve. `{names, reason}` — each entry NAMES the knobs it reads and
+  # those go through `documented?/2` like any literal, since a whitelist whose only content
+  # is a prose claim is the unenforced promise #566 was. Any OTHER file's read FAILS.
   @dynamic_read_sources %{
     "lib/loopctl/oban_config.ex" =>
-      "OBAN_QUEUE_<QUEUE> / OBAN_TENANT_FAIRSHARE_<QUEUE> — documented as families",
+      {["OBAN_QUEUE_<QUEUE>", "OBAN_TENANT_FAIRSHARE_<QUEUE>"], "per-queue families"},
+    "lib/loopctl/cli/config.ex" =>
+      {["LOOPCTL_SERVER", "LOOPCTL_API_KEY", "LOOPCTL_FORMAT"],
+       "names live in @env_overrides, read through an injected getter capture"},
     "lib/loopctl/secrets/fly_adapter.ex" =>
-      "per-tenant audit key names the app itself mints; never an operator knob"
+      {[], "per-tenant audit key names the app itself mints; never an operator knob"}
   }
 
   @impl Mix.Task
@@ -95,11 +99,19 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocs do
       Mix.raise("check_env_docs: #{@docs_file} not found. Run from the repo root.")
 
     vars =
-      Enum.reduce(@sources, MapSet.new(), fn {pattern, min}, acc ->
+      Enum.reduce(@sources, dynamic_families(), fn {pattern, min}, acc ->
         pattern |> scan_paths() |> check_not_vacuous(pattern, min) |> MapSet.union(acc)
       end)
 
     report(undocumented(vars, File.read!(@docs_file)), MapSet.size(vars))
+  end
+
+  @doc "Declared dynamic-read names, doc-checked like literals so deleting their row fails."
+  @spec dynamic_families() :: MapSet.t(binary())
+  def dynamic_families do
+    @dynamic_read_sources
+    |> Enum.flat_map(fn {_path, {names, _reason}} -> names end)
+    |> MapSet.new()
   end
 
   @doc """
@@ -164,28 +176,40 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocs do
   end
 
   @doc """
-  Whether `source` passes `System.get_env/1` a name the scan cannot resolve — a variable,
-  a concatenation, or a literal carrying interpolation.
+  Whether `source` reads env by a name the scan cannot resolve — a variable, a
+  concatenation, an interpolated literal, or a captured getter argued elsewhere. Heredocs
+  are stripped: prose DESCRIBING a call is not one. A literal of ANY case resolves, matching
+  `scan_env_vars/1` — the two must agree or the build names a cause that is untrue.
   """
   @spec dynamic_read?(binary()) :: boolean()
   def dynamic_read?(source) do
-    # Anything that is not a complete uppercase literal argument. The `\s*` is atomic so
-    # the engine cannot backtrack into a wrapped-but-literal call; `...` is prose.
+    # `\s*` is atomic so the engine cannot backtrack into a wrapped-but-literal call.
+    # A bare `)` is the zero-arity whole-environment read, which names no knob.
+    stripped = source |> strip_comments() |> String.replace(~r/"""[\s\S]*?"""/, "")
+
     String.match?(
-      strip_comments(source),
-      ~r/System\.(?:get_env|fetch_env!)\((?>\s*)(?!(?:"[A-Z][A-Z0-9_]*"\s*[,)]|\.\.\.))/
-    )
+      stripped,
+      ~r/System\.(?:get_env|fetch_env!)\((?>\s*)(?!(?:"[A-Za-z][A-Za-z0-9_]*"\s*[,)]|\)))/
+    ) or String.match?(stripped, ~r{&System\.(?:get_env|fetch_env!)/1})
   end
 
-  defp check_dynamic_reads(path, source) do
+  @doc """
+  Raises unless a file with a dynamic read is declared in `@dynamic_read_sources`. Public
+  so the RAISE is exercised: every real file with one is declared, so a guard driven through
+  `scan_paths/1` alone is never observed failing.
+  """
+  @spec check_dynamic_reads(binary(), binary()) :: :ok
+  def check_dynamic_reads(path, source) do
     if dynamic_read?(source) and not Map.has_key?(@dynamic_read_sources, path) do
       Mix.raise(
         "check_env_docs: #{path} reads an env var by a name built at runtime, which no " <>
           "textual scan can resolve — so the guard would pass over it in silence (#566). " <>
-          "Document the FAMILY in #{@docs_file} (members and defaults), then add " <>
-          "#{path} to @dynamic_read_sources with that reason."
+          "Document the name(s) in #{@docs_file} (defaults and effect), then add " <>
+          "#{path} to @dynamic_read_sources naming them."
       )
     end
+
+    :ok
   end
 
   defp check_not_vacuous(vars, pattern, min) do
@@ -202,19 +226,43 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocs do
     vars
   end
 
-  # Everything from a `#` to end of line, EXCEPT interpolation. A TRAILING comment matters
-  # as much as a whole-line one now that all of lib/ is scanned: an aside like
-  # `cap = default() # override with System.get_env("EXAMPLE")` would otherwise fail the
-  # build demanding a row for a variable nothing reads.
-  defp strip_comments(source), do: String.replace(source, ~r/\#(?!\{)[^\n]*/, "")
+  # Everything from a comment `#` to end of line, TRAILING as well as whole-line. A blanket
+  # `#`-to-EOL replace cuts a line short at a `#` inside a literal (`"https://x/#/app"`)
+  # and hides any read AFTER it — a silent miss, the shape this task exists to prevent. So
+  # a `#` is a comment only OUTSIDE a string and at a token boundary (sparing `~r/…#…/`).
+  defp strip_comments(source) do
+    source
+    |> String.split("\n")
+    |> Enum.map_join("\n", fn line ->
+      if String.contains?(line, "#"), do: strip_line(line, false, ""), else: line
+    end)
+  end
+
+  defp strip_line(<<>>, _in_string, acc), do: acc
+
+  defp strip_line(<<"\\", c::utf8, rest::binary>>, true, acc),
+    do: strip_line(rest, true, <<acc::binary, "\\", c::utf8>>)
+
+  defp strip_line(<<"\"", rest::binary>>, in_str, acc),
+    do: strip_line(rest, not in_str, <<acc::binary, "\"">>)
+
+  defp strip_line(<<"#", rest::binary>>, false, acc) do
+    if acc == "" or String.last(acc) in [" ", "\t"],
+      do: acc,
+      else: strip_line(rest, false, <<acc::binary, "#">>)
+  end
+
+  defp strip_line(<<c::utf8, rest::binary>>, in_string, acc),
+    do: strip_line(rest, in_string, <<acc::binary, c::utf8>>)
 
   # The name must head a markdown table row whose next two cells are non-blank: the row
   # anchor keeps a passing mention from standing in for a default and a description (the
   # `STH_SWEEP_CRON` note in the moduledoc), and the cells having to carry something keeps
   # a bare `| `VAR` |  |  |` from being the cheapest way past a failing guard. Whole-word
-  # anchoring also keeps `POOL_SIZE` off an unrelated `ADMIN_POOL_SIZE` row.
+  # anchoring also keeps `POOL_SIZE` off an unrelated `ADMIN_POOL_SIZE` row. Cells exclude
+  # `\n`: `[^|]` crosses rows, letting a row with no description borrow the next row's.
   defp documented?(docs, var) do
-    String.match?(docs, ~r/^\|\s*`#{Regex.escape(var)}`\s*\|\s*[^|\s][^|]*\|\s*[^|\s]/m)
+    String.match?(docs, ~r/^\|\s*`#{Regex.escape(var)}`\s*\|\s*[^|\s][^|\n]*\|\s*[^|\s]/m)
   end
 
   defp report([], scanned) do

--- a/lib/mix/tasks/loopctl.check_env_docs.ex
+++ b/lib/mix/tasks/loopctl.check_env_docs.ex
@@ -3,14 +3,12 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocs do
   Guards operator-facing environment variables against being shipped undocumented.
 
   An env var that exists only in our source is effectively invisible: the audience who
-  needs it (someone deploying loopctl) is exactly the audience who cannot read our
-  source tree. This failure is silent — nothing in review flags a `System.get_env/1`
-  with no matching doc line — and it accumulated to 24 undocumented variables before
-  anyone noticed, including the two self-hosting knobs (`SECRETS_ADAPTER`,
-  `FTS_REGCONFIG`) that a self-hoster could not run the app without.
-
-  Same guardrail idea as `mix loopctl.check_skill_citations` and
-  `mix loopctl.check_wiki_links`, applied to operator configuration.
+  needs it (someone deploying loopctl) is exactly the audience who cannot read our source
+  tree. This failure is silent — nothing in review flags a `System.get_env/1` with no
+  matching doc line — and it accumulated to 24 undocumented variables before anyone
+  noticed, including the two self-hosting knobs (`SECRETS_ADAPTER`, `FTS_REGCONFIG`) that
+  a self-hoster could not run the app without. Same guardrail idea as
+  `mix loopctl.check_skill_citations`, applied to operator configuration.
 
   ## What is checked
 
@@ -18,40 +16,37 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocs do
   every file matched by `sources/0` — `config/runtime.exs` **and** `lib/**/*.ex` — must
   have a table row in `deploy/FLY_SECRETS.md`.
 
-  `lib/` is scanned because reading the config file alone left a blind spot the size of
-  the whole `OBAN_*` family (#566): `runtime.exs` does evaluate those at boot, but it
-  does so by calling `Loopctl.ObanConfig`, so the literal name never appears in the
-  scanned file. The guard reported "42 runtime env var(s) documented" and exited 0
-  while eight variables it had never looked at were undocumented.
+  `lib/` is scanned because reading the config file alone left the `OBAN_*` family
+  outside the guard (#566): `runtime.exs` does evaluate those at boot, but it does so by
+  calling `Loopctl.ObanConfig`, so the literal name never appears in the scanned file.
 
   ### Why a table ROW, and not a mention
 
-  `STH_SWEEP_CRON` passed a whole-word text match for months on the strength of one
-  prose aside — "a deliberate choice after the `STH_SWEEP_CRON` incident" — which tells
-  an operator neither its default nor what it does. Naming a variable while explaining
+  `STH_SWEEP_CRON` passed a whole-word text match for months on the strength of one prose
+  aside — "a deliberate choice after the `STH_SWEEP_CRON` incident" — which tells an
+  operator neither its default nor what it does. Naming a variable while explaining
   something else is not documenting it, so the match is anchored to the name heading a
-  markdown table row, where a default and a description are structurally adjacent.
+  markdown table row that also carries a NON-BLANK default and description cell.
 
   ### Limits of a textual scan
 
-  The scan is textual, not an AST walk. Two consequences, both accepted:
+  The scan is textual, not an AST walk, so a name BUILT at runtime
+  (`"OBAN_QUEUE_" <> queue`) cannot be resolved. Such a name is still an operator knob —
+  `OBAN_QUEUE_<QUEUE>` and `OBAN_TENANT_FAIRSHARE_<QUEUE>` are retuned mid-incident — so a
+  dynamic read is not ignored: its file must be listed in `@dynamic_read_sources` with a
+  reason, and the family documented by hand.
 
-    * a name built by interpolation is not detected — fine, because operator knobs are
-      read by literal name;
-    * a literal read written inside a `@moduledoc` is detected, because a docstring is
-      not a comment line. Name variables in prose (or as `System.get_env/1`) rather
-      than writing a fake call with a placeholder name, or the guard will demand that
-      the placeholder be documented.
-
-  Lines that are entirely a `#` comment are skipped, so the commented-out `phx.new` TLS
-  boilerplate (`SOME_APP_SSL_KEY_PATH`) is not demanded to be documented.
+  A literal read inside a `@moduledoc` IS detected (a docstring is not a comment), so name
+  variables in prose or as `System.get_env/1` rather than writing a fake call with a
+  placeholder name. Comments — whole-line and trailing alike — are stripped first, so the
+  commented-out `phx.new` TLS boilerplate is not demanded.
 
   ## Adding a variable
 
-  Give it a row in the appropriate table in `deploy/FLY_SECRETS.md` with its DEFAULT
-  and what breaks if it is wrong. If a variable is genuinely internal (never set by an
-  operator), add it to `@exempt` WITH a reason — an exemption without a rationale is
-  how the undocumented set grew in the first place.
+  Give it a row in the appropriate table in `deploy/FLY_SECRETS.md` with its DEFAULT and
+  what breaks if it is wrong. If a variable is genuinely internal (never set by an
+  operator), add it to `@exempt` WITH a reason — an exemption without a rationale is how
+  the undocumented set grew in the first place.
 
   ## Usage
 
@@ -69,11 +64,12 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocs do
   # {wildcard, minimum vars expected from THAT wildcard}.
   #
   # The floor is per-source on purpose. One floor over the union cannot detect a broken
-  # `lib/**/*.ex` glob at all: runtime.exs alone contributes ~42 vars, so the union
-  # clears any sane threshold while the second source silently contributes nothing —
-  # which is precisely the vacuous-guard shape this task exists to prevent, reintroduced
-  # one level up. Each floor sits below its current count with room to delete a knob or
-  # two, and far above zero.
+  # `lib/**/*.ex` glob at all: runtime.exs alone clears any sane threshold while the second
+  # source silently contributes nothing — the vacuous-guard shape this task exists to
+  # prevent, one level up. Each floor sits below its current count and far above zero.
+  # Lowering one is legitimate in exactly one case: a change that deliberately MOVES reads
+  # to another scanned source (`Loopctl.Config` blesses either placement now that both are
+  # scanned) — then both floors move in that same commit. An unexplained drop is a break.
   @sources [
     {"config/runtime.exs", 20},
     {"lib/**/*.ex", 6}
@@ -82,6 +78,16 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocs do
   # Variables deliberately NOT in the operator docs. Each needs a reason.
   # (Empty today — every scanned variable is documented.)
   @exempt %{}
+
+  # Files that read env by a name built at RUNTIME, which no textual scan can resolve. Not
+  # a free pass: a built name is still an operator knob, so each entry says where the
+  # FAMILY is documented. Any OTHER file's dynamic read FAILS the guard — #566, one down.
+  @dynamic_read_sources %{
+    "lib/loopctl/oban_config.ex" =>
+      "OBAN_QUEUE_<QUEUE> / OBAN_TENANT_FAIRSHARE_<QUEUE> — documented as families",
+    "lib/loopctl/secrets/fly_adapter.ex" =>
+      "per-tenant audit key names the app itself mints; never an operator knob"
+  }
 
   @impl Mix.Task
   def run(_args) do
@@ -120,7 +126,11 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocs do
 
       files ->
         files
-        |> Enum.map(&(&1 |> File.read!() |> scan_env_vars()))
+        |> Enum.map(fn path ->
+          source = File.read!(path)
+          check_dynamic_reads(path, source)
+          scan_env_vars(source)
+        end)
         |> Enum.reduce(MapSet.new(), &MapSet.union/2)
     end
   end
@@ -139,42 +149,72 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocs do
   end
 
   @doc """
-  The env var names read (outside full-line comments) in the given source text.
+  The env var names read (outside comments) in the given source text.
+
+  Matched over the WHOLE source, not line by line: `mix format` wraps a long argument onto
+  its own line, and a per-line match then sees no read at all — reporting a variable that
+  is read at runtime, and absent from the docs, as fine.
   """
   @spec scan_env_vars(binary()) :: MapSet.t(binary())
   def scan_env_vars(source) do
-    source
-    |> String.split("\n")
-    |> Enum.reject(&comment_line?/1)
-    |> Enum.flat_map(fn line ->
-      ~r/System\.(?:get_env|fetch_env!)\(\s*"([A-Z][A-Z0-9_]*)"/
-      |> Regex.scan(line, capture: :all_but_first)
-      |> List.flatten()
-    end)
+    ~r/System\.(?:get_env|fetch_env!)\(\s*"([A-Z][A-Z0-9_]*)"/
+    |> Regex.scan(strip_comments(source), capture: :all_but_first)
+    |> List.flatten()
     |> MapSet.new()
+  end
+
+  @doc """
+  Whether `source` passes `System.get_env/1` a name the scan cannot resolve — a variable,
+  a concatenation, or a literal carrying interpolation.
+  """
+  @spec dynamic_read?(binary()) :: boolean()
+  def dynamic_read?(source) do
+    # Anything that is not a complete uppercase literal argument. The `\s*` is atomic so
+    # the engine cannot backtrack into a wrapped-but-literal call; `...` is prose.
+    String.match?(
+      strip_comments(source),
+      ~r/System\.(?:get_env|fetch_env!)\((?>\s*)(?!(?:"[A-Z][A-Z0-9_]*"\s*[,)]|\.\.\.))/
+    )
+  end
+
+  defp check_dynamic_reads(path, source) do
+    if dynamic_read?(source) and not Map.has_key?(@dynamic_read_sources, path) do
+      Mix.raise(
+        "check_env_docs: #{path} reads an env var by a name built at runtime, which no " <>
+          "textual scan can resolve — so the guard would pass over it in silence (#566). " <>
+          "Document the FAMILY in #{@docs_file} (members and defaults), then add " <>
+          "#{path} to @dynamic_read_sources with that reason."
+      )
+    end
   end
 
   defp check_not_vacuous(vars, pattern, min) do
     if MapSet.size(vars) < min do
       Mix.raise(
         "check_env_docs scanned #{pattern} and found only #{MapSet.size(vars)} env " <>
-          "var(s), expected at least #{min}. That source's scan is broken — fix it " <>
-          "rather than lowering the floor, or this guard passes vacuously for #{pattern}."
+          "var(s), expected at least #{min}. Unless this change deliberately MOVED " <>
+          "reads to another scanned source (lower both floors together, in this same " <>
+          "commit), that source's scan is broken — fix it rather than lowering the " <>
+          "floor, or this guard passes vacuously for #{pattern}."
       )
     end
 
     vars
   end
 
-  defp comment_line?(line), do: String.match?(line, ~r/^\s*#/)
+  # Everything from a `#` to end of line, EXCEPT interpolation. A TRAILING comment matters
+  # as much as a whole-line one now that all of lib/ is scanned: an aside like
+  # `cap = default() # override with System.get_env("EXAMPLE")` would otherwise fail the
+  # build demanding a row for a variable nothing reads.
+  defp strip_comments(source), do: String.replace(source, ~r/\#(?!\{)[^\n]*/, "")
 
-  # The name must head a markdown table row. Anchoring to the row (rather than to any
-  # whole-word mention) is what keeps a passing mention from standing in for a default
-  # and a description — see the `STH_SWEEP_CRON` note in the moduledoc. Anchoring to a
-  # whole word within the row also keeps `POOL_SIZE` from being satisfied by an
-  # unrelated `ADMIN_POOL_SIZE` row.
+  # The name must head a markdown table row whose next two cells are non-blank: the row
+  # anchor keeps a passing mention from standing in for a default and a description (the
+  # `STH_SWEEP_CRON` note in the moduledoc), and the cells having to carry something keeps
+  # a bare `| `VAR` |  |  |` from being the cheapest way past a failing guard. Whole-word
+  # anchoring also keeps `POOL_SIZE` off an unrelated `ADMIN_POOL_SIZE` row.
   defp documented?(docs, var) do
-    String.match?(docs, ~r/^\|\s*`#{Regex.escape(var)}`/m)
+    String.match?(docs, ~r/^\|\s*`#{Regex.escape(var)}`\s*\|\s*[^|\s][^|]*\|\s*[^|\s]/m)
   end
 
   defp report([], scanned) do

--- a/lib/mix/tasks/loopctl.check_env_docs.ex
+++ b/lib/mix/tasks/loopctl.check_env_docs.ex
@@ -2,33 +2,56 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocs do
   @moduledoc """
   Guards operator-facing environment variables against being shipped undocumented.
 
-  `config/runtime.exs` is where every operator-tunable knob is read, and an env var
-  that exists only there is effectively invisible: the audience who needs it (someone
-  deploying loopctl) is exactly the audience who cannot read our source tree. This
-  failure is silent — nothing in review flags a `System.get_env/1` with no matching
-  doc line — and it accumulated to 24 undocumented variables before anyone noticed,
-  including the two self-hosting knobs (`SECRETS_ADAPTER`, `FTS_REGCONFIG`) that a
-  self-hoster could not run the app without.
+  An env var that exists only in our source is effectively invisible: the audience who
+  needs it (someone deploying loopctl) is exactly the audience who cannot read our
+  source tree. This failure is silent — nothing in review flags a `System.get_env/1`
+  with no matching doc line — and it accumulated to 24 undocumented variables before
+  anyone noticed, including the two self-hosting knobs (`SECRETS_ADAPTER`,
+  `FTS_REGCONFIG`) that a self-hoster could not run the app without.
 
   Same guardrail idea as `mix loopctl.check_skill_citations` and
   `mix loopctl.check_wiki_links`, applied to operator configuration.
 
   ## What is checked
 
-  Every `System.get_env("X")` / `System.fetch_env!("X")` read in `config/runtime.exs`
-  must have its name documented in `deploy/FLY_SECRETS.md`.
+  Every `System.get_env/1` / `System.fetch_env!/1` read of a LITERAL uppercase name, in
+  every file matched by `sources/0` — `config/runtime.exs` **and** `lib/**/*.ex` — must
+  have a table row in `deploy/FLY_SECRETS.md`.
 
-  Lines that are entirely a `#` comment are skipped, so the commented-out `phx.new`
-  TLS boilerplate (`SOME_APP_SSL_KEY_PATH`) is not demanded to be documented. The
-  scan is textual, not an AST walk: a var name built by string interpolation is not
-  detected. That is an accepted limit — operator knobs are read by literal name.
+  `lib/` is scanned because reading the config file alone left a blind spot the size of
+  the whole `OBAN_*` family (#566): `runtime.exs` does evaluate those at boot, but it
+  does so by calling `Loopctl.ObanConfig`, so the literal name never appears in the
+  scanned file. The guard reported "42 runtime env var(s) documented" and exited 0
+  while eight variables it had never looked at were undocumented.
+
+  ### Why a table ROW, and not a mention
+
+  `STH_SWEEP_CRON` passed a whole-word text match for months on the strength of one
+  prose aside — "a deliberate choice after the `STH_SWEEP_CRON` incident" — which tells
+  an operator neither its default nor what it does. Naming a variable while explaining
+  something else is not documenting it, so the match is anchored to the name heading a
+  markdown table row, where a default and a description are structurally adjacent.
+
+  ### Limits of a textual scan
+
+  The scan is textual, not an AST walk. Two consequences, both accepted:
+
+    * a name built by interpolation is not detected — fine, because operator knobs are
+      read by literal name;
+    * a literal read written inside a `@moduledoc` is detected, because a docstring is
+      not a comment line. Name variables in prose (or as `System.get_env/1`) rather
+      than writing a fake call with a placeholder name, or the guard will demand that
+      the placeholder be documented.
+
+  Lines that are entirely a `#` comment are skipped, so the commented-out `phx.new` TLS
+  boilerplate (`SOME_APP_SSL_KEY_PATH`) is not demanded to be documented.
 
   ## Adding a variable
 
-  Document it in the appropriate table in `deploy/FLY_SECRETS.md` with its DEFAULT
-  and what breaks if it is wrong. If a variable is genuinely internal (never set by
-  an operator), add it to `@exempt` WITH a reason — an exemption without a rationale
-  is how the undocumented set grew in the first place.
+  Give it a row in the appropriate table in `deploy/FLY_SECRETS.md` with its DEFAULT
+  and what breaks if it is wrong. If a variable is genuinely internal (never set by an
+  operator), add it to `@exempt` WITH a reason — an exemption without a rationale is
+  how the undocumented set grew in the first place.
 
   ## Usage
 
@@ -39,45 +62,74 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocs do
 
   use Mix.Task
 
-  @shortdoc "Check that runtime.exs env vars are documented for operators"
+  @shortdoc "Check that operator env vars are documented in deploy/FLY_SECRETS.md"
 
-  @config_file "config/runtime.exs"
   @docs_file "deploy/FLY_SECRETS.md"
 
-  # Variables deliberately NOT in the operator docs. Each needs a reason.
-  # (Empty today — every runtime.exs variable is documented.)
-  @exempt %{}
+  # {wildcard, minimum vars expected from THAT wildcard}.
+  #
+  # The floor is per-source on purpose. One floor over the union cannot detect a broken
+  # `lib/**/*.ex` glob at all: runtime.exs alone contributes ~42 vars, so the union
+  # clears any sane threshold while the second source silently contributes nothing —
+  # which is precisely the vacuous-guard shape this task exists to prevent, reintroduced
+  # one level up. Each floor sits below its current count with room to delete a knob or
+  # two, and far above zero.
+  @sources [
+    {"config/runtime.exs", 20},
+    {"lib/**/*.ex", 6}
+  ]
 
-  # Vacuity guard: runtime.exs reads dozens of variables, so a scan returning
-  # almost nothing means the regex or the file moved — a guard that silently
-  # checks nothing is worse than no guard (the check_skill_citations lesson).
-  @min_expected_vars 20
+  # Variables deliberately NOT in the operator docs. Each needs a reason.
+  # (Empty today — every scanned variable is documented.)
+  @exempt %{}
 
   @impl Mix.Task
   def run(_args) do
-    for file <- [@config_file, @docs_file] do
-      File.exists?(file) ||
-        Mix.raise("check_env_docs: #{file} not found. Run from the repo root.")
-    end
+    File.exists?(@docs_file) ||
+      Mix.raise("check_env_docs: #{@docs_file} not found. Run from the repo root.")
 
-    vars = scan_env_vars(File.read!(@config_file))
-
-    if MapSet.size(vars) < @min_expected_vars do
-      Mix.raise(
-        "check_env_docs scanned #{@config_file} and found only #{MapSet.size(vars)} " <>
-          "env var(s), expected at least #{@min_expected_vars}. The scan is broken — " <>
-          "fix it rather than lowering the floor, or this guard passes vacuously."
-      )
-    end
+    vars =
+      Enum.reduce(@sources, MapSet.new(), fn {pattern, min}, acc ->
+        pattern |> scan_paths() |> check_not_vacuous(pattern, min) |> MapSet.union(acc)
+      end)
 
     report(undocumented(vars, File.read!(@docs_file)), MapSet.size(vars))
   end
 
   @doc """
-  The scanned variables that are neither exempt nor named in `docs`, sorted.
+  The scanned sources as `{wildcard, minimum expected vars}` pairs.
 
-  Public so the guard's FAILING behaviour is testable — a doc guard that has only
-  ever been observed passing is indistinguishable from one that can never fail.
+  Public so a test can assert over the SAME list the task scans — a test that re-lists
+  the sources itself passes happily when a source is dropped from the task.
+  """
+  @spec sources() :: [{binary(), non_neg_integer()}]
+  def sources, do: @sources
+
+  @doc """
+  The env var names read across every file matching `pattern`.
+
+  Raises when the wildcard matches no file at all: an empty match would otherwise be
+  reported as "this source contributes no variables", which is indistinguishable from
+  a source that genuinely has none.
+  """
+  @spec scan_paths(binary()) :: MapSet.t(binary())
+  def scan_paths(pattern) do
+    case Path.wildcard(pattern) do
+      [] ->
+        Mix.raise("check_env_docs: #{pattern} matched no files. Run from the repo root.")
+
+      files ->
+        files
+        |> Enum.map(&(&1 |> File.read!() |> scan_env_vars()))
+        |> Enum.reduce(MapSet.new(), &MapSet.union/2)
+    end
+  end
+
+  @doc """
+  The scanned variables that are neither exempt nor documented in `docs`, sorted.
+
+  Public so the guard's FAILING behaviour is testable — a doc guard that has only ever
+  been observed passing is indistinguishable from one that can never fail.
   """
   @spec undocumented(MapSet.t(binary()) | [binary()], binary()) :: [binary()]
   def undocumented(vars, docs) do
@@ -102,32 +154,48 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocs do
     |> MapSet.new()
   end
 
+  defp check_not_vacuous(vars, pattern, min) do
+    if MapSet.size(vars) < min do
+      Mix.raise(
+        "check_env_docs scanned #{pattern} and found only #{MapSet.size(vars)} env " <>
+          "var(s), expected at least #{min}. That source's scan is broken — fix it " <>
+          "rather than lowering the floor, or this guard passes vacuously for #{pattern}."
+      )
+    end
+
+    vars
+  end
+
   defp comment_line?(line), do: String.match?(line, ~r/^\s*#/)
 
-  # The name must appear as a whole word, so `POOL_SIZE` is not satisfied by an
-  # unrelated `ADMIN_POOL_SIZE` row (substring matching is how a doc guard goes
-  # quietly vacuous).
+  # The name must head a markdown table row. Anchoring to the row (rather than to any
+  # whole-word mention) is what keeps a passing mention from standing in for a default
+  # and a description — see the `STH_SWEEP_CRON` note in the moduledoc. Anchoring to a
+  # whole word within the row also keeps `POOL_SIZE` from being satisfied by an
+  # unrelated `ADMIN_POOL_SIZE` row.
   defp documented?(docs, var) do
-    String.match?(docs, ~r/(?<![A-Z0-9_])#{Regex.escape(var)}(?![A-Z0-9_])/)
+    String.match?(docs, ~r/^\|\s*`#{Regex.escape(var)}`/m)
   end
 
   defp report([], scanned) do
-    Mix.shell().info("#{scanned} runtime env var(s) documented in #{@docs_file}")
+    Mix.shell().info("#{scanned} operator env var(s) documented in #{@docs_file}")
   end
 
   defp report(undocumented, _scanned) do
     list = Enum.map_join(undocumented, "\n", &"  - #{&1}")
+    scanned = Enum.map_join(@sources, ", ", fn {pattern, _min} -> pattern end)
 
     Mix.raise("""
     Undocumented operator environment variable(s):
 
     #{list}
 
-    Each is read in #{@config_file} but appears nowhere in #{@docs_file}, so an
-    operator cannot discover it without reading our source.
+    Each is read in #{scanned} but has no table row in #{@docs_file}, so an operator
+    cannot discover it without reading our source.
 
-    Document each in the appropriate table in #{@docs_file} — its DEFAULT and what
-    breaks if it is wrong. If one is genuinely internal, add it to @exempt in
+    Give each a row in the appropriate table in #{@docs_file} — its DEFAULT and what
+    breaks if it is wrong. A passing mention in prose does not count. If one is
+    genuinely internal, add it to @exempt in
     #{__MODULE__ |> Module.split() |> Enum.join(".")} with a reason.
     """)
   end

--- a/test/loopctl/config_test.exs
+++ b/test/loopctl/config_test.exs
@@ -25,8 +25,11 @@ defmodule Loopctl.ConfigTest do
       end
     end
 
-    # The read stays a literal System.get_env("NAME") in runtime.exs so
-    # mix loopctl.check_env_docs (a textual scan of that file) keeps seeing the var.
+    # The read stays a LITERAL name (not one built by interpolation) so the textual
+    # scan behind mix loopctl.check_env_docs keeps seeing the var. Since #566 that
+    # guard scans lib/ as well, so this no longer pins the read to runtime.exs — but
+    # the read IS there, and a scan that stopped finding it would mean the literal
+    # shape had been refactored away, which is the half still worth pinning.
     test "SCALE_ALERTS_ENABLED is read literally in runtime.exs, under the env-docs guard" do
       assert "config/runtime.exs"
              |> File.read!()

--- a/test/loopctl/db_capacity_test.exs
+++ b/test/loopctl/db_capacity_test.exs
@@ -210,4 +210,40 @@ defmodule Loopctl.DbCapacityTest do
       assert :ok = DbCapacity.budget_status(100, nodes, primary_only)
     end
   end
+
+  describe "parse_expected_app_nodes/1" do
+    import ExUnit.CaptureLog
+
+    test "a usable positive integer is taken verbatim" do
+      assert DbCapacity.parse_expected_app_nodes("6") == 6
+      assert DbCapacity.parse_expected_app_nodes(" 6\n") == 6
+    end
+
+    test "unset falls back to the compiled default" do
+      assert DbCapacity.parse_expected_app_nodes(nil) == 2
+    end
+
+    test "an unusable value degrades to the default rather than crashing BOOT" do
+      # Both callers take this as a DEFAULT ARGUMENT, which is evaluated in the generated
+      # zero-arity clause — outside warn_if_over_budget/1's `rescue`. So a raise here came
+      # straight out of Application.start/2. `0` and negatives got past the old
+      # String.to_integer/1 entirely and then hit replica_budget_status/2's `nodes > 0`
+      # guard inside warn_if_replica_over_budget/1, which has no rescue at all. An
+      # advisory, log-only capacity check must not be able to take the node down.
+      for bad <- ["0", "-1", "abc", "", "2.5", "6 nodes"] do
+        assert capture_log(fn ->
+                 assert DbCapacity.parse_expected_app_nodes(bad) == 2
+               end) =~ "EXPECTED_APP_NODES"
+      end
+    end
+
+    test "the degraded value is one every downstream guard accepts" do
+      # The point of the clamp is not "some number" — it is a number that clears the
+      # `nodes > 0` guards, which is what the crash was.
+      nodes = DbCapacity.parse_expected_app_nodes("0")
+
+      assert :ok = DbCapacity.replica_budget_status(100, nodes)
+      assert DbCapacity.peak_total(nodes) > 0
+    end
+  end
 end

--- a/test/loopctl/verification/github_actions_test.exs
+++ b/test/loopctl/verification/github_actions_test.exs
@@ -1,0 +1,27 @@
+defmodule Loopctl.Verification.GitHubActionsTest do
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Verification.GitHubActions
+
+  describe "auth_headers/1" do
+    test "a usable token becomes a bearer header" do
+      assert GitHubActions.auth_headers("ghp_abc") == [{"authorization", "Bearer ghp_abc"}]
+      assert GitHubActions.auth_headers(" ghp_abc\n") == [{"authorization", "Bearer ghp_abc"}]
+    end
+
+    test "no token sends no authorization header" do
+      assert GitHubActions.auth_headers(nil) == []
+    end
+
+    test "a BLANK token sends none either — an empty bearer is worse than none" do
+      # `if token do` is truthy for "", which is the shape a templated deploy config
+      # produces for an unset secret. That sent `Authorization: Bearer ` and GitHub 401'd
+      # every check-run lookup, so verification reported github_api_error instead of a CI
+      # verdict — strictly worse than the anonymous path, which works for a public repo.
+      for blank <- ["", "   ", "\n", "\t "] do
+        assert GitHubActions.auth_headers(blank) == [],
+               "a blank token must not become a bearer header"
+      end
+    end
+  end
+end

--- a/test/mix/tasks/loopctl_check_env_docs_test.exs
+++ b/test/mix/tasks/loopctl_check_env_docs_test.exs
@@ -69,6 +69,26 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocsTest do
       assert CheckEnvDocs.undocumented(["ADMIN_POOL_SIZE"], docs) == []
     end
 
+    test "#566: a passing MENTION in prose does not count as documented" do
+      # How the guard went quietly vacuous for `STH_SWEEP_CRON`: it was named once, in an
+      # aside explaining a DIFFERENT decision ("after the STH_SWEEP_CRON incident"), and a
+      # whole-word text match read that as documentation. An operator learns neither the
+      # default nor what the knob does from a sentence about something else, so the match
+      # is anchored to a table row — where a default and a description sit structurally
+      # adjacent and cannot be omitted by accident.
+      docs = """
+      > A deliberate choice after the `STH_SWEEP_CRON` incident, so a bad placeholder
+      > can never take the app down at startup.
+      """
+
+      assert CheckEnvDocs.undocumented(["STH_SWEEP_CRON"], docs) == ["STH_SWEEP_CRON"]
+
+      assert CheckEnvDocs.undocumented(
+               ["STH_SWEEP_CRON"],
+               docs <> "\n| `STH_SWEEP_CRON` | `*/5 * * * *` | STH safety sweep cron |"
+             ) == []
+    end
+
     test "returns every missing variable, sorted" do
       vars = ["ZED_VAR", "ALPHA_VAR", "MID_VAR"]
       assert CheckEnvDocs.undocumented(vars, "nothing here") == ~w(ALPHA_VAR MID_VAR ZED_VAR)
@@ -81,16 +101,53 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocsTest do
   end
 
   describe "the live repo" do
-    test "every runtime.exs env var is documented, and the scan is not vacuous" do
-      vars = CheckEnvDocs.scan_env_vars(File.read!("config/runtime.exs"))
+    setup do
+      %{
+        vars:
+          Enum.reduce(CheckEnvDocs.sources(), MapSet.new(), fn {pattern, min}, acc ->
+            found = CheckEnvDocs.scan_paths(pattern)
 
-      # Non-vacuity: assert the scan actually matched a substantial set. Without
-      # this, a broken regex would make the assertion below trivially true.
-      assert MapSet.size(vars) >= 20,
-             "scan found only #{MapSet.size(vars)} vars in runtime.exs — the scan is broken"
+            # Per-source non-vacuity, asserted per source for the same reason the task
+            # enforces it per source: over the UNION, runtime.exs's ~42 vars would clear
+            # any sane floor on their own, so a `lib/**/*.ex` glob that silently matched
+            # nothing would still look healthy.
+            assert MapSet.size(found) >= min,
+                   "scan of #{pattern} found only #{MapSet.size(found)} vars — it is broken"
 
+            MapSet.union(acc, found)
+          end)
+      }
+    end
+
+    test "every scanned env var is documented", %{vars: vars} do
       assert CheckEnvDocs.undocumented(vars, File.read!("deploy/FLY_SECRETS.md")) == [],
              "undocumented operator env vars — run: mix loopctl.check_env_docs"
+    end
+
+    test "#566: the scan covers lib/ as well as config/runtime.exs", %{vars: vars} do
+      # Iterating `sources/0` above means the assertion above cannot notice a source being
+      # DROPPED from that list — it would simply iterate one fewer and pass. These anchors
+      # are named because each can only come from one source, which is what makes removing
+      # either source a test failure rather than a quieter guard.
+      #
+      # `OBAN_*` is the family that motivated #566: runtime.exs does evaluate it at boot,
+      # but via `Loopctl.ObanConfig`, so the literal name never appears in the config file
+      # and eight variables sat outside a green guard.
+      assert "OBAN_TENANT_FAIRSHARE_SNOOZE_SECONDS" in vars,
+             "lib/ is no longer scanned — the #566 blind spot is back"
+
+      assert "DATABASE_URL" in vars, "config/runtime.exs is no longer scanned"
+    end
+  end
+
+  describe "scan_paths/1" do
+    test "raises rather than reporting zero when a wildcard matches nothing" do
+      # A wildcard that matches no file yields an empty set, which is indistinguishable
+      # from a source that genuinely reads no env vars — and a mistyped path is by far the
+      # likelier cause. Fail loud instead.
+      assert_raise Mix.Error, ~r/matched no files/, fn ->
+        CheckEnvDocs.scan_paths("lib/no/such/directory/**/*.ex")
+      end
     end
   end
 end

--- a/test/mix/tasks/loopctl_check_env_docs_test.exs
+++ b/test/mix/tasks/loopctl_check_env_docs_test.exs
@@ -31,6 +31,11 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocsTest do
       """
 
       assert CheckEnvDocs.scan_env_vars(source) == MapSet.new(["METRICS_PORT"])
+
+      # A `#` inside a STRING is not a comment: cutting the line there hides the read after
+      # it — the silent pass this task exists to prevent, from the stripper itself.
+      assert CheckEnvDocs.scan_env_vars(~S|u = "https://x/#/a"; System.get_env("A_VAR")|) ==
+               MapSet.new(["A_VAR"])
     end
 
     test "tolerates whitespace inside the call and dedupes repeats" do
@@ -104,6 +109,11 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocsTest do
       assert CheckEnvDocs.undocumented(["NEW_VAR"], "| `NEW_VAR` |  |  |") == ["NEW_VAR"]
       assert CheckEnvDocs.undocumented(["NEW_VAR"], "| `NEW_VAR` | `7` |  |") == ["NEW_VAR"]
       assert CheckEnvDocs.undocumented(["NEW_VAR"], "| `NEW_VAR` | `7` | Does a thing |") == []
+
+      # Same hole in a second shape: a cell pattern matching newlines runs past the end of
+      # the row and takes "has a description" from whatever row FOLLOWS.
+      borrowed = "| `NEW_VAR` | 7\n| `OTHER_VAR` | 1 | Does a thing |"
+      assert CheckEnvDocs.undocumented(["NEW_VAR"], borrowed) == ["NEW_VAR"]
     end
 
     test "returns every missing variable, sorted" do
@@ -119,21 +129,24 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocsTest do
 
   describe "the live repo" do
     setup do
-      %{
-        vars:
-          Enum.reduce(CheckEnvDocs.sources(), MapSet.new(), fn {pattern, min}, acc ->
-            found = CheckEnvDocs.scan_paths(pattern)
+      # Seeded with the declared dynamic-read names: no scan can find them, so without this
+      # the whitelist's claim that they are documented is #566's unenforced promise again.
+      vars =
+        Enum.reduce(CheckEnvDocs.sources(), CheckEnvDocs.dynamic_families(), fn {pattern, min},
+                                                                                acc ->
+          found = CheckEnvDocs.scan_paths(pattern)
 
-            # Per-source non-vacuity, asserted per source for the same reason the task
-            # enforces it per source: over the UNION, runtime.exs's ~42 vars would clear
-            # any sane floor on their own, so a `lib/**/*.ex` glob that silently matched
-            # nothing would still look healthy.
-            assert MapSet.size(found) >= min,
-                   "scan of #{pattern} found only #{MapSet.size(found)} vars — it is broken"
+          # Per-source non-vacuity, asserted per source for the same reason the task
+          # enforces it per source: over the UNION, runtime.exs's ~42 vars would clear
+          # any sane floor on their own, so a `lib/**/*.ex` glob that silently matched
+          # nothing would still look healthy.
+          assert MapSet.size(found) >= min,
+                 "scan of #{pattern} found only #{MapSet.size(found)} vars — it is broken"
 
-            MapSet.union(acc, found)
-          end)
-      }
+          MapSet.union(acc, found)
+        end)
+
+      %{vars: vars}
     end
 
     test "every scanned env var is documented", %{vars: vars} do
@@ -157,16 +170,39 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocsTest do
     end
   end
 
-  describe "dynamic_read?/1" do
+  describe "dynamic_read?/1 and check_dynamic_reads/2" do
     test "flags a runtime-built name, which the literal scan cannot resolve" do
       # The residual #566 shape: an OBAN_QUEUE_ name built at runtime is an operator knob
       # no textual scan can name, so it must FAIL the guard, not pass over in silence.
       assert CheckEnvDocs.dynamic_read?(~S|System.get_env("OBAN_QUEUE_" <> name)|)
       assert CheckEnvDocs.dynamic_read?(~S|System.get_env(env_var)|)
       assert CheckEnvDocs.dynamic_read?(~S|System.get_env("#{prefix}_URL")|)
+      assert CheckEnvDocs.dynamic_read?(~S|def read(get \\ &System.get_env/1), do: get.(v)|)
       refute CheckEnvDocs.dynamic_read?(~S|System.get_env("FTS_REGCONFIG")|)
       refute CheckEnvDocs.dynamic_read?("x =\n  System.get_env(\n    \"A_VAR\"\n  )\n")
+      refute CheckEnvDocs.dynamic_read?(~S|u = "https://x/#/a"; System.get_env("A_VAR")|)
       refute CheckEnvDocs.dynamic_read?(~S|# was System.get_env(name)|)
+
+      # Each of these failed the build naming a cause that is not true: a lowercase literal
+      # (which `scan_env_vars/1` ignores — the two must agree about one input), the
+      # zero-arity whole-environment read, and PROSE describing a call rather than making
+      # one, which turned a docs-only change red.
+      refute CheckEnvDocs.dynamic_read?(~S|System.get_env("https_proxy")|)
+      refute CheckEnvDocs.dynamic_read?(~S|all = System.get_env()|)
+      refute CheckEnvDocs.dynamic_read?(~s|@doc """\nReads System.get_env(env_var).\n"""|)
+    end
+
+    test "check_dynamic_reads/2 raises for an undeclared file, passes for a declared one" do
+      # The enforcement half: every file that reads dynamically today is already declared,
+      # so driving it through the real tree alone never observes it failing.
+      assert_raise Mix.Error, ~r/built at runtime/, fn ->
+        CheckEnvDocs.check_dynamic_reads("lib/loopctl/new_thing.ex", "System.get_env(name)")
+      end
+
+      assert CheckEnvDocs.check_dynamic_reads(
+               "lib/loopctl/oban_config.ex",
+               ~S|System.get_env("OBAN_QUEUE_" <> queue)|
+             ) == :ok
     end
   end
 

--- a/test/mix/tasks/loopctl_check_env_docs_test.exs
+++ b/test/mix/tasks/loopctl_check_env_docs_test.exs
@@ -22,10 +22,11 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocsTest do
                MapSet.new(["DATABASE_URL", "SECRET_KEY_BASE"])
     end
 
-    test "skips full-line comments (the commented-out phx.new TLS boilerplate)" do
+    test "skips comments — whole-line (phx.new TLS boilerplate) and TRAILING alike" do
       source = """
       #         keyfile: System.get_env("SOME_APP_SSL_KEY_PATH"),
         # certfile: System.get_env("SOME_APP_SSL_CERT_PATH")
+      cap = default() # override with System.get_env("EXAMPLE_KNOB")
       real = System.get_env("METRICS_PORT")
       """
 
@@ -39,6 +40,14 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocsTest do
       """
 
       assert CheckEnvDocs.scan_env_vars(source) == MapSet.new(["FTS_REGCONFIG"])
+    end
+
+    test "finds a read the formatter wrapped onto the next line" do
+      # A per-LINE match sees nothing here: the variable is read at runtime, absent from
+      # the docs, and reported as fine — #566's vacuous pass, one level down.
+      source = "base =\n  System.get_env(\n    \"METRICS_PORT\"\n  )\n"
+
+      assert CheckEnvDocs.scan_env_vars(source) == MapSet.new(["METRICS_PORT"])
     end
 
     test "ignores non-literal and lowercase reads" do
@@ -89,6 +98,14 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocsTest do
              ) == []
     end
 
+    test "a row with a blank default or description does not count as documented" do
+      # The cheapest way past a failing guard is a bare row, which teaches an operator
+      # neither the default nor what breaks — so the anchor requires both cells.
+      assert CheckEnvDocs.undocumented(["NEW_VAR"], "| `NEW_VAR` |  |  |") == ["NEW_VAR"]
+      assert CheckEnvDocs.undocumented(["NEW_VAR"], "| `NEW_VAR` | `7` |  |") == ["NEW_VAR"]
+      assert CheckEnvDocs.undocumented(["NEW_VAR"], "| `NEW_VAR` | `7` | Does a thing |") == []
+    end
+
     test "returns every missing variable, sorted" do
       vars = ["ZED_VAR", "ALPHA_VAR", "MID_VAR"]
       assert CheckEnvDocs.undocumented(vars, "nothing here") == ~w(ALPHA_VAR MID_VAR ZED_VAR)
@@ -132,11 +149,24 @@ defmodule Mix.Tasks.Loopctl.CheckEnvDocsTest do
       #
       # `OBAN_*` is the family that motivated #566: runtime.exs does evaluate it at boot,
       # but via `Loopctl.ObanConfig`, so the literal name never appears in the config file
-      # and eight variables sat outside a green guard.
+      # and the family sat outside a green guard.
       assert "OBAN_TENANT_FAIRSHARE_SNOOZE_SECONDS" in vars,
              "lib/ is no longer scanned — the #566 blind spot is back"
 
       assert "DATABASE_URL" in vars, "config/runtime.exs is no longer scanned"
+    end
+  end
+
+  describe "dynamic_read?/1" do
+    test "flags a runtime-built name, which the literal scan cannot resolve" do
+      # The residual #566 shape: an OBAN_QUEUE_ name built at runtime is an operator knob
+      # no textual scan can name, so it must FAIL the guard, not pass over in silence.
+      assert CheckEnvDocs.dynamic_read?(~S|System.get_env("OBAN_QUEUE_" <> name)|)
+      assert CheckEnvDocs.dynamic_read?(~S|System.get_env(env_var)|)
+      assert CheckEnvDocs.dynamic_read?(~S|System.get_env("#{prefix}_URL")|)
+      refute CheckEnvDocs.dynamic_read?(~S|System.get_env("FTS_REGCONFIG")|)
+      refute CheckEnvDocs.dynamic_read?("x =\n  System.get_env(\n    \"A_VAR\"\n  )\n")
+      refute CheckEnvDocs.dynamic_read?(~S|# was System.get_env(name)|)
     end
   end
 


### PR DESCRIPTION
Closes #566.

`mix loopctl.check_env_docs` exists because 24 operator knobs once accumulated undocumented with nothing noticing. It has been running with the same silence in a second place the whole time: it scanned `config/runtime.exs` only, so every variable read from `lib/` was invisible to it. The whole `OBAN_*` family slipped through an unlucky indirection — `runtime.exs` does evaluate those at boot, but via `Loopctl.ObanConfig`, so the literal name never appears in the scanned file. The guard reported "42 runtime env var(s) documented" and exited 0 while eight variables it had never looked at were undocumented.

### Two bounds, because widening the scan alone would have been dishonest

**The vacuity floor is now per source.** One floor over the union cannot detect a broken `lib/**/*.ex` glob at all: `runtime.exs` contributes ~42 vars on its own, so the union clears any sane threshold while the second source silently contributes nothing. That is precisely the vacuous-guard shape this task exists to prevent, reintroduced one level up.

**A variable now needs a table ROW, not a mention.** Widening the scan brought `STH_SWEEP_CRON` under the guard, where it passed immediately — on the strength of one prose aside explaining a different decision ("a deliberate choice after the `STH_SWEEP_CRON` incident"). That sentence tells an operator neither the default nor what the knob does. The match is now anchored to the name heading a markdown table row, where a default and a description sit structurally adjacent and cannot be omitted by accident.

### Six variables documented

`EXPECTED_APP_NODES`, `STH_SWEEP_CRON`, `OBAN_TENANT_FAIRSHARE_SNOOZE_SECONDS`, `OBAN_TENANT_FAIRSHARE_SNOOZE_JITTER`, `GITHUB_TOKEN`, and the Fly secrets-adapter pair `FLY_APP_NAME` / `FLY_API_TOKEN`.

The issue suggested the last three were plausibly platform-injected and might warrant an exemption instead. None of them earned one. `FLY_API_TOKEN` is not injected by anything, and without it (or `FLY_APP_NAME`) the default secrets adapter refuses every write with `fly_not_configured` — which fails tenant signup, since signup mints and stores a per-tenant audit keypair. That is the opposite of internal, and it is the knob a self-hoster most needs to know to swap for `SECRETS_ADAPTER=local_file`.

### One new scan limit, stated rather than worked around

A literal read written inside a `@moduledoc` is detected, because a docstring is not a comment line. Two docstrings wrote fake calls with placeholder names, and the guard duly demanded the placeholders be documented. Both sentences also asserted that the read had to STAY in `runtime.exs` to stay guarded — which this change makes false — so both were rewritten rather than dodged.

### Verification

Three new guards, each mutation-verified by breaking it and watching a named test fail:

| Mutation | Failing test |
|---|---|
| drop `lib/**/*.ex` from the source list | "the scan covers lib/ as well as config/runtime.exs" |
| relax the match back to a whole-word mention | "a passing MENTION in prose does not count as documented" |
| let an empty wildcard report zero instead of raising | "raises rather than reporting zero when a wildcard matches nothing" |

The first anchor matters: the live-repo test iterates `sources/0`, so dropping a source would otherwise make it iterate one fewer and pass. It names a variable only `lib/` can supply.

`mix precommit` green: 6665 tests, 0 failures.

Docs updated in the same PR: `CONTRIBUTING.md`, `CLAUDE.md`, `CHANGELOG.md`, and the three in-source comments that claimed the guard scanned `runtime.exs` alone.
