### PR TITLE
#588 Prime the SystemConfig cache before the Endpoint starts

### DIFF
--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -140,7 +140,12 @@ number, is the load-bearing invariant. To monitor and keep it healthy over time:
   changes reach every node within 60s via the per-minute `SystemConfigRefreshWorker`. The side table
   is a NARROW relation (the ANN fetches only `article_id` from a lean heap), so it reads measurably
   FASTER than the wide legacy column at equal recall — adding the relation IMPROVED latency, it did not
-  cost it. Cutover prod EXPLAIN + p95 artifact: GH #464.
+  cost it. Cutover prod EXPLAIN + p95 artifact: GH #464. A cache MISS answers the in-code default
+  `0` = the LEGACY column, so the boot prime is ORDERED, not merely fast: the supervised one-shot
+  `Loopctl.SystemConfig.CachePrimer` primes synchronously inside its `start_link/1` and is listed in
+  `Loopctl.Application.children/0` after `Loopctl.AdminRepo` and before `Oban` and the Endpoint
+  (GH #588). Never make it a `Task` child or a `handle_continue/2` — both return to the supervisor
+  immediately and restore the boot window in which every vector read silently used the legacy column.
   Production resolves the decision through `Loopctl.Embeddings.ReadPathBehaviour` (default impl
   `Loopctl.Embeddings.SystemConfigReadPath`, which also owns the flag-key string); `config/test.exs`
   points it at `Loopctl.MockEmbeddingReadPath`. **Tests must stub that mock per-process**

--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -26,12 +26,46 @@ defmodule Loopctl.Application do
     # write it observes.
     IngestionWriteStats.attach()
 
-    children = [
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: Loopctl.Supervisor]
+    result = Supervisor.start_link(children(), opts)
+
+    post_boot_checks()
+
+    result
+  end
+
+  # The supervision-tree child list, extracted so its ORDER can be asserted
+  # statically (GH #588) without booting anything — a supervisor starts children
+  # synchronously in list order, so the order in this list IS the guarantee.
+  @doc false
+  @spec children() :: [Supervisor.child_spec() | {module(), term()} | module()]
+  def children do
+    [
       LoopctlWeb.Telemetry,
       Loopctl.Vault,
       Loopctl.Repo,
       Loopctl.AdminRepo,
       Loopctl.HeavyReadRepo,
+      # GH #588: primes the SystemConfig :persistent_term cache from the DB
+      # SYNCHRONOUSLY (inside its start_link/1, then returns :ignore), so the
+      # cache is authoritative before ANY consumer starts. Placement is the whole
+      # point: a supervisor starts children in list order, so sitting AFTER
+      # Loopctl.AdminRepo (which refresh/0 reads through) and BEFORE {Oban, ...}
+      # and LoopctlWeb.Endpoint is what makes "primed before work is accepted" a
+      # guarantee rather than a race. This replaces a post-`start_link` prime,
+      # under which both consumers served requests against an EMPTY cache for a
+      # startup window — and a miss returns the caller's in-code default, which
+      # for the embeddings read-routing flag ("embedding_side_table_reads") is
+      # the RETIRED legacy `articles.embedding` column. Every boot therefore
+      # silently reverted the completed cutover on semantic search, suggest-links
+      # and the novelty gate. Never make this a Task child or a
+      # handle_continue/2: both return to the supervisor immediately and
+      # reproduce the race. A failed prime is loud (log + telemetry) but NEVER
+      # blocks boot — the in-code defaults apply until the per-minute
+      # SystemConfigRefreshWorker succeeds.
+      Loopctl.SystemConfig.CachePrimer,
       {DNSCluster, query: Application.get_env(:loopctl, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: Loopctl.PubSub},
       {Task.Supervisor, name: Loopctl.TaskSupervisor},
@@ -158,19 +192,11 @@ defmodule Loopctl.Application do
       Loopctl.AuditChain.ProofCache,
       LoopctlWeb.Endpoint
     ]
+  end
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
-    # for other strategies and supported options
-    opts = [strategy: :one_for_one, name: Loopctl.Supervisor]
-    result = Supervisor.start_link(children, opts)
-
-    # Prime the SystemConfig :persistent_term cache from the DB now that the repos
-    # are started, so the ingestion/extraction hot path reads live values from the
-    # first request. refresh/0 is rescue-wrapped (a DB blip logs and no-ops), so a
-    # failed prime NEVER blocks boot — the in-code defaults simply apply until the
-    # per-minute refresh cron succeeds.
-    Loopctl.SystemConfig.refresh()
-
+  # Boot-time observability checks that need the tree running. Log/telemetry only,
+  # with the single deliberate exception noted below.
+  defp post_boot_checks do
     # US-27.11 (AC-27.11.5): warn if the actual configured pools would exceed the live
     # DB max_connections at the expected node count. Prod only (dev/test pools differ),
     # log-only, never blocks boot.
@@ -203,7 +229,7 @@ defmodule Loopctl.Application do
     if Application.get_env(:loopctl, :env) == :prod,
       do: Loopctl.ClusterReadiness.warn_if_expected_peers_missing()
 
-    result
+    :ok
   end
 
   # Tell Phoenix to update the endpoint configuration

--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -31,7 +31,15 @@ defmodule Loopctl.Application do
     opts = [strategy: :one_for_one, name: Loopctl.Supervisor]
     result = Supervisor.start_link(children(), opts)
 
-    post_boot_checks()
+    # ONLY on a successful start: these checks need the tree RUNNING, and one of them
+    # (ReplicaReadiness) raises by design. On a failed start every already-started child
+    # has been torn down, so running them there replaces the real
+    # `{:error, {:shutdown, {:failed_to_start_child, ...}}}` — the diagnosis — with an
+    # unrelated crash from a check querying a repo that no longer exists.
+    case result do
+      {:ok, _pid} -> post_boot_checks()
+      _error -> :ok
+    end
 
     result
   end

--- a/lib/loopctl/system_config.ex
+++ b/lib/loopctl/system_config.ex
@@ -20,19 +20,35 @@ defmodule Loopctl.SystemConfig do
   DB the cache was never primed from) behaves exactly like the pre-existing
   in-code default.
 
+  That fallback is NOT neutral for every key. For the US-41.1 embeddings
+  read-routing flag (`"embedding_side_table_reads"`, see
+  `Loopctl.Embeddings.SystemConfigReadPath`) the in-code default is `0` = the
+  RETIRED legacy `articles.embedding` column, so an unprimed cache silently
+  reverts a completed cutover for as long as it stays unprimed. That is why the
+  boot prime is now ORDERED ahead of every consumer rather than run after the
+  supervision tree is up (GH #588).
+
   ## Refresh lifecycle
 
   The cache is (re)loaded from the DB via `Loopctl.AdminRepo`:
 
-    * once at boot (`Loopctl.Application.start/2`, guarded) — this is what primes
-      EVERY node, and
+    * once at boot by the supervised one-shot child
+      `Loopctl.SystemConfig.CachePrimer`, which primes SYNCHRONOUSLY inside its
+      `start_link/1` and then returns `:ignore`. It is listed in
+      `Loopctl.Application.children/0` after `Loopctl.AdminRepo` (its data
+      source) and before `Oban` and `LoopctlWeb.Endpoint` — because a supervisor
+      starts children synchronously in list order, that placement GUARANTEES the
+      cache is authoritative before either of those consumers accepts work, and
     * every cron tick by `Loopctl.Workers.SystemConfigRefreshWorker` — but that
       job runs on ONE node per tick, so on a multi-node cluster a given node's
       refresh cadence is not bounded to one minute, and
     * immediately for a single key on `put/2` (the writing node only).
 
-  `refresh/0` is `try/rescue`-wrapped so a DB blip logs and no-ops — it never
-  crashes boot or the cron worker; the previously-cached values simply persist.
+  `refresh/0` is `try/rescue`-wrapped so a DB blip can never crash boot or the
+  cron worker; the previously-cached values simply persist. It REPORTS the
+  failure as `{:error, reason}` (rather than swallowing it into `:ok`) so the
+  primer can make a failed boot prime loud — a silently empty cache is what turns
+  a bounded startup window into an unbounded one.
 
   The `:persistent_term` key is `{__MODULE__, key_string}` — string keys are used
   verbatim (never `String.to_atom/1` on them).
@@ -64,10 +80,13 @@ defmodule Loopctl.SystemConfig do
   @doc """
   Loads ALL settings from the DB (via `AdminRepo`) into `:persistent_term`.
 
-  Wrapped in `try/rescue`: a DB error logs and no-ops (returns `:ok`) so it can
-  never crash boot or the refresh cron. The existing cache is left untouched.
+  Wrapped in `try/rescue`: a DB error logs and returns `{:error, reason}` — it
+  never raises, so it can never crash boot or the refresh cron, and the existing
+  cache is left untouched. Callers that must react to a failed prime (see
+  `Loopctl.SystemConfig.CachePrimer`) match on the error tuple; callers that only
+  want best-effort propagation (the cron worker, `Loopctl.Release`) ignore it.
   """
-  @spec refresh() :: :ok
+  @spec refresh() :: :ok | {:error, term()}
   def refresh do
     Setting
     |> AdminRepo.all()
@@ -83,7 +102,7 @@ defmodule Loopctl.SystemConfig do
           Exception.message(e)
       )
 
-      :ok
+      {:error, e}
   end
 
   @doc """

--- a/lib/loopctl/system_config.ex
+++ b/lib/loopctl/system_config.ex
@@ -44,11 +44,15 @@ defmodule Loopctl.SystemConfig do
       refresh cadence is not bounded to one minute, and
     * immediately for a single key on `put/2` (the writing node only).
 
-  `refresh/0` is `try/rescue`-wrapped so a DB blip can never crash boot or the
-  cron worker; the previously-cached values simply persist. It REPORTS the
-  failure as `{:error, reason}` (rather than swallowing it into `:ok`) so the
-  primer can make a failed boot prime loud — a silently empty cache is what turns
-  a bounded startup window into an unbounded one.
+  `refresh/0` guards the DB read with `rescue` AND `catch :exit, :throw` so a DB
+  blip can never crash boot or the cron worker; the previously-cached values
+  simply persist. Both kinds are required: a DBConnection/Postgrex fault against
+  an unstarted (`:noproc`), wedged (`{:timeout, _}`) or dying pool EXITS rather
+  than raises, and a `rescue`-only guard would let that exit escape — which, from
+  the supervised primer, aborts the whole tree start instead of degrading. It
+  REPORTS the failure as `{:error, reason}` (rather than swallowing it into `:ok`)
+  so the primer can make a failed boot prime loud — a silently empty cache is what
+  turns a bounded startup window into an unbounded one.
 
   The `:persistent_term` key is `{__MODULE__, key_string}` — string keys are used
   verbatim (never `String.to_atom/1` on them).
@@ -59,6 +63,7 @@ defmodule Loopctl.SystemConfig do
   require Logger
 
   alias Loopctl.AdminRepo
+  alias Loopctl.ExitClass
   alias Loopctl.SystemConfig.Setting
 
   @doc """
@@ -80,16 +85,24 @@ defmodule Loopctl.SystemConfig do
   @doc """
   Loads ALL settings from the DB (via `AdminRepo`) into `:persistent_term`.
 
-  Wrapped in `try/rescue`: a DB error logs and returns `{:error, reason}` — it
-  never raises, so it can never crash boot or the refresh cron, and the existing
-  cache is left untouched. Callers that must react to a failed prime (see
-  `Loopctl.SystemConfig.CachePrimer`) match on the error tuple; callers that only
-  want best-effort propagation (the cron worker, `Loopctl.Release`) ignore it.
+  Guarded by `rescue` AND `catch`: a DB error logs and returns `{:error, reason}`
+  — it never raises AND never exits, so it can never crash boot or the refresh
+  cron, and the existing cache is left untouched. Callers that must react to a
+  failed prime (see `Loopctl.SystemConfig.CachePrimer`) match on the error tuple;
+  callers that only want best-effort propagation (the cron worker,
+  `Loopctl.Release`) ignore it.
   """
   @spec refresh() :: :ok | {:error, term()}
-  def refresh do
-    Setting
-    |> AdminRepo.all()
+  def refresh, do: refresh_from(fn -> AdminRepo.all(Setting) end)
+
+  @doc false
+  # Public ONLY as a seam for the guard's own tests: the test database always answers
+  # `AdminRepo.all/1` successfully, so left inline the `catch` arm below would be a guard
+  # nothing ever exercises — the same reason `Knowledge.heat_projection_exit/2` is public.
+  # `refresh/0` is the sole production caller and passes the real read.
+  @spec refresh_from((-> [Setting.t()])) :: :ok | {:error, term()}
+  def refresh_from(load) when is_function(load, 0) do
+    load.()
     |> Enum.each(fn %Setting{key: key, value: value} ->
       :persistent_term.put(pt_key(key), value)
     end)
@@ -103,6 +116,26 @@ defmodule Loopctl.SystemConfig do
       )
 
       {:error, e}
