### PR TITLE
Tune autovacuum where the tables actually accumulate

### DIFF
--- a/lib/loopctl/workers/audit_partition_worker.ex
+++ b/lib/loopctl/workers/audit_partition_worker.ex
@@ -22,6 +22,14 @@ defmodule Loopctl.Workers.AuditPartitionWorker do
   @default_retention_days 90
   @future_months 3
 
+  # Autovacuum tuning stamped onto every partition (#579). Append-only leaves accumulate
+  # rather than churn, so the INSERT-driven trigger is the knob — the update-churn
+  # `vacuum_scale_factor` would wait on dead tuples that never arrive. Kept in lockstep with
+  # `20260804230000_tune_autovacuum_on_append_heavy_tables.exs`, which stamps the partitions
+  # that already existed; a partitioned PARENT has no heap and rejects these params entirely.
+  @analyze_scale_factor "0.05"
+  @vacuum_insert_scale_factor "0.1"
+
   @impl Oban.Worker
   def perform(_job) do
     create_future_partitions()
@@ -68,15 +76,64 @@ defmodule Loopctl.Workers.AuditPartitionWorker do
 
       case SQL.query(Loopctl.Repo, sql, []) do
         {:ok, _} ->
-          :ok
+          stamp_autovacuum(partition_name)
 
         {:error, %{postgres: %{code: :duplicate_table}}} ->
-          :ok
+          stamp_autovacuum(partition_name)
 
         {:error, reason} ->
           Logger.warning("Failed to create partition #{partition_name}: #{inspect(reason)}")
       end
     end
+  end
+
+  # `CREATE TABLE ... PARTITION OF` does NOT inherit the parent's reloptions — and the parent
+  # cannot carry storage autovacuum params at all (no heap). So every partition must be
+  # stamped individually or it is created with the global defaults, which is how the whole
+  # corpus went un-analyzed until #579.
+  #
+  # SELF-HEALING, and stamped on the duplicate_table branch too: that covers a partition
+  # created before this code existed, and one created untuned during a deploy window. Guarded
+  # on the reloption being ABSENT rather than stamped unconditionally, because `ALTER TABLE`
+  # takes a SHARE UPDATE EXCLUSIVE lock and would fight the very autovacuum it is enabling.
+  defp stamp_autovacuum(partition_name) do
+    # Two statements rather than one `DO $$` block: a DO block takes no bind parameters
+    # (`$1` inside it is procedural, not a placeholder), so the name would have to be
+    # interpolated into the anonymous block anyway. This way the LOOKUP is parameterised and
+    # only the ALTER interpolates — and that name is generated from a year/month integer pair
+    # by `partition_name/2`, never from caller input.
+    already_tuned =
+      SQL.query(
+        Loopctl.Repo,
+        "SELECT 1 FROM pg_class WHERE relname = $1 AND $2 = ANY(reloptions)",
+        [partition_name, "autovacuum_analyze_scale_factor=#{@analyze_scale_factor}"]
+      )
+
+    case already_tuned do
+      {:ok, %{num_rows: 0}} -> apply_autovacuum_opts(partition_name)
+      {:ok, _} -> :ok
+      {:error, reason} -> log_tuning_failure(partition_name, reason)
+    end
+  end
+
+  defp apply_autovacuum_opts(partition_name) do
+    sql = """
+    ALTER TABLE #{partition_name} SET (
+      autovacuum_analyze_scale_factor = #{@analyze_scale_factor},
+      autovacuum_vacuum_insert_scale_factor = #{@vacuum_insert_scale_factor}
+    )
+    """
+
+    case SQL.query(Loopctl.Repo, sql, []) do
+      {:ok, _} -> :ok
+      {:error, reason} -> log_tuning_failure(partition_name, reason)
+    end
+  end
+
+  # Never fail partition creation over tuning — an untuned partition still accepts writes,
+  # and the next run re-attempts the stamp.
+  defp log_tuning_failure(partition_name, reason) do
+    Logger.warning("Failed to tune partition #{partition_name}: #{inspect(reason)}")
   end
 
   defp drop_expired_partitions do

--- a/lib/loopctl/workers/audit_partition_worker.ex
+++ b/lib/loopctl/workers/audit_partition_worker.ex
@@ -23,6 +23,15 @@ defmodule Loopctl.Workers.AuditPartitionWorker do
   @default_retention_days 90
   @future_months 3
 
+  # Every statement here is DDL, and `CREATE ... PARTITION OF`, `DROP TABLE` and
+  # `ALTER TABLE ... SET (...)` all require OWNERSHIP of the relation. In production
+  # `Loopctl.Repo` connects as `loopctl_app`, which holds only SELECT/INSERT/UPDATE/DELETE
+  # grants (deploy/FLY_SECRETS.md); migrations — and therefore the partitions they create —
+  # run as `loopctl_admin`, the owner, which is AdminRepo's role. Through Repo every
+  # statement below would fail in prod and be swallowed by the fail-soft warning, leaving
+  # the tuning real only in the dev/test superuser DBs.
+  @ddl_repo Loopctl.AdminRepo
+
   # Autovacuum tuning stamped onto every partition (#579). Append-only leaves accumulate
   # rather than churn, so the INSERT-driven trigger is the knob — the update-churn
   # `vacuum_scale_factor` would wait on dead tuples that never arrive. Kept in lockstep with
@@ -34,6 +43,11 @@ defmodule Loopctl.Workers.AuditPartitionWorker do
     "autovacuum_analyze_scale_factor=#{@analyze_scale_factor}",
     "autovacuum_vacuum_insert_scale_factor=#{@vacuum_insert_scale_factor}"
   ]
