### PR TITLE
Teach the reconciler its third drift class: never embedded at all

### DIFF
--- a/lib/loopctl/embeddings.ex
+++ b/lib/loopctl/embeddings.ex
@@ -1883,6 +1883,53 @@ defmodule Loopctl.Embeddings do
     end
   end
 
+  @doc """
+  Published articles for a tenant that have NO side-table embedding row **at any dimension**.
+
+  The third drift class, and the one the reconciliation sweep was blind to. Its two existing
+  classes both presuppose a PARTIAL write:
+
+    * the dual-write crash window needs `articles.embedding` populated without its mirror;
+    * the active-dimension gap needs a row at SOME dimension but not the active one.
+
+  An article that was never embedded at all matches neither, so it had no repair path
+  whatsoever — it is simply absent from every semantic search, silently and permanently.
+  Measured on the hosted corpus 2026-08-05: **81 published articles**, oldest 2026-06-19,
+  newest 2026-07-22, all with real bodies, none carrying a legacy `articles.embedding` and
+  none carrying a side-table row of any dimension. Six weeks unsearchable while an hourly
+  reconciler reported healthy.
+
+  Deliberately NOT keyed to the active dimension: the question here is existence, not
+  currency. A row at the wrong dimension is the OTHER class's business, and asking about the
+  active dimension here would re-introduce the same blindness one level down.
+
+  Empty bodies are excluded — they cannot produce a meaningful embedding, so enqueuing them
+  would generate a permanent retry loop against the provider rather than a repair.
+  """
+  @spec unembedded_articles(Ecto.UUID.t(), pos_integer()) :: [Article.t()]
+  def unembedded_articles(tenant_id, limit) when is_binary(tenant_id) and is_integer(limit) do
+    AdminRepo.all(
+      from(a in Article,
+        as: :article,
+        where: a.tenant_id == ^tenant_id,
+        where: a.status == :published,
+        where: not is_nil(a.body) and fragment("length(btrim(?)) > 0", a.body),
+        where:
+          not exists(
+            from(ae in ArticleEmbedding,
+              where: ae.article_id == parent_as(:article).id,
+              select: 1
+            )
+          ),
+        # Oldest first: an article unsearchable since June has been failing longer than one
+        # ingested this morning, and a bounded run should repair the longest-standing gap
+        # first rather than an arbitrary slice.
+        order_by: [asc: a.inserted_at],
+        limit: ^limit
+      )
+    )
+  end
+
   @doc "The memories twin of `pending_reembed_articles/3`."
   @spec pending_reembed_memories(Ecto.UUID.t(), pos_integer(), pos_integer()) :: [Memory.t()]
   def pending_reembed_memories(tenant_id, target_dim, limit)

--- a/lib/loopctl/workers/embedding_reconciliation_worker.ex
+++ b/lib/loopctl/workers/embedding_reconciliation_worker.ex
@@ -4,7 +4,8 @@ defmodule Loopctl.Workers.EmbeddingReconciliationWorker do
   the cutover runbook calls for, made executable and scheduled rather than an IEx-only
   library call.
 