+  catch
+    # DBConnection/Postgrex EXIT rather than raise when the pool is not started
+    # (`{:noproc, {DBConnection, ...}}`), is wedged (`{:timeout, {GenServer, :call, _}}`),
+    # or dies mid-query (`{{%Postgrex.Error{}, stack}, {DBConnection, :execute, _}}`).
+    # `rescue` alone MISSES all three, and the boot primer is a supervision child: an
+    # escaping exit is converted by the supervisor into a failed child start, so the node
+    # never boots — the exact inverse of "a failed prime NEVER blocks boot". A `throw` is
+    # caught for the same reason (enumerating two of the three non-local exit kinds is how
+    # this hole keeps reappearing).
+    #
+    # Logged by BOUNDED class, never the raw reason: an exit reason carries the checkout
+    # tuple, which on the crash-propagation shape carries the failing statement and its
+    # bound parameters (#562).
+    kind, reason when kind in [:exit, :throw] ->
+      Logger.warning(
+        "Loopctl.SystemConfig.refresh/0 failed; keeping existing cache: " <>
+          "error_class=#{ExitClass.classify(kind, reason)}"
+      )
+
+      {:error, {kind, reason}}
   end
 
   @doc """

--- a/lib/loopctl/system_config/cache_primer.ex
+++ b/lib/loopctl/system_config/cache_primer.ex
@@ -53,6 +53,7 @@ defmodule Loopctl.SystemConfig.CachePrimer do
 
   require Logger
 
+  alias Loopctl.ExitClass
   alias Loopctl.SystemConfig
 
   @doc false
@@ -81,19 +82,46 @@ defmodule Loopctl.SystemConfig.CachePrimer do
         :ignore
 
       {:error, reason} ->
+        class = error_class(reason)
+
         Logger.error(
           "Loopctl.SystemConfig.CachePrimer: boot prime FAILED; this node serves in-code " <>
             "defaults (for the embeddings read flag that is the LEGACY column) until a " <>
-            "SystemConfigRefreshWorker tick lands on it: #{inspect(reason)}"
+            "SystemConfigRefreshWorker tick lands on it: error_class=#{class}"
         )
 
         :telemetry.execute(
           [:loopctl, :system_config, :prime_failed],
           %{count: 1},
-          %{reason: reason}
+          %{error_class: class}
         )
 
         :ignore
     end
   end
+
+  @doc false
+  # Public ONLY as a seam for this classifier's own tests (the same reason
+  # `SystemConfig.refresh_from/1` is): the test database always answers `AdminRepo.all/1`,
+  # so the EXIT shape — the one whose raw reason actually carries a payload — cannot be
+  # driven through `start_link/1` at all, and left private the clause that sanitizes it
+  # would be unexercised.
+  #
+  # `refresh_from/1` returns TWO error shapes, and BOTH reach a log line and telemetry
+  # metadata here, so both are reduced to the bounded class first: an exit reason carries
+  # the DBConnection checkout tuple, which on the crash-propagation shape carries the
+  # failing statement and its bound parameters (#562), and an inspected Postgrex /
+  # DBConnection struct names the backend host, database and role (`ExitTag`). Emitting
+  # the raw term one frame up would undo the sanitization `refresh_from/1`'s guard exists
+  # to perform.
+  @spec error_class(term()) :: String.t()
+  def error_class({kind, reason}) when kind in [:exit, :throw],
+    do: ExitClass.classify(kind, reason)
+
+  def error_class(e) when is_exception(e), do: ExitClass.classify(:raise, e)
+
+  # An unforeseen shape must not raise: a FunctionClauseError here would escape
+  # `start_link/1`, and a supervisor converts an exiting child start into a failed boot —
+  # the exact outcome "a failed prime NEVER blocks boot" promises to avoid.
+  def error_class(_reason), do: "unclassified"
 end

--- a/lib/loopctl/system_config/cache_primer.ex
+++ b/lib/loopctl/system_config/cache_primer.ex
@@ -40,6 +40,15 @@ defmodule Loopctl.SystemConfig.CachePrimer do
   log-only, and crashing every deploy on a transient DB blip is a worse failure
   than the one being fixed: boot proceeds on the in-code defaults, exactly as it
   did before this child existed.
+
+  That guarantee rests entirely on `SystemConfig.refresh/0` returning rather than
+  escaping, for EVERY fault shape — which is why its guard catches exits and
+  throws as well as raises. A DB pool that is unstarted, wedged, or dying
+  mid-query EXITS; a `rescue`-only guard would let that exit escape into
+  `start_link/1`, and a supervisor converts an exiting child start into
+  `{:error, {:shutdown, {:failed_to_start_child, ...}}}` — so the node would fail
+  to boot on precisely the "DB blip at boot" scenario this section promises to
+  survive.
   """
 
   require Logger

