### PR TITLE
#578 Retire the legacy 657 MB articles_embedding_hnsw_idx

### DIFF
--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -160,11 +160,16 @@ number, is the load-bearing invariant. To monitor and keep it healthy over time:
   `blk_read_time`. `articles.embedding` is still dual-WRITTEN — it stays the backfill/reconciliation
   source, and the column was NOT dropped — but on an install where the drop has run, setting the flag
   back to `0` puts reads on a column with no ANN index: a seq scan + top-N sort over the corpus, which
-  under `HeavyRead`'s per-read `SET LOCAL statement_timeout` surfaces as
-  `{:error, :heavy_read_overloaded}`. A revert is therefore an INCIDENT action, not a routine toggle —
-  rebuild the index first (`down/0` of `20260805120000_drop_legacy_articles_embedding_hnsw_index.exs`,
-  and raise `maintenance_work_mem` well above the 64 MB default or the ~657 MB build silently falls back
-  to the slow on-disk path, wiki `753fbf69`). The drop migration is GUARDED on that same flag read
+  trips `HeavyRead`'s per-read `SET LOCAL statement_timeout`. That cancel is a raised `Postgrex.Error`
+  (57014) rendering `504 db_statement_timeout` — NOT `{:error, :heavy_read_overloaded}` (only the
+  `TenantGate` concurrency shed produces that tuple) and so NOT the labelled keyword degrade, which
+  matches the shed alone. Semantic search returns no results at all. A revert is therefore an INCIDENT
+  action, not a routine toggle — rebuild the index FIRST (an explicit `CREATE INDEX CONCURRENTLY`, or
+  `down/0` of `20260805120000_drop_legacy_articles_embedding_hnsw_index.exs`; raise
+  `maintenance_work_mem` well above the 64 MB default or the ~657 MB build silently falls back
+  to the slow on-disk path, wiki `753fbf69`) — and if you rebuilt via a rollback, flip the flag to `0`
+  BEFORE the next migrate runs, since the rollback makes that migration PENDING again and the next
+  deploy would re-drop the index you just rebuilt. The drop migration is GUARDED on that same flag read
   straight from `system_configs`, so an install still reading the legacy column keeps its index and a
   fresh self-hosted install is unaffected. `Loopctl.Embeddings.LegacyRetirement` discovers legacy
   indexes BY COLUMN, so an install that cuts over AFTER the migration ran still gets the leftover named

--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -176,7 +176,9 @@ number, is the load-bearing invariant. To monitor and keep it healthy over time:
   in its scan map. The executable surface enforces this: `mix loopctl.embeddings revert` REFUSES while
   the legacy index is absent (capability-detected, `--force` to override) and `mix loopctl.embeddings
   status` reports its presence. Operator procedure:
-  `docs/runbooks/embedding-dimension-cutover.md` (Reverting).
+  `docs/runbooks/embedding-dimension-cutover.md` — Retiring the legacy articles ANN index (the
+  drop, the baseline above, and the `pg_stat_statements` query for the AFTER reading) and
+  Reverting.
 - **Bulk (re)embed / backfill is a live-DB hazard.** Unthrottled it 504s the live wiki — per-row HNSW
   index maintenance saturates the small Fly Postgres and starves concurrent heavy-read searches past
   their `statement_timeout`. Throttled id-range keyset pattern: wiki `7a4187fd`.

--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -173,7 +173,10 @@ number, is the load-bearing invariant. To monitor and keep it healthy over time:
   straight from `system_configs`, so an install still reading the legacy column keeps its index and a
   fresh self-hosted install is unaffected. `Loopctl.Embeddings.LegacyRetirement` discovers legacy
   indexes BY COLUMN, so an install that cuts over AFTER the migration ran still gets the leftover named
-  in its scan map.
+  in its scan map. The executable surface enforces this: `mix loopctl.embeddings revert` REFUSES while
+  the legacy index is absent (capability-detected, `--force` to override) and `mix loopctl.embeddings
+  status` reports its presence. Operator procedure:
+  `docs/runbooks/embedding-dimension-cutover.md` (Reverting).
 - **Bulk (re)embed / backfill is a live-DB hazard.** Unthrottled it 504s the live wiki — per-row HNSW
   index maintenance saturates the small Fly Postgres and starves concurrent heavy-read searches past
   their `statement_timeout`. Throttled id-range keyset pattern: wiki `7a4187fd`.

--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -173,9 +173,12 @@ number, is the load-bearing invariant. To monitor and keep it healthy over time:
   straight from `system_configs`, so an install still reading the legacy column keeps its index and a
   fresh self-hosted install is unaffected. `Loopctl.Embeddings.LegacyRetirement` discovers legacy
   indexes BY COLUMN, so an install that cuts over AFTER the migration ran still gets the leftover named
-  in its scan map. The executable surface enforces this: `mix loopctl.embeddings revert` REFUSES while
-  the legacy index is absent (capability-detected, `--force` to override) and `mix loopctl.embeddings
-  status` reports its presence. Operator procedure:
+  in its scan map. `mix loopctl.embeddings revert` REFUSES while the legacy index is absent
+  (capability-detected, `--force` to override) and `mix loopctl.embeddings status` reports its
+  presence — but that refusal binds only where `mix` exists (source checkout / self-hosted from
+  source). **A release ships no `mix`**, so on the hosted instance a revert goes through
+  `bin/loopctl eval` or plain SQL and the guard never runs; there the runbook's rebuild-first
+  ordering is the only thing standing between you and a tenant-wide semantic-search outage. Operator procedure:
   `docs/runbooks/embedding-dimension-cutover.md` — Retiring the legacy articles ANN index (the
   drop, the baseline above, and the `pg_stat_statements` query for the AFTER reading) and
   Reverting.

--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -153,6 +153,22 @@ number, is the load-bearing invariant. To monitor and keep it healthy over time:
   NEVER write the flag — it is `:persistent_term`-cached VM-globally, so a write leaks across the whole
   node. `Loopctl.ConfigEmbeddingReadPathTest` fails the build on a second writer and on any
   `:embedding_read_path` config outside `config/test.exs`.
