### PR TITLE
Re-apply category in the heat-index projection, and fix two notes that contradict the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,9 +288,10 @@ Operator-facing changes for deployments outside the hosted instance.
   openable with `knowledge_get` instead of 404ing, and **no backfill runs** — measured on the
   hosted deployment before deciding, not assumed: across 56,033 access events and 23 published
   canonicals there are ZERO `get` (and zero `drill`) rows against a system-scoped article, so
-  the migration would have had an empty subject. Before this change no path could emit a `get`
-  for a canonical at all, which makes any such row you DO find on your own deployment
-  drill-origin and safe to relabel; the rolling window (90 days by default) ages the rest out.
+  the migration would have had an empty subject. Before this change the DRILL was the only path
+  that could emit a `get` for a canonical, which makes any such row you DO find on your own
+  deployment drill-origin and safe to relabel; the rolling window (90 days by default) ages the
+  rest out.
 
 - **`meta.chars` / `meta.char_budget` on `heat_index` are BYTES of the encoded stub array**,
   array framing included. They were graphemes summed per stub, so a CJK or emoji payload was

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -9130,7 +9130,7 @@ defmodule Loopctl.Knowledge do
           |> heat_counts_query(top_k + 1, since, category, vis)
           |> then(&HeavyRead.all(tenant_id, &1, HeavyRead.opts(:heat_index)))
 
-        {counted, heat_stubs(tenant_id, Enum.take(counted, top_k), vis)}
+        {counted, heat_stubs(tenant_id, Enum.take(counted, top_k), category, vis)}
       end)
 
     ranked = Enum.take(counted, top_k)
@@ -9333,18 +9333,22 @@ defmodule Loopctl.Knowledge do
   # default admin-pool contention would convert into shed (429) heavy reads for that tenant on
   # unrelated endpoints. The work itself is bounded — a primary-key lookup of at most
   # `@max_relevance_page_size` ids with `left(body, ...)` clipping the body, i.e. no scan,
-  # unlike the aggregate it follows. `status` and visibility are re-applied
+  # unlike the aggregate it follows. `status`, visibility AND `category` are all re-applied
   # rather than trusted from the ranking query: the two run on separate connections, so an
-  # article can be unpublished in between, and this is the query that actually reads a title.
+  # article can be unpublished — or RE-CATEGORISED — in between, and this is the query that
+  # actually reads a title. Category was the one predicate omitted here, so a
+  # `category:`-filtered index could return a stub that had since moved out of that category;
+  # every filter the aggregate applies must be re-applied here or the invariant is only
+  # partial, which is worse than not claiming it.
   # The budget for a FULL page: `n` stubs at the per-stub cap, plus the JSON array framing
   # `chars` now measures — `[`, `]`, and the `n - 1` commas between stubs. An empty page
   # encodes as `[]`, hence the floor of 2.
   defp heat_array_budget(0), do: 2
   defp heat_array_budget(n), do: n * @heat_stub_char_cap + 2 + (n - 1)
 
-  defp heat_stubs(_tenant_id, [], _vis), do: []
+  defp heat_stubs(_tenant_id, [], _category, _vis), do: []
 
-  defp heat_stubs(tenant_id, rows, vis) do
+  defp heat_stubs(tenant_id, rows, category, vis) do
     ids = Enum.map(rows, & &1.article_id)
 
     by_id =
@@ -9359,6 +9363,7 @@ defmodule Loopctl.Knowledge do
           summary_source: fragment("left(?, ?)", a.body, ^(@heat_summary_chars * 8))
         }
       )
+      |> heat_filter_category(category)
       |> maybe_filter_by_visibility(vis)
       |> heat_stub_projection(tenant_id)
       |> Map.new(&{&1.id, &1})
@@ -9437,11 +9442,13 @@ defmodule Loopctl.Knowledge do
     end
   end
 
-  # A pool-side failure is saturation only when the pool actually SHED the checkout —
-  # `:queue_timeout`, a request that waited past the queue deadline. `reason: :error` is every
-  # OTHER connection fault (econnrefused, a credential rotated mid-deploy, a TLS failure), and
-  # those are outages, not this tenant reading too much; re-raised, the backstop renders them
-  # as the 503 `db_unavailable` every other DB path in the app returns for a ConnectionError.
+  # A pool-side failure — ANY `DBConnection.ConnectionError`, whatever its `:reason` — is
+  # treated as saturation and shed as a 429. That is deliberate and the paragraph below gives
+  # the measurement behind it. (An earlier version of this comment claimed the opposite: that
+  # only `:queue_timeout` sheds and `reason: :error` re-raises into a 503. It described a
+  # narrowing that was made once, measured to be wrong, and reverted — the code never matched
+  # it, and the test at heat_index_test.exs asserts all three of `:queue_timeout`, `:closed`
+  # and `:error` shed.)
   #
   # A SERVER-side fault is only saturation on `@heat_saturation_sqlstates`. A `Postgrex.Error`
   # carrying no SQLSTATE at all is a client-side encode/decode fault — a code bug, never load.


### PR DESCRIPTION
Three of the four residuals from the **PR #31 review's out-of-scope list**. Each was re-verified against current `master` before I touched it — every line number had moved and **none had been fixed** by the six PRs merged since.

The fourth (a global admission bound on the heat-index AdminRepo projection) is a concurrency change with production consequences and gets its own PR.

## 1. The projection now re-applies `:category`

`status` and visibility were already re-applied rather than trusted from the ranking query, on the comment's own stated grounds: the two run on separate connections, so an article can change in between. **Category was the one predicate omitted**, so a `category:`-filtered index could return a stub for an article that had since been re-categorised.

Narrow window, low severity — but the comment *asserts* the invariant, and a partial invariant is worse than one not claimed.

## 2. `heat_saturation?/1`'s lead-in comment specified the opposite of the code

It said a pool-side failure is saturation only on `:queue_timeout`, and that `reason: :error` re-raises into a 503. The code sheds **every** `DBConnection.ConnectionError` as a 429 — and the paragraph eight lines below already documents that correctly, with the measurement behind it (`reason: :closed`, from driving `AdminRepo.query!` past a `pg_sleep`).

So one comment block contradicted both the code and its own continuation. Replaced with a lead-in naming the narrowing as something already attempted, measured wrong, and reverted — the part actually worth keeping.

**No code change.** The behaviour is deliberate, and `heat_index_test.exs` asserts all three of `:queue_timeout`, `:closed` and `:error` shed.

## 3. The CHANGELOG note for #572 contradicted itself

> "Before this change no path could emit a `get` for a canonical at all"

Its own preceding sentence says *"a canonical's drill stayed counted"*, and the claim defeats its own conclusion — if no path could emit one, there would be nothing to relabel. Confirmed against the pre-#572 source (`git show f23bd6c^`), where `progressive_drill/3`'s canonical fallback passed `access_type: "get"` literally. Now reads "the DRILL was the only path that could".

## On testing the category fix — stated rather than papered over

The race is **not drivable from a test without adding a production seam**, and any test I could write would pass with or without the change. That is the vacuous-guard shape this repo has been bitten by before, so there is **no new test claiming to guard it**. I considered adding one and rejected it deliberately; a test that cannot fail is worse than an honest gap.

The existing `:category narrows the index` test and the other 38 heat-index tests cover the non-race path and pass.

## Gate

`mix precommit` green — **6868 tests, 0 failures**; credo --strict clean; dialyzer 117 skips, 0 unnecessary.

No enhanced-review run on this branch: it is the out-of-scope fix list from #31's review, already produced and verified by a full review pass. Re-reviewing it is the hop the chain bound refuses.