--- a/lib/loopctl/system_config/cache_primer.ex
+++ b/lib/loopctl/system_config/cache_primer.ex
@@ -1,0 +1,90 @@
+defmodule Loopctl.SystemConfig.CachePrimer do
+  @moduledoc """
+  Supervised ONE-SHOT child that primes the `Loopctl.SystemConfig`
+  `:persistent_term` cache from the DB at boot, BEFORE any consumer of that cache
+  is started (GH #588).
+
+  ## Why a supervision child and not a post-boot call
+
+  A supervisor starts its children synchronously, in list order, so a child's
+  position in `Loopctl.Application.children/0` IS the ordering guarantee. Priming
+  after `Supervisor.start_link/2` returns (what this replaced) left a window in
+  which `LoopctlWeb.Endpoint` and `Oban` already served work against an EMPTY
+  cache — and `SystemConfig.get_int/2` answers a miss with the caller's in-code
+  default, which for the embeddings read-routing flag is the RETIRED legacy
+  column. Every boot silently reverted a completed cutover for the length of that
+  window.
+
+  The prime therefore runs to completion INSIDE `start_link/1`. It must NOT be a
+  `Task` child or a `handle_continue/2`: both return to the supervisor
+  immediately, so the next child (the consumer) starts while the prime is still
+  in flight — which is exactly the bug this module closes.
+
+  Having primed, `start_link/1` returns `:ignore` — no process is left running.
+  The per-minute `Loopctl.Workers.SystemConfigRefreshWorker` owns the ongoing
+  refresh cadence; this child must never poll or re-prime on a timer, because a
+  `:persistent_term.put/2` triggers a global GC scan across all processes. The
+  child spec declares `restart: :transient` (NOT `:temporary`) so the supervisor
+  RETAINS the spec after `:ignore` and the child stays visible in
+  `Supervisor.which_children/1` with pid `:undefined`.
+
+  ## Failure is loud, never fatal
+
+  A failed prime is logged at `:error` and emitted as
+  `[:loopctl, :system_config, :prime_failed]` telemetry, because a silently empty
+  cache is what turns a bounded startup window into an unbounded one (a node that
+  missed its prime keeps serving in-code defaults until a cron tick happens to
+  land on it — and the cron enqueues one job per tick CLUSTER-WIDE).
+
+  It does NOT raise. Every other boot-time check in `Loopctl.Application` is
+  log-only, and crashing every deploy on a transient DB blip is a worse failure
+  than the one being fixed: boot proceeds on the in-code defaults, exactly as it
+  did before this child existed.
+  """
+
+  require Logger
+
+  alias Loopctl.SystemConfig
+
+  @doc false
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      type: :worker,
+      # NOT :temporary — a :temporary child that returns :ignore has its spec
+      # DISCARDED, which would hide this child from Supervisor.which_children/1.
+      restart: :transient
+    }
+  end
+
+  @doc """
+  Primes the `SystemConfig` cache synchronously and returns `:ignore`.
+
+  Always returns `:ignore` — including when the prime fails, which is reported
+  via `Logger.error/1` and `[:loopctl, :system_config, :prime_failed]` telemetry
+  rather than by aborting boot.
+  """
+  @spec start_link(keyword()) :: :ignore
+  def start_link(_opts \\ []) do
+    case SystemConfig.refresh() do
+      :ok ->
+        :ignore
+
+      {:error, reason} ->
+        Logger.error(
+          "Loopctl.SystemConfig.CachePrimer: boot prime FAILED; this node serves in-code " <>
+            "defaults (for the embeddings read flag that is the LEGACY column) until a " <>
+            "SystemConfigRefreshWorker tick lands on it: #{inspect(reason)}"
+        )
+
+        :telemetry.execute(
+          [:loopctl, :system_config, :prime_failed],
+          %{count: 1},
+          %{reason: reason}
+        )
+
+        :ignore
+    end
+  end
+end

