### PR TITLE
Stop unattended writers from creating drafts nobody will ever publish

### DIFF
--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -2309,9 +2309,16 @@ defmodule Loopctl.Coordination do
   #     inject an un-deduplicated published article during an embedding outage; it
   #     returns `{:error, :gate_unavailable}` so the caller retries once embeddings
   #     recover. Matches the reviewed Memory graduation posture (Memory.propose_opts/2).
+  # `on_low_novelty: :skip` for the same reason as `Memory.propose_opts/2`: channel-post
+  # graduation is an UNATTENDED writer, so the gate's `:draft` default produces articles
+  # nobody will ever publish. `propose_article/3`'s own comment names this failure, and it
+  # was measured — 26 stranded drafts, seven producers, zero automatic consumers. A
+  # low-novelty proposal means the knowledge is already published somewhere; skipping loses
+  # only the duplicate.
   defp propose_opts(agent_id, role, params) do
     (params[:audit] || [])
     |> Keyword.put(:on_gate_unavailable, :skip)
+    |> Keyword.put(:on_low_novelty, :skip)
     |> Keyword.merge(visibility_opts(agent_id, role))
   end
 

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -2185,8 +2185,22 @@ defmodule Loopctl.Memory do
   # impersonated_at / effective_role) for a superadmin-impersonated graduation; forward it
   # so the graduated article's audit entry records WHO impersonated, not just the SA key
   # id — a silent gap in a custody-relevant write path otherwise.
+  # `on_low_novelty: :skip`, NOT the `:draft` default. Graduation is an UNATTENDED writer —
+  # no reviewer stands behind it — and `propose_article/3`'s own comment predicts what the
+  # default does here: the gated drafts "accumulate as invisible corpus debris that nothing
+  # ever resolves". Measured 2026-08-05: 26 such drafts on the hosted corpus, seven producing
+  # paths and ZERO automatic consumers (publish is orchestrator/user-gated and no worker
+  # calls it), two of them arriving during the very session that audited the backlog.
+  #
+  # Skipping loses nothing a draft would have kept: a low-novelty proposal means a
+  # near-identical article is ALREADY published, so the knowledge is in the corpus either
+  # way. The only difference is whether an unreadable copy of it also accumulates.
+  #
+  # This is deliberately not solved by auto-publishing the drafts instead. "No human in the
+  # loop" must mean "do not create the queue", never "approve unvetted content into the
+  # corpus every agent reads".
   defp propose_opts(%MemorySchema{subject_id: subject_id} = memory, opts) do
-    [visibility_agent_id: subject_id, on_gate_unavailable: :skip]
+    [visibility_agent_id: subject_id, on_gate_unavailable: :skip, on_low_novelty: :skip]
     |> maybe_put_embedding(memory)
     |> Keyword.merge(Keyword.take(opts, [:actor_id, :actor_label, :actor_type, :metadata]))
   end

--- a/test/loopctl/memory/graduation_test.exs
+++ b/test/loopctl/memory/graduation_test.exs
@@ -109,11 +109,49 @@ defmodule Loopctl.Memory.GraduationTest do
         )
 
       assert {:ok, verdict, article} = Memory.graduate_memory(scope, memory.id)
-      assert verdict in [:created, :gated_to_draft, :duplicate, :deduplicated]
+      # `:gated_to_draft` is deliberately absent: graduation is an unattended writer and now
+      # passes `on_low_novelty: :skip`, so it can never produce a draft. Leaving it in the
+      # allowed set would let a regression back to the `:draft` default pass silently.
+      assert verdict in [:created, :duplicate, :deduplicated]
       assert article.project_id == project.id
       assert article.body == "runbook: restart the worker pool"
       assert article.category == :finding
       refute is_nil(reload(memory).graduated_at)
+    end
+
+    test "a LOW-NOVELTY graduation creates nothing at all, rather than a stranded draft", %{
+      scope: scope,
+      project: project
+    } do
+      # Graduation is an UNATTENDED writer. The novelty gate's `:draft` default hands it a
+      # queue with no consumer: publishing is orchestrator/user-gated and no worker calls it,
+      # so a gated draft is invisible forever. `propose_article/3`'s own comment predicts
+      # exactly this, and it was measured — 26 stranded drafts on the hosted corpus across
+      # seven producing paths and zero automatic consumers.
+      #
+      # Skipping loses nothing a draft would have kept: low novelty MEANS a near-identical
+      # article is already published, so the knowledge is in the corpus either way.
+      expect(Loopctl.MockProposalAssessor, :assess, fn _tenant_id, _attrs, _opts ->
+        %{verdict: :low_novelty, score: 0.91, neighbors: []}
+      end)
+
+      memory =
+        fixture(:memory,
+          tenant_id: scope.tenant_id,
+          subject_id: scope.subject_id,
+          project_id: project.id,
+          text: "a near-duplicate of something already published"
+        )
+
+      before = AdminRepo.aggregate(Article, :count, :id)
+
+      assert {:ok, :skipped_low_novelty, nil} = Memory.graduate_memory(scope, memory.id)
+
+      assert AdminRepo.aggregate(Article, :count, :id) == before,
+             "a low-novelty graduation must create NO article row — not even a draft"
+
+      refute AdminRepo.exists?(from(a in Article, where: a.status == :draft)),
+             "the whole point is that no draft is produced for an unattended writer"
     end
 
     test "re_scope: :global promotes a PROJECT memory to a tenant-wide (project_id nil) article",


### PR DESCRIPTION
The novelty gate defaults to `on_low_novelty: :draft`. That's right where a reviewer stands behind the write, and wrong everywhere else — and `propose_article/3`'s **own comment already says so**:

> an UNATTENDED writer (session capture) has no such reviewer, so its drafts accumulate as invisible corpus debris that nothing ever resolves.

## Measured

On the hosted corpus 2026-08-05: **26 stranded drafts, seven producing paths, zero automatic consumers.** Publishing is orchestrator/user-gated and no worker calls it. Two of the 26 arrived *during* the session that audited the backlog, so the producers are demonstrably live.

It's the same monotone-accumulator shape as the conflict queue: many automatic producers, no automatic drain.

## The fix

Memory graduation and channel-post graduation now pass `on_low_novelty: :skip`. Both are unattended by construction.

**Skipping loses nothing a draft would have kept.** Low novelty *means* a near-identical article is already published — the knowledge is in the corpus either way. The only difference is whether an unreadable copy of it also accumulates.

## What I deliberately did NOT do

**Auto-publish the drafts.** With no human in the loop, the correct reading is *"don't create the queue"* — never *"approve unvetted content into the corpus every agent reads."* Auto-publishing would put the gate's own rejects into the shared plane, which is worse than the debris.

## What I left alone, having checked rather than assumed

- **`review_finding` articles** — all 15 on the corpus are **published**, so that path strands nothing.
- **OKF import** and **`publish: false` ingestion** — draft-by-design, with a caller who explicitly asked for it.

## One stale assertion removed

The existing graduation test allowed `:gated_to_draft` in its verdict set. That's now unreachable from this path, so it's gone — leaving it would let a regression back to the `:draft` default pass silently.

**Mutation-verified:** reverting `memory.ex` to the `:draft` default fails the new test.

`mix precommit` green — **6875 tests, 0 failures**.

Separately, the existing backlog was triaged by hand: 7 published (2 with corrections), 17 archived as superseded or below-bar. Draft count is now 2, both post-audit arrivals.
