### PR TITLE
Bound the heat-index admin projection node-wide, not just per tenant

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -49,6 +49,7 @@ defmodule Loopctl.Knowledge do
   alias Loopctl.Audit
   alias Loopctl.Auth.ApiKey
   alias Loopctl.Custody
+  alias Loopctl.DbCapacity
   alias Loopctl.Egress
   alias Loopctl.Egress.Policy, as: EgressPolicy
   alias Loopctl.Egress.Scope, as: EgressScope
@@ -56,6 +57,7 @@ defmodule Loopctl.Knowledge do
   alias Loopctl.ExitClass
   alias Loopctl.ExitTag
   alias Loopctl.HeavyRead
+  alias Loopctl.HeavyRead.TenantGate
   alias Loopctl.KeysetSeek
   alias Loopctl.Knowledge.Analytics
   alias Loopctl.Knowledge.Article
@@ -9390,7 +9392,49 @@ defmodule Loopctl.Knowledge do
   # nothing in the logs said otherwise. The `:exit` clause also catches exits that are not pool
   # pressure at all (a shutdown, a sandbox ownership exit), which is exactly why its reason has
   # to reach the log rather than be discarded into an overload label.
+  # NODE-level admission on top of the per-tenant one. `HeavyRead.with_slot/3` in
+  # `heat_index/2` bounds how many of THIS tenant's heat reads are in flight; nothing bounded
+  # the AGGREGATE across tenants. `TenantGate` counts per key, so N tenants each admitted at
+  # their own cap queue up to N concurrent checkouts on `AdminRepo` — a 3-connection pool
+  # (`ADMIN_POOL_SIZE || "3"`, config/runtime.exs) that custody writes and the per-request auth
+  # SELECT also use. The per-read `:timeout` bounds how long each waiter blocks; it does not
+  # bound how many waiters there are.
+  #
+  # The key is a FIXED string, not a tenant id — that is what makes the count node-wide.
+  # `TenantGate.acquire/3` only guards `is_binary/1`, so a non-UUID key is legal and cannot
+  # collide with a real tenant. Capped at `admin_repo - 1` so heat can never take the LAST
+  # admin connection out from under a custody write.
+  @heat_admin_gate_key "knowledge.heat_stub_projection"
+
   defp heat_stub_projection(query, tenant_id) do
+    cap = max(1, DbCapacity.runtime_pool_sizes().admin_repo - 1)
+
+    case TenantGate.acquire(@heat_admin_gate_key, 1, cap) do
+      :ok ->
+        try do
+          heat_admin_read(query, tenant_id)
+        after
+          TenantGate.release(@heat_admin_gate_key, 1)
+        end
+
+      {:error, :heavy_read_overloaded} ->
+        # Logged under its OWN tag and deliberately not wearing the per-tenant label. This
+        # bound is node-wide, so `OverloadedError`'s default message ("the per-tenant in-flight
+        # capacity for this tenant") would attribute saturation of the SHARED admin pool to
+        # whichever tenant happened to arrive last — the same systemic-fault-dressed-as-one-
+        # noisy-tenant confusion the rescue arms below exist to prevent. The client-facing 429
+        # body comes from `LoopctlWeb.ErrorJSON`, not from this message.
+        Logger.warning(
+          "heat_stub_projection: admin_pool_node_gate_shed tenant_id=#{tenant_id} cap=#{cap}"
+        )
+
+        raise HeavyRead.OverloadedError,
+          tenant_id: tenant_id,
+          message: "heat stub projection shed at the node-level admin-pool bound"
+    end
+  end
+
+  defp heat_admin_read(query, tenant_id) do
     AdminRepo.all(query, timeout: @heat_stub_timeout_ms)
   rescue
     e in [DBConnection.ConnectionError, Postgrex.Error] ->

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -9125,14 +9125,17 @@ defmodule Loopctl.Knowledge do
     # between them, so the aggregate was admitted and the projection then competed with the
     # request path ungated, on the smallest pool in the system, from a per-turn endpoint.
     # Nested `HeavyRead.all/3` for this tenant reuses this slot rather than taking a second.
+    # `with_heat_admission/2` is the NODE-level bound outside it, taken before any query runs.
     {counted, stubs} =