--- a/lib/loopctl/system_config/cache_primer.ex
+++ b/lib/loopctl/system_config/cache_primer.ex
@@ -31,7 +31,12 @@ defmodule Loopctl.SystemConfig.CachePrimer do
   ## Failure is loud, never fatal
 
   A failed prime is logged at `:error` and emitted as
-  `[:loopctl, :system_config, :prime_failed]` telemetry, because a silently empty
+  `[:loopctl, :system_config, :prime_failed]` telemetry — which
+  `Loopctl.Telemetry.ScaleMetrics.scale_metrics/0` consumes as the
+  `loopctl.system_config.prime_failed.count` Prometheus counter (metric 25), keyed by
+  the classified `error_class`. An emitted event with no metric definition would be a
+  handler-less no-op, leaving the log line as the only trace — not alertable, and easy
+  to miss on a rolling deploy. Telemetry is claimed here because a silently empty
   cache is what turns a bounded startup window into an unbounded one (a node that
   missed its prime keeps serving in-code defaults until a cron tick happens to
   land on it — and the cron enqueues one job per tick CLUSTER-WIDE).

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -357,6 +357,18 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
         distinguishable in Prometheus from a genuinely stable reading — a
         non-zero, incrementing rate on this counter means the corresponding gauge is
         stale, not that the system is actually quiet.
+    25. **Boot-cache-prime-failure counter** (#588) —
+        `loopctl.system_config.prime_failed.count`, keyed by `[:error_class]` only
+        (the already-CLASSIFIED closed set from `Loopctl.ExitClass`, plus
+        `"unclassified"` — never a raw exit reason). Sourced from
+        `[:loopctl, :system_config, :prime_failed]`
+        (`Loopctl.SystemConfig.CachePrimer`). Wired for the same reason as metrics
+        8-17: emitted-but-dead is invisible to Prometheus. It matters more here
+        because the degradation it reports is UNBOUNDED — a node that missed its boot
+        prime keeps answering `SystemConfig.get_int/2` with in-code defaults (the
+        RETIRED legacy column for the embeddings read flag) until a
+        `SystemConfigRefreshWorker` tick lands on it, and one `Logger.error` line in
+        the log stream is not something a rolling deploy can be alerted on.
   """
 
   import Telemetry.Metrics
@@ -421,8 +433,9 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   degradation signals), US-34.1's three Oban metrics (per-{state, queue}
   gauge over the non-terminal states, the `:executing` orphan gauge, and a
   poll-failure counter), US-36.3's ingestion backlog-gate fail-open counter,
-  US-36.4's article-linking corpus-size gauge, and US-38.3's clustering-readiness
-  peer gauge. Appended to `LoopctlWeb.Telemetry.metrics/0`.
+  US-36.4's article-linking corpus-size gauge, US-38.3's clustering-readiness
+  peer gauge, and #588's boot-cache-prime-failure counter. Appended to
+  `LoopctlWeb.Telemetry.metrics/0`.
   """
   @spec scale_metrics() :: [Telemetry.Metrics.t()]
   def scale_metrics do
@@ -801,8 +814,47 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
           "Outbound provider calls refused by the fail-closed egress guard, by reason and tenant.",
         tags: [:reason, :tenant_id],
         tag_values: &egress_blocked_tags/1
+      ),
+
+      # 25. Boot-cache-prime-failure counter (#588). `Loopctl.SystemConfig.CachePrimer`
+      #     emits `[:loopctl, :system_config, :prime_failed]` when the boot prime fails;
+      #     without this definition that event terminates in a handler-less no-op (the
+      #     emitted-but-dead class above), leaving ONE `Logger.error` line as the only
+      #     trace of an unbounded degradation: a node that missed its prime answers
+      #     `SystemConfig.get_int/2` with the caller's in-code default — for the
+      #     embeddings read flag, the RETIRED legacy column — until a
+      #     `SystemConfigRefreshWorker` tick happens to land on that node. A log line in
+      #     the Fly stream is not alertable and is easy to miss on a rolling deploy; the
+      #     counter is.
+      #
+      #     `error_class` is the already-CLASSIFIED string `CachePrimer.error_class/1`
+      #     produces — `Loopctl.ExitClass`'s closed `"<kind>:<tag>"` set plus the
+      #     `"unclassified"` catch-all — never the raw exit reason (which carries the
+      #     failing statement and its bound parameters, #562) or an inspected Postgrex
+      #     struct (which names the backend host, database and role). UNTAGGED by
+      #     tenant: `system_configs` is a global, non-tenant table.
+      counter("loopctl.system_config.prime_failed.count",
+        event_name: [:loopctl, :system_config, :prime_failed],
+        measurement: :count,
+        description:
+          "Boot-time SystemConfig cache primes that failed (node serves in-code defaults), " <>
+            "by classified error class.",
+        tags: [:error_class],
+        tag_values: &system_config_prime_failed_tags/1
       )
     ]
