### PR TITLE
Make conflict suppression fail open, so an unjudged flag cannot delete the corpus

### DIFF
--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -44,9 +44,9 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:509-515`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:463-466`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8468`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8517`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
-   (`absolute_score/1`, `:8595-8600`) clears a scale-matched threshold AND beats the best retrieved
+   (`absolute_score/1`, `:8644-8649`) clears a scale-matched threshold AND beats the best retrieved
    candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:8646-8656`; the pure decision is
    `resolve_provenance/4`, `:8699-8710`) AND is authoritative (not superseded/conflicted — the caller
    passes only `list_curated_sources/2`-filtered scores). Otherwise `:retrieved`. Both branches return identical `results`/`meta`
@@ -67,7 +67,7 @@ never pass `tenant_id`/`subject_id`.
    `drafts`/`publish` are `:orchestrator` (`:33`).
    Agent edits are visibility-scoped: an agent can only touch an article it can see. (See `chain-of-custody`.)
 5. **Heat must not rank on a signal heat produces** — `Knowledge.heat_index/2`
-   (`knowledge.ex:9109`; the counted set is `@heat_read_access_types`, `:8979`). The heat index is the one retrieval route that
+   (`knowledge.ex:9158`; the counted set is `@heat_read_access_types`, `:8979`). The heat index is the one retrieval route that
    takes NO query, so its misses are uncorrelated with embedding similarity — which is worth nothing
    if its ordering is something a caller or the route itself generates. It has been violated FOUR
    times, each differently — and once by a FIX for one of the others — so treat any new input to

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -3066,8 +3066,14 @@ defmodule Loopctl.Knowledge do
   # shared system canonical (article ids are global) cannot retract that canonical
   # from ANOTHER tenant's list. For a tenant's own article the link necessarily
   # lives under that same tenant, so this predicate is a no-op restriction there.
-  # Mirrors the open-conflict definition in list_potential_conflicts/2.
+  # DELIBERATELY NO LONGER identical to `list_potential_conflicts/2`'s definition. The two
+  # answer different questions and the divergence is the point: the QUEUE must keep showing
+  # an unjudged conflict forever (it is still unjudged, and hiding it would strand it), while
+  # SUPPRESSION must expire (see the window below). Keep both in mind when editing either —
+  # re-unifying them would silently restore the unbounded suppression this exists to stop.
   defp open_conflict_subquery(tenant_id) do
+    cutoff = DateTime.add(DateTime.utc_now(), -conflict_suppression_window_days(), :day)
+
     from(l in ArticleLink,
       as: :link,
       where: l.tenant_id == ^tenant_id,
@@ -3076,9 +3082,40 @@ defmodule Loopctl.Knowledge do
       where:
         l.source_article_id == parent_as(:article).id or
           l.target_article_id == parent_as(:article).id,
+      # FAIL OPEN past the window. Suppression is a safety measure premised on the
+      # conflict being JUDGED soon; it is not premised on it being judged EVER. Left
+      # unbounded it degrades into silent corpus deletion — measured on the hosted
+      # deployment 2026-08-05: 16,117 open auto-generated conflicts, growing +500 every
+      # night with no automatic drain, each removing BOTH of its articles from every
+      # curated answer. That is up to ~32k article-slots withheld indefinitely to guard
+      # against a contradiction nobody has confirmed exists.
+      #
+      # The trade, stated plainly: past the window a genuinely contradictory pair can be
+      # cited again. That is the lesser harm. An unjudged flag is a SUSPICION raised by
+      # cosine similarity >= 0.93 — which measures "these say similar things", not "these
+      # disagree" — and withholding the corpus forever on an unconfirmed suspicion fails
+      # the route's own purpose more reliably than the contradiction would.
+      #
+      # This is the backstop, not the mechanism. The drain is the automatic judge; this
+      # exists so a stalled or crashed judge cannot silently empty curated retrieval
+      # again. If you find yourself widening the window to mask a judge that is not
+      # keeping up, fix the judge.
+      where: l.inserted_at > ^cutoff,
       where: not exists(conflict_unresolved_subquery()),
       select: 1
     )
+  end
+
+  @doc """
+  How long an UNJUDGED auto-generated `potential_conflict` suppresses its articles from
+  curated sources.
+
+  Public so the suppression window and the tests that pin it read one number. Override with
+  `config :loopctl, :conflict_suppression_window_days, n`.
+  """
+  @spec conflict_suppression_window_days() :: pos_integer()
+  def conflict_suppression_window_days do
+    Application.get_env(:loopctl, :conflict_suppression_window_days, 14)
   end
 
   # THE single authority for "this potential_conflict link is still unresolved":
@@ -3148,12 +3185,21 @@ defmodule Loopctl.Knowledge do
   # filter would be while also participating for system articles (AC-31.1.3). Mirrors
   # open_conflict_subquery/0 and shares conflict_unresolved_subquery/0.
   defp article_in_open_conflict?(%Article{id: article_id}) do
+    # The SAME fail-open window as `open_conflict_subquery/1` — see the long note there for
+    # why suppression expires. These are two separate predicates serving one invariant (the
+    # per-article authority check and the list query), so the window MUST be applied to both
+    # or the invariant is only half true: a stale conflict would keep an article out of
+    # `authoritative_curated?/1` while the list happily returned it, which is worse than
+    # either behaviour consistently applied.
+    cutoff = DateTime.add(DateTime.utc_now(), -conflict_suppression_window_days(), :day)
+
     query =
       from(l in ArticleLink,
         as: :link,
         where: l.relationship_type == :potential_conflict,
         where: fragment("(?->>'auto_generated') = 'true'", l.metadata),
         where: l.source_article_id == ^article_id or l.target_article_id == ^article_id,
+        where: l.inserted_at > ^cutoff,
         where: not exists(conflict_unresolved_subquery())
       )
 

--- a/test/loopctl/knowledge_curated_test.exs
+++ b/test/loopctl/knowledge_curated_test.exs
@@ -293,6 +293,53 @@ defmodule Loopctl.KnowledgeCuratedTest do
       refute curated.id in ids(Knowledge.list_curated_sources(tenant.id))
     end
 
+    test "an UNJUDGED conflict stops suppressing once it ages past the window" do
+      # Suppression is premised on the conflict being judged SOON, not on it being judged
+      # ever. Unbounded it becomes silent corpus deletion: measured on the hosted deployment
+      # 2026-08-05, 16,117 open auto-generated conflicts growing +500/night with no automatic
+      # drain, each withholding BOTH its articles from every curated answer.
+      #
+      # Both predicates are asserted, because they are separate implementations of one
+      # invariant — `authoritative_curated?/1` and `list_curated_sources/1`. Fixing one and
+      # not the other is how a half-applied invariant ships.
+      tenant = fixture(:tenant)
+      curated = curated_article(tenant.id, %{title: "Aged Conflict"})
+      other = fixture(:article, %{tenant_id: tenant.id, status: :published, title: "Rival"})
+
+      link =
+        fixture(:article_link, %{
+          tenant_id: tenant.id,
+          source_article_id: curated.id,
+          target_article_id: other.id,
+          relationship_type: :potential_conflict,
+          metadata: %{"auto_generated" => true, "similarity_score" => 0.95}
+        })
+
+      # Fresh: suppressed, exactly as the sibling test above asserts.
+      refute Knowledge.authoritative_curated?(curated)
+      refute curated.id in ids(Knowledge.list_curated_sources(tenant.id))
+
+      # Age it one day past the window. `article_links` is deliberately immutable (no update
+      # changeset, `updated_at: false`), so backdate through the repo directly.
+      aged_at =
+        DateTime.add(
+          DateTime.utc_now(),
+          -(Knowledge.conflict_suppression_window_days() + 1),
+          :day
+        )
+
+      link
+      |> Ecto.Changeset.change(%{inserted_at: aged_at})
+      |> AdminRepo.update!()
+
+      # Still unjudged — no conflict_resolutions row was written — but no longer suppressing.
+      assert Knowledge.authoritative_curated?(curated),
+             "an aged unjudged conflict must stop suppressing the per-article authority check"
+
+      assert curated.id in ids(Knowledge.list_curated_sources(tenant.id)),
+             "an aged unjudged conflict must stop suppressing the curated-sources list"
+    end
+
     test "authoritative_curated?/1 does not crash on a system canonical (tenant_id nil)" do
       tenant = fixture(:tenant)
       system = curated_system_article(%{title: "System Canonical"}, tenant.id)


### PR DESCRIPTION
**An open auto-generated `potential_conflict` withholds BOTH its articles from every curated answer** (AC-31.1.4). That is correct only if the conflict actually gets judged.

Measured on the hosted deployment 2026-08-05:

```
16,117 open auto-generated conflicts
    +500 every night, with NO automatic drain of any kind
  => up to ~32,000 article-slots withheld from curated retrieval, indefinitely