+  # The ALTER's SET list is DERIVED from the guard's expected set, never spelled out a second
+  # time: a third reloption added to only one of them would leave the containment check
+  # permanently unsatisfiable, and the worker would re-take the SHARE UPDATE EXCLUSIVE lock
+  # on every retained partition every day — the exact lock the guard exists to avoid.
+  @reloptions_sql Enum.join(@reloptions, ", ")
 
   @impl Oban.Worker
   def perform(_job) do
@@ -79,7 +93,7 @@ defmodule Loopctl.Workers.AuditPartitionWorker do
         FOR VALUES FROM ('#{from_date}') TO ('#{to_date}')
       """
 
-      case SQL.query(Loopctl.Repo, sql, []) do
+      case SQL.query(@ddl_repo, sql, []) do
         {:ok, _} ->
           stamp_autovacuum(partition_name)
 
@@ -108,16 +122,21 @@ defmodule Loopctl.Workers.AuditPartitionWorker do
     # Two statements rather than one `DO $$` block: a DO block takes no bind parameters
     # (`$1` inside it is procedural, not a placeholder), so the name would have to be
     # interpolated into the anonymous block anyway. This way the LOOKUP is parameterised and
-    # only the ALTER interpolates — and that name is generated from a year/month integer pair
-    # by `partition_name/2`, never from caller input.
+    # only the ALTER interpolates. The name is never caller input: the create loop generates
+    # it from a year/month integer pair via `partition_name/2`, and the retention sweep —
+    # which passes a `pg_class.relname`, i.e. database data — only reaches here through the
+    # anchored `~r/^audit_log_y\d{4}m\d{2}$/` filter in `sweep_existing_partitions/0`. Drop
+    # that regex and this interpolation becomes an injection sink.
     #
-    # `to_regclass` resolves through the same search_path the ALTER below binds to, so the
-    # check and the write can never mean two different same-named relations. `<@` requires
-    # BOTH reloptions: keying on the analyze factor alone would read a partition that lost
-    # only `vacuum_insert` as tuned and never restore the insert-driven trigger.
+    # `to_regclass` narrows the check to ONE relation, where the old `relname = $1` could
+    # match same-named relations in several schemas; it resolves through the connection's
+    # search_path, as the unqualified ALTER below does, but nothing in this code BINDS the
+    # two statements to one session — they rely on a uniform search_path config. `<@`
+    # requires BOTH reloptions: keying on the analyze factor alone would read a partition
+    # that lost only `vacuum_insert` as tuned and never restore the insert-driven trigger.
     already_tuned =
       SQL.query(
-        Loopctl.Repo,
+        @ddl_repo,
         "SELECT 1 FROM pg_class WHERE oid = to_regclass($1) AND $2 <@ reloptions",
         [partition_name, @reloptions]
       )
@@ -130,14 +149,9 @@ defmodule Loopctl.Workers.AuditPartitionWorker do
   end
 
   defp apply_autovacuum_opts(partition_name) do
-    sql = """
-    ALTER TABLE #{partition_name} SET (
-      autovacuum_analyze_scale_factor = #{@analyze_scale_factor},
-      autovacuum_vacuum_insert_scale_factor = #{@vacuum_insert_scale_factor}
-    )
-    """
+    sql = "ALTER TABLE #{partition_name} SET (#{@reloptions_sql})"
 
-    case SQL.query(Loopctl.Repo, sql, []) do
+    case SQL.query(@ddl_repo, sql, []) do
       {:ok, _} -> :ok
       {:error, reason} -> log_tuning_failure(partition_name, reason)
     end
@@ -155,16 +169,18 @@ defmodule Loopctl.Workers.AuditPartitionWorker do
     cutoff_year = cutoff.year
     cutoff_month = cutoff.month
 
-    # Query pg_inherits for existing partition tables
+    # Query pg_inherits for existing partition LEAVES. `relkind = 'r'` matches the migration
+    # and the test helper: a sub-partitioned child ('p') has no heap and would reject the
+    # ALTER the retained branch now issues.
     {:ok, %{rows: rows}} =
       SQL.query(
-        Loopctl.Repo,
+        @ddl_repo,
         """
         SELECT child.relname
         FROM pg_inherits
         JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
         JOIN pg_class child ON pg_inherits.inhrelid = child.oid