+  end
+
+  @doc """
+  `tag_values` for the boot-cache-prime-failure counter (#588). Passes through the
+  BOUNDED `error_class` `Loopctl.SystemConfig.CachePrimer.error_class/1` already
+  produced (`Loopctl.ExitClass`'s closed set, or `"unclassified"`) and NOTHING else —
+  the raw reason never reaches a label. A missing key defaults to `"unknown"` so a
+  direct `:telemetry.execute/3` with a partial map never emits a blank label.
+  """
+  @spec system_config_prime_failed_tags(map()) :: map()
+  def system_config_prime_failed_tags(metadata) do
+    %{error_class: Map.get(metadata, :error_class) || "unknown"}
   end
 
   @doc """

--- a/lib/loopctl/workers/system_config_refresh_worker.ex
+++ b/lib/loopctl/workers/system_config_refresh_worker.ex
@@ -4,8 +4,10 @@ defmodule Loopctl.Workers.SystemConfigRefreshWorker do
   cache from the DB every minute, so a `system_configs` UPDATE propagates to every
   node within ~60s without a redeploy.
 
-  `SystemConfig.refresh/0` is itself `try/rescue`-wrapped (a DB blip logs and
-  no-ops), so this worker's `perform/1` always returns `:ok`.
+  `SystemConfig.refresh/0` never raises and never exits — a DB blip logs and
+  returns `{:error, reason}`, leaving the existing cache intact. This worker
+  deliberately DISCARDS that result and always returns `:ok`: a failed tick needs
+  no Oban retry because the next minute's cron tick is the retry.
   """
 
   use Oban.Worker, queue: :maintenance, max_attempts: 3

--- a/test/loopctl/application_boot_order_test.exs
+++ b/test/loopctl/application_boot_order_test.exs
@@ -1,0 +1,66 @@
+defmodule Loopctl.ApplicationBootOrderTest do
+  @moduledoc """
+  GH #588: the SystemConfig cache prime must be ORDERED ahead of every consumer of
+  that cache, not merely fast. A supervisor starts children synchronously in list
+  order, so `Loopctl.Application.children/0` IS the guarantee — these assertions
+  are static list indexes, never timing.
+  """
+  use ExUnit.Case, async: true
+
+  alias Loopctl.SystemConfig.CachePrimer
+
+  # The child list entries are bare module atoms or `{Module, opts}` tuples;
+  # match the raw entry rather than resolving child specs.
+  defp index_of(children, module) do
+    Enum.find_index(children, fn
+      ^module -> true
+      {^module, _opts} -> true
+      _ -> false
+    end)
+  end
+
+  describe "children/0 ordering (AC: primed before the Endpoint starts)" do
+    test "the SystemConfig cache primer sits after AdminRepo and before Oban and the Endpoint" do
+      children = Loopctl.Application.children()
+
+      admin_repo_idx = index_of(children, Loopctl.AdminRepo)
+      primer_idx = index_of(children, CachePrimer)
+      oban_idx = index_of(children, Oban)
+      endpoint_idx = index_of(children, LoopctlWeb.Endpoint)
+
+      # ANTI-VACUITY: a rename must FAIL this test, not silently turn every
+      # comparison below into `nil < nil`. Assert each child was actually found
+      # before comparing positions.
+      assert is_integer(admin_repo_idx), "Loopctl.AdminRepo is not in Application.children/0"
+      assert is_integer(primer_idx), "#{inspect(CachePrimer)} is not in Application.children/0"
+      assert is_integer(oban_idx), "Oban is not in Application.children/0"
+      assert is_integer(endpoint_idx), "LoopctlWeb.Endpoint is not in Application.children/0"
+
+      # After its data source: refresh/0 reads system_configs through AdminRepo.
+      assert admin_repo_idx < primer_idx
+
+      # Before every consumer that can read the cache. Oban matters as much as the
+      # Endpoint: the embedding/ingestion workers read the read-routing flag too.
+      assert primer_idx < oban_idx
+      assert primer_idx < endpoint_idx
+    end
+
+    test "the Endpoint is still last, so nothing serves requests ahead of the tree" do
+      children = Loopctl.Application.children()
+      assert List.last(children) == LoopctlWeb.Endpoint
+    end
+  end
+
+  describe "live supervision-tree wiring" do
+    test "the primer is a child of the running tree with pid :undefined (it returned :ignore)" do
+      children = Supervisor.which_children(Loopctl.Supervisor)
+
+      primer_child = Enum.find(children, fn {id, _pid, _type, _mods} -> id == CachePrimer end)
+
+      # pid is :undefined precisely BECAUSE start_link/1 returned :ignore after
+      # priming synchronously — and the spec is retained (rather than discarded)
+      # because the child spec declares restart: :transient, not :temporary.
+      assert {CachePrimer, :undefined, :worker, _modules} = primer_child
+    end
+  end
+end

--- a/test/loopctl/system_config/cache_primer_test.exs
+++ b/test/loopctl/system_config/cache_primer_test.exs
@@ -49,7 +49,8 @@ defmodule Loopctl.SystemConfig.CachePrimerTest do
   # a `rescue`-only guard misses, and the one that would abort the whole supervision-tree
   # start from here — is covered one level down, in `Loopctl.SystemConfigTest`'s
   # "refresh_from/1 guard" block: `refresh/0` is what converts it into the `{:error, reason}`