-  Two classes of drift, swept every run:
+  THREE classes of drift, swept every run. The first two both presuppose a PARTIAL write;
+  the third exists because that assumption left total absence unrepairable:
 
     * **The dual-write crash window** — a legacy `articles.embedding` /
       `memories.embedding` written without its dim-1536 side-table mirror (the process
@@ -23,11 +24,28 @@ defmodule Loopctl.Workers.EmbeddingReconciliationWorker do
       rows; re-enqueuing the ordinary embedding workers re-embeds them at the active
       dimension.
 
+    * **Never embedded at all** — a published article with NO side-table row at ANY
+      dimension. It matches neither class above (no legacy column to mirror, no row at
+      another dimension to re-point), so before this it had no repair path and was simply
+      absent from every semantic search, silently and permanently.
+      `Embeddings.unembedded_articles/2` enumerates them oldest-first.
+
+      Measured on the hosted corpus 2026-08-05: **81 published articles**, oldest
+      2026-06-19, all with real bodies, none carrying a legacy embedding and none carrying
+      a side-table row — six weeks unsearchable while this worker ran hourly and reported
+      healthy. That is the shape of a reconciler that reconciles DRIFT BETWEEN two
+      representations but cannot see that both are missing.
+
   ## Scheduling
 
-  Runs `mode: "all_tenants"` from the Oban crontab (hourly). It fans out one
-  per-tenant job for every tenant that has embedding rows, each bounded per run, so a
-  large backlog drains over successive runs rather than in one long transaction.
+  Runs `mode: "all_tenants"` from the Oban crontab (hourly). It fans out one per-tenant job
+  for every tenant with embedding rows **or with published articles**, each bounded per run,
+  so a large backlog drains over successive runs rather than in one long transaction.
+
+  That second condition is load-bearing: keying the fan-out only on existing embedding rows
+  made the sweep structurally unable to reach the tenant that most needed it — one whose
+  articles were never embedded has no rows, so it was never enqueued, so it was never
+  repaired. A fan-out keyed on the artifact you are trying to create can never create it.
   """
 
   use Oban.Worker, queue: :knowledge, max_attempts: 3
@@ -38,6 +56,7 @@ defmodule Loopctl.Workers.EmbeddingReconciliationWorker do
 
   alias Loopctl.AdminRepo
   alias Loopctl.Embeddings
+  alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleEmbedding
   alias Loopctl.Memory.MemoryEmbedding
   alias Loopctl.Workers.ArticleEmbeddingWorker
@@ -72,7 +91,42 @@ defmodule Loopctl.Workers.EmbeddingReconciliationWorker do
     # step that actually reads a tenant argument. The global backfill / live_denorm
     # repair ran once in the `all_tenants` branch above.
     reenqueue_active_dimension_gaps(tenant_id)
+    reenqueue_unembedded(tenant_id)
     :ok
+  end
+
+  # The THIRD drift class: never embedded at all. Both classes above presuppose a PARTIAL
+  # write — one needs the legacy column populated, the other needs a row at some other
+  # dimension — so an article with no embedding row anywhere matched neither and had no
+  # repair path. Measured 2026-08-05: 81 published articles unsearchable since June while
+  # this worker ran hourly and reported healthy.
+  defp reenqueue_unembedded(tenant_id) do
+    batch = 100
+
+    case Embeddings.unembedded_articles(tenant_id, batch) do
+      [] ->
+        :ok
+
+      articles ->
+        Enum.each(articles, fn article ->
+          %{tenant_id: tenant_id, article_id: article.id}
+          |> ArticleEmbeddingWorker.new()
+          |> Oban.insert()
+        end)
+
+        # Logged at :warning, not :info. A dimension gap is an expected race; an article
+        # that was never embedded means an embedding job was lost or permanently discarded,
+        # and the only reason the previous 81 went unnoticed for six weeks is that nothing
+        # ever said so out loud.
+        Logger.warning(
+          "EmbeddingReconciliationWorker: tenant=#{tenant_id} found #{length(articles)} " <>
+            "published article(s) with NO embedding at any dimension — invisible to semantic " <>
+            "search until re-embedded. Re-enqueued (batch cap #{batch}); a persistent count " <>
+            "here means the embedding jobs are failing, not that the backlog is draining."
+        )
+
+        :ok
+    end
   end
 
   # Re-embed the rows the completion sweep could have stranded at a dropped dimension.
@@ -107,7 +161,14 @@ defmodule Loopctl.Workers.EmbeddingReconciliationWorker do
     :ok
   end
 
-  # Every tenant that carries ANY embedding side-table row (article OR memory).
+  # Every tenant that carries any embedding side-table row, PLUS every tenant that has
+  # published articles at all.
+  #
+  # The second half is load-bearing and was missing. Selecting only tenants that already
+  # HAVE embedding rows makes the sweep unable to reach precisely the tenant it most needs
+  # to: one whose articles were never embedded has no rows, so it was never enqueued, so it
+  # was never repaired — the failure is self-concealing, and a fan-out keyed on the artifact
+  # you are trying to create can never produce it.
   defp tenant_ids do
     article_tenants =
       AdminRepo.all(from(ae in ArticleEmbedding, distinct: true, select: ae.tenant_id))
@@ -115,6 +176,16 @@ defmodule Loopctl.Workers.EmbeddingReconciliationWorker do
     memory_tenants =
       AdminRepo.all(from(me in MemoryEmbedding, distinct: true, select: me.tenant_id))
 
-    (article_tenants ++ memory_tenants) |> Enum.uniq()
+    published_article_tenants =
+      AdminRepo.all(
+        from(a in Article,
+          where: a.status == :published,
+          where: not is_nil(a.tenant_id),
+          distinct: true,
+          select: a.tenant_id
+        )
+      )
+
+    (article_tenants ++ memory_tenants ++ published_article_tenants) |> Enum.uniq()
   end
 end

--- a/test/loopctl/workers/embedding_reconciliation_worker_test.exs
+++ b/test/loopctl/workers/embedding_reconciliation_worker_test.exs
@@ -1,0 +1,145 @@
+defmodule Loopctl.Workers.EmbeddingReconciliationWorkerTest do
+  @moduledoc """
+  The reconciliation sweep's THIRD drift class: an article that was never embedded at all.
+
+  This worker had no test file before. That is not incidental to the defect it carried — its
+  two original classes both presuppose a PARTIAL write (a legacy column without its mirror, a
+  row at the wrong dimension), so an article with no embedding row anywhere matched neither
+  and had no repair path. Measured on the hosted corpus 2026-08-05: 81 published articles,
+  oldest 2026-06-19, invisible to semantic search for six weeks while this worker ran hourly
+  and reported healthy.
+  """
+  use Loopctl.DataCase, async: true
+  use Oban.Testing, repo: Loopctl.Repo
+
+  setup :verify_on_exit!
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Embeddings
+  alias Loopctl.Knowledge.ArticleEmbedding
+  alias Loopctl.Workers.EmbeddingReconciliationWorker
+
+  # Published, with NO embedding row of any kind. Built through AdminRepo rather than the
+  # publish path so the inline embedding cascade never fires — that cascade is exactly what
+  # is ABSENT in the production case being reproduced.
+  defp published_unembedded(tenant_id, attrs \\ %{}) do
+    base = %{
+      title: "Article #{System.unique_integer([:positive])}",
+      body: "A real body with content.",
+      category: :pattern,
+      status: :draft,
+      tags: []
+    }
+
+    fixture(:article, Map.merge(base, Map.put(attrs, :tenant_id, tenant_id)))
+    |> Ecto.Changeset.change(%{status: :published})
+    |> AdminRepo.update!()
+  end
+
+  defp embedding_rows(article_id) do
+    AdminRepo.all(from(ae in ArticleEmbedding, where: ae.article_id == ^article_id))
+  end
+
+  describe "unembedded_articles/2" do
+    test "finds a published article with no embedding row at any dimension" do
+      tenant = fixture(:tenant)
+      orphan = published_unembedded(tenant.id)
+
+      assert embedding_rows(orphan.id) == [], "precondition: the article must start unembedded"
+
+      ids = tenant.id |> Embeddings.unembedded_articles(100) |> Enum.map(& &1.id)
+      assert orphan.id in ids
+    end
+
+    test "excludes an article that already has an embedding at ANY dimension" do
+      # The question this class answers is EXISTENCE, not currency. An article embedded at a
+      # non-active dimension is the other class's business; claiming it here would re-create
+      # the same blindness one level down and double-enqueue every re-embed.
+      tenant = fixture(:tenant)
+      article = published_unembedded(tenant.id)
+
+      %ArticleEmbedding{}
+      |> Ecto.Changeset.change(%{
+        tenant_id: tenant.id,
+        article_id: article.id,
+        dim: 768,
+        live_denorm: false,
+        embedding: List.duplicate(0.1, 768)
+      })
+      |> AdminRepo.insert!()
+
+      ids = tenant.id |> Embeddings.unembedded_articles(100) |> Enum.map(& &1.id)
+      refute article.id in ids
+    end
+
+    test "excludes drafts and empty bodies" do
+      # A draft is not yet expected to be searchable, and an empty body cannot produce a
+      # meaningful embedding — enqueuing it would be a permanent retry loop against the
+      # provider rather than a repair.
+      tenant = fixture(:tenant)
+
+      draft =
+        fixture(:article, %{tenant_id: tenant.id, title: "Draft", body: "b", category: :pattern})
+
+      # The changeset requires a body, so blank it through the repo — which is also how a
+      # whitespace-only body could realistically arrive (a direct write, an import).
+      empty =
+        tenant.id
+        |> published_unembedded()
+        |> Ecto.Changeset.change(%{body: "   "})
+        |> AdminRepo.update!()
+
+      ids = tenant.id |> Embeddings.unembedded_articles(100) |> Enum.map(& &1.id)
+      refute draft.id in ids
+      refute empty.id in ids
+    end
+
+    test "is tenant-isolated" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      theirs = published_unembedded(tenant_b.id)
+
+      ids = tenant_a.id |> Embeddings.unembedded_articles(100) |> Enum.map(& &1.id)
+      refute theirs.id in ids
+    end
+  end
+
+  describe "perform/1 per-tenant" do
+    test "re-enqueues an article that was never embedded" do
+      tenant = fixture(:tenant)
+      orphan = published_unembedded(tenant.id)
+
+      assert :ok =
+               EmbeddingReconciliationWorker.perform(%Oban.Job{
+                 args: %{"tenant_id" => tenant.id}
+               })
+
+      # The inline Oban cascade runs the embedding worker, so the repair is observable as an
+      # embedding row rather than only as an enqueue.
+      assert embedding_rows(orphan.id) != [],
+             "a never-embedded published article must be repaired by the sweep"
+    end
+  end
+
+  describe "all_tenants fan-out" do
+    test "reaches a tenant that has published articles but ZERO embedding rows" do
+      # The self-concealing half of the defect: the fan-out selected only tenants that
+      # already HAD embedding rows, so a tenant whose articles were never embedded was never
+      # enqueued, so it was never repaired. A fan-out keyed on the artifact you are trying to
+      # create can never create it.
+      tenant = fixture(:tenant)
+      orphan = published_unembedded(tenant.id)
+
+      assert AdminRepo.all(from(ae in ArticleEmbedding, where: ae.tenant_id == ^tenant.id)) == [],
+             "precondition: this tenant must have no embedding rows at all"
+
+      assert :ok =
+               EmbeddingReconciliationWorker.perform(%Oban.Job{args: %{"mode" => "all_tenants"}})
+
+      assert embedding_rows(orphan.id) != [],
+             "the fan-out must reach a tenant with no embedding rows, or the gap is permanent"
+    end
+  end
+end


### PR DESCRIPTION
The reconciliation sweep swept **two** classes of drift, and both presuppose a **partial** write:

- the dual-write crash window needs `articles.embedding` populated without its mirror;
- the active-dimension gap needs a row at *some* dimension but not the active one.

An article that was **never embedded at all** matches neither. It had no repair path and was simply absent from every semantic search — silently, permanently.

## Measured, not theorised

On the hosted corpus 2026-08-05:

```
81 published articles with NO embedding row at any dimension
   oldest 2026-06-19, newest 2026-07-22
   all with real bodies
   none carrying a legacy articles.embedding
```

**Six weeks unsearchable while this worker ran hourly and reported healthy.** That is the shape of a reconciler that reconciles *drift between* two representations but cannot see that both are missing.

## Two halves — and the second is why the first alone wouldn't work

**1. `Embeddings.unembedded_articles/2`** enumerates published articles with no side-table row at any dimension, **oldest first**, so a bounded run repairs the longest-standing gap rather than an arbitrary slice.

Deliberately **not** keyed to the active dimension: the question is *existence*, not currency. Asking about the active dimension here would re-introduce the same blindness one level down. Drafts and empty bodies are excluded — an empty body can't produce a meaningful embedding, so enqueuing it is a permanent provider retry loop, not a repair.

**2. The fan-out selected only tenants that already had embedding rows.** A tenant whose articles were never embedded has no rows → never enqueued → never repaired. **The failure is self-concealing: a fan-out keyed on the artifact you are trying to create can never create it.** It now also includes every tenant with published articles.

## Loud, not quiet

The new class logs at `:warning`, not `:info`. A dimension gap is an expected race. An article never embedded means an embedding job was **lost or permanently discarded** — and the only reason those 81 went unnoticed for six weeks is that nothing ever said so out loud.

## Testing

**This worker had no test file at all**, which is not incidental to the defect it carried. It has one now, covering both halves plus tenant isolation and the exclusion rules.

**Mutation-verified, each half independently:**
- removing the third class → 2 failures
- reverting *only* the fan-out → exactly the fan-out test fails

`mix precommit` green — **6880 tests, 0 failures**.

Once merged and deployed, the hourly sweep repairs the 81 on its own; no manual backfill needed.
