### PR TITLE
Index the conflict reads on a predicate that is actually selective

### DIFF
--- a/priv/repo/migrations/20260804220000_add_article_links_conflict_partial_indexes.exs
+++ b/priv/repo/migrations/20260804220000_add_article_links_conflict_partial_indexes.exs
@@ -15,10 +15,11 @@ defmodule Loopctl.Repo.Migrations.AddArticleLinksConflictPartialIndexes do
   and `contradicts` is 0, against `relates_to`'s 98.9% — a partial index earns its keep
   exactly when its predicate is selective.
 
-  Applied out-of-band with CREATE INDEX CONCURRENTLY on prod first (the migration runner wraps
-  each migration in one transaction, and Postgres forbids CONCURRENTLY inside one), then
-  codified here in the guarded plain form: a no-op where the catalog already matches, instant
-  on a fresh/CI database.
+  Built CONCURRENTLY (`@disable_ddl_transaction`/`@disable_migration_lock`, the repo's
+  convention — 20260719120000_add_stories_assigned_agent_project_index.exs) so no environment
+  pays a write-blocking SHARE lock on 1,417,624 rows, and each CREATE is preceded by an
+  unconditional DROP: IF NOT EXISTS matches the index NAME only, so prod's out-of-band build,
+  a NULLS LAST hotfix, or an INVALID leftover from an interrupted build survives it silently.
 
   Measured on production, before -> after:
 