-  # this branch handles, and the branch itself is shape-agnostic.
+  # this branch handles. How THIS branch then reduces each shape to a bounded class is
+  # covered by the `error_class/1` block below.
   describe "start_link/1 when the prime FAILS" do
     test "logs at :error, emits prime_failed telemetry, and STILL returns :ignore" do
       {handler_id, ref} = attach_prime_failed_handler()
@@ -67,7 +68,59 @@ defmodule Loopctl.SystemConfig.CachePrimerTest do
         end)
 
       assert log =~ "boot prime FAILED"
-      assert_received {^ref, %{reason: _reason}}
+
+      # The RAISE shape's bounded class, never the exception's own message — which on a
+      # Postgrex/DBConnection struct names the backend host, database and role.
+      assert log =~ "error_class=raise:"
+      assert_received {^ref, %{error_class: class}}
+      assert is_binary(class)
+      assert String.starts_with?(class, "raise:")
+    end
+  end
+
+  # #588 review: `refresh_from/1`'s catch arm logs the exit by BOUNDED class precisely
+  # because the raw reason carries the DBConnection checkout tuple — statement and bound
+  # parameters (#562). This branch is one frame UP from that guard, and it logs and emits
+  # the same reason, so it has to sanitize it too or the guard buys nothing.
+  #
+  # Driven through the seam rather than `start_link/1`: the test database always answers
+  # `AdminRepo.all/1` successfully, so no prime can be made to EXIT — and the exit is the
+  # shape whose raw reason actually carries a payload.
+  describe "error_class/1" do
+    test "an exit reason is reduced to its bounded class, dropping statement and params" do
+      reason = {:noproc, {DBConnection, :execute, ["SELECT secret FROM t", ["bound-param"]]}}
+
+      class = CachePrimer.error_class({:exit, reason})
+
+      assert class == "exit:noproc"
+      refute class =~ "bound-param"
+      refute class =~ "SELECT secret"
+    end
+
+    test "the crash-propagation shape reports the exception MODULE, not its message" do
+      reason =
+        {{%Postgrex.Error{message: "host=db user=secret"}, []}, {DBConnection, :execute, []}}
+
+      class = CachePrimer.error_class({:exit, reason})
+
+      assert class == "exit:Postgrex.Error"
+      refute class =~ "secret"
+    end
+
+    test "a throw keeps its kind prefix" do
+      assert CachePrimer.error_class({:throw, :boom}) == "throw:other"
+    end
+
+    test "the rescue arm's bare exception struct is classified as a :raise" do
+      assert CachePrimer.error_class(%Postgrex.Error{message: "host=db user=secret"}) ==
+               "raise:Postgrex.Error"
+
+      assert CachePrimer.error_class(%RuntimeError{message: "db down"}) == "raise:other"
+    end
+
+    test "an unforeseen shape is labelled, never raised — a crash here would abort boot" do
+      assert CachePrimer.error_class(:something_else) == "unclassified"
+      assert CachePrimer.error_class({:not_a_kind, :whatever}) == "unclassified"
     end
   end
 

--- a/test/loopctl/system_config/cache_primer_test.exs
+++ b/test/loopctl/system_config/cache_primer_test.exs
@@ -1,0 +1,96 @@
+defmodule Loopctl.SystemConfig.CachePrimerTest do
+  use Loopctl.DataCase, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Loopctl.SystemConfig
+  alias Loopctl.SystemConfig.CachePrimer
+
+  setup :verify_on_exit!
+
+  # NOTE ON ASYNC ISOLATION (same rule as system_config_test.exs): `:persistent_term`
+  # is VM-global with no per-process isolation, so every test here uses the UNIQUE
+  # key minted by the `:system_config` fixture. In particular no test writes the real
+  # "embedding_side_table_reads" flag — `Loopctl.ConfigEmbeddingReadPathTest` fails
+  # the build on a second writer, and it is a known cross-test flake source.
+  #
+  # `system_configs` is a GLOBAL, non-tenant table (AdminRepo only), so there is no
+  # tenant-isolation test.
+
+  @prime_failed [:loopctl, :system_config, :prime_failed]
+
+  describe "start_link/1" do
+    test "primes the cache from the DB and returns :ignore" do
+      # Insert DIRECTLY via the fixture (which bypasses put/2's cache write), so
+      # this proves the PRIMER — not put/2 — is what populates the cache.
+      setting = fixture(:system_config, value: 9001)
+
+      assert SystemConfig.get_int(setting.key, -1) == -1
+
+      assert CachePrimer.start_link([]) == :ignore
+
+      assert SystemConfig.get_int(setting.key, -1) == 9001
+    end
+
+    test "a successful prime is silent — no prime_failed telemetry" do
+      {handler_id, ref} = attach_prime_failed_handler()
+
+      try do
+        assert CachePrimer.start_link([]) == :ignore
+      after
+        :telemetry.detach(handler_id)
+      end
+
+      refute_received {^ref, _meta}
+    end
+  end
+
+  describe "start_link/1 when the prime FAILS" do
+    test "logs at :error, emits prime_failed telemetry, and STILL returns :ignore" do
+      {handler_id, ref} = attach_prime_failed_handler()
+
+      log =
+        capture_log(fn ->
+          try do
+            # A bare `spawn` does NOT propagate `$callers`, so this process has no
+            # sandbox ownership and AdminRepo raises — a genuine refresh failure,
+            # with no Application.put_env and no test-only DI seam.
+            assert run_primer_without_db() == :ignore
+          after
+            :telemetry.detach(handler_id)
+          end
+        end)
+
+      assert log =~ "boot prime FAILED"
+      assert_received {^ref, %{reason: _reason}}
+    end
+  end
+
+  defp attach_prime_failed_handler do
+    ref = make_ref()
+    handler_id = {__MODULE__, ref}
+    test_pid = self()
+
+    :telemetry.attach(
+      handler_id,
+      @prime_failed,
+      fn _event, _measurements, meta, _config -> send(test_pid, {ref, meta}) end,
+      nil
+    )
+
+    {handler_id, ref}
+  end
+
+  defp run_primer_without_db do
+    parent = self()
+    ref = make_ref()
+
+    spawn(fn -> send(parent, {ref, CachePrimer.start_link([])}) end)
+
+    receive do
+      {^ref, result} -> result
+    after
+      5_000 -> flunk("the primer never returned")
+    end
+  end
+end

