### PR TITLE
#585 Rewrite list_unused_articles NOT IN as a NOT EXISTS anti-join

### DIFF
--- a/lib/loopctl/knowledge/analytics.ex
+++ b/lib/loopctl/knowledge/analytics.ex
@@ -855,6 +855,26 @@ defmodule Loopctl.Knowledge.Analytics do
   # Unused articles
   # ---------------------------------------------------------------------------
 
+  # "Not accessed since the cutoff" is a correlated `not exists`, never
+  # `a.id not in subquery(accessed_ids)` (#585). Same shape as the orphan check in
+  # `Loopctl.Knowledge.find_orphan_articles/3` (#574), but for a different reason: this
+  # one was HEALTHY in production, so the rewrite removes a cliff rather than a fire.
+  #
+  # PostgreSQL never converts `NOT IN (subquery)` into an anti-join — three-valued NULL
+  # semantics forbid it, and it does not use a NOT NULL constraint to enable the
+  # transformation (verified: `article_access_events.article_id` is NOT NULL and the
+  # transformation still does not happen). What it does instead depends purely on SIZE.
+  # If the subquery result fits `work_mem` it builds a hashed SubPlan (measured on prod:
+  # work_mem 4 MB, 8,797 distinct accessed articles in the 30-day window, total plan cost
+  # 2,663 — fine). If it does not fit, it silently degrades to Materialize plus one
+  # re-scan per outer row, which is exactly what cost #574 2.21 BILLION. There is no
+  # error and no warning at the crossover: the endpoint just goes from milliseconds to
+  # unusable. Growth drivers here are articles read per window, the caller-supplied
+  # `days_unused` (up to 365 via the controller), and raw event volume.
+  #
+  # A correlated `NOT EXISTS` is anti-join-able, so each candidate article becomes one
+  # index probe on `article_access_events_tenant_article_time_idx`
+  # (tenant_id, article_id, accessed_at) regardless of how large the accessed set gets.
   @doc """
   Returns published articles with zero accesses in the configured window.
 
@@ -870,20 +890,20 @@ defmodule Loopctl.Knowledge.Analytics do
     offset = opts |> Keyword.get(:offset, 0) |> max(0)
     cutoff = DateTime.add(DateTime.utc_now(), -days_unused * 86_400, :second)
 
-    # Subquery: article ids that HAVE been accessed since the cutoff
-    accessed_ids =
-      from(e in ArticleAccessEvent,
-        where: e.tenant_id == ^tenant_id,
-        where: e.accessed_at >= ^cutoff,
-        distinct: true,
-        select: e.article_id
-      )
-
     query =
       from(a in Article,
+        as: :article,
         where: a.tenant_id == ^tenant_id,
         where: a.status == :published,
-        where: a.id not in subquery(accessed_ids),
+        where:
+          not exists(
+            from(e in ArticleAccessEvent,
+              where: e.tenant_id == ^tenant_id,
+              where: e.accessed_at >= ^cutoff,
+              where: e.article_id == parent_as(:article).id,
+              select: 1
+            )
+          ),
         order_by: [asc: a.inserted_at, asc: a.id],
         limit: ^limit,
         offset: ^offset,

--- a/test/loopctl/knowledge_analytics_test.exs
+++ b/test/loopctl/knowledge_analytics_test.exs
@@ -258,6 +258,43 @@ defmodule Loopctl.KnowledgeAnalyticsTest do
       rows = Knowledge.list_unused_articles(tenant.id, days_unused: 30)
       assert Enum.any?(rows, &(&1.article_id == article.id))
     end
+
+    test "#585: the unused check is an ANTI-JOIN, never `id not in subquery`" do
+      # The two correctness tests above pass under BOTH shapes — which is why this class
+      # of defect keeps surviving review. `NOT IN (subquery)` is never converted to an
+      # anti-join by PostgreSQL (three-valued NULL semantics; a NOT NULL column does not
+      # enable it either). Below `work_mem` it builds a hashed SubPlan and looks fine;
+      # above it, it silently falls back to Materialize plus a re-scan per outer row —
+      # the plan that cost #574 2.21 BILLION. On prod this query is currently on the good
+      # side of that line (work_mem 4 MB, 8,797 distinct accessed articles), so nothing is
+      # broken today; the rewrite removes the cliff.
+      #
+      # A plan-shape assertion cannot be the guard here: at test-data scale the planner
+      # picks whatever it likes, so this anchors to the CODE. The function body is sliced
+      # by a BOUNDED regex (an unbounded span would silently match a later function), the
+      # slice is asserted non-empty, and the positive assertion is COUNTED so the guard
+      # cannot pass by matching nothing.
+      source = File.read!("lib/loopctl/knowledge/analytics.ex")
+
+      [_ | _] = unused_fn = Regex.run(~r/\n  def list_unused_articles.*?\n  end\n/s, source)
+      body = hd(unused_fn)
+
+      assert body =~ "AdminRepo.all()",
+             "the regex slice must cover the whole function body, not a prefix of it"
+
+      correlated = Regex.scan(~r/not exists\(/, body)
+
+      assert length(correlated) == 1,
+             "expected exactly one correlated NOT EXISTS, got #{length(correlated)}"
+
+      assert body =~ "parent_as(:article)", "the subquery must correlate to the outer row"
+
+      assert body =~ "e.tenant_id == ^tenant_id",
+             "AdminRepo is BYPASSRLS, so the correlated subquery must stay tenant-scoped"
+
+      refute body =~ "not in subquery",
+             "`id not in subquery(...)` blocks the anti-join and has a silent work_mem cliff"
+    end
   end
 
   describe "tenant isolation" do


### PR DESCRIPTION
Rewrites the "not accessed since the cutoff" predicate in
Loopctl.Knowledge.Analytics.list_unused_articles/2 from a NOT IN subquery to a
correlated NOT EXISTS anti-join. Latent, not a live defect: this query is
healthy in production today, so the change removes a cliff rather than a fire.

## Why the shape is the defect

PostgreSQL never converts NOT IN (subquery) into an anti-join, because of
three-valued NULL semantics, and it does not use a NOT NULL constraint to
enable the transformation either (article_access_events.article_id is NOT NULL
and the transformation still does not happen). What it does instead depends
purely on SIZE:

- fits work_mem: hashed SubPlan, fast. Prod today is here (work_mem 4 MB,
  8,797 distinct accessed articles in the 30-day window, total plan cost 2,663).
- does not fit: Materialize plus one re-scan per outer row. That is the plan
  that cost #574 2.21 billion and got the nightly lint job discarded.

There is no error and no warning at the crossover; the endpoint just goes from
milliseconds to unusable. Growth drivers here are articles read per window, the
caller-supplied days_unused (up to 365 at the controller), and event volume.

A correlated NOT EXISTS is anti-join-able, so each candidate article becomes one
index probe on article_access_events_tenant_article_time_idx
(tenant_id, article_id, accessed_at) regardless of how large the accessed set
gets. That index already exists, so there is no migration and no index change.

## Plan evidence

Generated SQL is a correlated NOT EXISTS, tenant-scoped on both sides:

    SELECT a0."id" FROM "articles" AS a0
    WHERE (a0."tenant_id" = $1) AND (a0."status" = 'published')
      AND (NOT (exists((SELECT 1 FROM "article_access_events" AS sa0
           WHERE (sa0."tenant_id" = $2) AND (sa0."accessed_at" >= $3)
             AND (sa0."article_id" = a0."id")))))

EXPLAIN on the dev database yields a Nested Loop Anti Join probing the intended
index, with no hashed SubPlan:

    Limit
      -> Sort  (Sort Key: a0.inserted_at, a0.id)
        -> Nested Loop Anti Join
          -> Seq Scan on articles a0
          -> Index Only Scan using article_access_events_tenant_article_time_idx

Note the honest limit on that evidence: the dev corpus is small, so the cost
numbers there mean nothing. What it does show is that the anti-join
transformation is now AVAILABLE at all, which it structurally never is for the
old shape at any size. Prod EXPLAIN should be re-run after deploy to confirm the
same node type on real statistics.

## Behavior is unchanged

Same days_unused default of 30 clamped to at least 1, same limit default of 50
clamped 1..200, same offset clamped at 0, same order_by inserted_at then id for
stable pagination, published only, category still stringified on the way out.
AdminRepo is BYPASSRLS, so the explicit tenant_id predicate IS the isolation and
it is kept on BOTH the outer query and the correlated subquery. No signature
change, no controller change, no MCP tool-surface change.

## The guard

The two existing correctness tests pass under BOTH shapes, which is precisely
why this class of defect keeps surviving review. They are unchanged and are not
the guard. The new guard is source-anchored and modelled on the #574 guard in
knowledge_lint_test.exs:

- the function body is sliced with a BOUNDED regex, since an unbounded span
  silently matches a later function with the same shape
- the slice is asserted non-empty AND asserted to reach the end of the body, so
  a truncated match cannot make the negative assertion pass vacuously
- the positive assertion is COUNTED: exactly one not exists, correlated via
  parent_as(:article), with the inner tenant_id predicate present

A plan-shape assertion cannot be the guard here: at test-data scale the planner
picks whatever it likes, and PlanAssertions.assert_fresh_stats!/0 is meaningful
only against a committed, ANALYZEd, prod-scale corpus. No scale_nightly test was
added.

MUTATION-VERIFIED: restoring the old shape fails the new guard (expected exactly
one correlated NOT EXISTS, got 0) while both existing correctness tests still
pass. The guard was then confirmed green again after restoring the fix.

## Repo-wide sweep (third acceptance bullet)

Grepping lib for the old subquery shape now returns only two COMMENT lines that
reference it by name (this fix and the #574 write-up). Zero code sites remain.
The one other not in usage in an Ecto query, knowledge.ex:5968
(n.id not in type(^visited_ids, ...)), is a bounded PARAMETER array rather than
a subquery, so it has no plan cliff and is out of scope.

## Gate

mix precommit green: compile clean, format clean, credo --strict found no
issues, dialyzer clean, 6741 tests 0 failures.

No CHANGELOG entry (no operator-facing change), no new env var, no API
constraint change.

Closes #585