-        WHERE parent.relname = 'audit_log'
+        WHERE parent.relname = 'audit_log' AND child.relkind = 'r'
         ORDER BY child.relname
         """,
         []
@@ -174,7 +190,7 @@ defmodule Loopctl.Workers.AuditPartitionWorker do
         partition_name =~ ~r/^audit_log_y\d{4}m\d{2}$/ do
       case parse_partition_date(partition_name) do
         {year, month} when year < cutoff_year or (year == cutoff_year and month < cutoff_month) ->
-          SQL.query(Loopctl.Repo, "DROP TABLE IF EXISTS #{partition_name}", [])
+          SQL.query(@ddl_repo, "DROP TABLE IF EXISTS #{partition_name}", [])
 
           Logger.info("AuditPartitionWorker dropped expired partition: #{partition_name}")
 

--- a/lib/loopctl/workers/audit_partition_worker.ex
+++ b/lib/loopctl/workers/audit_partition_worker.ex
@@ -24,12 +24,19 @@ defmodule Loopctl.Workers.AuditPartitionWorker do
   @future_months 3
 
   # Every statement here is DDL, and `CREATE ... PARTITION OF`, `DROP TABLE` and
-  # `ALTER TABLE ... SET (...)` all require OWNERSHIP of the relation. In production
-  # `Loopctl.Repo` connects as `loopctl_app`, which holds only SELECT/INSERT/UPDATE/DELETE
-  # grants (deploy/FLY_SECRETS.md); migrations — and therefore the partitions they create —
-  # run as `loopctl_admin`, the owner, which is AdminRepo's role. Through Repo every
-  # statement below would fail in prod and be swallowed by the fail-soft warning, leaving
-  # the tuning real only in the dev/test superuser DBs.
+  # `ALTER TABLE ... SET (...)` all require OWNERSHIP of the relation — a grant is not
+  # enough. AdminRepo is the repo whose role owns them: migrations run through it
+  # (`Loopctl.Release.migrate/0`), so it created every partition and every table this touches.
+  #
+  # This is correctness against the DOCUMENTED split (`deploy/FLY_SECRETS.md`: `DATABASE_URL`
+  # is the grants-only `loopctl_app`, `ADMIN_DATABASE_URL` the owner `loopctl_admin`), NOT a
+  # repair of a live outage — measured 2026-08-04, the hosted deployment does not currently
+  # run that split. Its `DATABASE_URL` connects as `loopctl`, `ADMIN_DATABASE_URL` is UNSET so
+  # `config/runtime.exs` falls it back to the same URL, and the partitions are owned by
+  # `loopctl` — so Repo did own them and the DDL was succeeding. Do not "simplify" this back
+  # to Repo on the strength of that: the moment the documented split is actually deployed,
+  # every statement below starts failing into the fail-soft warning and the tuning silently
+  # stops being applied, which is exactly the undetected shape #579 was.
   @ddl_repo Loopctl.AdminRepo
 
   # Autovacuum tuning stamped onto every partition (#579). Append-only leaves accumulate

--- a/lib/loopctl/workers/audit_partition_worker.ex
+++ b/lib/loopctl/workers/audit_partition_worker.ex
@@ -7,8 +7,9 @@ defmodule Loopctl.Workers.AuditPartitionWorker do
   1. **Creates future partitions** — ensures partitions exist for the current
      month plus 3 months ahead, preventing insert failures.
 
-  2. **Drops old partitions** — removes partitions older than the configured
-     retention period (default: 90 days) to prevent unbounded table growth.
+  2. **Sweeps existing partitions** — drops those older than the configured retention
+     period (default: 90 days) to prevent unbounded table growth, and re-stamps the
+     autovacuum tuning on every partition it retains.
 
   Partition naming convention: `audit_log_yYYYYmMM`
   """
@@ -29,11 +30,15 @@ defmodule Loopctl.Workers.AuditPartitionWorker do
   # that already existed; a partitioned PARENT has no heap and rejects these params entirely.
   @analyze_scale_factor "0.05"
   @vacuum_insert_scale_factor "0.1"
+  @reloptions [
+    "autovacuum_analyze_scale_factor=#{@analyze_scale_factor}",
+    "autovacuum_vacuum_insert_scale_factor=#{@vacuum_insert_scale_factor}"
+  ]
 
   @impl Oban.Worker
   def perform(_job) do
     create_future_partitions()
-    drop_expired_partitions()
+    sweep_existing_partitions()
     :ok
   end
 
@@ -92,21 +97,29 @@ defmodule Loopctl.Workers.AuditPartitionWorker do
   # stamped individually or it is created with the global defaults, which is how the whole
   # corpus went un-analyzed until #579.
   #
-  # SELF-HEALING, and stamped on the duplicate_table branch too: that covers a partition
-  # created before this code existed, and one created untuned during a deploy window. Guarded
-  # on the reloption being ABSENT rather than stamped unconditionally, because `ALTER TABLE`
-  # takes a SHARE UPDATE EXCLUSIVE lock and would fight the very autovacuum it is enabling.
+  # SELF-HEALING over the whole RETENTION window, not just the create window: stamped on the
+  # duplicate_table branch, and again from the retention sweep, so a partition created before
+  # this code existed, created untuned during a deploy window, or rebuilt by a copy-swap that
+  # silently drops reloptions is repaired on the next run wherever it sits in the window.
+  # Guarded on the reloptions being ABSENT rather than stamped unconditionally, because
+  # `ALTER TABLE` takes a SHARE UPDATE EXCLUSIVE lock and would fight the very autovacuum it
+  # is enabling.
   defp stamp_autovacuum(partition_name) do
     # Two statements rather than one `DO $$` block: a DO block takes no bind parameters
     # (`$1` inside it is procedural, not a placeholder), so the name would have to be
     # interpolated into the anonymous block anyway. This way the LOOKUP is parameterised and
     # only the ALTER interpolates — and that name is generated from a year/month integer pair
     # by `partition_name/2`, never from caller input.
+    #
+    # `to_regclass` resolves through the same search_path the ALTER below binds to, so the
+    # check and the write can never mean two different same-named relations. `<@` requires
+    # BOTH reloptions: keying on the analyze factor alone would read a partition that lost
+    # only `vacuum_insert` as tuned and never restore the insert-driven trigger.
     already_tuned =
       SQL.query(
         Loopctl.Repo,
-        "SELECT 1 FROM pg_class WHERE relname = $1 AND $2 = ANY(reloptions)",
-        [partition_name, "autovacuum_analyze_scale_factor=#{@analyze_scale_factor}"]
+        "SELECT 1 FROM pg_class WHERE oid = to_regclass($1) AND $2 <@ reloptions",
+        [partition_name, @reloptions]
       )
 
     case already_tuned do
@@ -136,7 +149,7 @@ defmodule Loopctl.Workers.AuditPartitionWorker do
     Logger.warning("Failed to tune partition #{partition_name}: #{inspect(reason)}")
   end
 
-  defp drop_expired_partitions do
+  defp sweep_existing_partitions do
     retention_days = Application.get_env(:loopctl, :audit_retention_days, @default_retention_days)
     cutoff = DateTime.utc_now() |> DateTime.add(-retention_days * 86_400, :second)
     cutoff_year = cutoff.year
@@ -165,8 +178,12 @@ defmodule Loopctl.Workers.AuditPartitionWorker do
 
           Logger.info("AuditPartitionWorker dropped expired partition: #{partition_name}")
 