--- a/test/loopctl/system_config/cache_primer_test.exs
+++ b/test/loopctl/system_config/cache_primer_test.exs
@@ -45,6 +45,11 @@ defmodule Loopctl.SystemConfig.CachePrimerTest do
     end
   end
 
+  # The failing shape below is a RAISE (a sandbox ownership error). The EXIT shape — the one
+  # a `rescue`-only guard misses, and the one that would abort the whole supervision-tree
+  # start from here — is covered one level down, in `Loopctl.SystemConfigTest`'s
+  # "refresh_from/1 guard" block: `refresh/0` is what converts it into the `{:error, reason}`
+  # this branch handles, and the branch itself is shape-agnostic.
   describe "start_link/1 when the prime FAILS" do
     test "logs at :error, emits prime_failed telemetry, and STILL returns :ignore" do
       {handler_id, ref} = attach_prime_failed_handler()

--- a/test/loopctl/system_config_test.exs
+++ b/test/loopctl/system_config_test.exs
@@ -1,6 +1,8 @@
 defmodule Loopctl.SystemConfigTest do
   use Loopctl.DataCase, async: true
 
+  import ExUnit.CaptureLog
+
   alias Loopctl.SystemConfig
   alias Loopctl.SystemConfig.Setting
   alias Loopctl.Workers.ContentIngestionWorker
@@ -64,6 +66,90 @@ defmodule Loopctl.SystemConfigTest do
 
       assert :ok = SystemConfig.refresh()
       assert SystemConfig.get_int(setting.key, -1) == 9001
+    end
+  end
+
+  # #588 review: the boot primer is a SUPERVISION CHILD, and its documented contract is
+  # "a failed prime is loud but NEVER blocks boot". That contract is delivered entirely by
+  # refresh/0's guard returning rather than escaping. A `rescue`-only guard delivered it for
+  # a RAISE and missed every EXIT — and an exit escaping start_link/1 is converted by the
+  # supervisor into a failed child start, so the node never boots at all: the inverse of the
+  # contract, on the "DB blip at boot" scenario the contract names.
+  #
+  # The seam exists because the test database always answers AdminRepo.all/1 successfully;
+  # refresh/0 itself is proven wired to refresh_from/1 by the describe block above and by
+  # `Loopctl.SystemConfig.CachePrimerTest`.
+  describe "refresh_from/1 guard: a DB fault that EXITS, not just one that raises" do
+    test "a pool EXIT is caught and reported as an error tuple instead of escaping" do
+      # The REAL shape DBConnection/Postgrex exits with — a `{reason, call}` tuple, not a
+      # bare atom. A guard tested against `exit(:noproc)` would look correct while missing
+      # every production exit.
+      reason = {:noproc, {DBConnection, :execute, []}}
+
+      log =
+        capture_log(fn ->
+          assert SystemConfig.refresh_from(fn -> exit(reason) end) == {:error, {:exit, reason}}
+        end)
+
+      assert log =~ "error_class=exit:noproc"
+    end
+
+    test "the crash-propagation shape (pool died mid-query) is caught too" do
+      # What a pooled connection dying WHILE the query is checked out produces — the shape
+      # `Loopctl.ExitClass`/`DbErrorBackstop` were written for (#558).
+      reason = {{%Postgrex.Error{message: "boom"}, []}, {DBConnection, :execute, []}}
+
+      log =
+        capture_log(fn ->
+          assert SystemConfig.refresh_from(fn -> exit(reason) end) == {:error, {:exit, reason}}
+        end)
+
+      assert log =~ "error_class=exit:Postgrex.Error"
+    end
+
+    test "the exit reason is logged by BOUNDED class only — never the statement or its params" do
+      reason = {:noproc, {DBConnection, :execute, ["SELECT secret FROM t", ["bound-param"]]}}
+
+      log = capture_log(fn -> SystemConfig.refresh_from(fn -> exit(reason) end) end)
+
+      assert log =~ "error_class=exit:noproc"
+      refute log =~ "bound-param", "bound parameters must never reach the log"
+      refute log =~ "SELECT secret", "the failing statement must never reach the log"
+    end
+
+    test "a THROW is caught for the same reason (three non-local kinds, not two)" do
+      log =
+        capture_log(fn ->
+          assert SystemConfig.refresh_from(fn -> throw(:boom) end) == {:error, {:throw, :boom}}
+        end)
+
+      assert log =~ "error_class=throw:other"
+    end
+
+    test "a RAISE is still caught (the pre-existing arm keeps its {:error, exception} shape)" do
+      log =
+        capture_log(fn ->
+          assert {:error, %RuntimeError{}} = SystemConfig.refresh_from(fn -> raise "db down" end)
+        end)
+
+      assert log =~ "keeping existing cache"
+    end
+
+    test "an already-cached value SURVIVES a failed refresh of any kind" do
+      key = unique_key()
+      assert {:ok, _} = SystemConfig.put(key, 77)
+
+      capture_log(fn ->
+        for fail <- [
+              fn -> exit({:noproc, {DBConnection, :execute, []}}) end,
+              fn -> throw(:boom) end,
+              fn -> raise "db down" end
+            ] do
+          assert {:error, _} = SystemConfig.refresh_from(fail)
+        end
+      end)
+
+      assert SystemConfig.get_int(key, -1) == 77
     end
   end
 

