### PR TITLE
Make the orphan check an anti-join, so the nightly lint can finish

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -10626,8 +10626,12 @@ defmodule Loopctl.Knowledge do
      }}
   end
 
+  # `as: :article` names the binding so `find_orphan_articles/3` can correlate a
+  # `not exists` subquery back to it via `parent_as/1`. Naming a binding is inert for every
+  # other consumer that re-composes this query.
   defp published_base_query(tenant_id, nil) do
     from(a in Article,
+      as: :article,
       where: a.tenant_id == ^tenant_id,
       where: a.status == :published
     )
@@ -10636,6 +10640,7 @@ defmodule Loopctl.Knowledge do
   defp published_base_query(tenant_id, project_id) do
     base =
       from(a in Article,
+        as: :article,
         where: a.tenant_id == ^tenant_id,
         where: a.status == :published
       )
@@ -10682,26 +10687,45 @@ defmodule Loopctl.Knowledge do
     end)
   end
 
-  defp find_orphan_articles(base, tenant_id, project_id) do
-    # Subquery: article IDs that appear in any link (source or target)
-    linked_ids_subquery =
-      from(al in ArticleLink,
-        where: al.tenant_id == ^tenant_id,
-        select: %{id: al.source_article_id}
-      )
-      |> maybe_scope_links_to_project(project_id)
-
-    linked_target_ids_subquery =
-      from(al in ArticleLink,
-        where: al.tenant_id == ^tenant_id,
-        select: %{id: al.target_article_id}
-      )
-      |> maybe_scope_links_to_project(project_id)
-
+  # An orphan is an article that appears in NO link, in either direction.
+  #
+  # Expressed as two correlated `not exists` rather than `id not in subquery(...)` (#574).
+  # That difference is not stylistic: PostgreSQL CANNOT turn `NOT IN (subquery)` into an
+  # anti-join, because of three-valued NULL semantics — a single NULL in the subquery makes
+  # the whole predicate NULL, so the planner has to keep the entire set. It therefore
+  # materialised all 1.4M `article_links` rows TWICE and re-scanned that tuplestore once per
+  # candidate article: a measured plan cost of 2.21 BILLION, six sequential scans per
+  # execution across the parallel workers, and the single largest source of the 1.65 billion
+  # `seq_tup_read` this table had accumulated.
+  #
+  # It did not merely run slowly — the nightly `KnowledgeLintWorker` for the only tenant with
+  # a real corpus was DISCARDED after 3 attempts every night (a pool timeout inside this
+  # query), so the lint had never once succeeded there. `NOT EXISTS` is anti-join-able, so
+  # each candidate becomes an index probe on `article_links_source_article_id_index` /
+  # `_target_article_id_index`.
+  #
+  # No index would have rescued the old shape: one tenant owns 100% of `article_links`, so
+  # the `tenant_id` predicate those subqueries filtered on is entirely non-selective. The
+  # SHAPE was the defect.
+  defp find_orphan_articles(base, tenant_id, _project_id) do
     query =
       from(a in base,
-        where: a.id not in subquery(linked_ids_subquery),
-        where: a.id not in subquery(linked_target_ids_subquery),
+        where:
+          not exists(
+            from(l in ArticleLink,
+              where: l.tenant_id == ^tenant_id,
+              where: l.source_article_id == parent_as(:article).id,
+              select: 1
+            )
+          ),
+        where:
+          not exists(
+            from(l in ArticleLink,
+              where: l.tenant_id == ^tenant_id,
+              where: l.target_article_id == parent_as(:article).id,
+              select: 1
+            )
+          ),
         select: %{
           id: a.id,
           title: a.title,
@@ -10720,16 +10744,6 @@ defmodule Loopctl.Knowledge do
         suggested_action: "Consider linking to related articles or reviewing for relevance"
       }
     end)
-  end
-
-  defp maybe_scope_links_to_project(query, nil), do: query
-
-  defp maybe_scope_links_to_project(query, _project_id) do
-    # Links don't have project_id — we keep all links within the tenant.
-    # The orphan check is scoped via the base query (published articles for
-    # the project). A link to/from articles outside this project scope is
-    # still valid and means the article is NOT orphaned.
-    query
   end
 
   defp find_contradiction_clusters(tenant_id, project_id) do