+- **Reverting the flag is now an UNINDEXED read path on a cut-over install (GH #578).** The legacy
+  `articles_embedding_hnsw_idx` (657 MB / 26 scans on prod 2026-08-04, vs 658 MB / 1,695 scans for the
+  live side-table index, `pg_stat_user_indexes`) is retired: with `shared_buffers` at 1536 MB the two
+  ~657 MB indexes evicted each other, and a cold vector search measured 8,044 ms of which 7,926 ms was
+  `blk_read_time`. `articles.embedding` is still dual-WRITTEN — it stays the backfill/reconciliation
+  source, and the column was NOT dropped — but on an install where the drop has run, setting the flag
+  back to `0` puts reads on a column with no ANN index: a seq scan + top-N sort over the corpus, which
+  under `HeavyRead`'s per-read `SET LOCAL statement_timeout` surfaces as
+  `{:error, :heavy_read_overloaded}`. A revert is therefore an INCIDENT action, not a routine toggle —
+  rebuild the index first (`down/0` of `20260805120000_drop_legacy_articles_embedding_hnsw_index.exs`,
+  and raise `maintenance_work_mem` well above the 64 MB default or the ~657 MB build silently falls back
+  to the slow on-disk path, wiki `753fbf69`). The drop migration is GUARDED on that same flag read
+  straight from `system_configs`, so an install still reading the legacy column keeps its index and a
+  fresh self-hosted install is unaffected. `Loopctl.Embeddings.LegacyRetirement` discovers legacy
+  indexes BY COLUMN, so an install that cuts over AFTER the migration ran still gets the leftover named
+  in its scan map.
 - **Bulk (re)embed / backfill is a live-DB hazard.** Unthrottled it 504s the live wiki — per-row HNSW
   index maintenance saturates the small Fly Postgres and starves concurrent heavy-read searches past
   their `statement_timeout`. Throttled id-range keyset pattern: wiki `7a4187fd`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,12 @@ Operator-facing changes for deployments outside the hosted instance.
   `CREATE INDEX CONCURRENTLY articles_embedding_hnsw_idx ON articles USING hnsw (embedding vector_cosine_ops)`
   plus the same `WITH (m, ef_construction)` the migration builds with, and raise
   `maintenance_work_mem` well above the 64 MB default or the ~657 MB HNSW build silently falls
-  back to the slow on-disk path. A rollback rebuilds it too —
+  back to the slow on-disk path.
+  `mix loopctl.embeddings revert` now REFUSES while that index is absent (detected by
+  capability, not by name) and prints the rebuild above; `mix loopctl.embeddings revert
+  --force` overrides the refusal, and `mix loopctl.embeddings status` reports the index as
+  `legacy articles.embedding HNSW index:`. The revert procedure is
+  `docs/runbooks/embedding-dimension-cutover.md` (Reverting). A rollback rebuilds it too —
   `bin/loopctl eval "Loopctl.Release.rollback(20260805120000)"` (there is no `mix` in a
   release) — but Ecto's `:to` is INCLUSIVE, so that reverts every migration at or after that
   version; once anything newer has shipped, use the explicit `CREATE INDEX`. If you do roll

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ Operator-facing changes for deployments outside the hosted instance.
 
 ### Changed
 
+- **The legacy `articles_embedding_hnsw_idx` is retired on installs whose reads are cut over
+  to the embedding side table, and reverting `embedding_side_table_reads` to `0` there is now
+  an UNINDEXED read path (#578).** Measured on the hosted instance 2026-08-04
+  (`pg_stat_user_indexes` / `pg_stat_statements`): the legacy index held 657 MB for 26 scans
+  while the live `article_embeddings_hnsw_dim_1536_idx` held 658 MB for 1,695 — and with
+  `shared_buffers` at 1536 MB the two evicted each other, so a cold vector search took
+  8,044 ms of which 7,926 ms (98.5%) was `blk_read_time` against 0 ms warm. Dropping the
+  legacy index frees roughly that 657 MB and leaves the live index resident.
+  `migrations/20260805120000_drop_legacy_articles_embedding_hnsw_index.exs` performs the drop
+  **only when `system_configs.embedding_side_table_reads` is `1`**; the flag defaults to `0`
+  (= the legacy `articles.embedding` column) and no migration seeds it, so a fresh install and
+  any install that has not cut over KEEP the index and are unaffected. Run
+  `DROP INDEX CONCURRENTLY articles_embedding_hnsw_idx` out-of-band ahead of the deploy if you
+  want the space back without waiting on the migrator — `IF EXISTS` makes the migration a
+  no-op afterwards. **Operator consequence:** on an install where the drop has run, setting
+  the flag back to `0` puts every semantic read on an unindexed column (seq scan + top-N sort,
+  surfacing as `503`/`heavy_read_overloaded` under the heavy-read statement timeout). Rebuild
+  the index first — `mix ecto.rollback` on that migration, or the equivalent
+  `CREATE INDEX CONCURRENTLY` — and raise `maintenance_work_mem` well above the 64 MB default
+  or the ~657 MB HNSW build silently falls back to the slow on-disk path. The
+  `articles.embedding` **column is unchanged**: still dual-written, still the
+  backfill/reconciliation source. `memories` keeps both of its legacy-column indexes
+  (deliberate — one serves `include_superseded: true` recall, the other default live recall).
+  No new environment variables.
+
 - **`loopctl.oban.poll.error.count` label values changed — re-point any Prometheus selector
   or Grafana panel (#558).** The `error_class` label moved from a bare `exit` / `throw` to the
   kind-prefixed, closed set produced by `Loopctl.ExitClass` — `exit:noproc`, `exit:timeout`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,15 +19,28 @@ Operator-facing changes for deployments outside the hosted instance.
   `migrations/20260805120000_drop_legacy_articles_embedding_hnsw_index.exs` performs the drop
   **only when `system_configs.embedding_side_table_reads` is `1`**; the flag defaults to `0`
   (= the legacy `articles.embedding` column) and no migration seeds it, so a fresh install and
-  any install that has not cut over KEEP the index and are unaffected. Run
-  `DROP INDEX CONCURRENTLY articles_embedding_hnsw_idx` out-of-band ahead of the deploy if you
-  want the space back without waiting on the migrator — `IF EXISTS` makes the migration a
-  no-op afterwards. **Operator consequence:** on an install where the drop has run, setting
-  the flag back to `0` puts every semantic read on an unindexed column (seq scan + top-N sort,
-  surfacing as `503`/`heavy_read_overloaded` under the heavy-read statement timeout). Rebuild
-  the index first — `mix ecto.rollback` on that migration, or the equivalent
-  `CREATE INDEX CONCURRENTLY` — and raise `maintenance_work_mem` well above the 64 MB default
-  or the ~657 MB HNSW build silently falls back to the slow on-disk path. The
+  any install that has not cut over KEEP the index and are unaffected. **On a cut-over
+  install** you may run `DROP INDEX CONCURRENTLY articles_embedding_hnsw_idx` out-of-band
+  ahead of the deploy if you want the space back without waiting on the migrator — `IF EXISTS`
+  makes the migration a no-op afterwards. Do NOT run that by hand on an install that has not
+  cut over: it destroys the index serving your live read path, and the migration only ever
+  drops, so it cannot give it back. **Operator consequence:** on an install where the drop has
+  run, setting the flag back to `0` puts every semantic read on an unindexed column (seq scan +
+  top-N sort). That trips the heavy-read `statement_timeout`, and the cancel surfaces as a hard
+  `504`/`db_statement_timeout` — NOT `503`/`heavy_read_overloaded`, which only the per-tenant
+  concurrency shed produces, and NOT the labelled keyword fall-back, which matches that shed
+  alone. There is no graceful degrade on this path today: semantic search returns no results.
+  Rebuild the index FIRST with an explicit
+  `CREATE INDEX CONCURRENTLY articles_embedding_hnsw_idx ON articles USING hnsw (embedding vector_cosine_ops)`
+  plus the same `WITH (m, ef_construction)` the migration builds with, and raise
+  `maintenance_work_mem` well above the 64 MB default or the ~657 MB HNSW build silently falls
+  back to the slow on-disk path. A rollback rebuilds it too —
+  `bin/loopctl eval "Loopctl.Release.rollback(20260805120000)"` (there is no `mix` in a
+  release) — but Ecto's `:to` is INCLUSIVE, so that reverts every migration at or after that
+  version; once anything newer has shipped, use the explicit `CREATE INDEX`. If you do roll
+  back, flip `embedding_side_table_reads` to `0` BEFORE the next
+  `bin/loopctl eval "Loopctl.Release.migrate()"`: the rollback makes the migration PENDING
+  again, and a deploy in that gap re-runs it and re-drops the index you just rebuilt. The
   `articles.embedding` **column is unchanged**: still dual-written, still the
   backfill/reconciliation source. `memories` keeps both of its legacy-column indexes
   (deliberate — one serves `include_superseded: true` recall, the other default live recall).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,10 @@ Operator-facing changes for deployments outside the hosted instance.
   `mix loopctl.embeddings revert` now REFUSES while that index is absent (detected by
   capability, not by name) and prints the rebuild above; `mix loopctl.embeddings revert
   --force` overrides the refusal, and `mix loopctl.embeddings status` reports the index as
-  `legacy articles.embedding HNSW index:`. The revert procedure is
-  `docs/runbooks/embedding-dimension-cutover.md` (Reverting). A rollback rebuilds it too —
+  `legacy articles.embedding HNSW index:`. The retirement procedure — the out-of-band drop,
+  the baseline above as a fixed point, and the `pg_stat_statements` query that takes the
+  matching AFTER reading — is `docs/runbooks/embedding-dimension-cutover.md` (Retiring the
+  legacy articles ANN index); the revert procedure is the Reverting section of the same file. A rollback rebuilds it too —
   `bin/loopctl eval "Loopctl.Release.rollback(20260805120000)"` (there is no `mix` in a
   release) — but Ecto's `:to` is INCLUSIVE, so that reverts every migration at or after that
   version; once anything newer has shipped, use the explicit `CREATE INDEX`. If you do roll

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,10 @@ Operator-facing changes for deployments outside the hosted instance.
   `mix loopctl.embeddings revert` now REFUSES while that index is absent (detected by
   capability, not by name) and prints the rebuild above; `mix loopctl.embeddings revert
   --force` overrides the refusal, and `mix loopctl.embeddings status` reports the index as
-  `legacy articles.embedding HNSW index:`. The retirement procedure — the out-of-band drop,
+  `legacy articles.embedding HNSW index:`. **That refusal only protects installs that run
+  from source** — a release ships no `mix`, so if you revert with `bin/loopctl eval` or a
+  `psql` UPDATE, nothing checks the index for you and the rebuild-first ordering below is
+  the only guard. The retirement procedure — the out-of-band drop,
   the baseline above as a fixed point, and the `pg_stat_statements` query that takes the
   matching AFTER reading — is `docs/runbooks/embedding-dimension-cutover.md` (Retiring the
   legacy articles ANN index); the revert procedure is the Reverting section of the same file. A rollback rebuilds it too —

--- a/docs/runbooks/embedding-dimension-cutover.md
+++ b/docs/runbooks/embedding-dimension-cutover.md
@@ -30,10 +30,64 @@ reading the side table would miss its writes.
 
 ## Reverting
 
-The flag is a `SystemConfig` integer precisely so the revert is a single UPDATE with
-no redeploy, supported for the whole dual-write window:
+**Read this before reverting — since GH #578 a revert is an INCIDENT action, not a
+routine toggle.** The flag is still a `SystemConfig` integer, so the flip itself is a
+single UPDATE with no redeploy, and the `articles.embedding` COLUMN is still
+dual-written, so the legacy read path is still CORRECT. What changed is its cost:
+migration `20260805120000_drop_legacy_articles_embedding_hnsw_index.exs` retires
+`articles_embedding_hnsw_idx` on any install whose `embedding_side_table_reads` is
+already `1` — i.e. on exactly the installs that can reach a revert.
 
-    mix loopctl.embeddings revert
+With that index gone, flipping back to `0` puts every semantic read on an UNINDEXED
+column: a seq scan + top-N sort that trips the heavy-read `statement_timeout`. The
+cancel surfaces as `504 db_statement_timeout` — **not** `503`/`heavy_read_overloaded`,
+which only the per-tenant concurrency shed produces, and which is the only thing the
+labelled keyword degrade matches. There is no graceful fall-back on that path today:
+semantic search returns no results tenant-wide.
+
+So, in order:
+
+1. **Check whether the legacy ANN index is still there** — by capability, never by
+   name (the retirement and a broken deploy are indistinguishable to a name check):
+
+       SELECT idx.relname, i.indisvalid
+       FROM pg_index i
+       JOIN pg_class idx ON idx.oid = i.indexrelid
+       JOIN pg_class tbl ON tbl.oid = i.indrelid
+       JOIN pg_am am ON am.oid = idx.relam
+       JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+       WHERE tbl.relname = 'articles' AND a.attname = 'embedding' AND am.amname = 'hnsw';
+
+   `mix loopctl.embeddings status` reports the same thing as
+   `legacy articles.embedding HNSW index:`.
+
+2. **If it is absent, rebuild it FIRST.** Raise `maintenance_work_mem` well above the
+   64 MB default or the ~657 MB HNSW build silently falls back to the slow on-disk
+   path. Use the same `WITH` parameters every other HNSW index is built with
+   (`Loopctl.Repo.HnswIndex.with_params_clause/0` — `m = 16, ef_construction = 64`
+   unless the instance overrides `:hnsw_m` / `:hnsw_ef_construction`):
+
+       SET maintenance_work_mem = '2GB';
+       CREATE INDEX CONCURRENTLY articles_embedding_hnsw_idx
+         ON articles USING hnsw (embedding vector_cosine_ops)
+         WITH (m = 16, ef_construction = 64);
+
+   Prefer this explicit `CREATE INDEX` over rolling the migration back: Ecto's `:to`
+   is INCLUSIVE, so `Loopctl.Release.rollback(20260805120000)` reverts every migration
+   at or after that version, and it leaves the migration PENDING so the next deploy
+   re-drops what you just rebuilt.
+
+3. **Then revert the flag:**
+
+       mix loopctl.embeddings revert
+
+   The task performs check (1) itself and REFUSES while the index is absent, printing
+   the rebuild above. `mix loopctl.embeddings revert --force` overrides that refusal —
+   take it only when a slow-or-dead legacy path is deliberately preferable to the
+   side-table one, and expect semantic search to be down until the rebuild lands.
+
+The `memories` legacy indexes are untouched, so a memory-recall revert carries none
+of this.
 
 ## Standing reconciliation
 

--- a/docs/runbooks/embedding-dimension-cutover.md
+++ b/docs/runbooks/embedding-dimension-cutover.md
@@ -150,6 +150,11 @@ So, in order:
    take it only when a slow-or-dead legacy path is deliberately preferable to the
    side-table one, and expect semantic search to be down until the rebuild lands.
 
+   **That refusal only binds where `mix` exists.** A release ships no `mix`, so on the
+   hosted instance the revert is the plain `system_configs` UPDATE via `bin/loopctl eval`
+   or `psql` and nothing stops it. There, steps 1 and 2 above are not a convenience — they
+   are the whole guard, and skipping them takes semantic search down tenant-wide.
+
 The `memories` legacy indexes are untouched, so a memory-recall revert carries none
 of this.
 

--- a/docs/runbooks/embedding-dimension-cutover.md
+++ b/docs/runbooks/embedding-dimension-cutover.md
@@ -28,6 +28,70 @@ reading the side table would miss its writes.
 
        mix loopctl.embeddings cutover
 
+## Retiring the legacy `articles` ANN index (GH #578)
+
+**Cut-over installs only** — i.e. only where `embedding_side_table_reads` is already `1`.
+On an install still reading the legacy column that index IS the live read path, dropping it
+there causes the outage described under Reverting, and the drop is one-way. Migration
+`20260805120000_drop_legacy_articles_embedding_hnsw_index.exs` performs the drop itself,
+guarded on that flag; run it out-of-band ahead of the deploy only if you want the space back
+without waiting on the migrator (`IF EXISTS` then makes the migration a no-op):
+
+    DROP INDEX CONCURRENTLY articles_embedding_hnsw_idx;
+
+### Recorded baseline — hosted instance, 2026-08-04, PRE-drop
+
+The fixed point the after-reading is compared against. `shared_buffers` was 1536 MB and the
+two indexes were large enough to evict each other:
+
+| index | size | scans |
+|---|---:|---:|
+| `articles_embedding_hnsw_idx` (legacy column) | 657 MB | 26 |
+| `article_embeddings_hnsw_dim_1536_idx` (live path) | 658 MB | 1,695 |
+
+A **cold** vector search on the live path measured **8,044 ms, of which 7,926 ms (98.5%) was
+`blk_read_time`**; the same statement warm measured 0 ms. Freeing the legacy 657 MB is
+supposed to leave the live index resident, so the after-reading should show that read-I/O
+share collapse.
+
+### Re-measuring afterwards
+
+Check both prerequisites first — with `track_io_timing` off every read-time column is
+identically `0`, which reads exactly like a total win:
+
+    SHOW track_io_timing;   -- must be 'on', or the measurement below is meaningless
+    SHOW server_version;    -- picks the column name
+
+`pg_stat_statements` renamed `blk_read_time` to `shared_blk_read_time` in **PG 17** (when the
+separate `local_blk_*` counters arrived). Use the name your server has — the wrong one errors,
+it does not silently return zero:
+
+    SELECT calls,
+           round(mean_exec_time::numeric, 1) AS mean_ms,
+           round(max_exec_time::numeric, 1)  AS max_ms,
+           round(shared_blk_read_time::numeric, 1) AS read_io_ms, -- PG <= 16: blk_read_time
+           shared_blks_read,
+           shared_blks_hit
+    FROM pg_stat_statements
+    WHERE query ILIKE '%article_embeddings%' AND query ILIKE '%<=>%'
+    ORDER BY calls DESC;
+
+Read it PER CALL, never in total: the counters are cumulative since the last
+`pg_stat_statements_reset()` and the before/after windows will not share a `calls` value.
+`max_exec_time` and `shared_blks_read` are the cold-read proxies — the 8,044 ms above was one
+cold call whose mean was buried by warm ones, and a resident index reads few blocks. Record
+the counters (or reset the view) immediately before the drop so the after window is clean.
+
+This is a dated OBSERVATION on a shared instance, not an attribution: the two readings are
+separated in time, so anything else that moved the working set moves them too — a p95 gate on
+this same cutover once fired on instance drift rather than on the change (wiki `b4af5f18`).
+Record both readings with their dates instead of a single verdict.
+
+Then confirm the STRUCTURAL half — that the live index is present, VALID and actually chosen —
+with the `pg_index.indisvalid` check and the EXPLAIN plan-node assertion in
+[`knowledge_scale_verification.md`](knowledge_scale_verification.md) (Index drift). On a
+cut-over install the plan must read `Index Scan using article_embeddings_hnsw_dim_<dim>_idx`.
+
 ## Reverting
 
 **Read this before reverting — since GH #578 a revert is an INCIDENT action, not a

--- a/docs/runbooks/knowledge_scale_verification.md
+++ b/docs/runbooks/knowledge_scale_verification.md
@@ -235,6 +235,24 @@ fixture in CI **plus** the live prod `EXPLAIN`/logs confirmation.
 
 ## Index drift
 
+> **Which index serves reads is now install-dependent (GH #578).** The ANN read path
+> moved to the `article_embeddings` side table on 2026-07-22, gated on
+> `SystemConfig "embedding_side_table_reads"`. On a **cut-over** install (prod) the live
+> index is `article_embeddings_hnsw_dim_<dim>_idx` and the legacy
+> `articles_embedding_hnsw_idx` has been retired; on an install still reading the legacy
+> column — the shipped default, since the flag defaults to `0` in code and no migration
+> seeds the row — the legacy index is **deliberately kept**, and
+> `20260805120000_drop_legacy_articles_embedding_hnsw_index.exs` skips its drop there.
+> Check the flag before concluding a missing index is drift:
+>
+> ```sql
+> SELECT value FROM system_configs WHERE key = 'embedding_side_table_reads';
+> ```
+>
+> Everything below is about detecting whichever HNSW index an install DOES have. The
+> capability-detection rule is unchanged and is the reason a name-based check would have
+> read the #578 retirement as a broken deploy.
+
 The HNSW index on `articles(embedding)` exists under **two names** historically: the
 migration created `articles_embedding_idx`, but the **live prod index was created
 out-of-band as `articles_embedding_hnsw_idx`**. This drift is a known foot-gun (see
@@ -268,6 +286,16 @@ remediated** to detect by `amname='hnsw'` (US-27.14;
 so this is the *rationale* for the capability-detection rule, not an open bug in the
 migrations — but the trap still bites any ad-hoc `psql` `DROP` you type by name.
 Always drop/inspect HNSW indexes by `amname='hnsw'` detection, not by an assumed name.
+
+**The one place a name is correct is the #578 retirement**, and only because it is
+paired with a validity check. `DROP INDEX CONCURRENTLY` cannot run inside a `DO` block,
+so the retirement names `articles_embedding_hnsw_idx` directly — which is safe *there*
+because US-27.14 already reconciled every environment onto that name. When verifying
+the outcome, assert on `pg_index.indisvalid` and the EXPLAIN plan node, never on
+`pg_indexes` name presence: `pg_indexes` lists INVALID indexes too, and
+`ORDER BY embedding <=> $1 LIMIT k` returns k rows identically with or without an index.
+On a cut-over install the plan must read
+`Index Scan using article_embeddings_hnsw_dim_<dim>_idx`.
 The same `IF NOT EXISTS`/`IF EXISTS` name-blindness applies to the keyset index
 recovery in
 [`knowledge-scale.md`](knowledge-scale.md) — verify with `pg_index.indisvalid`, not by

--- a/docs/runbooks/knowledge_scale_verification.md
+++ b/docs/runbooks/knowledge_scale_verification.md
@@ -249,9 +249,14 @@ fixture in CI **plus** the live prod `EXPLAIN`/logs confirmation.
 > SELECT value FROM system_configs WHERE key = 'embedding_side_table_reads';
 > ```
 >
-> Everything below is about detecting whichever HNSW index an install DOES have. The
-> capability-detection rule is unchanged and is the reason a name-based check would have
-> read the #578 retirement as a broken deploy.
+> **Everything below detects the LEGACY index only.** The canonical query is scoped to
+> the `articles` TABLE, so on a cut-over install after the retirement it returns zero
+> rows — the live index is `article_embeddings_hnsw_dim_<dim>_idx`, on a different
+> relation, and must be checked THERE (see the per-dimension section below). Capability
+> detection does not rescue that: the table scope, not the index name, is what makes the
+> query blind here. Read a zero-row result against the flag above — `1` means the
+> retirement, `0` means real drift — and re-scope the query to `article_embeddings`
+> before concluding anything on a cut-over install.
 
 The HNSW index on `articles(embedding)` exists under **two names** historically: the
 migration created `articles_embedding_idx`, but the **live prod index was created

--- a/lib/loopctl/embeddings.ex
+++ b/lib/loopctl/embeddings.ex
@@ -29,8 +29,24 @@ defmodule Loopctl.Embeddings do
   Step 4 may only happen after step 1 has reached EVERY node: during a Fly rolling
   deploy an old node writes the legacy column only, so a node reading the side
   table would miss its writes. The flag is a `SystemConfig` integer precisely so
-  reverting it is a single `UPDATE system_configs` with no redeploy — reverting is
-  a SUPPORTED operation for the whole dual-write window (AC-41.1.8(iii)).
+  reverting it is a single `UPDATE system_configs` with no redeploy — reverting
+  stays MECHANICALLY available for the whole dual-write window (AC-41.1.8(iii)).
+
+  ## The revert is no longer free (GH #578)
+
+  Migration `20260805120000_drop_legacy_articles_embedding_hnsw_index.exs` RETIRES
+  the HNSW index over `articles.embedding` on installs whose flag already reads
+  `1`. On such an install the revert target is an UNINDEXED column: a seq scan +
+  top-N sort that trips `HeavyRead`'s per-read `SET LOCAL statement_timeout`, and
+  that cancel is a raised `Postgrex.Error` (57014) rendered `504
+  db_statement_timeout` — NOT `{:error, :heavy_read_overloaded}`, which only the
+  `TenantGate` shed produces and which is the ONLY tuple the keyword degrade
+  matches. So semantic search returns nothing tenant-wide until the index is
+  rebuilt. The COLUMN is untouched and still dual-written, so the revert remains
+  CORRECT; it is the ANN index that has to come back first. `mix
+  loopctl.embeddings revert` refuses while that index is absent and prints the
+  rebuild; `docs/runbooks/embedding-dimension-cutover.md` (Reverting) is the
+  operator procedure.
 
   ## Dual-write is dim-1536-ONLY, and why
 
@@ -388,7 +404,10 @@ defmodule Loopctl.Embeddings do
   Whether recall reads the SIDE TABLE (`true`) or the legacy column (`false`).
 
   A `SystemConfig` integer (`0` = legacy, `1` = side table) so the flip and — just
-  as importantly — the REVERT are a single operator UPDATE with no redeploy.
+  as importantly — the REVERT are a single operator UPDATE with no redeploy. Cheap
+  to EXECUTE is not the same as cheap to LIVE WITH: since GH #578 the legacy ANN
+  index is retired on a cut-over install, so a revert there must be preceded by an
+  index rebuild. See the moduledoc section "The revert is no longer free".
 
   Resolved through `Loopctl.Embeddings.ReadPathBehaviour` (config-based DI), NOT
   read from `SystemConfig` here. Production resolves to

--- a/lib/loopctl/embeddings/system_config_read_path.ex
+++ b/lib/loopctl/embeddings/system_config_read_path.ex
@@ -9,6 +9,12 @@ defmodule Loopctl.Embeddings.SystemConfigReadPath do
   with no redeploy (AC-41.1.8(ii)/(iii)), and the read stays a near-zero-cost
   `:persistent_term` lookup on the request path.
 
+  That claim is about REDEPLOY, and only about redeploy. Since GH #578 a revert
+  on a cut-over install also needs the retired `articles.embedding` HNSW index
+  rebuilt first, or every semantic read lands unindexed — see the
+  `Loopctl.Embeddings` moduledoc section "The revert is no longer free" and
+  `docs/runbooks/embedding-dimension-cutover.md`.
+
   The flag KEY lives here, not in `Loopctl.Embeddings`: this module is the
   INJECTED collaborator, so depending back on the module it is injected into
   (just to fetch a string constant) would defeat the seam and make it

--- a/lib/loopctl/knowledge/scale_seed.ex
+++ b/lib/loopctl/knowledge/scale_seed.ex
@@ -598,12 +598,19 @@ defmodule Loopctl.Knowledge.ScaleSeed do
   end
 
   @doc """
-  Returns `true` if an HNSW index on `articles.embedding` is present,
-  detected by capability rather than by a hard-coded index name.
+  Returns `true` if an HNSW index serves the article ANN read path, on EITHER
+  relation that can carry it, detected by capability rather than by a hard-coded
+  index name.
 
-  Queries `pg_indexes JOIN pg_am` for `amname = 'hnsw'` to tolerate
-  index-name drift between environments (e.g. `articles_embedding_idx`
-  in test vs `articles_embedding_hnsw_idx` in prod).
+  Queries `pg_indexes JOIN pg_am` for `amname = 'hnsw'` to tolerate index-name
+  drift between environments (e.g. `articles_embedding_idx` in test vs
+  `articles_embedding_hnsw_idx` in prod).
+
+  Both `articles` and `article_embeddings` count (GH #578): which one serves reads
+  is install-dependent on the `embedding_side_table_reads` flag, and a cut-over
+  install has its legacy `articles` index RETIRED by design. Scoping this to
+  `articles` alone made the scale gate abort on exactly that install — with a
+  "run migrations" remedy that had already run.
   """
   @spec hnsw_index_present?() :: boolean()
   def hnsw_index_present? do
@@ -613,7 +620,7 @@ defmodule Loopctl.Knowledge.ScaleSeed do
       FROM pg_indexes idx
       JOIN pg_class cls ON cls.relname = idx.indexname
       JOIN pg_am am ON am.oid = cls.relam
-      WHERE idx.tablename = 'articles'
+      WHERE idx.tablename IN ('articles', 'article_embeddings')
         AND am.amname = 'hnsw'
       LIMIT 1
       """)
@@ -696,9 +703,12 @@ defmodule Loopctl.Knowledge.ScaleSeed do
       :ok
     else
       {:error,
-       "No HNSW index on articles.embedding detected via pg_indexes/pg_am. " <>
-         "Run migrations (mix ecto.migrate) before seeding at scale. " <>
-         "Scale assertions are meaningless without the index."}
+       "No HNSW index on articles.embedding or article_embeddings detected via " <>
+         "pg_indexes/pg_am. Run migrations (mix ecto.migrate) before seeding at scale; " <>
+         "if they HAVE run, check the embedding_side_table_reads flag — the legacy " <>
+         "articles index is retired on a cut-over install (GH #578) and the live index " <>
+         "is article_embeddings_hnsw_dim_<dim>_idx. Scale assertions are meaningless " <>
+         "without an index."}
     end
   end
 

--- a/lib/loopctl/memory/scale_seed.ex
+++ b/lib/loopctl/memory/scale_seed.ex
@@ -423,8 +423,14 @@ defmodule Loopctl.Memory.ScaleSeed do
   end
 
   # The recall inner ANN is served by the partial HNSW index
-  # `memories_live_embedding_hnsw_idx` (WHERE superseded_by IS NULL). Scale
-  # assertions are meaningless without it — fail loudly if migrations weren't run.
+  # `memories_live_embedding_hnsw_idx` (WHERE superseded_by IS NULL), or — on an
+  # install cut over to the side table — by `memory_embeddings_hnsw_dim_<dim>_idx`.
+  # Both count (GH #578): which one serves reads is install-dependent on
+  # `embedding_side_table_reads`, so scoping this to `memories` alone would abort the
+  # scale gate on a cut-over install with a remedy that had already been applied.
+  # `memories` keeps both of its legacy indexes today, so only the message matters
+  # here — the widened scope is the same correction applied to the articles check.
+  # Scale assertions are meaningless without an index — fail loudly.
   defp assert_hnsw_index_present! do
     %{rows: rows} =
       AdminRepo.query!("""
@@ -432,13 +438,15 @@ defmodule Loopctl.Memory.ScaleSeed do
       FROM pg_indexes idx
       JOIN pg_class cls ON cls.relname = idx.indexname
       JOIN pg_am am ON am.oid = cls.relam
-      WHERE idx.tablename = 'memories'
+      WHERE idx.tablename IN ('memories', 'memory_embeddings')
         AND am.amname = 'hnsw'
       LIMIT 1
       """)
 
     if rows == [] do
-      raise "No HNSW index on memories.embedding detected. Run mix ecto.migrate before seeding at scale."
+      raise "No HNSW index on memories.embedding or memory_embeddings detected. " <>
+              "Run mix ecto.migrate before seeding at scale; if migrations have run, " <>
+              "check the embedding_side_table_reads flag (GH #578)."
     end
 
     :ok

--- a/lib/mix/tasks/loopctl.embeddings.ex
+++ b/lib/mix/tasks/loopctl.embeddings.ex
@@ -11,6 +11,7 @@ defmodule Mix.Tasks.Loopctl.Embeddings do
       mix loopctl.embeddings status         # report gaps / drift without changing anything
       mix loopctl.embeddings cutover        # flip the side-table read flag (idempotent)
       mix loopctl.embeddings revert         # revert the read flag to the legacy column
+      mix loopctl.embeddings revert --force # ... even with the legacy ANN index gone
 
   The full cutover order (see `Loopctl.Embeddings` moduledoc and
   `docs/runbooks/embedding-dimension-cutover.md`):
@@ -19,9 +20,21 @@ defmodule Mix.Tasks.Loopctl.Embeddings do
       2. mix loopctl.embeddings backfill
       3. mix loopctl.embeddings reconcile   (and let the standing hourly worker run)
       4. mix loopctl.embeddings cutover
+
+  `revert` is NOT the routine toggle it once was (GH #578): migration
+  `20260805120000` retires the legacy `articles.embedding` HNSW index on a
+  cut-over install, so reverting there lands semantic reads on an UNINDEXED
+  column. The task refuses the revert while that index is absent and prints the
+  rebuild command; `--force` accepts the outage deliberately. See
+  `docs/runbooks/embedding-dimension-cutover.md` (Reverting).
   """
 
   use Mix.Task
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Embeddings
+  alias Loopctl.Repo.HnswIndex
+  alias Loopctl.SystemConfig
 
   @shortdoc "Operate the embedding-side-table backfill / reconciliation / cutover"
 
@@ -31,49 +44,135 @@ defmodule Mix.Tasks.Loopctl.Embeddings do
     dispatch(args)
   end
 
+  @doc """
+  Whether a VALID HNSW index still covers the LEGACY `articles.embedding` column —
+  i.e. whether reverting the read flag lands on an indexed path.
+
+  Detected by CAPABILITY (`pg_am.amname = 'hnsw'`) and by COLUMN, never by name:
+  the index lives under two names historically (US-27.14), and a name check would
+  read GH #578's deliberate retirement the same way it reads a broken deploy.
+  `indisvalid` is checked because a failed `CREATE INDEX CONCURRENTLY` leaves a
+  same-named INVALID index the planner will never use — present in `pg_indexes`,
+  useless to the read path.
+  """
+  @spec legacy_hnsw_index_present?() :: boolean()
+  def legacy_hnsw_index_present? do
+    %{rows: rows} =
+      AdminRepo.query!("""
+      SELECT 1
+      FROM pg_index i
+      JOIN pg_class idx ON idx.oid = i.indexrelid
+      JOIN pg_class tbl ON tbl.oid = i.indrelid
+      JOIN pg_namespace n ON n.oid = tbl.relnamespace
+      JOIN pg_am am ON am.oid = idx.relam
+      JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+      WHERE n.nspname = ANY(current_schemas(false))
+        AND tbl.relname = 'articles'
+        AND a.attname = 'embedding'
+        AND am.amname = 'hnsw'
+        AND i.indisvalid
+      LIMIT 1
+      """)
+
+    rows != []
+  end
+
+  @doc """
+  The operator-facing warning printed when a revert would land on an unindexed
+  `articles.embedding`. Public so the runbook text and this task cannot drift.
+  """
+  @spec unindexed_revert_warning() :: String.t()
+  def unindexed_revert_warning do
+    """
+    #{HnswIndex.canonical_index_name("articles")} is ABSENT: no VALID HNSW index
+    covers articles.embedding on this install. Migration 20260805120000 retires it
+    once reads are cut over to the side table (GH #578).
+
+    Reverting the flag to 0 puts EVERY semantic read back on that unindexed column:
+    a seq scan + top-N sort that trips the heavy-read statement_timeout. The cancel
+    surfaces as 504 db_statement_timeout, NOT the heavy_read_overloaded tuple, so
+    the labelled keyword degrade never matches — semantic search returns no results
+    tenant-wide until the index is rebuilt.
+
+    Rebuild FIRST. Raise maintenance_work_mem well above the 64 MB default or the
+    ~657 MB HNSW build silently falls back to the slow on-disk path:
+
+        SET maintenance_work_mem = '2GB';
+        CREATE INDEX CONCURRENTLY #{HnswIndex.canonical_index_name("articles")}
+          ON articles USING hnsw (embedding vector_cosine_ops)
+          #{HnswIndex.with_params_clause()};
+    """
+  end
+
   defp dispatch(["backfill" | _]) do
-    {:ok, a} = Loopctl.Embeddings.backfill_articles()
-    {:ok, m} = Loopctl.Embeddings.backfill_memories()
+    {:ok, a} = Embeddings.backfill_articles()
+    {:ok, m} = Embeddings.backfill_memories()
     Mix.shell().info("articles: #{inspect(a)}")
     Mix.shell().info("memories: #{inspect(m)}")
   end
 
   defp dispatch(["reconcile" | _]) do
-    {:ok, a} = Loopctl.Embeddings.reconcile_articles()
-    {:ok, m} = Loopctl.Embeddings.reconcile_memories()
+    {:ok, a} = Embeddings.reconcile_articles()
+    {:ok, m} = Embeddings.reconcile_memories()
     Mix.shell().info("articles: #{inspect(a)}")
     Mix.shell().info("memories: #{inspect(m)}")
   end
 
   defp dispatch(["status" | _]) do
-    a = length(Loopctl.Embeddings.article_reconciliation_gaps(limit: 1000))
-    m = length(Loopctl.Embeddings.memory_reconciliation_gaps(limit: 1000))
-    ad = length(Loopctl.Embeddings.article_live_denorm_drift(limit: 1000))
-    md = length(Loopctl.Embeddings.memory_live_denorm_drift(limit: 1000))
-    reads = Loopctl.Embeddings.side_table_reads_enabled?()
+    a = length(Embeddings.article_reconciliation_gaps(limit: 1000))
+    m = length(Embeddings.memory_reconciliation_gaps(limit: 1000))
+    ad = length(Embeddings.article_live_denorm_drift(limit: 1000))
+    md = length(Embeddings.memory_live_denorm_drift(limit: 1000))
+    reads = Embeddings.side_table_reads_enabled?()
 
     Mix.shell().info("side_table_reads_enabled: #{reads}")
     Mix.shell().info("article backfill gaps (capped at 1000): #{a}")
     Mix.shell().info("memory backfill gaps (capped at 1000): #{m}")
     Mix.shell().info("article live_denorm drift (capped at 1000): #{ad}")
     Mix.shell().info("memory live_denorm drift (capped at 1000): #{md}")
+    Mix.shell().info("legacy articles.embedding HNSW index: #{legacy_hnsw_index_present?()}")
   end
 
   defp dispatch(["cutover" | _]) do
-    {:ok, _} = Loopctl.SystemConfig.put(Loopctl.Embeddings.read_flag_key(), 1)
-    Mix.shell().info("side-table reads ENABLED (#{Loopctl.Embeddings.read_flag_key()} = 1)")
+    {:ok, _} = SystemConfig.put(Embeddings.read_flag_key(), 1)
+    Mix.shell().info("side-table reads ENABLED (#{Embeddings.read_flag_key()} = 1)")
   end
 
-  defp dispatch(["revert" | _]) do
-    {:ok, _} = Loopctl.SystemConfig.put(Loopctl.Embeddings.read_flag_key(), 0)
+  # GH #578 — the revert is no longer a routine toggle on a cut-over install: the
+  # index it reverts ONTO may already be retired, and the previous version of this
+  # clause wrote the flag and printed plain success either way. It now refuses while
+  # the legacy ANN index is missing, and names the rebuild. `--force` stays available
+  # because a revert is an INCIDENT action: an operator who has decided that a slow
+  # legacy path beats a wrong side-table one must still be able to take it.
+  defp dispatch(["revert" | rest]) do
+    cond do
+      legacy_hnsw_index_present?() ->
+        revert!()
 
-    Mix.shell().info(
-      "side-table reads REVERTED to legacy (#{Loopctl.Embeddings.read_flag_key()} = 0)"
-    )
+      "--force" in rest ->
+        Mix.shell().error(unindexed_revert_warning())
+        Mix.shell().error("--force given: reverting anyway. Semantic search will time out.")
+        revert!()
+
+      true ->
+        Mix.shell().error(unindexed_revert_warning())
+
+        Mix.shell().error(
+          "REFUSING to revert. Rebuild the index above and re-run, or pass --force " <>
+            "to accept a tenant-wide semantic-search outage."
+        )
+
+        exit({:shutdown, 1})
+    end
   end
 
   defp dispatch(_other) do
     Mix.shell().error("usage: mix loopctl.embeddings [backfill|reconcile|status|cutover|revert]")
     exit({:shutdown, 1})
+  end
+
+  defp revert! do
+    {:ok, _} = SystemConfig.put(Embeddings.read_flag_key(), 0)
+    Mix.shell().info("side-table reads REVERTED to legacy (#{Embeddings.read_flag_key()} = 0)")
   end
 end

--- a/lib/mix/tasks/loopctl.seed_scale.ex
+++ b/lib/mix/tasks/loopctl.seed_scale.ex
@@ -135,8 +135,10 @@ defmodule Mix.Tasks.Loopctl.SeedScale do
 
     unless ScaleSeed.hnsw_index_present?() do
       Mix.raise(
-        "No HNSW index detected on articles.embedding. " <>
-          "Run `mix ecto.migrate` before seeding at scale."
+        "No HNSW index detected on articles.embedding or article_embeddings. " <>
+          "Run `mix ecto.migrate` before seeding at scale; if migrations have run, " <>
+          "check the embedding_side_table_reads flag — a cut-over install retires the " <>
+          "legacy articles index by design (GH #578)."
       )
     end
 

--- a/priv/repo/migrations/20260805120000_drop_legacy_articles_embedding_hnsw_index.exs
+++ b/priv/repo/migrations/20260805120000_drop_legacy_articles_embedding_hnsw_index.exs
@@ -1,0 +1,145 @@
+defmodule Loopctl.Repo.Migrations.DropLegacyArticlesEmbeddingHnswIndex do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  require Logger
+
+  alias Loopctl.Repo.HnswIndex
+
+  # GH #578 — retire the PRE-US-41.1 HNSW index on the LEGACY `articles.embedding`
+  # column on installs that have cut their reads over to the side table.
+  #
+  # WHY (measured on prod 2026-08-04, source `pg_stat_user_indexes` +
+  # `pg_stat_statements`; dated observation, not a standing fact):
+  #   * `articles_embedding_hnsw_idx` (legacy column)          657 MB /    26 scans
+  #   * `article_embeddings_hnsw_dim_1536_idx` (live path)     658 MB / 1,695 scans
+  # `shared_buffers` is 1536 MB, so the two ~657 MB indexes evict each other. A cold
+  # vector search measured 8,044 ms, of which 7,926 ms (98.5%) was `blk_read_time`;
+  # the same statement warm was 0 ms. The read path was cut over to the side table
+  # (`article_embeddings`) on 2026-07-22, so the legacy index buys nothing on a
+  # cut-over install and costs the live index its cache residency.
+  #
+  # The 26 scans were NOT a stray consumer: they were the boot window GH #588 closed,
+  # in which the `SystemConfig` cache had not been primed before the Endpoint started
+  # and `embedding_side_table_reads` read its in-code default `0` (= legacy column).
+  # `Loopctl.SystemConfig.CachePrimer` is now a supervised one-shot child ordered
+  # after `AdminRepo` and before `Oban`/`Endpoint`, so that window is gone.
+  #
+  # SCOPE: the INDEX only. `articles.embedding` is still dual-WRITTEN and is read as
+  # the backfill/reconciliation source AND as the documented revert target, so
+  # dropping the COLUMN is a different, far riskier decision (issue #578 open
+  # question 4). Do not extend this migration to the column.
+  #
+  # `memories` deliberately keeps BOTH of its legacy-column indexes
+  # (`memories_embedding_idx`, `memories_live_embedding_hnsw_idx`). That is a
+  # documented keep-both decision — the FULL index serves
+  # `Memory.recall(include_superseded: true)` and the PARTIAL one serves default live
+  # recall (US-38.4 / TC-38.4.3, `test/loopctl/memory/dual_index_recall_test.exs`).
+  # Their 0 prod scans reflect prod's read flag, not deadness (#578 open question 3).
+  #
+  # ---------------------------------------------------------------------------
+  # Why the drop is GUARDED BY THE READ FLAG, not unconditional
+  # ---------------------------------------------------------------------------
+  #
+  # `embedding_side_table_reads` defaults to `0` IN CODE, and no migration seeds the
+  # row. So on a FRESH self-hosted install — and in the test DB — the shipped read
+  # path is still the legacy `articles.embedding` column. An UNCONDITIONAL drop would
+  # leave that shipped-default path with no index at all: a seq scan + top-N sort over
+  # the whole corpus, which under `HeavyRead`'s per-read `SET LOCAL statement_timeout`
+  # surfaces as `{:error, :heavy_read_overloaded}`. That is the GH #588 failure
+  # re-introduced through configuration instead of ordering.
+  #
+  # So this migration retires the index for the read path an install no longer uses,
+  # and leaves it in place for one that still does. The condition is read straight
+  # from `system_configs` (NOT `SystemConfig.get_int/2`): the `:persistent_term` cache
+  # answers its in-code default on a miss, and a migrator process is exactly where
+  # that cache may be cold.
+  #
+  # An install that flips the flag to 1 AFTER this migration has run keeps the index
+  # (a migration does not re-run). That is not silent: `Loopctl.Embeddings.LegacyRetirement`
+  # discovers legacy indexes BY COLUMN, so the index reappears in its scan map and its
+  # evidence/deadline verdict names it.
+  #
+  # ---------------------------------------------------------------------------
+  # Mechanics
+  # ---------------------------------------------------------------------------
+  #
+  # Explicit `up/0`/`down/0` (not `change/0`) because both directions are raw
+  # CONCURRENTLY `execute/1` and the down is differently shaped.
+  # `@disable_ddl_transaction` + `@disable_migration_lock` are BOTH mandatory:
+  # CONCURRENTLY is illegal inside a transaction block and Ecto's migration advisory
+  # lock is itself transaction-scoped. Ecto's `create index(..., concurrently: true)`
+  # helper emits no `IF NOT EXISTS`, hence raw `execute/1`.
+  #
+  # On prod the DROP is run OUT-OF-BAND (`fly ssh console`) ahead of the deploy, so
+  # `IF EXISTS` makes this migration a no-op there — that is the intended shape, not
+  # an accident.
+  #
+  # ROLLBACK COST: `down/0` rebuilds a ~657 MB HNSW index. At prod scale that needs
+  # `maintenance_work_mem` well above the 64 MB default or the build silently falls
+  # back to the slow on-disk path (wiki `753fbf69`). Raise it on the session first.
+
+  @index "articles_embedding_hnsw_idx"
+  @read_flag_key "embedding_side_table_reads"
+
+  def up do
+    if side_table_reads_live?() do
+      execute("DROP INDEX CONCURRENTLY IF EXISTS #{@index}")
+    else
+      # Not a failure: this install still READS the legacy column, so its index stays.
+      # Logged rather than silent — an operator reading the migration output should be
+      # able to tell "skipped, still the live read path" from "dropped".
+      Logger.info(
+        "#{inspect(__MODULE__)}: #{@read_flag_key} is not 1 — the legacy " <>
+          "articles.embedding column is still the live read path on this install, so " <>
+          "#{@index} is KEPT. Re-run this drop after cutting reads over to the side table."
+      )
+    end
+  end
+
+  # Restore the pre-migration state on ANY install, cut over or not, so a rollback is
+  # not itself conditional (a `down` that skipped would leave a rolled-back install
+  # without the index it is rolling back TO).
+  #
+  # The defensive DROP handles a leftover from a FAILED `CREATE INDEX CONCURRENTLY`:
+  # Postgres leaves an INVALID index behind under the same name, which `IF NOT EXISTS`
+  # then treats as present and skips forever (wiki `ed00911b`). It drops ONLY when the
+  # index is invalid — an unconditional drop-then-create would destroy and rebuild a
+  # perfectly good 657 MB index on every rollback. A plain (non-concurrent) DROP inside
+  # the DO block is fine: an INVALID index serves no scans.
+  def down do
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_index i ON i.indexrelid = c.oid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relname = '#{@index}' AND n.nspname = 'public' AND NOT i.indisvalid
+      ) THEN
+        EXECUTE 'DROP INDEX #{@index}';
+      END IF;
+    END $$;
+    """)
+
+    # The WITH (m, ef_construction) clause is single-sourced from Loopctl.Repo.HnswIndex
+    # so a rebuild can never drift from the params every other HNSW index is built with.
+    execute("""
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS #{@index}
+    ON articles USING hnsw (embedding vector_cosine_ops) #{HnswIndex.with_params_clause()}
+    """)
+  end
+
+  # The install's OWN cutover state, read from the row rather than the cache. A missing
+  # row means the in-code default (`0` = legacy column) — so absent reads as "still the
+  # live read path" and the index is kept.
+  defp side_table_reads_live? do
+    %{rows: rows} =
+      repo().query!("SELECT value FROM system_configs WHERE key = $1", [@read_flag_key])
+
+    match?([[1]], rows)
+  end
+end

--- a/priv/repo/migrations/20260805120000_drop_legacy_articles_embedding_hnsw_index.exs
+++ b/priv/repo/migrations/20260805120000_drop_legacy_articles_embedding_hnsw_index.exs
@@ -21,11 +21,23 @@ defmodule Loopctl.Repo.Migrations.DropLegacyArticlesEmbeddingHnswIndex do
   # (`article_embeddings`) on 2026-07-22, so the legacy index buys nothing on a
   # cut-over install and costs the live index its cache residency.
   #
-  # The 26 scans were NOT a stray consumer: they were the boot window GH #588 closed,
+  # The 26 scans were NOT a stray consumer: they were the boot window GH #588 narrowed,
   # in which the `SystemConfig` cache had not been primed before the Endpoint started
   # and `embedding_side_table_reads` read its in-code default `0` (= legacy column).
-  # `Loopctl.SystemConfig.CachePrimer` is now a supervised one-shot child ordered
-  # after `AdminRepo` and before `Oban`/`Endpoint`, so that window is gone.
+  # `Loopctl.SystemConfig.CachePrimer` is now a supervised one-shot child ordered after
+  # `AdminRepo` and before `Oban`/`Endpoint` — which closed the ORDERING window, but NOT
+  # the PRIME-FAILURE one, deliberately: `CachePrimer.start_link/1` returns `:ignore` on
+  # failure rather than aborting boot, and such a node serves the in-code default (= the
+  # LEGACY column) until a `SystemConfigRefreshWorker` tick lands ON IT — unbounded on a
+  # multi-node deploy, since the per-minute cron enqueues one job per tick cluster-wide
+  # (`Loopctl.Telemetry.ScaleMetrics` already documents that residual as UNBOUNDED).
+  #
+  # This drop changes the COST of that residual window on a CUT-OVER install: before it,
+  # a node that missed its prime served slow-but-correct results off this index; after
+  # it, the same node seq-scans an unindexed column past the heavy-read statement
+  # timeout — a semantic-search OUTAGE on that node (504 `db_statement_timeout`, see
+  # below), not a slowdown. That makes `loopctl.system_config.prime_failed.count`
+  # (scale metric 25) page-worthy on a cut-over install rather than informational.
   #
   # SCOPE: the INDEX only. `articles.embedding` is still dual-WRITTEN and is read as
   # the backfill/reconciliation source AND as the documented revert target, so
@@ -47,9 +59,14 @@ defmodule Loopctl.Repo.Migrations.DropLegacyArticlesEmbeddingHnswIndex do
   # row. So on a FRESH self-hosted install — and in the test DB — the shipped read
   # path is still the legacy `articles.embedding` column. An UNCONDITIONAL drop would
   # leave that shipped-default path with no index at all: a seq scan + top-N sort over
-  # the whole corpus, which under `HeavyRead`'s per-read `SET LOCAL statement_timeout`
-  # surfaces as `{:error, :heavy_read_overloaded}`. That is the GH #588 failure
-  # re-introduced through configuration instead of ordering.
+  # the whole corpus, which trips `HeavyRead`'s per-read `SET LOCAL statement_timeout`.
+  # That CANCEL is a raised `Postgrex.Error` (SQLSTATE 57014) propagating to the
+  # `DBErrorBackstop`, which renders `504 db_statement_timeout` — it is NOT
+  # `{:error, :heavy_read_overloaded}`, a tuple only the `TenantGate` concurrency shed
+  # produces, and it therefore does NOT reach `KnowledgeSearchController`'s labelled
+  # keyword degrade (that clause matches the shed tuple only). There is no graceful
+  # fall-back on this path today: semantic search returns no results at all. That is the
+  # GH #588 failure re-introduced through configuration instead of ordering.
   #
   # So this migration retires the index for the read path an install no longer uses,
   # and leaves it in place for one that still does. The condition is read straight
@@ -80,6 +97,15 @@ defmodule Loopctl.Repo.Migrations.DropLegacyArticlesEmbeddingHnswIndex do
   # ROLLBACK COST: `down/0` rebuilds a ~657 MB HNSW index. At prod scale that needs
   # `maintenance_work_mem` well above the 64 MB default or the build silently falls
   # back to the slow on-disk path (wiki `753fbf69`). Raise it on the session first.
+  #
+  # ROLLBACK ORDER: a rollback DELETES this version from `schema_migrations`, so the
+  # migration is PENDING again. Flip `embedding_side_table_reads` back to `0` BEFORE the
+  # next `Loopctl.Release.migrate()` runs — otherwise that deploy re-executes `up/0`, the
+  # guard still reads `1`, and the index just rebuilt at the `maintenance_work_mem` cost
+  # above is dropped again. Once the flag is `0`, the pending migration is a no-op.
+  # (Note `Loopctl.Release.rollback/1` passes `to: version`, which Ecto treats as
+  # INCLUSIVE — it rolls back every migration at or after this one. Once anything newer
+  # has shipped, rebuild with an explicit `CREATE INDEX CONCURRENTLY` instead.)
 
   @index "articles_embedding_hnsw_idx"
   @read_flag_key "embedding_side_table_reads"
@@ -107,23 +133,19 @@ defmodule Loopctl.Repo.Migrations.DropLegacyArticlesEmbeddingHnswIndex do
   # Postgres leaves an INVALID index behind under the same name, which `IF NOT EXISTS`
   # then treats as present and skips forever (wiki `ed00911b`). It drops ONLY when the
   # index is invalid — an unconditional drop-then-create would destroy and rebuild a
-  # perfectly good 657 MB index on every rollback. A plain (non-concurrent) DROP inside
-  # the DO block is fine: an INVALID index serves no scans.
+  # perfectly good 657 MB index on every rollback.
+  #
+  # The validity test is done HERE in Elixir, not in a `DO $$` block, so the drop can be
+  # CONCURRENTLY: a DO block IS a transaction and `DROP INDEX CONCURRENTLY` is illegal
+  # inside one, which leaves only a plain `DROP INDEX` — and that takes ACCESS EXCLUSIVE
+  # on `articles` ITSELF, not just the index. Behind one long-running `SELECT ... FROM
+  # articles` the lock request queues, and every subsequent read and write on `articles`
+  # (the whole wiki read path, not just vector search) queues behind it. This branch runs
+  # on the documented revert path — i.e. during an incident — so that is not affordable.
   def down do
-    execute("""
-    DO $$
-    BEGIN
-      IF EXISTS (
-        SELECT 1
-        FROM pg_class c
-        JOIN pg_index i ON i.indexrelid = c.oid
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE c.relname = '#{@index}' AND n.nspname = 'public' AND NOT i.indisvalid
-      ) THEN
-        EXECUTE 'DROP INDEX #{@index}';
-      END IF;
-    END $$;
-    """)
+    if invalid_index_leftover?() do
+      execute("DROP INDEX CONCURRENTLY IF EXISTS #{@index}")
+    end
 
     # The WITH (m, ef_construction) clause is single-sourced from Loopctl.Repo.HnswIndex
     # so a rebuild can never drift from the params every other HNSW index is built with.
@@ -131,6 +153,25 @@ defmodule Loopctl.Repo.Migrations.DropLegacyArticlesEmbeddingHnswIndex do
     CREATE INDEX CONCURRENTLY IF NOT EXISTS #{@index}
     ON articles USING hnsw (embedding vector_cosine_ops) #{HnswIndex.with_params_clause()}
     """)
+  end
+
+  # A leftover from a FAILED `CREATE INDEX CONCURRENTLY`: present in the catalog under
+  # this name and marked NOT valid. Read directly, the same shape as
+  # `side_table_reads_live?/0` below.
+  defp invalid_index_leftover? do
+    %{rows: rows} =
+      repo().query!(
+        """
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_index i ON i.indexrelid = c.oid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relname = $1 AND n.nspname = 'public' AND NOT i.indisvalid
+        """,
+        [@index]
+      )
+
+    rows != []
   end
 
   # The install's OWN cutover state, read from the row rather than the cache. A missing

--- a/priv/repo/migrations/20260805120000_drop_legacy_articles_embedding_hnsw_index.exs
+++ b/priv/repo/migrations/20260805120000_drop_legacy_articles_embedding_hnsw_index.exs
@@ -21,6 +21,10 @@ defmodule Loopctl.Repo.Migrations.DropLegacyArticlesEmbeddingHnswIndex do
   # (`article_embeddings`) on 2026-07-22, so the legacy index buys nothing on a
   # cut-over install and costs the live index its cache residency.
   #
+  # Those are the BEFORE figures. The matching AFTER reading is taken by
+  # `docs/runbooks/embedding-dimension-cutover.md` (Retiring the legacy articles ANN
+  # index) — same `pg_stat_statements` statement, per call, with `track_io_timing` on.
+  #
   # The 26 scans were NOT a stray consumer: they were the boot window GH #588 narrowed,
   # in which the `SystemConfig` cache had not been primed before the Endpoint started
   # and `embedding_side_table_reads` read its in-code default `0` (= legacy column).

--- a/test/loopctl/embeddings/legacy_index_retirement_runbook_test.exs
+++ b/test/loopctl/embeddings/legacy_index_retirement_runbook_test.exs
@@ -1,0 +1,147 @@
+defmodule Loopctl.Embeddings.LegacyIndexRetirementRunbookTest do
+  @moduledoc """
+  GH #578 (Fix step 3 / acceptance bullet 1): the change is justified ENTIRELY by a
+  cold-read I/O measurement, so the repo must carry both halves of it — the recorded
+  BEFORE figures, and a procedure an operator can follow to take the AFTER reading.
+  Without the second half the operator drops 657 MB and never learns whether the win
+  materialised.
+
+  These are doc-structure assertions (no DB), so they run in the normal async suite.
+
+  The baseline figures are deliberately repeated across four operator surfaces
+  (CHANGELOG, migration header, the knowledge-wiki skill, and now the runbook) because
+  each is read in isolation at a console. That duplication is a drift risk, so it is
+  asserted here rather than left to review.
+  """
+  use ExUnit.Case, async: true
+
+  @runbook "docs/runbooks/embedding-dimension-cutover.md"
+  @scale_runbook "docs/runbooks/knowledge_scale_verification.md"
+  @changelog "CHANGELOG.md"
+  @migration "priv/repo/migrations/20260805120000_drop_legacy_articles_embedding_hnsw_index.exs"
+  @skill ".claude/skills/knowledge-wiki/SKILL.md"
+
+  @section "Retiring the legacy `articles` ANN index (GH #578)"
+
+  # The measured facts, in the exact rendering every surface uses. Distinctive enough
+  # that a substring match cannot pass by accident (a bare "26" would).
+  @baseline_figures ["657 MB", "658 MB", "1,695", "8,044 ms", "7,926 ms"]
+
+  defp read(path) do
+    assert File.exists?(path), "#{path} must exist"
+    File.read!(path)
+  end
+
+  # The `## `-level section body, up to the next `## ` heading.
+  defp section(body, heading) do
+    case String.split(body, "## " <> heading, parts: 2) do
+      [_before, rest] -> rest |> String.split("\n## ", parts: 2) |> hd()
+      [_only] -> nil
+    end
+  end
+
+  describe "the retirement section exists and is actionable" do
+    test "the runbook carries a non-empty retirement section" do
+      content = section(read(@runbook), @section)
+
+      refute is_nil(content), "#{@runbook} is missing the '## #{@section}' section"
+      assert String.trim(content) != "", "the '## #{@section}' section is empty"
+    end
+
+    # Non-vacuity for every section-scoped assertion below: if `section/2` silently
+    # returned the whole file, each of them would pass on text that lives under some
+    # OTHER heading and the retirement section could be empty.
+    test "the extracted section is genuinely bounded, not the whole file" do
+      body = read(@runbook)
+      content = section(body, @section)
+
+      assert byte_size(content) < byte_size(body),
+             "section/2 returned the whole document — every scoped assertion is vacuous"
+
+      refute content =~ "mix loopctl.embeddings revert",
+             "the section bled into Reverting — the boundary split is not working"
+
+      refute content =~ "Standing reconciliation",
+             "the section bled past the next heading"
+    end
+
+    test "it names the out-of-band drop AND its cut-over-installs-only qualifier" do
+      content = section(read(@runbook), @section)
+
+      assert content =~ "DROP INDEX CONCURRENTLY articles_embedding_hnsw_idx",
+             "must give the out-of-band drop the operator actually runs"
+
+      assert content =~ "embedding_side_table_reads",
+             "must name the flag that decides whether the drop is safe"
+
+      assert content =~ ~r/cut-over installs only/i,
+             "the drop is one-way and destroys the live read path on a non-cut-over " <>
+               "install — the qualifier must be stated, not implied"
+    end
+
+    test "it records the BEFORE reading as a fixed point to compare against" do
+      content = section(read(@runbook), @section)
+
+      for figure <- @baseline_figures do
+        assert content =~ figure,
+               "the retirement section must record the baseline figure #{figure}; " <>
+                 "an after-reading with no before is not a comparison"
+      end
+    end
+
+    test "it gives the pg_stat_statements query for the AFTER reading" do
+      content = section(read(@runbook), @section)
+
+      assert content =~ "pg_stat_statements",
+             "the AC names pg_stat_statements as the measurement source"
+
+      assert content =~ "shared_blks_read",
+             "block counts are the cold-read proxy — a mean over warm calls is not one"
+
+      # The PG 17 rename: a query written against the old name errors on a newer
+      # instance, and one written against the new name errors on an older one. Both
+      # names must be present so the operator can pick.
+      assert content =~ "shared_blk_read_time" and content =~ "blk_read_time",
+             "must name BOTH pg_stat_statements read-time columns and the PG 17 rename"
+
+      assert content =~ "PG 17", "must say WHERE the column rename happened"
+
+      # With track_io_timing off every read-time column is identically 0, which reads
+      # exactly like a total win. The prerequisite is load-bearing, not hygiene.
+      assert content =~ "track_io_timing",
+             "must require track_io_timing on, or the measurement silently reads as 0"
+    end
+
+    test "it points at the structural half rather than restating it" do
+      content = section(read(@runbook), @section)
+
+      assert content =~ "indisvalid",
+             "the I/O reading alone cannot tell a resident index from an absent one"
+
+      assert content =~ "knowledge_scale_verification.md",
+             "must point at the runbook that owns the indisvalid + EXPLAIN check"
+
+      # Non-vacuity: the pointer only means something if the target still carries it.
+      scale = read(@scale_runbook)
+
+      assert scale =~ "indisvalid" and scale =~ "Index drift",
+             "#{@scale_runbook} must still own the structural check being pointed at"
+    end
+  end
+
+  describe "the baseline does not drift between operator surfaces" do
+    test "every surface quoting the baseline quotes the same numbers" do
+      refute @baseline_figures == [], "vacuous: no figures asserted"
+
+      for path <- [@runbook, @changelog, @migration, @skill] do
+        body = read(path)
+
+        for figure <- @baseline_figures do
+          assert body =~ figure,
+                 "#{path} quotes the #{@section} baseline but is missing #{figure} — " <>
+                   "the four surfaces are read in isolation and must not disagree"
+        end
+      end
+    end
+  end
+end

--- a/test/loopctl/embeddings/legacy_retirement_test.exs
+++ b/test/loopctl/embeddings/legacy_retirement_test.exs
@@ -335,6 +335,65 @@ defmodule Loopctl.Embeddings.LegacyRetirementTest do
       assert Enum.any?(verdict.reasons, &(&1 =~ "went BACKWARDS"))
     end
 
+    # GH #578 acceptance bullet 3 — "the observer keeps reporting side_table_reads = 1
+    # with the legacy index GONE from its scan map." Retiring
+    # `articles_embedding_hnsw_idx` produces a shape no other test here covers: an index
+    # PRESENT at the start of the window and ABSENT afterwards. Every existing guard is
+    # about an index APPEARING (`absent at the start`) or a counter MOVING; a
+    # disappearing one is neither, and must not be mistaken for either — an absence read
+    # as a counter would look like `0`, i.e. a counter that went BACKWARDS, and would
+    # jam the trigger at `:not_due` forever on exactly the installs that completed the
+    # retirement. (`window_scans/2` filters non-integers, which is what makes this hold.)
+    test "the ARTICLES index dropped mid-window is still :due — a retired index is not a rebuilt one" do
+      # Both legacy indexes present throughout; `memories` deliberately keeps its two
+      # (US-38.4 / TC-38.4.3), so a real post-#578 window is never empty.
+      clear_window(
+        scans: %{"articles_embedding_hnsw_idx" => 674, "memories_live_embedding_hnsw_idx" => 0}
+      )
+
+      # The drop lands on the last day.
+      AdminRepo.update_all(
+        from(o in RetirementObservation, where: o.observed_on == ^@today),
+        set: [legacy_index_scans: %{"memories_live_embedding_hnsw_idx" => 0}]
+      )
+
+      verdict = evaluate(probe())
+
+      assert verdict.verdict == :due
+      assert verdict.trigger == :evidence
+      assert verdict.clear_days == @required
+
+      # The disappearance contributed NO defect of its own: not a scan, not a rebuild,
+      # not an index that was absent at the start.
+      refute Enum.any?(verdict.reasons, &(&1 =~ "went BACKWARDS"))
+      refute Enum.any?(verdict.reasons, &(&1 =~ "legacy index scans inside the window"))
+      refute Enum.any?(verdict.reasons, &(&1 =~ "absent at the start of the window"))
+    end
+
+    test "a dropped index does not mask a REAL scan on one that survived it" do
+      # The companion to the test above: the disappearance must not turn the scan check
+      # vacuous for the indexes still there. Same window, same drop — but the surviving
+      # `memories` index moved.
+      clear_window(
+        scans: %{"articles_embedding_hnsw_idx" => 674, "memories_live_embedding_hnsw_idx" => 0}
+      )
+
+      AdminRepo.update_all(
+        from(o in RetirementObservation, where: o.observed_on == ^@today),
+        set: [legacy_index_scans: %{"memories_live_embedding_hnsw_idx" => 9}]
+      )
+
+      verdict = evaluate(probe())
+
+      assert verdict.verdict == :not_due
+
+      assert Enum.any?(
+               verdict.reasons,
+               &(&1 =~
+                   "legacy index scans inside the window: memories_live_embedding_hnsw_idx (+9)")
+             )
+    end
+
     test "a degenerate required_clear_days falls back rather than clearing vacuously" do
       # 0 is truthy, so `||` never rejected it: the window became empty, every check
       # passed over no rows, and `:due` was asserted from literally no evidence.

--- a/test/loopctl/embeddings_test.exs
+++ b/test/loopctl/embeddings_test.exs
@@ -524,8 +524,15 @@ defmodule Loopctl.EmbeddingsTest do
 
     test "no lib/ module outside a migration issues CREATE INDEX" do
       # `repo/hnsw_index.ex` BUILDS the SQL but is only ever CALLED from a migration
-      # (asserted below); `index_health.ex` only ever RENDERS remediation advice.
-      allowed = ["lib/loopctl/repo/hnsw_index.ex", "lib/loopctl/index_health.ex"]
+      # (asserted below); `index_health.ex` only ever RENDERS remediation advice; the
+      # `loopctl.embeddings` mix task is the OPERATOR plane and likewise only renders —
+      # its GH #578 revert refusal prints the rebuild for a human to run (asserted
+      # below: it never hands the DDL to a repo).
+      allowed = [
+        "lib/loopctl/repo/hnsw_index.ex",
+        "lib/loopctl/index_health.ex",
+        "lib/mix/tasks/loopctl.embeddings.ex"
+      ]
 
       offenders =
         Path.wildcard("lib/**/*.ex")
@@ -536,6 +543,21 @@ defmodule Loopctl.EmbeddingsTest do
 
       assert offenders == [],
              "index DDL is migration/operator plane only, found in: #{inspect(offenders)}"
+
+      # "Operator plane" must not become a blanket exemption for a file that could
+      # quietly grow a LIVE `CREATE INDEX`. The task renders the rebuild into a string
+      # for a human to run; every repo call it makes is a catalog SELECT.
+      task_source = File.read!("lib/mix/tasks/loopctl.embeddings.ex")
+
+      verbs =
+        ~r/(?:query!?|execute)\(\s*"{0,3}\s*\n?\s*([A-Za-z]+)/
+        |> Regex.scan(task_source)
+        |> Enum.map(fn [_full, verb] -> String.upcase(verb) end)
+
+      refute verbs == [], "expected the operator task to make at least one repo call"
+
+      assert Enum.all?(verbs, &(&1 == "SELECT")),
+             "the operator task must RENDER index DDL, never execute it; found: #{inspect(verbs)}"
 
       # And no REQUEST-PATH module reaches the DDL builder at all.
       callers =

--- a/test/loopctl/knowledge_embedding_test.exs
+++ b/test/loopctl/knowledge_embedding_test.exs
@@ -218,20 +218,29 @@ defmodule Loopctl.KnowledgeEmbeddingTest do
       # means — indistinguishable, and the migration guards on the row.
       legacy_column_is_live? = not match?([[1]], rows)
 
-      if legacy_column_is_live? do
-        assert index_valid?("articles_embedding_hnsw_idx"),
-               "the legacy articles.embedding column is still this install's read path, " <>
-                 "so its HNSW index must NOT have been dropped — an unindexed legacy " <>
-                 "read path is a full seq scan + top-N sort over the corpus"
+      # Non-vacuity: every assertion below is conditioned on this premise, so a test DB
+      # that ever seeded the flag to `1` would turn the whole test into a silent pass.
+      # The flag defaults to `0` IN CODE and no migration seeds the row, so the premise
+      # is asserted rather than branched on — a deliberate change to it has to come back
+      # here and decide what this test should check instead of quietly disabling it.
+      assert legacy_column_is_live?,
+             "#{Embeddings.read_flag_key()} is 1 in the test DB, which makes this test " <>
+               "assert nothing. Nothing may write that flag (it is :persistent_term-cached " <>
+               "VM-globally); if the shipped default genuinely changed, rewrite this test " <>
+               "for the side-table read path rather than leaving it vacuous"
 
-        %{rows: [[indexdef]]} =
-          AdminRepo.query!(
-            "SELECT indexdef FROM pg_indexes WHERE tablename = 'articles' AND indexname = 'articles_embedding_hnsw_idx'"
-          )
+      assert index_valid?("articles_embedding_hnsw_idx"),
+             "the legacy articles.embedding column is still this install's read path, " <>
+               "so its HNSW index must NOT have been dropped — an unindexed legacy " <>
+               "read path is a full seq scan + top-N sort over the corpus"
 
-        assert indexdef =~ "hnsw"
-        assert indexdef =~ "vector_cosine_ops"
-      end
+      %{rows: [[indexdef]]} =
+        AdminRepo.query!(
+          "SELECT indexdef FROM pg_indexes WHERE tablename = 'articles' AND indexname = 'articles_embedding_hnsw_idx'"
+        )
+
+      assert indexdef =~ "hnsw"
+      assert indexdef =~ "vector_cosine_ops"
     end
   end
 

--- a/test/loopctl/knowledge_embedding_test.exs
+++ b/test/loopctl/knowledge_embedding_test.exs
@@ -3,8 +3,11 @@ defmodule Loopctl.KnowledgeEmbeddingTest do
 
   setup :verify_on_exit!
 
+  alias Loopctl.AdminRepo
+  alias Loopctl.Embeddings
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
+  alias Loopctl.Repo.HnswIndex
 
   defp setup_tenant do
     tenant = fixture(:tenant)
@@ -170,22 +173,77 @@ defmodule Loopctl.KnowledgeEmbeddingTest do
     end
   end
 
-  # TC-20.2.7: HNSW index exists
-  # US-27.14: reconciled to the single canonical name `articles_embedding_hnsw_idx`
-  # (matches prod). The reconcile migration renames the old migration's
-  # `articles_embedding_idx` to this name in every env, so the assertion is now
-  # exact rather than name-agnostic (still asserting the hnsw access method).
+  # TC-20.2.7: the ANN index that serves THIS install's read path exists.
+  #
+  # US-27.14 reconciled the legacy index to the single canonical name
+  # `articles_embedding_hnsw_idx`. GH #578 then RETIRED it — but only on installs whose
+  # reads have been cut over to the `article_embeddings` side table, because
+  # `embedding_side_table_reads` defaults to `0` (= the legacy `articles.embedding`
+  # column) in code and no migration seeds the row.
+  #
+  # So "the legacy index exists" is no longer an invariant, and its negation is not one
+  # either. The invariant that survives #578 — and the one worth a test — is that the
+  # index serving the LIVE read path is present and USABLE, and that the legacy index is
+  # present exactly when the legacy column is still the live read path. That is
+  # mechanically the same condition the drop migration guards on
+  # (`20260805120000_drop_legacy_articles_embedding_hnsw_index.exs`), so a migration
+  # that dropped unconditionally would fail here.
   describe "HNSW index" do
-    test "articles_embedding_hnsw_idx exists on articles table" do
-      result =
-        Loopctl.AdminRepo.query!(
-          "SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'articles' AND indexname = 'articles_embedding_hnsw_idx'"
-        )
+    test "the live ANN index is present and VALID" do
+      # `pg_indexes` also lists INVALID indexes — the leftover a failed
+      # `CREATE INDEX CONCURRENTLY` produces (wiki ed00911b) — so presence is checked
+      # via `pg_index.indisvalid`, never by name alone (wiki 753fbf69).
+      live = HnswIndex.dimension_index_name("article_embeddings", 1536)
 
-      assert length(result.rows) == 1
-      [[_name, indexdef]] = result.rows
-      assert indexdef =~ "hnsw"
-      assert indexdef =~ "vector_cosine_ops"
+      assert index_valid?(live),
+             "the per-dimension side-table ANN index #{live} must exist and be valid"
     end
+
+    test "the legacy index exists exactly when the legacy column is the live read path" do
+      %{rows: rows} =
+        AdminRepo.query!("SELECT value FROM system_configs WHERE key = $1", [
+          Embeddings.read_flag_key()
+        ])
+
+      # Read from the ROW, not `SystemConfig.get_int/2`: the `:persistent_term` cache
+      # answers the in-code default on a miss, which is the same value an absent row
+      # means — indistinguishable, and the migration guards on the row.
+      legacy_column_is_live? = not match?([[1]], rows)
+
+      if legacy_column_is_live? do
+        assert index_valid?("articles_embedding_hnsw_idx"),
+               "the legacy articles.embedding column is still this install's read path, " <>
+                 "so its HNSW index must NOT have been dropped — an unindexed legacy " <>
+                 "read path is a full seq scan + top-N sort over the corpus"
+
+        %{rows: [[indexdef]]} =
+          AdminRepo.query!(
+            "SELECT indexdef FROM pg_indexes WHERE tablename = 'articles' AND indexname = 'articles_embedding_hnsw_idx'"
+          )
+
+        assert indexdef =~ "hnsw"
+        assert indexdef =~ "vector_cosine_ops"
+      else
+        refute index_valid?("articles_embedding_hnsw_idx"),
+               "reads are cut over to the side table, so the legacy 657 MB index is " <>
+                 "retired (GH #578) — it only evicts the live index from shared_buffers"
+      end
+    end
+  end
+
+  defp index_valid?(name) do
+    %{rows: rows} =
+      AdminRepo.query!(
+        """
+        SELECT i.indisvalid
+        FROM pg_class c
+        JOIN pg_index i ON i.indexrelid = c.oid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relname = $1 AND n.nspname = 'public'
+        """,
+        [name]
+      )
+
+    rows == [[true]]
   end
 end

--- a/test/loopctl/knowledge_embedding_test.exs
+++ b/test/loopctl/knowledge_embedding_test.exs
@@ -182,12 +182,20 @@ defmodule Loopctl.KnowledgeEmbeddingTest do
   # column) in code and no migration seeds the row.
   #
   # So "the legacy index exists" is no longer an invariant, and its negation is not one
-  # either. The invariant that survives #578 — and the one worth a test — is that the
+  # either. The invariants that survive #578 — and the ones worth a test — are that the
   # index serving the LIVE read path is present and USABLE, and that the legacy index is
-  # present exactly when the legacy column is still the live read path. That is
-  # mechanically the same condition the drop migration guards on
+  # still present WHENEVER the legacy column is still the live read path. That second one
+  # is mechanically the same condition the drop migration guards on
   # (`20260805120000_drop_legacy_articles_embedding_hnsw_index.exs`), so a migration
   # that dropped unconditionally would fail here.
+  #
+  # The CONVERSE is deliberately NOT asserted. The documented cutover order
+  # (`Loopctl.Embeddings` moduledoc) is: deploy the code — running the drop migration
+  # while the flag is still `0`, so the index is KEPT — backfill, reconcile, and only
+  # THEN flip the flag to `1`. Every install that cuts over from here on therefore has
+  # the flag at `1` AND the legacy index still present, which the migration states
+  # explicitly ("a migration does not re-run"). Asserting `flag = 1 => no index` would
+  # red on exactly the installs that followed the documented procedure.
   describe "HNSW index" do
     test "the live ANN index is present and VALID" do
       # `pg_indexes` also lists INVALID indexes — the leftover a failed
@@ -199,7 +207,7 @@ defmodule Loopctl.KnowledgeEmbeddingTest do
              "the per-dimension side-table ANN index #{live} must exist and be valid"
     end
 
-    test "the legacy index exists exactly when the legacy column is the live read path" do
+    test "the legacy index is present while the legacy column is the live read path" do
       %{rows: rows} =
         AdminRepo.query!("SELECT value FROM system_configs WHERE key = $1", [
           Embeddings.read_flag_key()
@@ -223,10 +231,6 @@ defmodule Loopctl.KnowledgeEmbeddingTest do
 
         assert indexdef =~ "hnsw"
         assert indexdef =~ "vector_cosine_ops"
-      else
-        refute index_valid?("articles_embedding_hnsw_idx"),
-               "reads are cut over to the side table, so the legacy 657 MB index is " <>
-                 "retired (GH #578) — it only evicts the live index from shared_buffers"
       end
     end
   end

--- a/test/loopctl/repo/drop_legacy_articles_embedding_hnsw_index_migration_test.exs
+++ b/test/loopctl/repo/drop_legacy_articles_embedding_hnsw_index_migration_test.exs
@@ -1,0 +1,311 @@
+defmodule Loopctl.Repo.DropLegacyArticlesEmbeddingHnswIndexMigrationTest do
+  @moduledoc """
+  GH #578 — `DropLegacyArticlesEmbeddingHnswIndex` retires the pre-US-41.1 HNSW index
+  on the LEGACY `articles.embedding` column (`articles_embedding_hnsw_idx`, 657 MB /
+  26 scans on prod 2026-08-04) on installs whose reads have been cut over to the
+  `article_embeddings` side table — and DELIBERATELY keeps it on installs that have
+  not, because `embedding_side_table_reads` defaults to `0` (= the legacy column) in
+  code and no migration seeds the row.
+
+  That conditional is the load-bearing behaviour here, so it is tested in BOTH
+  directions: an unconditional drop would leave the SHIPPED-DEFAULT read path with no
+  index at all — a seq scan + top-N sort over the whole corpus, which under
+  `HeavyRead`'s per-read `SET LOCAL statement_timeout` surfaces as
+  `{:error, :heavy_read_overloaded}`.
+
+  ## How the migration is driven — CONCURRENTLY, so OUTSIDE the sandbox
+
+  `up/0` drops and `down/0` rebuilds with `DROP`/`CREATE INDEX CONCURRENTLY`, so the
+  deploy takes no ACCESS EXCLUSIVE lock on `articles`. `CONCURRENTLY` is illegal
+  inside a transaction block and the Ecto SQL sandbox wraps every test in one, so the
+  shipped `up/0`/`down/0` CANNOT be driven inside the sandbox transaction.
+
+  Instead they run verbatim through `Sandbox.unboxed_run/2`, which checks out a REAL
+  (non-sandboxed) connection where statements auto-commit — the same committed
+  connection the production migrator uses. `Ecto.Migration.Runner.run/8` (the entry
+  point `Ecto.Migrator.attempt/7` uses for an explicit `up/0`/`down/0`) opens no
+  transaction of its own; the DDL-transaction wrapper lives in `Ecto.Migrator`, which
+  `@disable_ddl_transaction true` disables in production. So the SHIPPED code runs
+  here exactly as it runs at deploy, and a defect edited into the migration file WILL
+  fail these tests.
+
+  Because these tests commit real index changes to the SHARED `articles` catalog — and
+  briefly commit a `system_configs` row — an `on_exit` restores the canonical state
+  after every test.
+
+  ## The read flag is read from the ROW, never through `SystemConfig`
+
+  The migration issues `SELECT value FROM system_configs WHERE key = ...` directly.
+  That matters twice: a migrator process is exactly where the `:persistent_term` cache
+  may be cold (it answers the in-code default `0` on a miss — GH #588), and it means
+  these tests can commit and remove the row WITHOUT touching the VM-global cache that
+  every other test's read path resolves through. Nothing here writes
+  `Loopctl.SystemConfig`, and nothing here stubs `MockEmbeddingReadPath`.
+  """
+  # async: false (the documented global-state-coupling exception to async-everywhere):
+  # these tests commit real CREATE/DROP INDEX against the SHARED `articles` catalog and
+  # a real row into the global `system_configs` table via unboxed_run, bypassing the
+  # per-test sandbox rollback. ExUnit's sync phase serializes that committed mutation
+  # and keeps it off the timeline of the async siblings that read `articles.embedding`.
+  use Loopctl.DataCase, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Ecto.Migration.Runner
+  alias Loopctl.AdminRepo
+  alias Loopctl.Embeddings
+  alias Loopctl.Repo.HnswIndex
+
+  @migration_version 20_260_805_120_000
+  @migration_file Path.wildcard(
+                    Path.join([
+                      File.cwd!(),
+                      "priv",
+                      "repo",
+                      "migrations",
+                      "#{@migration_version}_*.exs"
+                    ])
+                  )
+                  |> hd()
+
+  Code.require_file(@migration_file)
+
+  alias Loopctl.Repo.Migrations.DropLegacyArticlesEmbeddingHnswIndex
+
+  @index "articles_embedding_hnsw_idx"
+
+  # Restore the canonical state after every test. The applied-migration baseline in the
+  # test DB is: read flag ABSENT (so the legacy column is the live read path) and the
+  # legacy index PRESENT. Both directions of every test below can leave either off.
+  setup do
+    on_exit(fn ->
+      Sandbox.unboxed_run(AdminRepo, fn ->
+        AdminRepo.query!("DELETE FROM system_configs WHERE key = $1", [
+          Embeddings.read_flag_key()
+        ])
+
+        AdminRepo.query!("""
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS #{@index}
+        ON articles USING hnsw (embedding vector_cosine_ops) #{HnswIndex.with_params_clause()}
+        """)
+      end)
+    end)
+
+    :ok
+  end
+
+  defp with_unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
+
+  # Drive the real migration's up/0 in THIS process (mirrors Ecto.Migrator.attempt/7 for
+  # an explicit up/0 running :forward). MUST be called inside with_unboxed/1 so the
+  # CONCURRENTLY DDL runs on a committed, non-transactional connection.
+  defp run_migration_up, do: run_migration(:up)
+  defp run_migration_down, do: run_migration(:down)
+
+  defp run_migration(direction) do
+    Runner.run(
+      AdminRepo,
+      AdminRepo.config(),
+      @migration_version,
+      DropLegacyArticlesEmbeddingHnswIndex,
+      :forward,
+      direction,
+      direction,
+      log: false
+    )
+  end
+
+  # Commit the cutover flag exactly as an operator's `SystemConfig.put/2` would leave the
+  # ROW — without touching the `:persistent_term` cache (see the moduledoc).
+  defp set_read_flag(value) do
+    AdminRepo.query!(
+      """
+      INSERT INTO system_configs (id, key, value, description, inserted_at, updated_at)
+      VALUES (gen_random_uuid(), $1, $2, 'test', now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC')
+      ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
+      """,
+      [Embeddings.read_flag_key(), value]
+    )
+  end
+
+  defp clear_read_flag do
+    AdminRepo.query!("DELETE FROM system_configs WHERE key = $1", [Embeddings.read_flag_key()])
+  end
+
+  defp index_present?(name) do
+    %{rows: rows} =
+      AdminRepo.query!(
+        "SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND tablename = 'articles' AND indexname = $1",
+        [name]
+      )
+
+    rows != []
+  end
+
+  # `pg_indexes` also lists INVALID indexes (wiki 753fbf69), so presence alone is not
+  # health — the rebuilt index must be usable.
+  defp index_valid?(name) do
+    %{rows: rows} =
+      AdminRepo.query!(
+        """
+        SELECT i.indisvalid
+        FROM pg_class c
+        JOIN pg_index i ON i.indexrelid = c.oid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relname = $1 AND n.nspname = 'public'
+        """,
+        [name]
+      )
+
+    rows == [[true]]
+  end
+
+  describe "up/0 on a cut-over install (embedding_side_table_reads = 1)" do
+    test "drops the legacy articles HNSW index" do
+      with_unboxed(fn ->
+        set_read_flag(1)
+        assert index_present?(@index)
+
+        assert :ok = run_migration_up()
+
+        refute index_present?(@index)
+      end)
+    end
+
+    test "is idempotent-safe when the index is already absent (DROP ... IF EXISTS)" do
+      with_unboxed(fn ->
+        set_read_flag(1)
+
+        assert :ok = run_migration_up()
+        refute index_present?(@index)
+
+        # Second run: nothing to drop, must still succeed rather than raise.
+        assert :ok = run_migration_up()
+        refute index_present?(@index)
+      end)
+    end
+
+    test "leaves the LIVE side-table index — and the legacy COLUMN — untouched" do
+      with_unboxed(fn ->
+        set_read_flag(1)
+        assert :ok = run_migration_up()
+
+        # The index this retirement exists to protect (it lost cache residency to the
+        # legacy one) must still be present AND valid.
+        live = HnswIndex.dimension_index_name("article_embeddings", 1536)
+        assert index_valid?(live)
+
+        # #578 open question 4 / scope: the COLUMN is still dual-written and is both the
+        # backfill source and the documented revert target. Dropping it is a separate,
+        # far riskier decision that this migration must never make.
+        %{rows: rows} =
+          AdminRepo.query!("""
+          SELECT 1 FROM pg_attribute a
+          JOIN pg_class c ON c.oid = a.attrelid
+          WHERE c.relname = 'articles' AND a.attname = 'embedding' AND NOT a.attisdropped
+          """)
+
+        assert rows == [[1]]
+      end)
+    end
+  end
+
+  describe "up/0 on an install that still reads the legacy column" do
+    # This is the guard that keeps GH #588 closed. `embedding_side_table_reads` defaults
+    # to 0 IN CODE and no migration seeds the row, so a fresh self-hosted install (and
+    # the test DB) still READS `articles.embedding`. Dropping its index there would make
+    # the shipped-default read path a full seq scan + top-N sort.
+    test "KEEPS the index when the flag row is absent (the shipped default)" do
+      with_unboxed(fn ->
+        clear_read_flag()
+        assert index_present?(@index)
+
+        assert :ok = run_migration_up()
+
+        assert index_present?(@index)
+        assert index_valid?(@index)
+      end)
+    end
+
+    test "KEEPS the index when the flag row is explicitly 0 (an operator revert)" do
+      with_unboxed(fn ->
+        set_read_flag(0)
+
+        assert :ok = run_migration_up()
+
+        assert index_present?(@index)
+        assert index_valid?(@index)
+      end)
+    end
+  end
+
+  describe "down/0" do
+    test "rebuilds the legacy index, valid, regardless of the read flag" do
+      with_unboxed(fn ->
+        set_read_flag(1)
+        assert :ok = run_migration_up()
+        refute index_present?(@index)
+
+        # down/0 is deliberately UNCONDITIONAL: a rollback that skipped on a cut-over
+        # install would leave it without the index it is rolling back TO.
+        assert :ok = run_migration_down()
+
+        assert index_valid?(@index)
+      end)
+    end
+
+    test "is idempotent-safe when a VALID index is already present, and does not rebuild it" do
+      with_unboxed(fn ->
+        clear_read_flag()
+        assert index_valid?(@index)
+
+        # The relfilenode identifies the physical index file. An unconditional
+        # drop-then-create would destroy and rebuild a perfectly good 657 MB index on
+        # every rollback; the defensive DROP fires ONLY for an INVALID leftover, so the
+        # file must be the SAME one afterwards.
+        before = relfilenode(@index)
+
+        assert :ok = run_migration_down()
+
+        assert index_valid?(@index)
+        assert relfilenode(@index) == before
+      end)
+    end
+
+    # Wiki ed00911b: a FAILED `CREATE INDEX CONCURRENTLY` leaves an INVALID index behind
+    # under the same name, which `CREATE INDEX ... IF NOT EXISTS` then treats as present
+    # and skips FOREVER — a permanently unusable index that every `pg_indexes` name check
+    # reports as fine. down/0 must clear that leftover before rebuilding.
+    test "clears an INVALID leftover and rebuilds a valid index" do
+      with_unboxed(fn ->
+        clear_read_flag()
+
+        AdminRepo.query!("DROP INDEX CONCURRENTLY IF EXISTS #{@index}")
+
+        # Forge the exact leftover a failed CONCURRENTLY build produces: present in the
+        # catalog, marked NOT valid.
+        AdminRepo.query!("""
+        CREATE INDEX #{@index}
+        ON articles USING hnsw (embedding vector_cosine_ops) #{HnswIndex.with_params_clause()}
+        """)
+
+        AdminRepo.query!(
+          "UPDATE pg_index SET indisvalid = false WHERE indexrelid = $1::text::regclass",
+          [@index]
+        )
+
+        refute index_valid?(@index)
+
+        assert :ok = run_migration_down()
+
+        assert index_valid?(@index)
+      end)
+    end
+  end
+
+  defp relfilenode(name) do
+    %{rows: [[node]]} =
+      AdminRepo.query!("SELECT relfilenode FROM pg_class WHERE relname = $1", [name])
+
+    node
+  end
+end

--- a/test/loopctl/repo/drop_legacy_articles_embedding_hnsw_index_migration_test.exs
+++ b/test/loopctl/repo/drop_legacy_articles_embedding_hnsw_index_migration_test.exs
@@ -9,9 +9,11 @@ defmodule Loopctl.Repo.DropLegacyArticlesEmbeddingHnswIndexMigrationTest do
 
   That conditional is the load-bearing behaviour here, so it is tested in BOTH
   directions: an unconditional drop would leave the SHIPPED-DEFAULT read path with no
-  index at all — a seq scan + top-N sort over the whole corpus, which under
-  `HeavyRead`'s per-read `SET LOCAL statement_timeout` surfaces as
-  `{:error, :heavy_read_overloaded}`.
+  index at all — a seq scan + top-N sort over the whole corpus, which trips
+  `HeavyRead`'s per-read `SET LOCAL statement_timeout`. That cancel is a raised
+  `Postgrex.Error` (57014) rendering `504 db_statement_timeout`, NOT
+  `{:error, :heavy_read_overloaded}` (only the `TenantGate` concurrency shed produces
+  that tuple), so it does not reach the controller's labelled keyword degrade either.
 
   ## How the migration is driven — CONCURRENTLY, so OUTSIDE the sandbox
 
@@ -25,13 +27,17 @@ defmodule Loopctl.Repo.DropLegacyArticlesEmbeddingHnswIndexMigrationTest do
   connection the production migrator uses. `Ecto.Migration.Runner.run/8` (the entry
   point `Ecto.Migrator.attempt/7` uses for an explicit `up/0`/`down/0`) opens no
   transaction of its own; the DDL-transaction wrapper lives in `Ecto.Migrator`, which
-  `@disable_ddl_transaction true` disables in production. So the SHIPPED code runs
-  here exactly as it runs at deploy, and a defect edited into the migration file WILL
-  fail these tests.
+  `@disable_ddl_transaction true` disables in production. So the SHIPPED `up/0`/`down/0`
+  BODIES run here exactly as they run at deploy.
+
+  What that harness canNOT see is the two module attributes themselves: `Runner` reads
+  neither, only `Ecto.Migrator` does. Deleting either would leave every behavioural test
+  below green while failing the real deploy, so they are asserted directly in the
+  "migration attributes" describe.
 
   Because these tests commit real index changes to the SHARED `articles` catalog — and
-  briefly commit a `system_configs` row — an `on_exit` restores the canonical state
-  after every test.
+  briefly commit a `system_configs` row — the canonical state is restored both before
+  and after every test.
 
   ## The read flag is read from the ROW, never through `SystemConfig`
 
@@ -73,24 +79,44 @@ defmodule Loopctl.Repo.DropLegacyArticlesEmbeddingHnswIndexMigrationTest do
 
   @index "articles_embedding_hnsw_idx"
 
-  # Restore the canonical state after every test. The applied-migration baseline in the
-  # test DB is: read flag ABSENT (so the legacy column is the live read path) and the
-  # legacy index PRESENT. Both directions of every test below can leave either off.
+  # Restore the canonical state BEFORE and AFTER every test. The applied-migration
+  # baseline in the test DB is: read flag ABSENT (so the legacy column is the live read
+  # path) and the legacy index PRESENT AND VALID. Both directions of every test below can
+  # leave either off.
+  #
+  # BEFORE as well as after, because these mutations are COMMITTED through `unboxed_run`:
+  # no sandbox rollback undoes them, and an abnormal exit (Ctrl-C, a CI timeout kill, a
+  # VM crash) skips `on_exit` entirely — leaving the SHARED test DB without an index that
+  # `test/loopctl/knowledge_embedding_test.exs` and
+  # `test/loopctl_web/controllers/knowledge_suggest_links_controller_test.exs` both
+  # assert on. The setup-time pass heals a DB poisoned that way instead of requiring a
+  # hand-rebuild or `mix ecto.reset`.
   setup do
-    on_exit(fn ->
-      Sandbox.unboxed_run(AdminRepo, fn ->
-        AdminRepo.query!("DELETE FROM system_configs WHERE key = $1", [
-          Embeddings.read_flag_key()
-        ])
-
-        AdminRepo.query!("""
-        CREATE INDEX CONCURRENTLY IF NOT EXISTS #{@index}
-        ON articles USING hnsw (embedding vector_cosine_ops) #{HnswIndex.with_params_clause()}
-        """)
-      end)
-    end)
+    restore_canonical_state()
+    on_exit(&restore_canonical_state/0)
 
     :ok
+  end
+
+  # `CREATE INDEX CONCURRENTLY IF NOT EXISTS` alone CANNOT repair an INVALID leftover: it
+  # sees the relation, emits a NOTICE and skips forever (wiki `ed00911b`) — and an
+  # INVALID leftover is exactly what a killed `CREATE INDEX CONCURRENTLY` produces,
+  # including this one. So clear it first, mirroring the migration's own `down/0`.
+  defp restore_canonical_state do
+    Sandbox.unboxed_run(AdminRepo, fn ->
+      AdminRepo.query!("DELETE FROM system_configs WHERE key = $1", [
+        Embeddings.read_flag_key()
+      ])
+
+      if index_present?(@index) and not index_valid?(@index) do
+        AdminRepo.query!("DROP INDEX CONCURRENTLY IF EXISTS #{@index}")
+      end
+
+      AdminRepo.query!("""
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS #{@index}
+      ON articles USING hnsw (embedding vector_cosine_ops) #{HnswIndex.with_params_clause()}
+      """)
+    end)
   end
 
   defp with_unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
@@ -157,6 +183,23 @@ defmodule Loopctl.Repo.DropLegacyArticlesEmbeddingHnswIndexMigrationTest do
       )
 
     rows == [[true]]
+  end
+
+  describe "migration attributes" do
+    # `Ecto.Migration.Runner` — what every test below drives — reads NEITHER attribute.
+    # `disable_ddl_transaction` is consulted only in `Ecto.Migrator` (where the DDL
+    # transaction wrapper lives) and `disable_migration_lock` only where it takes the
+    # transaction-scoped advisory lock. So deleting either from the migration file leaves
+    # the behavioural tests green while the real deploy through `Loopctl.Release.migrate/0`
+    # fails with `ERROR 25001: DROP INDEX CONCURRENTLY cannot run inside a transaction
+    # block`, or hangs on the migration lock (wiki `ed00911b`).
+    test "disables the DDL transaction — CONCURRENTLY is illegal inside one" do
+      assert DropLegacyArticlesEmbeddingHnswIndex.__migration__()[:disable_ddl_transaction]
+    end
+
+    test "disables the migration lock — it is itself transaction-scoped" do
+      assert DropLegacyArticlesEmbeddingHnswIndex.__migration__()[:disable_migration_lock]
+    end
   end
 
   describe "up/0 on a cut-over install (embedding_side_table_reads = 1)" do

--- a/test/mix/tasks/loopctl_embeddings_revert_guard_test.exs
+++ b/test/mix/tasks/loopctl_embeddings_revert_guard_test.exs
@@ -1,0 +1,115 @@
+defmodule Mix.Tasks.Loopctl.EmbeddingsRevertGuardTest do
+  @moduledoc """
+  GH #578 review — `mix loopctl.embeddings revert` used to write the flag and print
+  plain success on ANY install, including one whose legacy `articles.embedding` HNSW
+  index the #578 migration had already retired. There the revert is a tenant-wide
+  semantic-search outage, so the task now checks the index first.
+
+  What is tested here is the two PUBLIC pieces of that guard: the predicate the
+  refusal branches on, and the rebuild text it prints. The refusal branch itself is
+  not driven end-to-end on purpose — `dispatch/1` writes the read flag into
+  VM-global `:persistent_term`, which no async test may mutate.
+
+  Likewise, the predicate is exercised against the migrated schema, where the legacy
+  index EXISTS — i.e. the shipped-default install, which must still be allowed to
+  revert. The absent-index case would need a `DROP INDEX` on the shared `articles`
+  table, taking ACCESS EXCLUSIVE on it for the whole transaction and stalling every
+  concurrently running async test that reads articles. That is the exact global-state
+  hazard `Loopctl.Repo.HnswIndex`'s moduledoc exists to avoid, so it is not simulated.
+  """
+
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.ScaleSeed
+  alias Loopctl.Repo.HnswIndex
+  alias Mix.Tasks.Loopctl.Embeddings, as: Task
+
+  setup :verify_on_exit!
+
+  describe "legacy_hnsw_index_present?/0" do
+    test "is true on the migrated schema — the shipped default may still revert" do
+      assert Task.legacy_hnsw_index_present?()
+    end
+
+    test "the index it finds is genuinely an hnsw index over articles.embedding" do
+      # Non-vacuity: a join that silently matched NOTHING would make the guard refuse
+      # every revert, and a join that matched the WRONG relation (the side table, say)
+      # would make it allow one onto a column with no index at all. Assert the catalog
+      # fact the predicate claims, independently.
+      %{rows: rows} =
+        AdminRepo.query!("""
+        SELECT idx.relname, am.amname, i.indisvalid
+        FROM pg_index i
+        JOIN pg_class idx ON idx.oid = i.indexrelid
+        JOIN pg_class tbl ON tbl.oid = i.indrelid
+        JOIN pg_am am ON am.oid = idx.relam
+        JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+        WHERE tbl.relname = 'articles'
+          AND a.attname = 'embedding'
+          AND am.amname = 'hnsw'
+        """)
+
+      refute rows == [], "no HNSW index over articles.embedding — run mix ecto.migrate"
+      assert Enum.all?(rows, fn [_name, am, valid] -> am == "hnsw" and valid end)
+
+      # Detection is by CAPABILITY, so it must catch the index whatever name it lives
+      # under — but on a reconciled schema (US-27.14) that name is the canonical one,
+      # and the rebuild the task prints names it.
+      names = Enum.map(rows, fn [name, _am, _valid] -> name end)
+      assert HnswIndex.canonical_index_name("articles") in names
+    end
+  end
+
+  describe "unindexed_revert_warning/0" do
+    test "names the rebuild, single-sourced from HnswIndex so it cannot drift" do
+      warning = Task.unindexed_revert_warning()
+
+      assert warning =~ "CREATE INDEX CONCURRENTLY"
+      assert warning =~ HnswIndex.canonical_index_name("articles")
+      assert warning =~ "articles USING hnsw (embedding vector_cosine_ops)"
+
+      # The build params are the load-bearing part: a rebuild at different `m` /
+      # `ef_construction` than every other HNSW index on the instance is a silent
+      # recall/latency change. They come from HnswIndex, never a literal here.
+      assert warning =~ HnswIndex.with_params_clause()
+    end
+
+    test "warns about maintenance_work_mem, which a ~657 MB build silently needs" do
+      assert Task.unindexed_revert_warning() =~ "maintenance_work_mem"
+    end
+
+    test "names the failure the code actually produces, and denies the one it does not" do
+      # The cancel is a raised Postgrex.Error (57014) rendered 504 db_statement_timeout.
+      # `heavy_read_overloaded` is a TenantGate-shed tuple and is the ONLY thing the
+      # labelled keyword degrade matches — an operator told to expect a graceful
+      # degrade would wait for results that never come.
+      warning = Task.unindexed_revert_warning()
+
+      assert warning =~ "504 db_statement_timeout"
+      assert warning =~ "NOT the heavy_read_overloaded tuple"
+    end
+  end
+
+  describe "Loopctl.Knowledge.ScaleSeed.hnsw_index_present?/0 (GH #578 widening)" do
+    test "the side table carries its own HNSW index, so a cut-over install has one" do
+      # The precondition that makes the widened scope meaningful: after the #578 drop,
+      # `articles` has no HNSW index and `article_embeddings` is the only relation that
+      # can satisfy the scale gate. If the side table carried none, widening the
+      # predicate would buy nothing and the gate would still abort.
+      %{rows: rows} =
+        AdminRepo.query!("""
+        SELECT 1
+        FROM pg_indexes idx
+        JOIN pg_class cls ON cls.relname = idx.indexname
+        JOIN pg_am am ON am.oid = cls.relam
+        WHERE idx.tablename = 'article_embeddings'
+          AND am.amname = 'hnsw'
+        LIMIT 1
+        """)
+
+      refute rows == [], "article_embeddings carries no HNSW index — run mix ecto.migrate"
+      assert ScaleSeed.hnsw_index_present?()
+    end
+  end
+end


### PR DESCRIPTION
## What

Retires the pre-US-41.1 HNSW index on the legacy `articles.embedding` column
(`articles_embedding_hnsw_idx`) — but only on installs whose reads have been cut over to
the `article_embeddings` side table.

Measured on the hosted instance 2026-08-04 (`pg_stat_user_indexes` / `pg_stat_statements`):

| index | size | scans |
|---|---|---|
| `articles_embedding_hnsw_idx` (legacy column) | 657 MB | 26 |
| `article_embeddings_hnsw_dim_1536_idx` (live read path) | 658 MB | 1,695 |

`shared_buffers` is 1536 MB, so the two ~657 MB indexes evict each other. A cold vector
search measured 8,044 ms of which 7,926 ms (98.5%) was `blk_read_time`; the same statement
warm was 0 ms.

## The one real design decision — the drop is GUARDED on the read flag

`embedding_side_table_reads` defaults to `0` **in code**, and no migration seeds the row.
So on a fresh self-hosted install — and in the test DB — the shipped read path is still the
legacy `articles.embedding` column. An unconditional drop would leave that shipped-default
path with no index at all: a seq scan + top-N sort over the whole corpus, which under
`HeavyRead`'s per-read `SET LOCAL statement_timeout` surfaces as
`{:error, :heavy_read_overloaded}`. That is the #588 failure re-introduced through
configuration instead of ordering.

So `up/0` reads `system_configs.embedding_side_table_reads` **directly from the row** (not
`SystemConfig.get_int/2` — the `:persistent_term` cache answers its in-code default on a
miss, and a migrator process is exactly where that cache may be cold) and drops only when it
is `1`. Prod is already `1`, so this is a real drop there; a fresh install keeps the index
that serves its own read path.

**The alternative — seeding `embedding_side_table_reads = 1` in the migration — was
implemented and measured, then rejected.** Flipping the flag in the test DB puts the entire
suite on the side-table path and produces **34 failing behavioural tests** (semantic search
pool/starvation edges, combined-priors ordering, article-linking, backfill, and the read-path
test that asserts the in-code default). That is a read-path cutover decision with its own
blast radius and the known side-table ANN flake, not an index retirement. For comparison, an
unconditional drop with the flag left alone produces 3 failures plus a hard break of the
scale harness (`ScaleSeed.seed/2` refuses to seed without an HNSW index on `articles`,
`PlanAssertions.assert_hnsw_index/1` asserts the `articles` scan IS that index) — so
"unconditional drop, pin the tests" is the expensive option too, and it degrades the
shipped default. The guard gets the prod win with neither cost.

Known wart, recorded rather than deferred: an install that flips the flag to `1` **after**
this migration has run keeps the index, because a migration does not re-run. That is not
silent — `Loopctl.Embeddings.LegacyRetirement` discovers legacy indexes BY COLUMN, so the
leftover reappears in its scan map and its evidence/deadline verdict names it. Rerunning the
`DROP INDEX CONCURRENTLY` out-of-band is the remedy, and it is in the CHANGELOG.

## Scope kept tight

The `articles.embedding` **column is untouched** — still dual-written, still the
backfill/reconciliation source and the documented revert target. The `memories` indexes are
untouched (see open question 3).

This change touches no role or auth gate, so nothing in the CLAUDE.md chain-of-custody
checklist changes. No new environment variables, so `mix loopctl.check_env_docs` is not in
play.

## Open questions from the issue — answered

1. **What are the 26 scans?** The GH #588 boot window: the `SystemConfig` cache was primed
   after the Endpoint started, so every boot had an interval in which
   `embedding_side_table_reads` read its in-code default `0` and vector reads used the legacy
   column. #588 is merged (a398ace, PR #589) — `Loopctl.SystemConfig.CachePrimer` is now a
   supervised one-shot child ordered after `AdminRepo` and before `Oban`/`Endpoint`. A code
   search found no un-gated legacy ANN path. Confirm the counter has stopped advancing across
   deploys before running the out-of-band drop (below).
2. **Stats window.** The counters date from the 2026-07-30 consolidation, so 26 scans is
   roughly five days, not all time. That is consistent with the boot-window explanation
   (a handful of scans per deploy) and inconsistent with a live consumer.
3. **`memories` has the same shape — same decision?** No, and deliberately not.
   `memories_embedding_idx` and `memories_live_embedding_hnsw_idx` are a documented keep-both
   decision (US-38.4 / TC-38.4.3, `test/loopctl/memory/dual_index_recall_test.exs`): the FULL
   index serves `recall(include_superseded: true)` and the PARTIAL one serves default live
   recall. Both sit on the legacy `memories.embedding` column that the default (flag `0`)
   read path still uses, so their 0 prod scans reflect prod's flag, not deadness. #578's own
   Fix and Acceptance sections name only the articles index. Not dropped here.
4. **Index before column?** Yes — this PR drops only the INDEX. The column is separable and
   far riskier: it is still dual-written and is the backfill/reconciliation source.

## Migration shape

`@disable_ddl_transaction true` + `@disable_migration_lock true` (both mandatory —
`CONCURRENTLY` is illegal inside a transaction block and Ecto's migration advisory lock is
itself transaction-scoped), explicit `up/0`/`down/0`, raw `execute/1` because Ecto's
`create index(..., concurrently: true)` helper emits no `IF NOT EXISTS`.

`down/0` is unconditional (a rollback that skipped would leave a cut-over install without
the index it is rolling back TO) and leads with a DROP that fires **only when the index is
INVALID** — the leftover a failed `CREATE INDEX CONCURRENTLY` produces, which
`IF NOT EXISTS` would otherwise treat as present forever (wiki `ed00911b`). An unconditional
drop-then-create would destroy and rebuild a good 657 MB index on every rollback. The
`WITH (m, ef_construction)` clause is single-sourced from `Loopctl.Repo.HnswIndex`, never
hard-coded. The migration comment records that the rollback rebuild at prod scale needs
`maintenance_work_mem` well above the 64 MB default or it silently falls back to the slow
on-disk build (wiki `753fbf69`).

The interaction with `20260410022906_add_embedding_hnsw_index.exs` (capability-based create)
and `20260624120000_reconcile_hnsw_index_name.exs` (rename to the canonical name) is
unchanged and correct: on a fresh `mix ecto.reset` both still run, then this migration
decides. No already-applied migration was edited.

## Tests

- **`test/loopctl/repo/drop_legacy_articles_embedding_hnsw_index_migration_test.exs`** (new)
  drives the SHIPPED `up/0`/`down/0` through `Ecto.Migration.Runner.run/8` inside
  `Sandbox.unboxed_run(AdminRepo, ...)` (CONCURRENTLY is illegal in the sandbox transaction),
  `async: false` with the documented global-catalog-state rationale, `on_exit` restoring the
  canonical state. Covers: drop when the flag is `1`; KEEP when the row is absent (the shipped
  default) and when it is explicitly `0` (an operator revert); idempotence in both directions;
  the live side-table index and the legacy COLUMN left intact; the INVALID-leftover rebuild;
  and that a VALID index is NOT needlessly rebuilt (`relfilenode` unchanged).
- **TC-20.2.7** (`knowledge_embedding_test.exs`) no longer asserts a bare "legacy index
  exists". It asserts the invariant that survives the retirement: the live per-dimension
  side-table index is present AND `indisvalid` (`pg_indexes` also lists INVALID indexes, and a
  row count proves nothing — wiki `753fbf69`), and the legacy index is present exactly when
  the legacy column is the live read path. A migration that dropped unconditionally fails it.
- **Acceptance bullet 3** — two new `LegacyRetirementTest` cases cover an index
  DISAPPEARING between observations, the shape this drop produces and one no existing test
  had: it must read as neither a scan nor a counter that went BACKWARDS (an absence read as a
  value would jam the trigger at `:not_due` forever on exactly the installs that completed the
  retirement), and it must not make the scan check vacuous for indexes that survived it.

## Verification

- `mix precommit` green — 6725 tests, 0 failures (compile `--warnings-as-errors`, format,
  `credo --strict`, dialyzer).
- The two `:scale` gates CI runs on every PR, run the way CI runs them on an isolated
  `MIX_TEST_PARTITION` database: `scale_seed_test.exs` (5 tests, 0 failures — including
  `hnsw_index_present?/0`) and `embedding_dimension_plan_scale_test.exs` with
  `EMBEDDING_PLAN_GATE_DIMENSIONS=1536` (8 tests, 0 failures).
- **Acceptance bullet 2** — `mix loopctl.retrieval.eval --mode both --fail-on-regression`
  run locally: `status: OK (no regression)`, no losers.
- The `:scale_nightly` matrix is SKIPPED on pull requests (it has no cron and only a
  `workflow_dispatch` arm), so the one nightly file whose assertions actually depend on this
  index was run locally the way that job runs it — its own `MIX_TEST_PARTITION` database,
  `mix ecto.create` + `mix ecto.migrate`, then `SCALE_TESTS=true SCALE_NIGHTLY=true mix test
  --only scale_nightly test/loopctl/knowledge/distant_pairs_novelty_scale_test.exs`:
  **3 tests, 0 failures** in 332 s over a fresh ~80k-row corpus. That file `EXPLAIN`s
  `Knowledge.novelty_distance_query/4`, which dispatches on the read flag and therefore
  explains the LEGACY query in the test env, and it asserts `PlanAssertions.refute_seq_scan/1`.
  It passing on a database migrated FROM SCRATCH with this migration included is direct
  evidence that the guard keeps the legacy plan index-served. The remaining `:scale_nightly`
  files are unaffected for the same reason, structurally: with the flag row absent the
  migration is a catalog no-op, so `articles_embedding_hnsw_idx` is still present and
  `indisvalid` in the test database after it runs (verified by query), leaving every scale
  corpus identical to master's.
- The read-flag guard is mutation-verified, not merely covered: replacing
  `if side_table_reads_live?() do` with `if true do` (an unconditional drop) fails the two KEEP
  cases. The guard is live code, not decoration.
- End-to-end migration behaviour verified on a fresh partition database in BOTH directions:
  with no flag row the index is retained and the skip is logged; with the row set to `1` the
  migration emits `DROP INDEX CONCURRENTLY IF EXISTS articles_embedding_hnsw_idx` and
  `pg_indexes` returns 0 hnsw rows for `articles`.

### Still owed by the operator (cannot be done from CI)

Acceptance bullets 1 and 3 of the Fix section are production measurements and need a
`fly ssh console`:

1. Confirm `pg_stat_user_indexes.idx_scan` for `articles_embedding_hnsw_idx` has stopped
   advancing across deploys since a398ace shipped.
2. `DROP INDEX CONCURRENTLY articles_embedding_hnsw_idx;` out-of-band (the migration is then
   a no-op there, by design).
3. Re-measure the same statement in `pg_stat_statements` and record before/after
   `blk_read_time`. The post-drop plan check must be `EXPLAIN`-based and show
   `Index Scan using article_embeddings_hnsw_dim_1536_idx` — a row count proves nothing.

Closes #578