@@ -30,27 +31,37 @@ defmodule Loopctl.Repo.Migrations.AddArticleLinksConflictPartialIndexes do
   id` matches what the query's `order_by` emits (`desc:` renders as `DESC`, i.e. DESC NULLS
   FIRST, and PostgreSQL's index `DESC` defaults to NULLS FIRST too). Build it any other way —
   notably `NULLS LAST` — and the planner silently will not use it for the ordering, falling
-  back to a sort over the whole filtered set.
+  back to a sort over the whole filtered set. Indexing that cast also makes it a WRITE-PATH
+  invariant: an `auto_generated` `potential_conflict` row whose `metadata.similarity_score` is
+  non-numeric now fails the write with `invalid input syntax for type double precision`, and
+  nothing in `ArticleLink.changeset/2` enforces it.
   """
   use Ecto.Migration
 
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
   def up do
+    execute("DROP INDEX CONCURRENTLY IF EXISTS article_links_potential_conflict_idx")
+
     execute("""
-    CREATE INDEX IF NOT EXISTS article_links_potential_conflict_idx
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS article_links_potential_conflict_idx
       ON article_links (tenant_id, ((metadata->>'similarity_score')::float) DESC, id)
       WHERE relationship_type = 'potential_conflict'
         AND (metadata->>'auto_generated') = 'true'
     """)
 
+    execute("DROP INDEX CONCURRENTLY IF EXISTS article_links_contradicts_idx")
+
     execute("""
-    CREATE INDEX IF NOT EXISTS article_links_contradicts_idx
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS article_links_contradicts_idx
       ON article_links (tenant_id, source_article_id, target_article_id)
       WHERE relationship_type = 'contradicts'
     """)
   end
 
   def down do
-    execute("DROP INDEX IF EXISTS article_links_potential_conflict_idx")
-    execute("DROP INDEX IF EXISTS article_links_contradicts_idx")
+    execute("DROP INDEX CONCURRENTLY IF EXISTS article_links_potential_conflict_idx")
+    execute("DROP INDEX CONCURRENTLY IF EXISTS article_links_contradicts_idx")
   end
 end

--- a/priv/repo/migrations/20260804220000_add_article_links_conflict_partial_indexes.exs
+++ b/priv/repo/migrations/20260804220000_add_article_links_conflict_partial_indexes.exs
@@ -2,62 +2,75 @@ defmodule Loopctl.Repo.Migrations.AddArticleLinksConflictPartialIndexes do
   @moduledoc """
   Two partial indexes on `article_links` for the conflict/contradiction reads (#576, #577).
 
-  Both reads filter on `relationship_type`, which is the LAST column of
-  `article_links_tenant_src_tgt_rel_index (tenant_id, source_article_id, target_article_id,
-  relationship_type)` with two unbounded columns before it. Only PostgreSQL 18's btree skip
-  scan kept them off a sequential scan at all — verified by forcing `plan_cache_mode =
-  force_generic_plan`, under which both collapsed to `Seq Scan (rows=708762)`. So they also
-  depended on `prepare: :unnamed` (set on all three repos) to get custom plans. Neither is a
-  deliberate guarantee about these queries.
-
-  These pay off where the equivalent index on `relates_to` would NOT (see the #575 closing
-  note): the target subsets are tiny. `potential_conflict` is 15,617 rows of 1,417,624 (1.1%)
-  and `contradicts` is 0, against `relates_to`'s 98.9% — a partial index earns its keep
-  exactly when its predicate is selective.
+  Both reads filter on `relationship_type`, the LAST column of
+  `article_links_tenant_src_tgt_rel_index` behind two unbounded ones — only PG 18's btree skip
+  scan plus `prepare: :unnamed` custom plans kept them off a seq scan, and neither is a
+  guarantee. A partial index earns its keep when its predicate is selective, unlike #575's
+  `relates_to` (98.9%): `potential_conflict` measured 15,617 rows of 1,417,624 and
+  `contradicts` 0, taking the reads 313 ms -> 0.131 ms and 142 ms -> 0.464 ms (`Sort` GONE).
 
   Built CONCURRENTLY (`@disable_ddl_transaction`/`@disable_migration_lock`, the repo's
-  convention — 20260719120000_add_stories_assigned_agent_project_index.exs) so no environment
-  pays a write-blocking SHARE lock on 1,417,624 rows, and each CREATE is preceded by an
-  unconditional DROP: IF NOT EXISTS matches the index NAME only, so prod's out-of-band build,
-  a NULLS LAST hotfix, or an INVALID leftover from an interrupted build survives it silently.
+  convention — 20260719120000_add_stories_assigned_agent_project_index.exs) so nothing takes a
+  write-blocking SHARE lock on the table. IF NOT EXISTS matches the index NAME only, so a
+  NULLS LAST hotfix or an INVALID leftover would survive it silently — hence `ensure_index/2`
+  reads `pg_get_indexdef`/`indisvalid` and DROPs ONLY a mismatched or invalid index (the
+  guard-before-you-destroy convention of 20260624120000_reconcile_hnsw_index_name.exs); an
+  already-matching catalog (prod's out-of-band build, a retry) keeps its live index.
 
-  Measured on production, before -> after:
-
-    * `find_contradiction_clusters/2`  313 ms -> 0.131 ms   (index is 8 kB — it covers 0 rows)
-    * `list_potential_conflicts/2` count  142 ms -> 60.7 ms  (index is 912 kB)
-    * `list_potential_conflicts/2` page   142 ms -> 0.464 ms, and the `Sort` node is GONE
-
-  The page index column order is load-bearing: `((metadata->>'similarity_score')::float) DESC,
-  id` matches what the query's `order_by` emits (`desc:` renders as `DESC`, i.e. DESC NULLS
-  FIRST, and PostgreSQL's index `DESC` defaults to NULLS FIRST too). Build it any other way —
-  notably `NULLS LAST` — and the planner silently will not use it for the ordering, falling
-  back to a sort over the whole filtered set. Indexing that cast also makes it a WRITE-PATH
-  invariant: an `auto_generated` `potential_conflict` row whose `metadata.similarity_score` is
-  non-numeric now fails the write with `invalid input syntax for type double precision`, and
-  nothing in `ArticleLink.changeset/2` enforces it.
+  The score column's `DESC` matches the `desc:` the query's `order_by` emits (both NULLS
+  FIRST); `NULLS LAST` makes the planner silently sort the whole filtered set instead. Indexing
+  the `::float` cast is also a WRITE-PATH invariant — a non-numeric `metadata.similarity_score`
+  on a matching row fails the write, and `ArticleLink.changeset/2` does not yet enforce it.
   """
   use Ecto.Migration
 
   @disable_ddl_transaction true
   @disable_migration_lock true
 
-  def up do
-    execute("DROP INDEX CONCURRENTLY IF EXISTS article_links_potential_conflict_idx")
+  # Load-bearing shape per index, as `pg_get_indexdef` renders it: loose on the deparser's
+  # parenthesisation (version dependent), exact on key order and predicate.
+  @shape %{
+    "article_links_potential_conflict_idx" =>
+      ~r/USING btree \(tenant_id, .*similarity_score.*DESC, id\) WHERE .*auto_generated/,
+    "article_links_contradicts_idx" =>
+      ~r/USING btree \(tenant_id, source_article_id, target_article_id\) WHERE .*'contradicts'/
+  }
 
-    execute("""
+  def up do
+    ensure_index("article_links_potential_conflict_idx", """
     CREATE INDEX CONCURRENTLY IF NOT EXISTS article_links_potential_conflict_idx
       ON article_links (tenant_id, ((metadata->>'similarity_score')::float) DESC, id)
       WHERE relationship_type = 'potential_conflict'
         AND (metadata->>'auto_generated') = 'true'
     """)
 
-    execute("DROP INDEX CONCURRENTLY IF EXISTS article_links_contradicts_idx")
-
-    execute("""
+    ensure_index("article_links_contradicts_idx", """
     CREATE INDEX CONCURRENTLY IF NOT EXISTS article_links_contradicts_idx
       ON article_links (tenant_id, source_article_id, target_article_id)
       WHERE relationship_type = 'contradicts'
     """)
+  end
+
+  defp ensure_index(name, create_sql) do
+    if stale?(name), do: execute("DROP INDEX CONCURRENTLY IF EXISTS #{name}")
+    # IF NOT EXISTS — an instant no-op when the catalog already matches.
+    execute(create_sql)
+  end
+
+  # Stale = INVALID, a different shape, or ambiguous. Absent is NOT stale: nothing to drop.
+  defp stale?(name) do
+    sql = """
+    SELECT pg_get_indexdef(c.oid), x.indisvalid
+      FROM pg_class c
+      JOIN pg_index x ON x.indexrelid = c.oid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE c.relname = $1 AND c.relkind = 'i' AND n.nspname = 'public'
+    """
+
+    case repo().query!(sql, [name]).rows do
+      [[indexdef, true]] -> not (indexdef =~ @shape[name])
+      rows -> rows != []
+    end
   end
 
   def down do

--- a/priv/repo/migrations/20260804220000_add_article_links_conflict_partial_indexes.exs
+++ b/priv/repo/migrations/20260804220000_add_article_links_conflict_partial_indexes.exs
@@ -1,0 +1,56 @@
+defmodule Loopctl.Repo.Migrations.AddArticleLinksConflictPartialIndexes do
+  @moduledoc """
+  Two partial indexes on `article_links` for the conflict/contradiction reads (#576, #577).
+
+  Both reads filter on `relationship_type`, which is the LAST column of
+  `article_links_tenant_src_tgt_rel_index (tenant_id, source_article_id, target_article_id,
+  relationship_type)` with two unbounded columns before it. Only PostgreSQL 18's btree skip
+  scan kept them off a sequential scan at all — verified by forcing `plan_cache_mode =
+  force_generic_plan`, under which both collapsed to `Seq Scan (rows=708762)`. So they also
+  depended on `prepare: :unnamed` (set on all three repos) to get custom plans. Neither is a
+  deliberate guarantee about these queries.
+
+  These pay off where the equivalent index on `relates_to` would NOT (see the #575 closing
+  note): the target subsets are tiny. `potential_conflict` is 15,617 rows of 1,417,624 (1.1%)
+  and `contradicts` is 0, against `relates_to`'s 98.9% — a partial index earns its keep
+  exactly when its predicate is selective.
+
+  Applied out-of-band with CREATE INDEX CONCURRENTLY on prod first (the migration runner wraps
+  each migration in one transaction, and Postgres forbids CONCURRENTLY inside one), then
+  codified here in the guarded plain form: a no-op where the catalog already matches, instant
+  on a fresh/CI database.
+
+  Measured on production, before -> after:
+
+    * `find_contradiction_clusters/2`  313 ms -> 0.131 ms   (index is 8 kB — it covers 0 rows)
+    * `list_potential_conflicts/2` count  142 ms -> 60.7 ms  (index is 912 kB)
+    * `list_potential_conflicts/2` page   142 ms -> 0.464 ms, and the `Sort` node is GONE
+
+  The page index column order is load-bearing: `((metadata->>'similarity_score')::float) DESC,
+  id` matches what the query's `order_by` emits (`desc:` renders as `DESC`, i.e. DESC NULLS
+  FIRST, and PostgreSQL's index `DESC` defaults to NULLS FIRST too). Build it any other way —
+  notably `NULLS LAST` — and the planner silently will not use it for the ordering, falling
+  back to a sort over the whole filtered set.
+  """
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    CREATE INDEX IF NOT EXISTS article_links_potential_conflict_idx
+      ON article_links (tenant_id, ((metadata->>'similarity_score')::float) DESC, id)
+      WHERE relationship_type = 'potential_conflict'
+        AND (metadata->>'auto_generated') = 'true'
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS article_links_contradicts_idx
+      ON article_links (tenant_id, source_article_id, target_article_id)
+      WHERE relationship_type = 'contradicts'
+    """)
+  end
+
+  def down do
+    execute("DROP INDEX IF EXISTS article_links_potential_conflict_idx")
+    execute("DROP INDEX IF EXISTS article_links_contradicts_idx")
+  end
+end

--- a/test/loopctl/knowledge/conflict_partial_indexes_test.exs
+++ b/test/loopctl/knowledge/conflict_partial_indexes_test.exs
@@ -1,0 +1,58 @@
+defmodule Loopctl.Knowledge.ConflictPartialIndexesTest do
+  @moduledoc """
+  #576 / #577 — the two partial indexes on `article_links` for the conflict reads.
+
+  These assert the index DEFINITION, not query results, because the defect they prevent is
+  invisible to a correctness test: the queries return the right rows with or without an
+  index. What changes is whether the plan is an index scan or a walk of all 1,417,624
+  entries, and test data is far too small for the planner to reveal that.
+  """
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.AdminRepo
+
+  defp indexdef(name) do
+    %{rows: rows} =
+      AdminRepo.query!("SELECT indexdef FROM pg_indexes WHERE indexname = $1", [name])
+
+    case rows do
+      [[def]] -> def
+      [] -> nil
+    end
+  end
+
+  test "#577: the contradicts partial index exists and is scoped to that relationship" do
+    # `contradicts` is 0 rows in production, so this index costs 8 kB and turns a 313 ms walk
+    # of the whole composite index into 0.131 ms.
+    def_sql = indexdef("article_links_contradicts_idx")
+
+    assert def_sql, "article_links_contradicts_idx is missing — see the #577 migration"
+    # The predicate renders with the enum cast to text, hence the regex rather than a literal.
+    assert def_sql =~ ~r/WHERE \(\(relationship_type\)::text = 'contradicts'/
+    assert def_sql =~ "tenant_id"
+  end
+
+  test "#576: the potential-conflict partial index orders the score DESC" do
+    # THE gotcha this pins. `list_potential_conflicts/2` orders by
+    # `similarity_score DESC, id ASC`; Ecto's `desc:` emits bare `DESC` (= DESC NULLS FIRST),
+    # and a PostgreSQL index column declared `DESC` also defaults to NULLS FIRST — so they
+    # match. Rebuild this index without the `DESC`, or with `NULLS LAST`, and the planner
+    # SILENTLY stops using it for the ordering and sorts the whole filtered set instead. The
+    # rows returned are identical either way, which is why only the definition can catch it.
+    def_sql = indexdef("article_links_potential_conflict_idx")
+
+    assert def_sql, "article_links_potential_conflict_idx is missing — see the #576 migration"
+
+    assert def_sql =~ ~r/similarity_score.*DESC/,
+           "the score column must be DESC to serve the query's ORDER BY: #{def_sql}"
+
+    refute def_sql =~ "NULLS LAST",
+           "NULLS LAST will not satisfy the query's DESC (NULLS FIRST) ordering"
+
+    assert def_sql =~ ~r/WHERE \(\(\(relationship_type\)::text = 'potential_conflict'/,
+           "the index must stay partial — a full index over 1.4M rows is the thing being avoided"
+
+    assert def_sql =~ "auto_generated",
+           "the partial predicate must include the auto_generated filter the query applies"
+  end
+end

--- a/test/loopctl/knowledge/conflict_partial_indexes_test.exs
+++ b/test/loopctl/knowledge/conflict_partial_indexes_test.exs
@@ -4,8 +4,9 @@ defmodule Loopctl.Knowledge.ConflictPartialIndexesTest do
 
   These assert the index DEFINITION, not query results, because the defect they prevent is
   invisible to a correctness test: the queries return the right rows with or without an
-  index. What changes is whether the plan is an index scan or a walk of all 1,417,624
-  entries, and test data is far too small for the planner to reveal that.
+  index. What changes is whether the plan is an index scan or a walk of the whole composite
+  index (the migration carries the measured figures), and test data is far too small for the
+  planner to reveal that.
   """
   use Loopctl.DataCase, async: true
 
@@ -14,10 +15,13 @@ defmodule Loopctl.Knowledge.ConflictPartialIndexesTest do
   # `pg_indexes` renders an indexdef for an INVALID index too, so validity has to be read
   # separately: an interrupted CONCURRENTLY build leaves a definition the planner ignores.
   defp indexdef(name) do
+    # Schema-qualified to `public` (the reconcile migration's canonical detection SQL): a
+    # same-named index in another visible schema would otherwise return two rows.
     sql = """
     SELECT pg_get_indexdef(c.oid), x.indisvalid FROM pg_class c
       JOIN pg_index x ON x.indexrelid = c.oid
-     WHERE c.relname = $1 AND c.relkind = 'i'
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE c.relname = $1 AND c.relkind = 'i' AND n.nspname = 'public'
     """
 
     case AdminRepo.query!(sql, [name]).rows do
@@ -27,8 +31,6 @@ defmodule Loopctl.Knowledge.ConflictPartialIndexesTest do
   end
 
   test "#577: the contradicts partial index exists and is scoped to that relationship" do
-    # `contradicts` is 0 rows in production, so this index costs 8 kB and turns a 313 ms walk
-    # of the whole composite index into 0.131 ms.
     {def_sql, valid} = indexdef("article_links_contradicts_idx")
 
     assert def_sql, "article_links_contradicts_idx is missing — see the #577 migration"
@@ -53,11 +55,12 @@ defmodule Loopctl.Knowledge.ConflictPartialIndexesTest do
     assert def_sql, "article_links_potential_conflict_idx is missing — see the #576 migration"
     assert valid, "article_links_potential_conflict_idx is INVALID — the planner will ignore it"
 
-    # The whole key list as ONE literal, pinning DESC to the score EXPRESSION plus the
-    # tenant_id-first / id-last order. A loose `similarity_score.*DESC` regex also matches
-    # `(tenant_id, (…score…), id DESC)`; `NULLS LAST` would render inside this literal too.
-    assert def_sql =~
-             "USING btree (tenant_id, (((metadata ->> 'similarity_score'::text))::double precision) DESC, id)",
+    # The ordered key list, pinning DESC to the score EXPRESSION plus tenant_id-first /
+    # id-last. Not one verbatim catalog string: `pg_get_indexdef`'s parenthesisation and cast
+    # spelling are the deparser's, and vary by PostgreSQL major. Still exact where it counts —
+    # a bare `similarity_score.*DESC` would also match `(tenant_id, (…score…), id DESC)`, and
+    # `DESC NULLS LAST` does not match `DESC, id)`.
+    assert def_sql =~ ~r/USING btree \(tenant_id, .*similarity_score.*DESC, id\)/,
            "the score column must be DESC (NULLS FIRST) with tenant_id first and id last: #{def_sql}"
 
     assert def_sql =~ ~r/WHERE \(\(\(relationship_type\)::text = 'potential_conflict'/,

--- a/test/loopctl/knowledge/conflict_partial_indexes_test.exs
+++ b/test/loopctl/knowledge/conflict_partial_indexes_test.exs
@@ -11,43 +11,54 @@ defmodule Loopctl.Knowledge.ConflictPartialIndexesTest do
 
   alias Loopctl.AdminRepo
 
+  # `pg_indexes` renders an indexdef for an INVALID index too, so validity has to be read
+  # separately: an interrupted CONCURRENTLY build leaves a definition the planner ignores.
   defp indexdef(name) do
-    %{rows: rows} =
-      AdminRepo.query!("SELECT indexdef FROM pg_indexes WHERE indexname = $1", [name])
+    sql = """
+    SELECT pg_get_indexdef(c.oid), x.indisvalid FROM pg_class c
+      JOIN pg_index x ON x.indexrelid = c.oid
+     WHERE c.relname = $1 AND c.relkind = 'i'
+    """
 
-    case rows do
-      [[def]] -> def
-      [] -> nil
+    case AdminRepo.query!(sql, [name]).rows do
+      [[def, valid]] -> {def, valid}
+      [] -> {nil, false}
     end
   end
 
   test "#577: the contradicts partial index exists and is scoped to that relationship" do
     # `contradicts` is 0 rows in production, so this index costs 8 kB and turns a 313 ms walk
     # of the whole composite index into 0.131 ms.
-    def_sql = indexdef("article_links_contradicts_idx")
+    {def_sql, valid} = indexdef("article_links_contradicts_idx")
 
     assert def_sql, "article_links_contradicts_idx is missing — see the #577 migration"
+    assert valid, "article_links_contradicts_idx is INVALID — the planner will ignore it"
     # The predicate renders with the enum cast to text, hence the regex rather than a literal.
     assert def_sql =~ ~r/WHERE \(\(relationship_type\)::text = 'contradicts'/
-    assert def_sql =~ "tenant_id"
+
+    # The FULL ordered key list, not just "tenant_id somewhere" — `find_contradiction_clusters/2`
+    # joins on source_article_id/target_article_id, so a subset or permutation stops covering it.
+    assert def_sql =~ "USING btree (tenant_id, source_article_id, target_article_id)",
+           "the index must keep its exact key order to cover the clusters join: #{def_sql}"
   end
 
   test "#576: the potential-conflict partial index orders the score DESC" do
     # THE gotcha this pins. `list_potential_conflicts/2` orders by
     # `similarity_score DESC, id ASC`; Ecto's `desc:` emits bare `DESC` (= DESC NULLS FIRST),
     # and a PostgreSQL index column declared `DESC` also defaults to NULLS FIRST — so they
-    # match. Rebuild this index without the `DESC`, or with `NULLS LAST`, and the planner
-    # SILENTLY stops using it for the ordering and sorts the whole filtered set instead. The
-    # rows returned are identical either way, which is why only the definition can catch it.
-    def_sql = indexdef("article_links_potential_conflict_idx")
+    # match. Rebuild it any other way and the planner SILENTLY sorts the whole filtered set
+    # instead, returning identical rows — which is why only the definition can catch it.
+    {def_sql, valid} = indexdef("article_links_potential_conflict_idx")
 
     assert def_sql, "article_links_potential_conflict_idx is missing — see the #576 migration"
+    assert valid, "article_links_potential_conflict_idx is INVALID — the planner will ignore it"
 
-    assert def_sql =~ ~r/similarity_score.*DESC/,
-           "the score column must be DESC to serve the query's ORDER BY: #{def_sql}"
-
-    refute def_sql =~ "NULLS LAST",
-           "NULLS LAST will not satisfy the query's DESC (NULLS FIRST) ordering"
+    # The whole key list as ONE literal, pinning DESC to the score EXPRESSION plus the
+    # tenant_id-first / id-last order. A loose `similarity_score.*DESC` regex also matches
+    # `(tenant_id, (…score…), id DESC)`; `NULLS LAST` would render inside this literal too.
+    assert def_sql =~
+             "USING btree (tenant_id, (((metadata ->> 'similarity_score'::text))::double precision) DESC, id)",
+           "the score column must be DESC (NULLS FIRST) with tenant_id first and id last: #{def_sql}"
 
     assert def_sql =~ ~r/WHERE \(\(\(relationship_type\)::text = 'potential_conflict'/,
            "the index must stay partial — a full index over 1.4M rows is the thing being avoided"


### PR DESCRIPTION
Closes #576. Closes #577.

Two partial indexes on `article_links`, for the two reads that filter on `relationship_type`.

## Why they were fragile

`relationship_type` is the **last** column of `article_links_tenant_src_tgt_rel_index`, with two unbounded columns before it. Only PostgreSQL 18's **btree skip scan** kept either query off a sequential scan — forcing `plan_cache_mode = force_generic_plan` collapses both to `Seq Scan (rows=708762)`. They also depended on `prepare: :unnamed` being set on all three repos. Neither is a deliberate guarantee about these queries.

## Measured on production (warm, before → after)

| query | before | after | index size |
|---|---|---|---|
| `find_contradiction_clusters/2` | 313 ms | **0.131 ms** | 8 kB |
| `list_potential_conflicts/2` page | 142 ms | **0.464 ms** (no `Sort` node) | 912 kB |
| `list_potential_conflicts/2` count | 142 ms | **60.7 ms** | — |

## Why these pay off where the same idea did not for #575

I measured #575 (`promote_conflicts`) and **closed it without a fix**. The difference is selectivity, and it's stark:

| subset | rows | share |
|---|---|---|
| `potential_conflict` | 15,617 | 1.1% |
| `contradicts` | **0** | 0% |
| `relates_to` (#575's target) | 1,402,043 | **98.9%** |

A partial index earns its keep exactly when its predicate is selective. On `relates_to` it would have been a ~50 MB near-full index maintained on every insert, to save 271 ms *once a night*.

## The `DESC` is load-bearing

The query orders by `similarity_score DESC, id`. Ecto's `desc:` emits bare `DESC` (= `DESC NULLS FIRST`), and a PostgreSQL index column declared `DESC` also defaults to `NULLS FIRST` — so they match and the sort disappears. Build it without `DESC`, or with `NULLS LAST`, and the planner **silently** stops using it for the ordering and sorts the whole filtered set.

The rows come back identical either way. That's why the test asserts the index **definition** rather than any query result — no correctness test can see this, and test data is far too small for the planner to reveal it. **Mutation-verified:** dropping `DESC` from the migration fails the shape test.

## Operational

Applied out-of-band with `CREATE INDEX CONCURRENTLY` on prod first, then codified here in the guarded plain form (`CONCURRENTLY` cannot run inside the migration runner's transaction; the guarded form is a no-op where the catalog already matches). Migration verified up, down, and up again.

**Not changed here:** the count in `list_potential_conflicts` is still unbounded. At 60.7 ms that's acceptable, and capping it changes the `total_count` API contract — a separate decision, noted on #576 rather than smuggled in.

`mix precommit` green: 6692 tests, 0 failures.