--- a/test/loopctl/telemetry/scale_metrics_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_test.exs
@@ -41,6 +41,7 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
   """
   use ExUnit.Case, async: false
 
+  alias Loopctl.SystemConfig.CachePrimer
   alias Loopctl.Telemetry.ScaleMetrics
 
   @scale_metric_names [
@@ -69,7 +70,8 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
     "loopctl.ingestion.backlog_gate.failed_open.jobs",
     "loopctl.knowledge.article_linking.corpus_size",
     "loopctl.cluster.peers.count",
-    "loopctl.egress.blocked.count"
+    "loopctl.egress.blocked.count",
+    "loopctl.system_config.prime_failed.count"
   ]
 
   # The ONLY labels any scale metric may ever carry (AC-27.15.3). Anything outside this
@@ -1388,6 +1390,66 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
       # peer COUNT (never a node-name list) and a bounded status.
       assert is_integer(count)
       assert status in [:single_node, :clustered, :expected_peers_missing]
+    end
+  end
+
+  describe "system_config.prime_failed counter (#588)" do
+    test "the counter consumes exactly the event CachePrimer emits, tagged by error_class only" do
+      counter = metric("loopctl.system_config.prime_failed.count")
+
+      assert %Telemetry.Metrics.Counter{} = counter
+      assert counter.event_name == [:loopctl, :system_config, :prime_failed]
+      assert counter.measurement == :count
+      # The raw reason carries the failing statement + bound parameters (#562) and the
+      # backend host/database/role; only the CLASSIFIED class is ever a label, and there
+      # is no tenant dimension (`system_configs` is a global, non-tenant table).
+      assert counter.tags == [:error_class]
+      refute :tenant_id in counter.tags
+      refute :reason in counter.tags
+    end
+
+    test "system_config_prime_failed_tags/1 passes the class through and drops everything else" do
+      tags =
+        ScaleMetrics.system_config_prime_failed_tags(%{
+          error_class: "exit:noproc",
+          reason: {:noproc, {DBConnection, :execute, ["SELECT 1", ["secret-param"]]}}
+        })
+
+      assert tags == %{error_class: "exit:noproc"}
+      assert ScaleMetrics.system_config_prime_failed_tags(%{}) == %{error_class: "unknown"}
+    end
+
+    test "a failed boot prime reaches a real Prometheus scrape, labeled by the closed class" do
+      reporter_name = :"system_config_prime_failed_test_#{System.unique_integer([:positive])}"
+      counter = metric("loopctl.system_config.prime_failed.count")
+
+      start_supervised!(
+        {TelemetryMetricsPrometheus.Core,
+         [metrics: [counter], name: reporter_name, start_async: false]}
+      )
+
+      # Drive the label through the PRODUCER's own classifier rather than a literal, so a
+      # change to the closed vocabulary shows up here instead of silently re-labeling the
+      # series. This is the real production exit shape (an unstarted/wedged pool).
+      class =
+        CachePrimer.error_class(
+          {:exit, {:noproc, {DBConnection, :execute, ["SELECT 1", ["bound-param"]]}}}
+        )
+
+      for _i <- 1..2 do
+        :telemetry.execute([:loopctl, :system_config, :prime_failed], %{count: 1}, %{
+          error_class: class
+        })
+      end
+
+      scrape = TelemetryMetricsPrometheus.Core.scrape(reporter_name)
+
+      assert scrape =~ "loopctl_system_config_prime_failed_count"
+      assert scrape =~ ~s(error_class="exit:noproc")
+      assert scrape =~ ~r/loopctl_system_config_prime_failed_count\{[^}]*\} 2/
+      # The sanitization the classifier exists for must survive the metric path too.
+      refute scrape =~ "SELECT 1"
+      refute scrape =~ "bound-param"
     end
   end
 end


### PR DESCRIPTION
## The defect

`SystemConfig.refresh()` ran AFTER `Supervisor.start_link/2` returned, while `LoopctlWeb.Endpoint` and `{Oban, ...}` are children of that tree. Every boot therefore had a window in which both served work against an EMPTY `:persistent_term` cache — and `get_int/2` answers a miss with the caller's in-code default, which for `embedding_side_table_reads` is `0` = the retired legacy `articles.embedding` column. Semantic/hybrid search, suggest-links / ProposalGate / ArticleLinkingWorker, and the novelty gate all silently took the legacy branch in that window.

## The fix

`Loopctl.SystemConfig.CachePrimer` — a supervised one-shot child that primes SYNCHRONOUSLY inside `start_link/1` and then returns `:ignore`. It sits in `Loopctl.Application.children/0` after `Loopctl.AdminRepo` (the repo `refresh/0` reads through) and before `Oban` and the Endpoint. Supervisors start children synchronously in list order, so that placement is the guarantee, not a race.

Deliberate shape decisions:

- NOT a `{Task, ...}` child and NOT a `handle_continue/2`: both return to the supervisor immediately, so the next child starts while the prime is in flight — i.e. they reproduce the bug.
- `restart: :transient`, NOT `:temporary`: a `:temporary` child returning `:ignore` has its spec DISCARDED, which would hide it from `Supervisor.which_children/1`.
- One-shot, no timer or polling — a `:persistent_term.put/2` triggers a global GC scan; the per-minute `SystemConfigRefreshWorker` still owns the ongoing cadence.
- The in-code default stays `0` (the alternative the issue rejected): flipping it would break the flag's revert direction.
- Placed before Oban as well as the Endpoint — the issue's own body names Oban as an affected consumer, and it starts well before the Endpoint.

## Loud failure

`refresh/0` now returns `:ok | {:error, term()}`. It is STILL rescue-wrapped and still never raises, so `SystemConfigRefreshWorker` and `Loopctl.Release` are unaffected. The primer logs at `:error` and emits `[:loopctl, :system_config, :prime_failed]` telemetry on a failed prime, then STILL returns `:ignore` — a silent empty cache is what turns a bounded startup window into an unbounded one, but crashing every deploy on a transient DB blip is worse than the bug being fixed, and every other boot check in `Application` is log-only.

`start/2` also gained `children/0` and `post_boot_checks/0` so the ordering is assertable without booting anything.

## Tests

- `test/loopctl/application_boot_order_test.exs` — static ordering over `children/0`: `admin_repo < primer < oban` and `primer < endpoint`, plus Endpoint-still-last. Each index is asserted non-nil BEFORE comparing, so a rename fails the test instead of collapsing to `nil < nil`. MUTATION-VERIFIED: moving the primer after the Endpoint makes it fail (2 failures), restored after.
- Live-tree wiring: `which_children(Loopctl.Supervisor)` carries the primer id with pid `:undefined` — proof it is wired in AND returned `:ignore`.
- `test/loopctl/system_config/cache_primer_test.exs` — a uniquely-keyed `fixture(:system_config, ...)` (which bypasses `put/2`'s cache write) is invisible before the prime and readable after; a successful prime emits no telemetry; the failure branch is driven by a GENUINE `AdminRepo` failure (bare `spawn` does not propagate `$callers`, so the primer runs without sandbox ownership) and asserts the log, the telemetry meta, and that `:ignore` is still returned. No test writes the real `embedding_side_table_reads` key.

## Not in this PR

Dropping `articles_embedding_hnsw_idx` is #578, which this gates. The third acceptance bullet (index scan count stops advancing across deploys) is a post-merge `pg_stat_user_indexes` observation — no test fabricated for it.

`mix precommit` green: 6700 tests, 0 failures.

Closes #588