--- a/test/loopctl/knowledge_lint_test.exs
+++ b/test/loopctl/knowledge_lint_test.exs
@@ -120,6 +120,35 @@ defmodule Loopctl.KnowledgeLintTest do
       refute other.id in orphan_ids
     end
 
+    test "#574: the orphan check is an ANTI-JOIN, never `id not in subquery`" do
+      # The tests above are correctness-only, and correctness is exactly what BOTH shapes
+      # satisfy — which is why this defect survived: `id not in subquery(...)` returned the
+      # right orphans while being unable to complete on real data. PostgreSQL cannot convert
+      # `NOT IN (subquery)` into an anti-join (a single NULL makes the predicate NULL, so the
+      # whole set must be kept), so it materialised all 1.4M `article_links` rows TWICE and
+      # re-scanned them per candidate: plan cost 2.21 BILLION, and the nightly lint job was
+      # DISCARDED after 3 attempts every night on a pool timeout. Measured on production after
+      # the rewrite: cost 44,695 and 504 ms.
+      #
+      # A plan-shape assertion cannot run here (test data is tiny, so the planner seq-scans
+      # whatever we write), so this anchors to the CODE. Both directions are asserted, and the
+      # positive one is counted, so the guard cannot pass by matching nothing.
+      source = File.read!("lib/loopctl/knowledge.ex")
+
+      [_ | _] = orphan_fn = Regex.run(~r/defp find_orphan_articles.*?\n  end\n/s, source)
+      body = hd(orphan_fn)
+
+      correlated = Regex.scan(~r/not exists\(/, body)
+
+      assert length(correlated) == 2,
+             "expected two correlated NOT EXISTS (source + target), got #{length(correlated)}"
+
+      assert body =~ "parent_as(:article)", "the subqueries must correlate to the outer row"
+
+      refute body =~ "not in subquery",
+             "`id not in subquery(...)` blocks the anti-join and cannot complete on prod data"
+    end
+
     test "orphan_articles excludes draft articles" do
       tenant = fixture(:tenant)
 


### PR DESCRIPTION
Closes #574.

The nightly knowledge lint for the only tenant with a real corpus has been **discarded after 3 attempts every night** — Aug 2, 3 and 4 — on a pool timeout. It has never once succeeded there, and nothing alerted, because a discarded Oban job is silent.

## Cause

`find_orphan_articles/3` built its predicate as `id not in subquery(...)`, twice. **PostgreSQL cannot turn `NOT IN (subquery)` into an anti-join** — three-valued `NULL` semantics mean one NULL in the subquery makes the whole predicate NULL, so the planner must keep the entire set. It materialised all 1.4M `article_links` rows **twice** and re-scanned that tuplestore once per candidate article.

## Measured on production

| | plan cost | shape | wall clock |
|---|---|---|---|
| before | **2,210,462,997** | `Materialize` over `Seq Scan on article_links` ×2 | times out |
| after | **44,695** | two `Nested Loop Anti Join` on the id indexes | **504 ms** |

No sequential scan on `article_links` remains. That single query also accounted for the table-level figure this investigation started from: **2,774 seq scans reading 1.65 billion rows**.

## Why the fix adds no index

One tenant owns **100%** of `article_links` (1,417,624 rows), so the `tenant_id` predicate those subqueries filtered on is entirely non-selective — and the `NOT IN` blocks the anti-join regardless of access path. The **shape** was the defect.

## Notes

- `published_base_query/2` now names its binding `as: :article` so the subqueries can correlate via `parent_as/1`. Inert for the other consumer.
- `maybe_scope_links_to_project/2` went with the old subqueries. It was a documented no-op returning its argument unchanged; its stated semantics (a link to an article outside the project scope still means NOT orphaned) are preserved exactly, since the correlated subqueries are tenant-scoped only.
- Fixing this **exposes** #575 (`promote_conflicts/1`), a real parallel seq scan currently masked because the job dies here first.

## Test

The existing orphan tests are correctness-only — and correctness is what **both** shapes satisfy, which is how this survived. The new guard anchors to the code: counts two correlated `NOT EXISTS`, requires `parent_as`, refuses `not in subquery`. Both directions asserted and the positive one counted, so it cannot pass by matching nothing. **Mutation-verified:** restoring the `NOT IN` shape fails it.

`mix precommit` green: 6690 tests, 0 failures.