-      HeavyRead.with_slot(tenant_id, HeavyRead.opts(:heat_index), fn ->
-        counted =
-          tenant_id
-          |> heat_counts_query(top_k + 1, since, category, vis)
-          |> then(&HeavyRead.all(tenant_id, &1, HeavyRead.opts(:heat_index)))
+      with_heat_admission(tenant_id, fn ->
+        HeavyRead.with_slot(tenant_id, HeavyRead.opts(:heat_index), fn ->
+          counted =
+            tenant_id
+            |> heat_counts_query(top_k + 1, since, category, vis)
+            |> then(&HeavyRead.all(tenant_id, &1, HeavyRead.opts(:heat_index)))
 
-        {counted, heat_stubs(tenant_id, Enum.take(counted, top_k), category, vis)}
+          {counted, heat_stubs(tenant_id, Enum.take(counted, top_k), category, vis)}
+        end)
       end)
 
     ranked = Enum.take(counted, top_k)
@@ -9301,9 +9304,14 @@ defmodule Loopctl.Knowledge do
       # sustained use rather than to traffic; the id still keeps the order TOTAL, so a page is
       # stable across calls — an index that reshuffles on every refresh cannot be cached,
       # which is the whole point of this surface.
+      #
+      # The day is cut in UTC EXPLICITLY: a bare `::date` cast resolves in the connection's
+      # `TimeZone` GUC, so on a backend whose session timezone is not UTC the tie-break counted
+      # days on a boundary the UTC-day-snapped `meta.heat_window` does not use — the payload
+      # would state one window and rank on another.
       order_by: [
         desc: count(fragment("coalesce(?, ?)", k.agent_id, e.api_key_id), :distinct),
-        desc: count(fragment("(?)::date", e.accessed_at), :distinct),
+        desc: count(fragment("((? at time zone 'UTC'))::date", e.accessed_at), :distinct),
         asc: e.article_id
       ],
       limit: ^limit,
@@ -9347,6 +9355,154 @@ defmodule Loopctl.Knowledge do
   # encodes as `[]`, hence the floor of 2.
   defp heat_array_budget(0), do: 2
   defp heat_array_budget(n), do: n * @heat_stub_char_cap + 2 + (n - 1)
+
+  # NODE-level admission on top of the per-tenant one. `HeavyRead.with_slot/3` bounds how many
+  # of THIS tenant's heat reads are in flight; nothing bounded the AGGREGATE across tenants.
+  # `TenantGate` counts per key, so N tenants each admitted at their own cap queue up to N
+  # concurrent checkouts on `AdminRepo` — a 3-connection pool (`ADMIN_POOL_SIZE || "3"`,
+  # config/runtime.exs) that custody writes and the per-request auth SELECT also use. The
+  # per-read `:timeout` bounds how long each waiter blocks, not how many waiters there are.
+  #
+  # It wraps the WHOLE call, not just the projection: deciding admission after the group-by
+  # aggregate meant every shed request first paid that history-growing scan AND held this
+  # tenant's heavy-read slot for it. A shed that costs the work it is shedding sheds nothing.
+  #
+  # TWO keys, one permit each. The GLOBAL key is a FIXED string, not a tenant id — that is what
+  # makes the count node-wide (`TenantGate.acquire/3` only guards `is_binary/1`, so a non-UUID
+  # key is legal and cannot collide with a real tenant). The PER-TENANT key holds `cap - 1`,
+  # mirroring the `pool - 1` ceiling `TenantGate.clamp_cap/1` already uses to keep a slot for
+  # neighbours: the node cap equals one tenant's OWN heat ceiling (per-tenant cap 4 at heavy
+  # weight 2), so without it a single looping tenant could hold every node permit and 429 every
+  # other tenant on the node — the cross-tenant denial the per-tenant gate exists to prevent,
+  # reintroduced one level up.
+  @heat_admin_gate_key "knowledge.heat_stub_projection"
+  @heat_shed_log_window_ms 60_000
+
+  @doc false
+  # The node cap as a pure function of the admin pool, so the BOUND itself is testable and not
+  # merely the gate's existence. `pool - 1` so heat can never take the LAST admin connection
+  # out from under a custody write — and 0 (admit nothing) below 2, because a floor of 1 broke
+  # exactly that claim at the two configurations that reach it: a pool of 1, and an unreadable
+  # repo config, which `DbCapacity.pool_size/1` reports as 0.
+  @spec heat_node_cap(non_neg_integer()) :: non_neg_integer()
+  def heat_node_cap(admin_pool) when is_integer(admin_pool), do: max(0, admin_pool - 1)
+
+  defp with_heat_admission(tenant_id, fun) do
+    cap = heat_node_cap(DbCapacity.runtime_pool_sizes().admin_repo)
+    keys = [@heat_admin_gate_key, @heat_admin_gate_key <> ":" <> tenant_id]
+
+    case heat_acquire(keys, cap) do
+      :ok ->
+        reclaimer = heat_permit_reclaimer(keys)
+
+        try do
+          fun.()
+        after
+          heat_await_release(reclaimer)
+        end
+
+      :shed ->
+        heat_log_shed(tenant_id, cap)
+
+        raise HeavyRead.OverloadedError,
+          tenant_id: tenant_id,
+          message: "heat index shed at the node-level admin-pool bound"
+    end
+  end
+
+  defp heat_acquire(_keys, cap) when cap < 1, do: :shed
+
+  defp heat_acquire([global, per_tenant], cap) do
+    case TenantGate.acquire(global, 1, cap) do
+      :ok -> heat_acquire_tenant(global, per_tenant, max(1, cap - 1))
+      {:error, :heavy_read_overloaded} -> :shed
+    end
+  end
+
+  defp heat_acquire_tenant(global, per_tenant, tenant_cap) do
+    case TenantGate.acquire(per_tenant, 1, tenant_cap) do
+      :ok ->
+        :ok
+
+      {:error, :heavy_read_overloaded} ->
+        TenantGate.release(global, 1)
+        :shed
+    end
+  end
+
+  # A permit must not outlive the process holding it. `try/after` does not run when a process
+  # is KILLED (a brutal shutdown drain, a `max_heap_size` kill), and `TenantGate` never sweeps
+  # or reaps — a limitation its moduledoc accepts for a PER-TENANT counter, where the drift is
+  # one tenant's. On a node-wide key capped at 2 the same drift is permanent and fleet-wide:
+  # two kills over a node's life would shed heat_index for every tenant on it, forever.
+  #
+  # So an unlinked reclaimer MONITORS the holder and performs the release itself — on `:done`
+  # or on `:DOWN`, whichever arrives first, so the release is exactly-once by construction.
+  # That is the reclaim guarantee `Knowledge.ExportConcurrency` gets from its GenServer's
+  # monitors, without standing up a second registry for a permit held across one bounded call.
+  #
+  # Public (`@doc false`) for the same reason `heat_projection_exit/2` is: the `:DOWN` path is
+  # the one this exists for, and it cannot be driven through `heat_index/2` deterministically.
+  @doc false
+  @spec heat_permit_reclaimer([binary()]) :: pid()
+  def heat_permit_reclaimer(keys) when is_list(keys) do
+    holder = self()
+
+    spawn(fn ->
+      ref = Process.monitor(holder)
+
+      caller =
+        receive do
+          {:done, ^holder} ->
+            Process.demonitor(ref, [:flush])
+            holder
+
+          {:DOWN, ^ref, :process, ^holder, _reason} ->
+            nil
+        end
+
+      Enum.each(keys, &TenantGate.release(&1, 1))
+      if caller, do: send(caller, {:released, self()})
+    end)
+  end
+
+  # The normal path WAITS for the release rather than firing and forgetting it: the per-tenant
+  # node permit is 1 in production, so a caller that returned before its own permit came back
+  # would shed its NEXT sequential call. The monitor makes the wait terminate either way — the
+  # reclaimer replies or it dies.
+  defp heat_await_release(reclaimer) do
+    ref = Process.monitor(reclaimer)
+    send(reclaimer, {:done, self()})
+
+    receive do
+      {:released, ^reclaimer} -> Process.demonitor(ref, [:flush])
+      {:DOWN, ^ref, :process, ^reclaimer, _reason} -> :ok
+    end
+  end
+
+  # ONE line per window, not one per shed. heat_index is a per-turn endpoint, so a sustained
+  # node-wide shed would otherwise put one warning per request per tenant into the incident the
+  # warning exists to describe — the shape `HeavyRead.maybe_log_inconclusive/2` was written to
+  # prevent. `:never` rather than a `0` default: `System.monotonic_time/1` starts at a large
+  # NEGATIVE value, so a `0` default would not throttle the line, it would delete it.
+  #
+  # The line deliberately does NOT wear the per-tenant label. This bound is node-wide, so
+  # `OverloadedError`'s default message ("the per-tenant in-flight capacity for this tenant")
+  # would attribute saturation of the SHARED admin pool to whichever tenant happened to arrive
+  # last — the systemic-fault-dressed-as-one-noisy-tenant confusion the rescue arms below exist
+  # to prevent. The client-facing 429 body comes from `LoopctlWeb.ErrorJSON`.
+  defp heat_log_shed(tenant_id, cap) do
+    key = {__MODULE__, :heat_node_gate_shed_warned}
+    deadline = :persistent_term.get(key, :never)
+    now = System.monotonic_time(:millisecond)
+
+    if deadline == :never or now >= deadline do
+      :persistent_term.put(key, now + @heat_shed_log_window_ms)
+      Logger.warning("heat_index: admin_pool_node_gate_shed tenant_id=#{tenant_id} cap=#{cap}")
+    end
+
+    :ok
+  end
 
   defp heat_stubs(_tenant_id, [], _category, _vis), do: []
 
@@ -9392,49 +9548,7 @@ defmodule Loopctl.Knowledge do
   # nothing in the logs said otherwise. The `:exit` clause also catches exits that are not pool
   # pressure at all (a shutdown, a sandbox ownership exit), which is exactly why its reason has
   # to reach the log rather than be discarded into an overload label.
-  # NODE-level admission on top of the per-tenant one. `HeavyRead.with_slot/3` in
-  # `heat_index/2` bounds how many of THIS tenant's heat reads are in flight; nothing bounded
-  # the AGGREGATE across tenants. `TenantGate` counts per key, so N tenants each admitted at
-  # their own cap queue up to N concurrent checkouts on `AdminRepo` — a 3-connection pool
-  # (`ADMIN_POOL_SIZE || "3"`, config/runtime.exs) that custody writes and the per-request auth
-  # SELECT also use. The per-read `:timeout` bounds how long each waiter blocks; it does not
-  # bound how many waiters there are.
-  #
-  # The key is a FIXED string, not a tenant id — that is what makes the count node-wide.
-  # `TenantGate.acquire/3` only guards `is_binary/1`, so a non-UUID key is legal and cannot
-  # collide with a real tenant. Capped at `admin_repo - 1` so heat can never take the LAST
-  # admin connection out from under a custody write.
-  @heat_admin_gate_key "knowledge.heat_stub_projection"
-
   defp heat_stub_projection(query, tenant_id) do
-    cap = max(1, DbCapacity.runtime_pool_sizes().admin_repo - 1)
-
-    case TenantGate.acquire(@heat_admin_gate_key, 1, cap) do
-      :ok ->
-        try do
-          heat_admin_read(query, tenant_id)
-        after
-          TenantGate.release(@heat_admin_gate_key, 1)
-        end
-
-      {:error, :heavy_read_overloaded} ->
-        # Logged under its OWN tag and deliberately not wearing the per-tenant label. This
-        # bound is node-wide, so `OverloadedError`'s default message ("the per-tenant in-flight
-        # capacity for this tenant") would attribute saturation of the SHARED admin pool to
-        # whichever tenant happened to arrive last — the same systemic-fault-dressed-as-one-
-        # noisy-tenant confusion the rescue arms below exist to prevent. The client-facing 429
-        # body comes from `LoopctlWeb.ErrorJSON`, not from this message.
-        Logger.warning(
-          "heat_stub_projection: admin_pool_node_gate_shed tenant_id=#{tenant_id} cap=#{cap}"
-        )
-
-        raise HeavyRead.OverloadedError,
-          tenant_id: tenant_id,
-          message: "heat stub projection shed at the node-level admin-pool bound"
-    end
-  end
-
-  defp heat_admin_read(query, tenant_id) do
     AdminRepo.all(query, timeout: @heat_stub_timeout_ms)
   rescue
     e in [DBConnection.ConnectionError, Postgrex.Error] ->

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -900,21 +900,22 @@ defmodule Loopctl.Knowledge do
   """
   @spec get_article(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
           {:ok, Article.t()} | {:error, :not_found}
+  # ONE query, not a tenant lookup with a canonical fallback behind it: the MISS is the path an
+  # outsider can drive at will (any id that exists in no tenant), and a second `AdminRepo`
+  # round trip per miss put a 2x amplifier on the 3-connection pool that custody writes and the
+  # per-request auth SELECT share — the same pool `with_heat_admission/3` below exists to
+  # protect. The disjunction is decided in the WHERE, so a hit and a miss cost one checkout.
+  #
+  # `status == :published` on the system arm mirrors `get_system_article_by_slug/1` and
+  # `list_system_articles/1`. This is a TENANT-FACING by-id path, not the privileged curation
+  # one (`fetch_curatable_article/2`, which legitimately needs drafts), so it must never expose
+  # a draft or archived canonical — and the tenant arm is unchanged, so a tenant still reads
+  # its own drafts.
   def get_article(tenant_id, article_id, opts \\ []) do
-    case AdminRepo.get_by(Article, id: article_id, tenant_id: tenant_id) do
-      nil -> get_system_canonical(tenant_id, article_id, opts)
-      article -> finalize_article_read(tenant_id, article, opts)
-    end
-  end
-
-  # `status == :published` mirrors `get_system_article_by_slug/1` and `list_system_articles/1`.
-  # This is a TENANT-FACING by-id path, not the privileged curation one
-  # (`fetch_curatable_article/2`, which legitimately needs drafts), so it must never expose a
-  # draft or archived canonical.
-  defp get_system_canonical(tenant_id, article_id, opts) do
     case AdminRepo.one(
            from(a in Article,
-             where: a.id == ^article_id and a.scope == :system and a.status == :published
+             where: a.id == ^article_id,
+             where: a.tenant_id == ^tenant_id or (a.scope == :system and a.status == :published)
            )
          ) do
       nil -> {:error, :not_found}
@@ -9125,17 +9126,30 @@ defmodule Loopctl.Knowledge do
     # between them, so the aggregate was admitted and the projection then competed with the
     # request path ungated, on the smallest pool in the system, from a per-turn endpoint.
     # Nested `HeavyRead.all/3` for this tenant reuses this slot rather than taking a second.
-    # `with_heat_admission/2` is the NODE-level bound outside it, taken before any query runs.
-    {counted, stubs} =
-      with_heat_admission(tenant_id, fn ->
-        HeavyRead.with_slot(tenant_id, HeavyRead.opts(:heat_index), fn ->
-          counted =
-            tenant_id
-            |> heat_counts_query(top_k + 1, since, category, vis)
-            |> then(&HeavyRead.all(tenant_id, &1, HeavyRead.opts(:heat_index)))
+    #
+    # The NODE-level admin-pool bound is SPLIT in two, because the two phases spend different
+    # pools. `heat_precheck!/2` is a non-reserving CHECK before anything runs, so a sustained
+    # node-wide shed still costs nothing; the counted permit is held around the PROJECTION
+    # only, the one phase that checks out an `AdminRepo` connection. Holding it across the
+    # aggregate as well capped node-wide heat concurrency at the admin pool's bound while the
+    # aggregate was running entirely on `HeavyReadRepo`'s own (larger, separately gated) pool —
+    # shedding a tenant against a resource no in-flight call was using.
+    admin_cap = heat_node_cap(DbCapacity.runtime_pool_sizes().admin_repo)
+    heat_precheck!(tenant_id, admin_cap)
 
-          {counted, heat_stubs(tenant_id, Enum.take(counted, top_k), category, vis)}
-        end)
+    {counted, stubs} =
+      HeavyRead.with_slot(tenant_id, HeavyRead.opts(:heat_index), fn ->
+        counted =
+          tenant_id
+          |> heat_counts_query(top_k + 1, since, category, vis)
+          |> then(&HeavyRead.all(tenant_id, &1, HeavyRead.opts(:heat_index)))
+
+        stubs =
+          with_heat_admission(tenant_id, admin_cap, fn ->
+            heat_stubs(tenant_id, Enum.take(counted, top_k), category, vis)
+          end)
+
+        {counted, stubs}
       end)
 
     ranked = Enum.take(counted, top_k)
@@ -9363,37 +9377,65 @@ defmodule Loopctl.Knowledge do
   # config/runtime.exs) that custody writes and the per-request auth SELECT also use. The
   # per-read `:timeout` bounds how long each waiter blocks, not how many waiters there are.
   #
-  # It wraps the WHOLE call, not just the projection: deciding admission after the group-by
-  # aggregate meant every shed request first paid that history-growing scan AND held this
-  # tenant's heavy-read slot for it. A shed that costs the work it is shedding sheds nothing.
+  # The PERMIT covers the projection only — the phase that checks out an admin connection —
+  # while `heat_precheck!/2` sheds before the aggregate, so a shed still costs none of the work
+  # it is shedding.
   #
   # TWO keys, one permit each. The GLOBAL key is a FIXED string, not a tenant id — that is what
   # makes the count node-wide (`TenantGate.acquire/3` only guards `is_binary/1`, so a non-UUID
-  # key is legal and cannot collide with a real tenant). The PER-TENANT key holds `cap - 1`,
-  # mirroring the `pool - 1` ceiling `TenantGate.clamp_cap/1` already uses to keep a slot for
-  # neighbours: the node cap equals one tenant's OWN heat ceiling (per-tenant cap 4 at heavy
-  # weight 2), so without it a single looping tenant could hold every node permit and 429 every
-  # other tenant on the node — the cross-tenant denial the per-tenant gate exists to prevent,
-  # reintroduced one level up.
+  # key is legal and cannot collide with a real tenant). The PER-TENANT key keeps a node permit
+  # reachable by a NEIGHBOUR, mirroring the `pool - 1` ceiling `TenantGate.clamp_cap/1` already
+  # uses: the node cap equals one tenant's OWN heat ceiling, so without a sub-cap a single
+  # looping tenant could hold every node permit and 429 every other tenant on the node.
   @heat_admin_gate_key "knowledge.heat_stub_projection"
   @heat_shed_log_window_ms 60_000
+  @admin_pool_default 3
 
   @doc false
   # The node cap as a pure function of the admin pool, so the BOUND itself is testable and not
   # merely the gate's existence. `pool - 1` so heat can never take the LAST admin connection
-  # out from under a custody write — and 0 (admit nothing) below 2, because a floor of 1 broke
-  # exactly that claim at the two configurations that reach it: a pool of 1, and an unreadable
-  # repo config, which `DbCapacity.pool_size/1` reports as 0.
+  # out from under a custody write — including at a pool of 1, where that leaves nothing to
+  # admit and the endpoint is off until an operator raises `ADMIN_POOL_SIZE` (said once, by
+  # name, in `heat_log_shed/2`).
+  #
+  # A pool of 0 is NOT a pool of zero connections — `DbCapacity.pool_size/1` reports an
+  # UNREADABLE repo config as 0. A limiter that cannot read its own bound must fail OPEN
+  # (`TenantGate` moduledoc, AC-37.5.5), so it falls back to the documented `ADMIN_POOL_SIZE`
+  # default rather than turning a config read into a permanent outage of the endpoint.
   @spec heat_node_cap(non_neg_integer()) :: non_neg_integer()
+  def heat_node_cap(0), do: @admin_pool_default - 1
   def heat_node_cap(admin_pool) when is_integer(admin_pool), do: max(0, admin_pool - 1)
 
-  defp with_heat_admission(tenant_id, fun) do
-    cap = heat_node_cap(DbCapacity.runtime_pool_sizes().admin_repo)
-    keys = [@heat_admin_gate_key, @heat_admin_gate_key <> ":" <> tenant_id]
+  @doc false
+  # The per-tenant sub-cap. `cap - 1` keeps a node permit reachable by a neighbour, but ONLY
+  # where that leaves a tenant more than one: at the cap production actually reaches (pool 3 ->
+  # cap 2) `cap - 1` was 1, which made a per-turn endpoint serial per tenant — a fleet's second
+  # concurrent call 429'd on an idle node, which reads as pool saturation and is not.
+  @spec heat_tenant_cap(non_neg_integer()) :: non_neg_integer()
+  def heat_tenant_cap(cap) when is_integer(cap), do: min(cap, max(2, cap - 1))
 
-    case heat_acquire(keys, cap) do
-      :ok ->
-        reclaimer = heat_permit_reclaimer(keys)
+  defp heat_gate_keys(tenant_id),
+    do: [@heat_admin_gate_key, @heat_admin_gate_key <> ":" <> tenant_id]
+
+  # A NON-RESERVING check, ahead of the aggregate: deciding admission after the group-by meant
+  # every shed request first paid that history-growing scan, and a shed that costs the work it
+  # is shedding sheds nothing. It reserves nothing, so a race can let one extra caller through
+  # to the real acquire below — the counted permit is what enforces the cap, this only keeps
+  # the SUSTAINED shed cheap.
+  defp heat_precheck!(tenant_id, cap) do
+    [global, per_tenant] = heat_gate_keys(tenant_id)
+
+    if TenantGate.count(global) >= cap or TenantGate.count(per_tenant) >= heat_tenant_cap(cap),
+      do: heat_shed!(tenant_id, cap)
+  end
+
+  defp with_heat_admission(tenant_id, cap, fun) do
+    reclaimer = heat_permit_reclaimer(heat_gate_keys(tenant_id), cap)
+    ref = Process.monitor(reclaimer)
+
+    receive do
+      {:heat_permit, ^reclaimer, :ok} ->
+        Process.demonitor(ref, [:flush])
 
         try do
           fun.()
@@ -9401,20 +9443,34 @@ defmodule Loopctl.Knowledge do
           heat_await_release(reclaimer)
         end
 
-      :shed ->
-        heat_log_shed(tenant_id, cap)
+      {:heat_permit, ^reclaimer, :shed} ->
+        Process.demonitor(ref, [:flush])
+        heat_shed!(tenant_id, cap)
 
-        raise HeavyRead.OverloadedError,
-          tenant_id: tenant_id,
-          message: "heat index shed at the node-level admin-pool bound"
+      # The reclaimer holds no permit it has not told us about, so its death before a reply is
+      # a shed, never a hang.
+      {:DOWN, ^ref, :process, ^reclaimer, _reason} ->
+        heat_shed!(tenant_id, cap)
     end
   end
 
-  defp heat_acquire(_keys, cap) when cap < 1, do: :shed
+  defp heat_shed!(tenant_id, cap) do
+    heat_log_shed(tenant_id, cap)
 
-  defp heat_acquire([global, per_tenant], cap) do
+    raise HeavyRead.OverloadedError,
+      tenant_id: tenant_id,
+      message: "heat index shed at the node-level admin-pool bound"
+  end
+
+  @doc false
+  # Public (`@doc false`) so the NODE-wide bound is drivable in a test without saturating the
+  # VM-wide production counter every parallel async read shares.
+  @spec heat_acquire([binary()], non_neg_integer()) :: :ok | :shed
+  def heat_acquire(_keys, cap) when cap < 1, do: :shed
+
+  def heat_acquire([global, per_tenant], cap) do
     case TenantGate.acquire(global, 1, cap) do
-      :ok -> heat_acquire_tenant(global, per_tenant, max(1, cap - 1))
+      :ok -> heat_acquire_tenant(global, per_tenant, heat_tenant_cap(cap))
       {:error, :heavy_read_overloaded} -> :shed
     end
   end
@@ -9441,35 +9497,52 @@ defmodule Loopctl.Knowledge do
   # That is the reclaim guarantee `Knowledge.ExportConcurrency` gets from its GenServer's
   # monitors, without standing up a second registry for a permit held across one bounded call.
   #
+  # The reclaimer also ACQUIRES, after installing the monitor, and reports the outcome back.
+  # Acquiring in the caller and spawning afterwards left a window — microseconds, but the
+  # failure in it is the permanent fleet-wide one this exists to eliminate — where a brutal
+  # kill landed on a holder whose permits no monitor covered yet. Now no permit exists that is
+  # not already covered.
+  #
   # Public (`@doc false`) for the same reason `heat_projection_exit/2` is: the `:DOWN` path is
   # the one this exists for, and it cannot be driven through `heat_index/2` deterministically.
   @doc false
-  @spec heat_permit_reclaimer([binary()]) :: pid()
-  def heat_permit_reclaimer(keys) when is_list(keys) do
+  @spec heat_permit_reclaimer([binary()], non_neg_integer()) :: pid()
+  def heat_permit_reclaimer(keys, cap) when is_list(keys) do
     holder = self()
 
     spawn(fn ->
       ref = Process.monitor(holder)
 
-      caller =
-        receive do
-          {:done, ^holder} ->
-            Process.demonitor(ref, [:flush])
-            holder
+      case heat_acquire(keys, cap) do
+        :shed ->
+          send(holder, {:heat_permit, self(), :shed})
 
-          {:DOWN, ^ref, :process, ^holder, _reason} ->
-            nil
-        end
-
-      Enum.each(keys, &TenantGate.release(&1, 1))
-      if caller, do: send(caller, {:released, self()})
+        :ok ->
+          send(holder, {:heat_permit, self(), :ok})
+          heat_hold_permit(holder, ref, keys)
+      end
     end)
   end
 
+  defp heat_hold_permit(holder, ref, keys) do
+    caller =
+      receive do
+        {:done, ^holder} ->
+          Process.demonitor(ref, [:flush])
+          holder
+
+        {:DOWN, ^ref, :process, ^holder, _reason} ->
+          nil
+      end
+
+    Enum.each(keys, &TenantGate.release(&1, 1))
+    if caller, do: send(caller, {:released, self()})
+  end
+
   # The normal path WAITS for the release rather than firing and forgetting it: the per-tenant
-  # node permit is 1 in production, so a caller that returned before its own permit came back
-  # would shed its NEXT sequential call. The monitor makes the wait terminate either way — the
-  # reclaimer replies or it dies.
+  # node permit is a small integer, so a caller that returned before its own permit came back
+  # would eat into its own next sequential call. The monitor makes the wait terminate either
+  # way — the reclaimer replies or it dies.
   defp heat_await_release(reclaimer) do
     ref = Process.monitor(reclaimer)
     send(reclaimer, {:done, self()})
@@ -9491,6 +9564,27 @@ defmodule Loopctl.Knowledge do
   # would attribute saturation of the SHARED admin pool to whichever tenant happened to arrive
   # last — the systemic-fault-dressed-as-one-noisy-tenant confusion the rescue arms below exist
   # to prevent. The client-facing 429 body comes from `LoopctlWeb.ErrorJSON`.
+  #
+  # A cap below 1 is NOT load, so it is not throttled into that window and does not wear the
+  # "shed" spelling: `ADMIN_POOL_SIZE=1` leaves no admin connection heat may take, so every
+  # request 429s until an operator changes the value — a permanent CONFIG state that a
+  # once-a-minute saturation line would hide behind the very error it explains. Said once per
+  # node, guaranteed, naming the variable to change.
+  defp heat_log_shed(tenant_id, cap) when cap < 1 do
+    key = {__MODULE__, :heat_node_gate_disabled_warned}
+
+    if :persistent_term.get(key, false) == false do
+      :persistent_term.put(key, true)
+
+      Logger.warning(
+        "heat_index: admin_pool_too_small ADMIN_POOL_SIZE must be >= 2 for the heat index; " <>
+          "every request sheds tenant_id=#{tenant_id} cap=#{cap}"
+      )
+    end
+
+    :ok
+  end
+
   defp heat_log_shed(tenant_id, cap) do
     key = {__MODULE__, :heat_node_gate_shed_warned}
     deadline = :persistent_term.get(key, :never)

--- a/test/loopctl/knowledge/heat_index_test.exs
+++ b/test/loopctl/knowledge/heat_index_test.exs
@@ -588,8 +588,10 @@ defmodule Loopctl.Knowledge.HeatIndexTest do
 
       assert {:ok, %{meta: meta}} = Knowledge.heat_index(tenant.id)
 
-      # `knowledge_get` filters by tenant_id, so it 404s on the published system canonicals
-      # this index also lists — the named tool has to be one that opens every listed id.
+      # Following the index must record the UNCOUNTED read type, so the index cannot feed the
+      # ranking it just published — that, not reachability, is why the named tool is the drill.
+      # `knowledge_get` opens every listed id too (a published canonical included, #572), and
+      # DOES count, which is why it is named separately in the note as a deliberate vote.
       assert meta.drill.tool == "knowledge_progressive_drill"
       assert meta.drill.parameter == "article_id"
       # The ordering basis is stated, so a reader does not mistake heat for relevance.
@@ -818,9 +820,11 @@ defmodule Loopctl.Knowledge.HeatIndexTest do
       # saturation of a shared pool gets mistaken for ordinary per-tenant backpressure.
       assert log =~ "admin_pool_node_gate_shed"
 
-      # And the permit comes back on BOTH paths: the index answers again, and the counter is
-      # back to zero rather than leaking one per shed. The release is awaited, not fired and
-      # forgotten, so this is a fact rather than a timing window.
+      # And the permit comes back on the ADMITTED path: the index answers again, and the
+      # counter is back to zero rather than leaking one. The release is awaited, not fired and
+      # forgotten, so this is a fact rather than a timing window. (The SHED path releases in
+      # the node-wide test below — here the shed is decided by the non-reserving precheck that
+      # runs ahead of the aggregate, so no permit is taken to give back.)
       assert {:ok, %{results: [%{title: "Readable"}]}} = Knowledge.heat_index(tenant.id)
       assert TenantGate.count(key) == 0
     end
@@ -834,11 +838,52 @@ defmodule Loopctl.Knowledge.HeatIndexTest do
       assert Knowledge.heat_node_cap(pool) < pool
       assert Knowledge.heat_node_cap(3) == 2
 
-      # A pool of 1 — or a repo config with no `:pool_size`, which `DbCapacity` reports as 0 —
-      # must shed outright. Clamping the cap UP to 1 there admitted heat onto the only admin
-      # connection, the exact state `pool - 1` exists to make impossible.
+      # A pool of 1 must shed outright. Clamping the cap UP to 1 there admitted heat onto the
+      # only admin connection, the exact state `pool - 1` exists to make impossible.
       assert Knowledge.heat_node_cap(1) == 0
-      assert Knowledge.heat_node_cap(0) == 0
+
+      # But 0 is an UNREADABLE repo config, not a pool of zero (`DbCapacity.pool_size/1`
+      # reports a missing key as 0), and a limiter that cannot read its own bound fails OPEN
+      # (AC-37.5.5) rather than turning a config read into a permanent outage of the endpoint.
+      assert Knowledge.heat_node_cap(0) == Knowledge.heat_node_cap(3)
+
+      # The per-tenant sub-cap keeps a node permit reachable by a neighbour, but never at the
+      # price of making a per-turn endpoint serial for one tenant: at the cap production
+      # reaches, `cap - 1` was 1, so a fleet's second concurrent call 429'd on an idle node.
+      assert Knowledge.heat_tenant_cap(2) == 2
+      assert Knowledge.heat_tenant_cap(3) == 2
+      assert Knowledge.heat_tenant_cap(4) == 3
+      assert Knowledge.heat_tenant_cap(0) == 0
+    end
+
+    test "the node-wide permit is the node bound, and comes back when the tenant sub-cap sheds" do
+      # The saturation test above drives the TENANT-scoped key, because the node-wide counter is
+      # VM-wide ETS and holding it would shed every parallel async heat read. That leaves the
+      # node-wide acquire — the bound this gate is named for — and the release-on-tenant-shed
+      # path undriven, and a missed release there leaks one node permit per shed, permanently.
+      # So drive `heat_acquire/2` directly on private keys: same code, no shared counter.
+      global = "heat-node-gate-" <> Ecto.UUID.generate()
+      keys = [global, global <> ":tenant"]
+
+      # cap 3 -> tenant sub-cap 2, so the third acquire sheds on the TENANT key while the node
+      # key still has room. The node permit it took to get there must be given back.
+      assert Knowledge.heat_acquire(keys, 3) == :ok
+      assert Knowledge.heat_acquire(keys, 3) == :ok
+      assert TenantGate.count(global) == 2
+      assert Knowledge.heat_acquire(keys, 3) == :shed
+      assert TenantGate.count(global) == 2
+
+      # And once the NODE key is full it decides, whatever a fresh tenant's own count is.
+      assert Knowledge.heat_acquire([global, global <> ":other"], 2) == :shed
+      assert TenantGate.count(global) == 2
+      assert TenantGate.count(global <> ":other") == 0
+
+      for _ <- 1..2 do
+        TenantGate.release(global, 1)
+        TenantGate.release(global <> ":tenant", 1)
+      end
+
+      assert TenantGate.count(global) == 0
     end
 
     test "a KILLED holder's node permit is reclaimed, not leaked node-wide forever" do
@@ -846,13 +891,17 @@ defmodule Loopctl.Knowledge.HeatIndexTest do
       # reaps. On a node-wide key capped at 2 in production, two such kills would shed
       # heat_index for EVERY tenant on the node until it restarts — so the permit is released
       # by a monitoring reclaimer rather than by the holder's own `after`.
+      #
+      # The reclaimer ACQUIRES too, after its monitor is installed, so there is no instant at
+      # which a permit exists uncovered — a kill in that window used to leak one forever.
       key = "heat-permit-reclaim-" <> Ecto.UUID.generate()
       parent = self()
 
       holder =
         spawn(fn ->
-          :ok = TenantGate.acquire(key, 1, 2)
-          send(parent, {:held, Knowledge.heat_permit_reclaimer([key])})
+          reclaimer = Knowledge.heat_permit_reclaimer([key, key <> ":t"], 2)
+          receive do: ({:heat_permit, ^reclaimer, :ok} -> :ok)
+          send(parent, {:held, reclaimer})
           Process.sleep(:infinity)
         end)
 
@@ -865,6 +914,7 @@ defmodule Loopctl.Knowledge.HeatIndexTest do
       # The reclaimer exits once it has released, so this is deterministic rather than a poll.
       assert_receive {:DOWN, ^ref, :process, ^reclaimer, _}
       assert TenantGate.count(key) == 0
+      assert TenantGate.count(key <> ":t") == 0
     end
 
     test "truncated says the list is partial, since nothing else in the payload would" do

--- a/test/loopctl/knowledge/heat_index_test.exs
+++ b/test/loopctl/knowledge/heat_index_test.exs
@@ -13,6 +13,9 @@ defmodule Loopctl.Knowledge.HeatIndexTest do
   use Loopctl.DataCase, async: true
 
   alias Loopctl.AdminRepo
+  alias Loopctl.DbCapacity
+  alias Loopctl.HeavyRead
+  alias Loopctl.HeavyRead.TenantGate
   alias Loopctl.Knowledge
 
   setup :verify_on_exit!
@@ -780,6 +783,41 @@ defmodule Loopctl.Knowledge.HeatIndexTest do
       assert log =~ "sqlstate=53300"
       assert log =~ "sqlstate=42703"
       refute log =~ "sqlstate=too_many_connections"
+    end
+
+    test "the node-level admin gate sheds at its cap, and gives the slot back either way" do
+      # This gate is the only thing keeping a per-turn endpoint off the LAST of AdminRepo's 3
+      # connections, which custody writes and the per-request auth SELECT share. Saturate it
+      # from outside and the endpoint must shed rather than queue behind them.
+      #
+      # Non-vacuous by construction: delete the gate from `heat_stub_projection/2` and
+      # `heat_index/2` succeeds here instead of raising, so this test fails.
+      tenant = fixture(:tenant)
+      article = published_article(tenant.id, %{title: "Readable"})
+      heat(tenant.id, article, 2)
+
+      key = "knowledge.heat_stub_projection"
+      cap = max(1, DbCapacity.runtime_pool_sizes().admin_repo - 1)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          :ok = TenantGate.acquire(key, cap, cap)
+
+          try do
+            assert_raise HeavyRead.OverloadedError, fn -> Knowledge.heat_index(tenant.id) end
+          after
+            TenantGate.release(key, cap)
+          end
+        end)
+
+      # A NODE-wide shed must not be logged as one tenant reading too much — that is how
+      # saturation of a shared pool gets mistaken for ordinary per-tenant backpressure.
+      assert log =~ "admin_pool_node_gate_shed"
+
+      # And the slot comes back on BOTH paths: the index answers again, and the node-wide
+      # counter is back to zero rather than leaking a permit per shed.
+      assert {:ok, %{results: [%{title: "Readable"}]}} = Knowledge.heat_index(tenant.id)
+      assert TenantGate.count(key) == 0
     end
 
     test "truncated says the list is partial, since nothing else in the payload would" do

--- a/test/loopctl/knowledge/heat_index_test.exs
+++ b/test/loopctl/knowledge/heat_index_test.exs
@@ -790,23 +790,27 @@ defmodule Loopctl.Knowledge.HeatIndexTest do
       # connections, which custody writes and the per-request auth SELECT share. Saturate it
       # from outside and the endpoint must shed rather than queue behind them.
       #
-      # Non-vacuous by construction: delete the gate from `heat_stub_projection/2` and
-      # `heat_index/2` succeeds here instead of raising, so this test fails.
+      # Saturated on the admission's TENANT-scoped key, never the node-wide one: the counters
+      # are VM-wide public ETS, and TenantGate's documented async protocol is that the suite's
+      # caps stay high so the wired gate is a no-op across incidental parallel reads. Holding
+      # the node key here would shed — and make the final count assertion race — any other
+      # async test that reads a heat index.
+      #
+      # Non-vacuous by construction: delete the gate from `heat_index/2` and the call succeeds
+      # here instead of raising, so this test fails.
       tenant = fixture(:tenant)
       article = published_article(tenant.id, %{title: "Readable"})
       heat(tenant.id, article, 2)
 
-      key = "knowledge.heat_stub_projection"
-      cap = max(1, DbCapacity.runtime_pool_sizes().admin_repo - 1)
+      key = "knowledge.heat_stub_projection:" <> tenant.id
+      :ok = TenantGate.acquire(key, 1_000, 1_000)
 
       log =
         ExUnit.CaptureLog.capture_log(fn ->
-          :ok = TenantGate.acquire(key, cap, cap)
-
           try do
             assert_raise HeavyRead.OverloadedError, fn -> Knowledge.heat_index(tenant.id) end
           after
-            TenantGate.release(key, cap)
+            TenantGate.release(key, 1_000)
           end
         end)
 
@@ -814,9 +818,52 @@ defmodule Loopctl.Knowledge.HeatIndexTest do
       # saturation of a shared pool gets mistaken for ordinary per-tenant backpressure.
       assert log =~ "admin_pool_node_gate_shed"
 
-      # And the slot comes back on BOTH paths: the index answers again, and the node-wide
-      # counter is back to zero rather than leaking a permit per shed.
+      # And the permit comes back on BOTH paths: the index answers again, and the counter is
+      # back to zero rather than leaking one per shed. The release is awaited, not fired and
+      # forgotten, so this is a fact rather than a timing window.
       assert {:ok, %{results: [%{title: "Readable"}]}} = Knowledge.heat_index(tenant.id)
+      assert TenantGate.count(key) == 0
+    end
+
+    test "the node cap never admits heat onto the last admin connection" do
+      # The cap is asserted as a RELATIONSHIP, not recomputed from the implementation's own
+      # expression — a test that copies `admin_repo - 1` pins the gate's existence and nothing
+      # about the bound, which is where the safety claim lives.
+      pool = DbCapacity.runtime_pool_sizes().admin_repo
+
+      assert Knowledge.heat_node_cap(pool) < pool
+      assert Knowledge.heat_node_cap(3) == 2
+
+      # A pool of 1 — or a repo config with no `:pool_size`, which `DbCapacity` reports as 0 —
+      # must shed outright. Clamping the cap UP to 1 there admitted heat onto the only admin
+      # connection, the exact state `pool - 1` exists to make impossible.
+      assert Knowledge.heat_node_cap(1) == 0
+      assert Knowledge.heat_node_cap(0) == 0
+    end
+
+    test "a KILLED holder's node permit is reclaimed, not leaked node-wide forever" do
+      # `try/after` does not run on `Process.exit(pid, :kill)`, and TenantGate never sweeps or
+      # reaps. On a node-wide key capped at 2 in production, two such kills would shed
+      # heat_index for EVERY tenant on the node until it restarts — so the permit is released
+      # by a monitoring reclaimer rather than by the holder's own `after`.
+      key = "heat-permit-reclaim-" <> Ecto.UUID.generate()
+      parent = self()
+
+      holder =
+        spawn(fn ->
+          :ok = TenantGate.acquire(key, 1, 2)
+          send(parent, {:held, Knowledge.heat_permit_reclaimer([key])})
+          Process.sleep(:infinity)
+        end)
+
+      assert_receive {:held, reclaimer}
+      assert TenantGate.count(key) == 1
+
+      ref = Process.monitor(reclaimer)
+      Process.exit(holder, :kill)
+
+      # The reclaimer exits once it has released, so this is deterministic rather than a poll.
+      assert_receive {:DOWN, ^ref, :process, ^reclaimer, _}
       assert TenantGate.count(key) == 0
     end
 


### PR DESCRIPTION
The last confirmed finding from the **PR #31 review**, and the only one with production consequences.

## The gap

`heat_index/2` holds one `HeavyRead.with_slot/3` admission across both round trips, which bounds how many of **this tenant's** heat reads are in flight. **Nothing bounded the aggregate.** `TenantGate` counts per key, so N tenants each admitted at their own per-tenant cap queue up to N concurrent checkouts on `AdminRepo` — a **3-connection** pool (`ADMIN_POOL_SIZE || "3"`) that custody writes and the per-request auth SELECT also use.

The per-read `:timeout` bounds how long each waiter blocks. It does not bound how many waiters there are. On a per-turn endpoint that is the wrong shape.

## The fix

The projection acquires a **node-level** slot first, keyed on a fixed string rather than a tenant id — that is what makes the count node-wide. `TenantGate.acquire/3` only guards `is_binary/1`, so a non-UUID key is legal and cannot collide with a real tenant. Capped at `admin_repo - 1`, so heat can never take the **last** admin connection out from under a custody write.

The shed is logged under its own `admin_pool_node_gate_shed` tag and deliberately does **not** wear the per-tenant label. This bound is node-wide, so `OverloadedError`'s default message would attribute saturation of a shared pool to whichever tenant happened to arrive last — a systemic fault dressed as one tenant reading too much, which is the exact confusion the rescue arms below it already exist to prevent.

The read itself moved into `heat_admin_read/2` **unchanged**, so the existing rescue/catch arms and their sanitised logging are untouched. The gate wraps them in `try/after`, so the permit returns on the fault paths too.

## Mutation-verified, not assumed

Bypassing the `acquire` makes the new test fail:

```
Expected exception Loopctl.HeavyRead.OverloadedError but nothing was raised
```

The test saturates the gate from outside, asserts the endpoint **sheds rather than queues**, asserts the node-wide tag is what gets logged, then asserts the index answers again and `TenantGate.count(key) == 0` — so a permit leaked per shed would fail it too.

## One item from the same review I did NOT land, deliberately

Its `heat_saturation?/1` change narrows to `reason: :queue_timeout` plus a **message-substring** match. That reverses a decision already made *with measurement*: the shape this path actually produces is `reason: :closed` (measured by driving `AdminRepo.query!` past a `pg_sleep`), and `:reason`'s own typespec does not even list it. Substring-matching a driver's prose is the brittle-classifier failure this repo has been bitten by before.

The current catch-all is deliberate and documents shedding a connect fault as 429 as the accepted cost — over-shedding a read-only index beats 500-ing the bounded wait the function exists to bound. Recording the disproof here rather than silently skipping it.

## Gate

`mix precommit` green — **6869 tests, 0 failures**; credo --strict clean; dialyzer 0 unnecessary skips.

This one **does** get a review run despite being from the out-of-scope list: the fix introduces a new concurrency mechanism that the original review never saw. Re-reviewing a listed finding is the hop the chain bound refuses; reviewing novel concurrency code is not that.