+        # Retained: heal here, so the healing scope is the RETENTION window rather than the
+        # create window. A past-month partition that lost its reloptions to a rebuild is
+        # still read (audit history, STH verification) and is never revisited by the create
+        # loop, which only walks the current month forward.
         _ ->
-          :ok
+          stamp_autovacuum(partition_name)
       end
     end
   end

--- a/priv/repo/migrations/20260804230000_tune_autovacuum_on_append_heavy_tables.exs
+++ b/priv/repo/migrations/20260804230000_tune_autovacuum_on_append_heavy_tables.exs
@@ -26,6 +26,10 @@ defmodule Loopctl.Repo.Migrations.TuneAutovacuumOnAppendHeavyTables do
   `CREATE TABLE ... PARTITION OF` child does NOT inherit reloptions —
   `Loopctl.Workers.AuditPartitionWorker` re-stamps every partition inside the retention
   window on each daily run, which also repairs the reloptions a table REBUILD silently drops.
+  That self-heal covers the `audit_log` partitions ONLY: the four plain tables above are
+  stamped exactly once, here, and a REBUILD (pg_repack, copy-swap, `CREATE TABLE ... LIKE`)
+  silently drops their reloptions with nothing to restore them — re-apply `@opts` by hand
+  after any such rebuild, or #579 comes back unnoticed.
   The corollary: `down/0` does NOT stick for the partitions — the next worker run restores
   them within a day. Rolling back to diagnose an autovacuum problem means stopping that
   worker's cron entry (or changing its constants) as well; the RESET is durable only for the

--- a/priv/repo/migrations/20260804230000_tune_autovacuum_on_append_heavy_tables.exs
+++ b/priv/repo/migrations/20260804230000_tune_autovacuum_on_append_heavy_tables.exs
@@ -1,0 +1,85 @@
+defmodule Loopctl.Repo.Migrations.TuneAutovacuumOnAppendHeavyTables do
+  @moduledoc """
+  Per-table autovacuum tuning for the append-heavy tables (#579).
+
+  Autoanalyze had NEVER run on the four largest tables — `autoanalyze_count = 0`,
+  `last_autoanalyze IS NULL` — so `pg_stat_user_tables` reported row counts wrong by three
+  orders of magnitude: `articles` said 358 against a real 85,053, `article_links` said 6,026
+  against 1,417,624. Anything reading `n_live_tup` (capacity checks, dashboards) was simply
+  wrong, and column statistics age silently with the data.
+
+  Not a broken autovacuum — `autovacuum` is `on` and no table disables it. A THRESHOLD gap:
+  the trigger is `50 + 0.1 * reltuples`, i.e. ~8,555 changes for `articles`. The corpus was
+  bulk-loaded at the 2026-07-30 consolidation and has grown by less than that since, so it
+  legitimately never fired. Only `oban_jobs`, which churns constantly, was being analyzed.
+
+  These tables ACCUMULATE rather than churn (`n_dead_tup` measured ~0 on `article_links`,
+  `article_access_events`; 475 on `articles`), so the INSERT-driven trigger is the right knob,
+  not the update-churn `autovacuum_vacuum_scale_factor`. Halving the analyze scale factor
+  takes `articles` from ~8,555 changes to ~4,303 and `article_access_events` to ~2,868.
+
+  Catalog-only (instant, no rewrite), so it rides a normal migration rather than needing the
+  out-of-band DDL procedure.
+
+  NOT applied to the `audit_log` PARENT: a partitioned parent has no heap and rejects storage
+  autovacuum params. Partitions are stamped individually here, and — because a
+  `CREATE TABLE ... PARTITION OF` child does NOT inherit reloptions —
+  `Loopctl.Workers.AuditPartitionWorker` stamps every partition it creates, self-healingly.
+  A table REBUILD also silently drops reloptions, so re-apply after any copy-swap.
+  """
+  use Ecto.Migration
+
+  @append_heavy ~w(articles article_links article_embeddings article_access_events)
+
+  # `analyze` halved from the 0.1 default; `vacuum_insert` at 0.1 so an append-only table is
+  # still vacuumed for the visibility map (index-only scans) without waiting on dead tuples
+  # that never come.
+  @opts "autovacuum_analyze_scale_factor = 0.05, autovacuum_vacuum_insert_scale_factor = 0.1"
+
+  def up do
+    for table <- @append_heavy do
+      execute("ALTER TABLE #{table} SET (#{@opts})")
+    end
+
+    # Existing audit_log partitions (leaves only — the parent has no heap).
+    execute("""
+    DO $$
+    DECLARE part text;
+    BEGIN
+      FOR part IN
+        SELECT c.relname
+          FROM pg_inherits i
+          JOIN pg_class p ON p.oid = i.inhparent
+          JOIN pg_class c ON c.oid = i.inhrelid
+         WHERE p.relname = 'audit_log' AND c.relkind = 'r'
+      LOOP
+        EXECUTE format('ALTER TABLE %I SET (#{@opts})', part);
+      END LOOP;
+    END $$
+    """)
+  end
+
+  def down do
+    reset = "autovacuum_analyze_scale_factor, autovacuum_vacuum_insert_scale_factor"
+
+    for table <- @append_heavy do
+      execute("ALTER TABLE #{table} RESET (#{reset})")
+    end
+
+    execute("""
+    DO $$
+    DECLARE part text;
+    BEGIN
+      FOR part IN
+        SELECT c.relname
+          FROM pg_inherits i
+          JOIN pg_class p ON p.oid = i.inhparent
+          JOIN pg_class c ON c.oid = i.inhrelid
+         WHERE p.relname = 'audit_log' AND c.relkind = 'r'
+      LOOP
+        EXECUTE format('ALTER TABLE %I RESET (#{reset})', part);
+      END LOOP;
+    END $$
+    """)
+  end
+end

