### PR TITLE
Scope the poll-error handler to the emitting process, not the poller name

### DIFF
--- a/test/loopctl/telemetry/scale_metrics_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_test.exs
@@ -1078,11 +1078,23 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
       test_pid = self()
       handler_id = "test-guarded-measurement-#{System.unique_integer([:positive])}"
 
+      # `:telemetry.execute/3` runs handlers in the EMITTING process, so `self()` inside this
+      # handler is whoever fired the event. Forward only what THIS test process emitted.
+      #
+      # Scoping by the `poller:` NAME is not enough and #558 already tried it: the app's own
+      # 10s `telemetry_poller` shares this VM and emits the SAME `poller: :queue_state`
+      # events. When its sandbox owner terminates mid-suite it fires a
+      # `DBConnection.OwnershipError` poll error, which matched the `refute_receive` below
+      # and reddened CI at random — observed on run 31001046231, on a branch whose diff
+      # touched neither this file nor telemetry.
+      #
+      # It also silently weakened the `assert_receive`s: app noise carrying the right poller
+      # name could satisfy them without this module's guard having fired at all.
       :telemetry.attach(
         handler_id,
         [:loopctl, :oban, :poll, :error],
         fn _event, measurements, metadata, _config ->
-          send(test_pid, {:poll_error, metadata, measurements})
+          if self() == test_pid, do: send(test_pid, {:poll_error, metadata, measurements})
         end,
         nil
       )
@@ -1195,11 +1207,14 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
       test_pid = self()
       handler_id = "test-gate-poll-error-#{System.unique_integer([:positive])}"
 
+      # Same emitter scoping as the guarded_measurement setup above — the app's real poller
+      # emits `poller: :tenant_label_gate` too, and its OwnershipError noise appeared in the
+      # very failure that prompted this fix.
       :telemetry.attach(
         handler_id,
         [:loopctl, :oban, :poll, :error],
         fn _event, measurements, metadata, _config ->
-          send(test_pid, {:poll_error, metadata, measurements})
+          if self() == test_pid, do: send(test_pid, {:poll_error, metadata, measurements})
         end,
         nil
       )


### PR DESCRIPTION
**CI run 31001046231 failed on a branch (#596) whose diff touched neither this file nor telemetry.** A `DBConnection.OwnershipError` arrived as a `queue_state` poll error and matched a `refute_receive`. The cause is in the test, not in the branch under test.

## What is wrong

The setup attaches a handler to `[:loopctl, :oban, :poll, :error]` and forwards **every** such event to the test process. The application's own 10s `telemetry_poller` shares the VM and emits the **same** `poller: :queue_state` and `poller: :tenant_label_gate` events — and once its sandbox owner terminates mid-suite, it emits `OwnershipError` poll failures of its own. Those matched the refute.

Both were in the failure log together:

```
[warning] tenant-label gate refresh failed (DBConnection.OwnershipError); holding the gate for one cycle...
[warning] Oban queue/state poll failed (DBConnection.OwnershipError); the oban.jobs.count gauge keeps its last value...
```

**#558 already tried to fix this exact class by narrowing the match to the poller NAME.** The name is precisely what does not separate the two emitters, so the flake survived. That earlier comment is what pointed at the real fix — it is worth reading before touching this again.

## The fix

`:telemetry.execute/3` invokes handlers synchronously in the **emitting** process, so `self()` inside the handler is whoever fired the event. Forwarding only what the test process emitted is exact, and needs no allowlist of exception types or poller names.

## It also repairs a quieter defect in the same block

The two `assert_receive`s could be satisfied by app noise carrying the right poller name — **without `guarded_measurement/5` having fired at all**. A test passing for the wrong reason is worse than one failing at random, because nothing surfaces it. Both now require the event to have come from the test itself.

## Verification

Self-checking rather than asserted: if the emitting-process assumption were wrong, those `assert_receive`s would fail **immediately** under the new filter, because nothing would reach the mailbox. They pass.

- 79 tests in this file: green
- `mix precommit`: **6868 tests, 0 failures**; credo --strict clean; dialyzer 0 unnecessary skips

Test-only change; no production code touched.