```

Nothing in the codebase closes or deletes a `potential_conflict` automatically — the count is **monotone by construction**. The only judge is the operator-invoked `knowledge_resolve_conflict`. With no human in the loop, "suppress until judged" means "suppress forever."

## The fix

Suppression now expires after a configurable window (default **14 days**). Past it an unjudged conflict stops suppressing, while remaining fully visible in the review queue.

**The trade, stated in the code rather than left implicit:** past the window a genuinely contradictory pair can be cited again. That is the lesser harm. An unjudged flag is a *suspicion* raised by cosine similarity ≥ 0.93 — which measures that two articles say **similar** things, not that they **disagree** — and withholding the corpus forever on an unconfirmed suspicion fails the route's own purpose far more reliably than the contradiction would.

## Applied to both predicates

There are **two independent implementations** of this one invariant:
- `open_conflict_subquery/1` — behind `list_curated_sources/1`
- `article_in_open_conflict?/1` — behind `authoritative_curated?/1`

Fixing one would have left an article excluded from the per-article authority check while the list returned it happily. A half-applied invariant is worse than either behaviour applied consistently.

I also corrected a comment claiming this predicate "mirrors" `list_potential_conflicts/2`. They now **deliberately** differ, and the divergence is the point: the queue must keep showing an unjudged conflict forever (it *is* still unjudged, and hiding it would strand it), while suppression must expire. Re-unifying them would silently restore the unbounded behaviour.

## This is the backstop, not the mechanism

The drain is the automatic judge, which follows in the next PR. This exists so a stalled or crashed judge cannot silently empty curated retrieval again. If a future change is tempted to widen the window to mask a judge that isn't keeping up — fix the judge.

## Verification

**Mutation-verified:** removing the window from both predicates fails the new test with *"an aged unjudged conflict must stop suppressing the per-article authority check."*

`mix precommit` green — **6874 tests, 0 failures**.

Also re-pointed three `file:line` citations in the knowledge-wiki skill that this diff shifted (`hybrid_search`, `absolute_score`, `heat_index`). `CheckSkillCitationsTest` caught them — worth noting that this test is exactly why those citations stay honest while prose ones elsewhere rot.