--- a/priv/repo/migrations/20260804230000_tune_autovacuum_on_append_heavy_tables.exs
+++ b/priv/repo/migrations/20260804230000_tune_autovacuum_on_append_heavy_tables.exs
@@ -24,8 +24,12 @@ defmodule Loopctl.Repo.Migrations.TuneAutovacuumOnAppendHeavyTables do
   NOT applied to the `audit_log` PARENT: a partitioned parent has no heap and rejects storage
   autovacuum params. Partitions are stamped individually here, and — because a
   `CREATE TABLE ... PARTITION OF` child does NOT inherit reloptions —
-  `Loopctl.Workers.AuditPartitionWorker` stamps every partition it creates, self-healingly.
-  A table REBUILD also silently drops reloptions, so re-apply after any copy-swap.
+  `Loopctl.Workers.AuditPartitionWorker` re-stamps every partition inside the retention
+  window on each daily run, which also repairs the reloptions a table REBUILD silently drops.
+  The corollary: `down/0` does NOT stick for the partitions — the next worker run restores
+  them within a day. Rolling back to diagnose an autovacuum problem means stopping that
+  worker's cron entry (or changing its constants) as well; the RESET is durable only for the
+  four plain tables.
   """
   use Ecto.Migration
 

--- a/test/loopctl/workers/audit_partition_worker_test.exs
+++ b/test/loopctl/workers/audit_partition_worker_test.exs
@@ -1,12 +1,19 @@
 defmodule Loopctl.Workers.AuditPartitionWorkerTest do
-  use Loopctl.DataCase, async: true
+  # DELIBERATELY sync: not coupled to global STATE, but holding DDL LOCKS. The strip below
+  # takes SHARE UPDATE EXCLUSIVE on every audit_log leaf for the whole test transaction and
+  # `perform/1` then escalates to ACCESS EXCLUSIVE on the parent to drop expired partitions,
+  # while any async peer inserting an audit row holds ROW EXCLUSIVE — a circular wait. ExUnit
+  # runs sync modules after the async ones, so no peer holds those locks.
+  use Loopctl.DataCase, async: false
 
   setup :verify_on_exit!
 
-  alias Loopctl.Repo
+  alias Loopctl.AdminRepo
   alias Loopctl.Workers.AuditPartitionWorker
 
-  @both "autovacuum_analyze_scale_factor, autovacuum_vacuum_insert_scale_factor"
+  @analyze "autovacuum_analyze_scale_factor"
+  @insert "autovacuum_vacuum_insert_scale_factor"
+  @both "#{@analyze}, #{@insert}"
 
   describe "perform/1" do
     test "creates future partitions and succeeds" do
@@ -22,23 +29,21 @@ defmodule Loopctl.Workers.AuditPartitionWorkerTest do
 
     test "#579: every retained partition carries the tuning, and the stamp is SELF-HEALING" do
       # `CREATE TABLE ... PARTITION OF` does NOT inherit reloptions, and a partitioned parent
-      # cannot hold storage autovacuum params at all — so an unstamped partition is created
-      # with the global defaults. That is how the corpus went un-analyzed: autoanalyze had
-      # never run on the four largest tables, and `n_live_tup` read 358 for a table with
-      # 85,053 rows.
+      # cannot hold them at all — so an unstamped partition runs on the global defaults, which
+      # is how the corpus went un-analyzed (`n_live_tup` read 358 for 85,053 rows).
       #
-      # Loopctl.Repo throughout, because that is the repo the WORKER writes through. Repo and
-      # AdminRepo hold separate sandbox transactions, so a RESET issued on one is invisible to
-      # the other — and reading the assertion back through AdminRepo would only ever observe
-      # the stamp test_helper committed, staying green with the worker's stamp deleted.
+      # AdminRepo throughout, because that is the repo the WORKER writes through (it owns the
+      # partitions; `loopctl_app` may not ALTER them) and the two repos hold separate sandbox
+      # transactions — a RESET issued on one is invisible to the other, and asserting through
+      # the other would only ever observe the stamp test_helper committed.
       #
       # Stripping EVERY leaf rather than one arbitrary `LIMIT 1` row: it covers the retained
       # PAST months (which the create loop never revisits) as well as the create window, and
       # it cannot land on a partition this same run drops as expired.
-      for [name, _] <- partitions(), do: Repo.query!("ALTER TABLE #{name} RESET (#{@both})")
+      for [name, _] <- partitions(), do: AdminRepo.query!("ALTER TABLE #{name} RESET (#{@both})")
 
       for [name, reloptions] <- partitions() do
-        refute reloptions =~ "autovacuum_",
+        refute reloptions =~ ~r/#{@analyze}|#{@insert}/,
                "the RESET on #{name} did not take, so the repair below is unobservable"
       end
 
@@ -47,43 +52,57 @@ defmodule Loopctl.Workers.AuditPartitionWorkerTest do
       retained = partitions()
       assert retained != [], "no audit_log partitions found — the assertions below are vacuous"
 
-      for [name, reloptions] <- retained do
-        assert reloptions =~ "autovacuum_analyze_scale_factor=0.05",
-               "partition #{name} was left untuned: #{inspect(reloptions)}"
+      # Only a RETAINED partition before the current month exercises the sweep-only stamp path
+      # (fixed-width zero-padded names, so a string compare orders them).
+      assert Enum.any?(retained, fn [name, _] -> name < current_partition() end),
+             "every retained partition is in the create window — the sweep stamp is untested"
 
-        assert reloptions =~ "autovacuum_vacuum_insert_scale_factor=0.1",
-               "partition #{name} is missing the insert-driven vacuum trigger"
+      for [name, reloptions] <- retained do
+        assert reloptions =~ "#{@analyze}=0.05", "#{name} left untuned: #{inspect(reloptions)}"
+        assert reloptions =~ "#{@insert}=0.1", "#{name} lost the insert-driven vacuum trigger"
       end
     end
 
     test "#579: a partition that lost only the insert factor is re-stamped" do
-      # The already-tuned guard has to key on BOTH reloptions. Keying on the analyze factor
+      # The already-tuned guard has to key on BOTH reloptions: keying on the analyze factor
       # alone reads this half-stamped partition as tuned and never restores the insert-driven
-      # trigger — the knob this change exists for. The CURRENT month, derived the way the
-      # worker derives it, so the target is always a partition the worker is specified to
-      # visit and never one it drops as expired.
-      now = DateTime.utc_now()
-      name = "audit_log_y#{now.year}m#{String.pad_leading("#{now.month}", 2, "0")}"
+      # trigger. The CURRENT month, so the target is one the worker visits and never drops.
+      name = current_partition()
 
-      Repo.query!("ALTER TABLE #{name} SET (autovacuum_analyze_scale_factor = 0.05)")
-      Repo.query!("ALTER TABLE #{name} RESET (autovacuum_vacuum_insert_scale_factor)")
+      AdminRepo.query!("ALTER TABLE #{name} SET (#{@analyze} = 0.05)")
+      AdminRepo.query!("ALTER TABLE #{name} RESET (#{@insert})")
+
+      # Prove the half-stamped state first, or a guard that checks only the analyze factor
+      # passes on an insert factor the setup never removed.
+      half_stamped = reloptions(name)
+      assert half_stamped =~ "#{@analyze}=0.05"
+      refute half_stamped =~ @insert, "the RESET on #{name} did not take — guard unobservable"
 
       assert :ok = AuditPartitionWorker.perform(%Oban.Job{})
 
-      %{rows: [[reloptions]]} =
-        Repo.query!(
-          "SELECT coalesce(array_to_string(reloptions, ','), '') FROM pg_class WHERE oid = to_regclass($1)",
-          [name]
-        )
-
-      assert reloptions =~ "autovacuum_vacuum_insert_scale_factor=0.1",
+      assert reloptions(name) =~ "#{@insert}=0.1",
              "#{name} kept the analyze factor, so the guard skipped the missing insert factor"
     end
   end
 
+  defp current_partition do
+    now = DateTime.utc_now()
+    "audit_log_y#{now.year}m#{String.pad_leading("#{now.month}", 2, "0")}"
+  end
+
+  defp reloptions(name) do
+    %{rows: [[reloptions]]} =
+      AdminRepo.query!(
+        "SELECT coalesce(array_to_string(reloptions, ','), '') FROM pg_class WHERE oid = to_regclass($1)",
+        [name]
+      )
+
+    reloptions
+  end
+
   defp partitions do
     %{rows: rows} =
-      Repo.query!("""
+      AdminRepo.query!("""
       SELECT c.relname, coalesce(array_to_string(c.reloptions, ','), '')
         FROM pg_inherits i
         JOIN pg_class p ON p.oid = i.inhparent

--- a/test/loopctl/workers/audit_partition_worker_test.exs
+++ b/test/loopctl/workers/audit_partition_worker_test.exs
@@ -3,6 +3,8 @@ defmodule Loopctl.Workers.AuditPartitionWorkerTest do
 
   setup :verify_on_exit!
 
+  alias Loopctl.AdminRepo
+  alias Loopctl.Repo
   alias Loopctl.Workers.AuditPartitionWorker
 
   describe "perform/1" do
@@ -15,6 +17,75 @@ defmodule Loopctl.Workers.AuditPartitionWorkerTest do
     test "is idempotent — running twice does not error" do
       assert :ok = AuditPartitionWorker.perform(%Oban.Job{})
       assert :ok = AuditPartitionWorker.perform(%Oban.Job{})
+    end
+
+    test "#579: every partition it manages carries the autovacuum tuning" do
+      # `CREATE TABLE ... PARTITION OF` does NOT inherit reloptions, and a partitioned parent
+      # cannot hold storage autovacuum params at all — so an unstamped partition is created
+      # with the global defaults. That is how the corpus went un-analyzed: autoanalyze had
+      # never run on the four largest tables, and `n_live_tup` read 358 for a table with
+      # 85,053 rows.
+      assert :ok = AuditPartitionWorker.perform(%Oban.Job{})
+
+      %{rows: rows} =
+        AdminRepo.query!("""
+        SELECT c.relname, coalesce(array_to_string(c.reloptions, ','), '')
+          FROM pg_inherits i
+          JOIN pg_class p ON p.oid = i.inhparent
+          JOIN pg_class c ON c.oid = i.inhrelid
+         WHERE p.relname = 'audit_log' AND c.relkind = 'r'
+        """)
+
+      assert rows != [], "no audit_log partitions found — the assertion below would be vacuous"
+
+      for [name, reloptions] <- rows do
+        assert reloptions =~ "autovacuum_analyze_scale_factor=0.05",
+               "partition #{name} was created untuned: #{inspect(reloptions)}"
+
+        assert reloptions =~ "autovacuum_vacuum_insert_scale_factor=0.1",
+               "partition #{name} is missing the insert-driven vacuum trigger"
+      end
+    end
+
+    test "#579: the stamp is SELF-HEALING — it re-tunes a partition that lost its reloptions" do
+      # Covers the two ways a partition ends up untuned despite this code existing: created
+      # before it did, and created during a deploy window. A table REBUILD also silently drops
+      # reloptions. So the stamp must repair, not just apply-on-create.
+      # Loopctl.Repo throughout, because that is the repo the WORKER writes through. Repo and
+      # AdminRepo hold separate sandbox transactions, so a RESET issued on one is invisible to
+      # the other — the repair would look like it never happened when in fact the test never
+      # observed it.
+      %{rows: [[name] | _]} =
+        Repo.query!("""
+        SELECT c.relname FROM pg_inherits i
+          JOIN pg_class p ON p.oid = i.inhparent
+          JOIN pg_class c ON c.oid = i.inhrelid
+         WHERE p.relname = 'audit_log' AND c.relkind = 'r' LIMIT 1
+        """)
+
+      Repo.query!(
+        "ALTER TABLE #{name} RESET (autovacuum_analyze_scale_factor, autovacuum_vacuum_insert_scale_factor)"
+      )
+
+      %{rows: [[stripped]]} =
+        Repo.query!(
+          "SELECT coalesce(array_to_string(reloptions, ','), '') FROM pg_class WHERE relname = $1",
+          [name]
+        )
+
+      refute stripped =~ "autovacuum_analyze_scale_factor",
+             "the RESET did not take, so this test cannot observe the repair"
+
+      assert :ok = AuditPartitionWorker.perform(%Oban.Job{})
+
+      %{rows: [[repaired]]} =
+        Repo.query!(
+          "SELECT coalesce(array_to_string(reloptions, ','), '') FROM pg_class WHERE relname = $1",
+          [name]
+        )
+
+      assert repaired =~ "autovacuum_analyze_scale_factor=0.05",
+             "#{name} was not re-tuned — the stamp only applies on create, not on repair"
     end
   end
 end

--- a/test/loopctl/workers/audit_partition_worker_test.exs
+++ b/test/loopctl/workers/audit_partition_worker_test.exs
@@ -3,9 +3,10 @@ defmodule Loopctl.Workers.AuditPartitionWorkerTest do
 
   setup :verify_on_exit!
 
-  alias Loopctl.AdminRepo
   alias Loopctl.Repo
   alias Loopctl.Workers.AuditPartitionWorker
+
+  @both "autovacuum_analyze_scale_factor, autovacuum_vacuum_insert_scale_factor"
 
   describe "perform/1" do
     test "creates future partitions and succeeds" do
@@ -19,73 +20,77 @@ defmodule Loopctl.Workers.AuditPartitionWorkerTest do
       assert :ok = AuditPartitionWorker.perform(%Oban.Job{})
     end
 
-    test "#579: every partition it manages carries the autovacuum tuning" do
+    test "#579: every retained partition carries the tuning, and the stamp is SELF-HEALING" do
       # `CREATE TABLE ... PARTITION OF` does NOT inherit reloptions, and a partitioned parent
       # cannot hold storage autovacuum params at all — so an unstamped partition is created
       # with the global defaults. That is how the corpus went un-analyzed: autoanalyze had
       # never run on the four largest tables, and `n_live_tup` read 358 for a table with
       # 85,053 rows.
+      #
+      # Loopctl.Repo throughout, because that is the repo the WORKER writes through. Repo and
+      # AdminRepo hold separate sandbox transactions, so a RESET issued on one is invisible to
+      # the other — and reading the assertion back through AdminRepo would only ever observe
+      # the stamp test_helper committed, staying green with the worker's stamp deleted.
+      #
+      # Stripping EVERY leaf rather than one arbitrary `LIMIT 1` row: it covers the retained
+      # PAST months (which the create loop never revisits) as well as the create window, and
+      # it cannot land on a partition this same run drops as expired.
+      for [name, _] <- partitions(), do: Repo.query!("ALTER TABLE #{name} RESET (#{@both})")
+
+      for [name, reloptions] <- partitions() do
+        refute reloptions =~ "autovacuum_",
+               "the RESET on #{name} did not take, so the repair below is unobservable"
+      end
+
       assert :ok = AuditPartitionWorker.perform(%Oban.Job{})
 
-      %{rows: rows} =
-        AdminRepo.query!("""
-        SELECT c.relname, coalesce(array_to_string(c.reloptions, ','), '')
-          FROM pg_inherits i
-          JOIN pg_class p ON p.oid = i.inhparent
-          JOIN pg_class c ON c.oid = i.inhrelid
-         WHERE p.relname = 'audit_log' AND c.relkind = 'r'
-        """)
+      retained = partitions()
+      assert retained != [], "no audit_log partitions found — the assertions below are vacuous"
 
-      assert rows != [], "no audit_log partitions found — the assertion below would be vacuous"
-
-      for [name, reloptions] <- rows do
+      for [name, reloptions] <- retained do
         assert reloptions =~ "autovacuum_analyze_scale_factor=0.05",
-               "partition #{name} was created untuned: #{inspect(reloptions)}"
+               "partition #{name} was left untuned: #{inspect(reloptions)}"
 
         assert reloptions =~ "autovacuum_vacuum_insert_scale_factor=0.1",
                "partition #{name} is missing the insert-driven vacuum trigger"
       end
     end
 
-    test "#579: the stamp is SELF-HEALING — it re-tunes a partition that lost its reloptions" do
-      # Covers the two ways a partition ends up untuned despite this code existing: created
-      # before it did, and created during a deploy window. A table REBUILD also silently drops
-      # reloptions. So the stamp must repair, not just apply-on-create.
-      # Loopctl.Repo throughout, because that is the repo the WORKER writes through. Repo and
-      # AdminRepo hold separate sandbox transactions, so a RESET issued on one is invisible to
-      # the other — the repair would look like it never happened when in fact the test never
-      # observed it.
-      %{rows: [[name] | _]} =
-        Repo.query!("""
-        SELECT c.relname FROM pg_inherits i
-          JOIN pg_class p ON p.oid = i.inhparent
-          JOIN pg_class c ON c.oid = i.inhrelid
-         WHERE p.relname = 'audit_log' AND c.relkind = 'r' LIMIT 1
-        """)
+    test "#579: a partition that lost only the insert factor is re-stamped" do
+      # The already-tuned guard has to key on BOTH reloptions. Keying on the analyze factor
+      # alone reads this half-stamped partition as tuned and never restores the insert-driven
+      # trigger — the knob this change exists for. The CURRENT month, derived the way the
+      # worker derives it, so the target is always a partition the worker is specified to
+      # visit and never one it drops as expired.
+      now = DateTime.utc_now()
+      name = "audit_log_y#{now.year}m#{String.pad_leading("#{now.month}", 2, "0")}"
 
-      Repo.query!(
-        "ALTER TABLE #{name} RESET (autovacuum_analyze_scale_factor, autovacuum_vacuum_insert_scale_factor)"
-      )
-
-      %{rows: [[stripped]]} =
-        Repo.query!(
-          "SELECT coalesce(array_to_string(reloptions, ','), '') FROM pg_class WHERE relname = $1",
-          [name]
-        )
-
-      refute stripped =~ "autovacuum_analyze_scale_factor",
-             "the RESET did not take, so this test cannot observe the repair"
+      Repo.query!("ALTER TABLE #{name} SET (autovacuum_analyze_scale_factor = 0.05)")
+      Repo.query!("ALTER TABLE #{name} RESET (autovacuum_vacuum_insert_scale_factor)")
 
       assert :ok = AuditPartitionWorker.perform(%Oban.Job{})
 
-      %{rows: [[repaired]]} =
+      %{rows: [[reloptions]]} =
         Repo.query!(
-          "SELECT coalesce(array_to_string(reloptions, ','), '') FROM pg_class WHERE relname = $1",
+          "SELECT coalesce(array_to_string(reloptions, ','), '') FROM pg_class WHERE oid = to_regclass($1)",
           [name]
         )
 
-      assert repaired =~ "autovacuum_analyze_scale_factor=0.05",
-             "#{name} was not re-tuned — the stamp only applies on create, not on repair"
+      assert reloptions =~ "autovacuum_vacuum_insert_scale_factor=0.1",
+             "#{name} kept the analyze factor, so the guard skipped the missing insert factor"
     end
+  end
+
+  defp partitions do
+    %{rows: rows} =
+      Repo.query!("""
+      SELECT c.relname, coalesce(array_to_string(c.reloptions, ','), '')
+        FROM pg_inherits i
+        JOIN pg_class p ON p.oid = i.inhparent
+        JOIN pg_class c ON c.oid = i.inhrelid
+       WHERE p.relname = 'audit_log' AND c.relkind = 'r'
+      """)
+
+    rows
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -18,7 +18,8 @@ Ecto.Adapters.SQL.Sandbox.mode(Loopctl.AdminRepo, :manual)
 # (Prod is unaffected: the nightly AuditPartitionWorker keeps the window ahead.) Ensure a
 # generous window here. It must be COMMITTED DDL, so run it unboxed — a plain query would
 # execute inside the sandbox transaction and be rolled back before any test sees it.
-Ecto.Adapters.SQL.Sandbox.unboxed_run(Loopctl.Repo, fn ->
+# AdminRepo, because the worker issues its DDL through AdminRepo (it owns the partitions).
+Ecto.Adapters.SQL.Sandbox.unboxed_run(Loopctl.AdminRepo, fn ->
   Loopctl.Workers.AuditPartitionWorker.ensure_partitions(back: 12)
 end)
 


### PR DESCRIPTION
Closes #579.

Autoanalyze had **never run** on the four largest tables — `autoanalyze_count = 0`, `last_autoanalyze IS NULL` — so `pg_stat_user_tables` reported row counts wrong by three orders of magnitude:

| table | reported `n_live_tup` | actual |
|---|---|---|
| `articles` | 358 | **85,053** |
| `article_links` | 6,026 | **1,417,624** |

Anything reading `n_live_tup` — a capacity check, a dashboard — was simply wrong.

## Not a broken autovacuum — a threshold gap

`autovacuum` is `on`, no table disables it, and `oban_jobs` has been analyzed 27 times. The trigger is `50 + 0.1 * reltuples` ≈ **8,555 changes** for `articles`; the corpus was bulk-loaded at the 2026-07-30 consolidation and has grown by less than that since, so it legitimately never fired. `oban_jobs` churns constantly, which is why only it was covered.

## The knob follows the access pattern

These tables **accumulate** rather than churn — `n_dead_tup` measured ~0 on `article_links` and `article_access_events`, 475 on `articles` — so the **insert-driven** trigger is the right one. The update-churn `vacuum_scale_factor` would wait on dead tuples that never arrive (which is also why "no autovacuum, only autoanalyze" on an append-only table is correct, not a symptom).

Halving the analyze scale factor takes `articles` from ~8,555 changes to ~4,303, and `article_access_events` to ~2,868. Catalog-only and instant, so it rides a normal migration.

## Partitions

The `audit_log` **parent** is deliberately excluded — a partitioned parent has no heap and rejects storage autovacuum params outright. Partitions are stamped individually: existing ones by the migration, new ones by `AuditPartitionWorker`, because `CREATE TABLE ... PARTITION OF` does not inherit reloptions.

The stamp is **self-healing** and fires on the already-exists branch too, covering a partition created before this code and one created untuned during a deploy window (a table rebuild also silently drops reloptions). It's guarded on the reloption being *absent* rather than applied unconditionally — `ALTER TABLE` takes a `SHARE UPDATE EXCLUSIVE` lock and would fight the very autovacuum it's enabling. A tuning failure logs and never fails partition creation.

## Two things I got wrong, both caught by tests

- A `DO $$` block takes **no bind parameters** — the first version raised at runtime. It's now a parameterised lookup plus an `ALTER` that interpolates only a name generated from a year/month integer pair.
- The self-healing test first failed for the *wrong reason*: I reset reloptions through `AdminRepo` while the worker writes through `Repo`, and those hold **separate sandbox transactions** — so the test couldn't observe a repair that actually happened.

**Both guards mutation-verified:** making the stamp a no-op fails the self-healing test, and the coverage test asserts its row set is non-empty first so it cannot pass vacuously.

`mix precommit` green: 6694 tests, 0 failures.
