### PR TITLE
Close the unexecutable-resolution black hole, and stop the promoter sampling at random

### DIFF
--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -44,9 +44,9 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:509-515`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:463-466`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8517`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8579`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
-   (`absolute_score/1`, `:8644-8649`) clears a scale-matched threshold AND beats the best retrieved
+   (`absolute_score/1`, `:8706-8711`) clears a scale-matched threshold AND beats the best retrieved
    candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:8646-8656`; the pure decision is
    `resolve_provenance/4`, `:8699-8710`) AND is authoritative (not superseded/conflicted — the caller
    passes only `list_curated_sources/2`-filtered scores). Otherwise `:retrieved`. Both branches return identical `results`/`meta`
@@ -67,7 +67,7 @@ never pass `tenant_id`/`subject_id`.
    `drafts`/`publish` are `:orchestrator` (`:33`).
    Agent edits are visibility-scoped: an agent can only touch an article it can see. (See `chain-of-custody`.)
 5. **Heat must not rank on a signal heat produces** — `Knowledge.heat_index/2`
-   (`knowledge.ex:9158`; the counted set is `@heat_read_access_types`, `:8979`). The heat index is the one retrieval route that
+   (`knowledge.ex:9220`; the counted set is `@heat_read_access_types`, `:8979`). The heat index is the one retrieval route that
    takes NO query, so its misses are uncorrelated with embedding similarity — which is worth nothing
    if its ordering is something a caller or the route itself generates. It has been violated FOUR
    times, each differently — and once by a FIX for one of the others — so treat any new input to

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -4502,18 +4502,80 @@ defmodule Loopctl.Knowledge do
       )
       |> AdminRepo.all()
 
-    Enum.reduce_while(rows, 0, fn r, count ->
-      if System.monotonic_time(:millisecond) >= deadline do
-        Logger.info(
-          "ConflictExecutor: tenant=#{tenant_id} hit the #{budget_ms}ms execute budget " <>
-            "after #{count} resolution(s); remainder left for the next run."
-        )
+    executed =
+      Enum.reduce_while(rows, 0, fn r, count ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          Logger.info(
+            "ConflictExecutor: tenant=#{tenant_id} hit the #{budget_ms}ms execute budget " <>
+              "after #{count} resolution(s); remainder left for the next run."
+          )
 
-        {:halt, count}
-      else
-        {:cont, if(apply_resolution(tenant_id, r), do: count + 1, else: count)}
-      end
-    end)
+          {:halt, count}
+        else
+          {:cont, if(apply_resolution(tenant_id, r), do: count + 1, else: count)}
+        end
+      end)
+
+    close_unexecutable_resolutions(tenant_id)
+    executed
+  end
+
+  # The SILENT BLACK HOLE, closed.
+  #
+  # The executor above requires `confidence == :high`. A `:supersede` or `:merge` recorded at
+  # `:medium` or `:low` therefore never executes — and because the ROW EXISTS it also drops
+  # out of `list_potential_conflicts/2` (which excludes any pair with a resolution) and out of
+  # Consolidation's `judged_pairs/1`. So it vanishes from every surface while changing
+  # nothing: not pending, not applied, not visible, forever.
+  #
+  # That was survivable when a human might one day re-annotate it at high confidence. With no
+  # human in the loop it is a permanent leak, and permanent leaks are exactly what a system
+  # expected to run unattended cannot have.
+  #
+  # These are closed as DISMISSED rather than executed. The alternative — lowering the
+  # executor's bar to `:medium` — would let a low-confidence judgement RETIRE an article, and
+  # the confidence field exists precisely to say that judgement was not trusted. Dismissing
+  # keeps both articles, touches no article row, and is undone by re-annotating the pair at
+  # high confidence, which then executes normally. The reversible outcome is the only
+  # defensible default when nobody is going to adjudicate.
+  #
+  # Logged at :warning, with the count: a steady stream here means something upstream is
+  # emitting judgements it does not believe, which is worth knowing about.
+  defp close_unexecutable_resolutions(tenant_id) do
+    now = DateTime.utc_now()
+
+    {closed, _} =
+      from(r in ConflictResolution,
+        where: r.tenant_id == ^tenant_id,
+        where: is_nil(r.executed_at),
+        where: r.disposition in [:supersede, :merge],
+        where: r.confidence != :high
+      )
+      |> AdminRepo.update_all(
+        set: [
+          executed_at: now,
+          updated_at: now,
+          execution_result: %{
+            "action" => "skipped",
+            "reason" => "insufficient_confidence",
+            "detail" =>
+              "A supersede/merge below :high confidence is never executed by design. It was " <>
+                "closed as dismissed so it cannot sit invisible and unapplied forever; both " <>
+                "articles are retained. Re-annotate the pair at :high confidence to apply it."
+          }
+        ]
+      )
+
+    if closed > 0 do
+      Logger.warning(
+        "ConflictExecutor: tenant=#{tenant_id} closed #{closed} unexecutable resolution(s) " <>
+          "(supersede/merge below :high confidence). Both articles retained in each case. A " <>
+          "persistent count here means something upstream is recording judgements it does " <>
+          "not believe."
+      )
+    end
+
+    closed
   end
 
   defp execute_budget_ms do

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -246,6 +246,12 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
           target_article_id: l.target_article_id,
           metadata: l.metadata
         },
+        # A capped query with no ORDER BY takes an ARBITRARY `cap` rows — whichever the
+        # planner happens to emit first. That made the nightly 500 a random sample of the
+        # candidate set rather than the 500 most-similar pairs, so the strongest redundancy
+        # signals could sit unpromoted for weeks behind weaker ones. Ordering costs nothing
+        # here: `article_links_potential_conflict_idx` already covers this expression.
+        order_by: [desc: fragment("(?->>'similarity_score')::float", l.metadata)],
         limit: ^cap
       )
       |> AdminRepo.all()

--- a/test/loopctl/knowledge/potential_conflicts_test.exs
+++ b/test/loopctl/knowledge/potential_conflicts_test.exs
@@ -127,6 +127,47 @@ defmodule Loopctl.Knowledge.PotentialConflictsTest do
       assert %{meta: %{total_count: 0}, data: []} = Knowledge.list_potential_conflicts(t.id)
     end
 
+    test "a supersede BELOW high confidence is closed, not left invisible forever", ctx do
+      %{tenant: t, a: a, b: b} = ctx
+
+      # The silent black hole: the executor requires :high confidence, so a medium-confidence
+      # supersede never executes — yet because the ROW EXISTS it also drops out of the queue
+      # and out of Consolidation's judged pairs. It vanished from every surface while
+      # changing nothing: not pending, not applied, not visible. Survivable only if a human
+      # might one day re-annotate it, which is exactly what will not happen here.
+      assert {:ok, res} =
+               Knowledge.annotate_conflict(
+                 t.id,
+                 %{
+                   "source_article_id" => a.id,
+                   "target_article_id" => b.id,
+                   "disposition" => "supersede",
+                   "classification" => "redundant",
+                   "confidence" => "medium",
+                   "authoritative_article_id" => a.id
+                 },
+                 actor_label: "agent:x"
+               )
+
+      assert res.confidence == :medium
+      assert is_nil(res.executed_at), "precondition: it starts unexecuted"
+
+      assert 0 = Knowledge.execute_conflict_resolutions(t.id)
+
+      reloaded = AdminRepo.get!(Loopctl.Knowledge.ConflictResolution, res.id)
+
+      # Closed rather than executed: it no longer sits unexecuted forever.
+      refute is_nil(reloaded.executed_at)
+      assert reloaded.execution_result["action"] == "skipped"
+      assert reloaded.execution_result["reason"] == "insufficient_confidence"
+
+      # And BOTH articles survive. Lowering the executor's bar to :medium instead would let a
+      # judgement the annotator did not trust retire an article; the reversible outcome is
+      # the only defensible default with nobody to adjudicate.
+      assert AdminRepo.get!(Loopctl.Knowledge.Article, a.id).status == :published
+      assert AdminRepo.get!(Loopctl.Knowledge.Article, b.id).status == :published
+    end
+
     test "supersede at high confidence is applied by the executor (loser retired)", ctx do
       %{tenant: t, a: a, b: b} = ctx
 


### PR DESCRIPTION
Two defects that only matter because nobody is watching — which is now the operating assumption.

## 1. The silent black hole

The conflict executor requires `confidence == :high`. A `:supersede` or `:merge` recorded at `:medium` or `:low` therefore **never executes** — and because the row *exists*, it also drops out of `list_potential_conflicts/2` and out of Consolidation's `judged_pairs/1`.

It vanished from every surface while changing nothing: **not pending, not applied, not visible.** Forever.

That was survivable while a human might one day re-annotate it at high confidence. With no human, it's a permanent leak.

Such rows are now **closed as dismissed**, with an `execution_result` recording why, logged at `:warning` with a count. Both articles retained.

**Closing them rather than lowering the executor's bar to `:medium` is deliberate.** The confidence field exists precisely to say *"this judgement was not trusted."* Letting an untrusted judgement **retire an article** inverts its meaning. Dismissing touches no article row and is undone by re-annotating the pair at `:high`, which then executes normally. The reversible outcome is the only defensible default when nobody will adjudicate.

## 2. The promoter was sampling at random

The candidate query is capped at 500 **with no `ORDER BY`** — so it took whichever 500 rows the planner emitted first. The nightly promotion was a random sample of the candidate set, not the 500 most-similar pairs, letting the strongest redundancy signals sit unpromoted behind weaker ones indefinitely.

Now ordered by similarity descending. `article_links_potential_conflict_idx` already covers the expression, so it costs nothing.

## What I deliberately did NOT do

**Throttle the orphan re-link that feeds this**, despite flagging it earlier as a producer running ~50× the drain.

It re-links orphans at a lowered 0.5 threshold, which is the documented reason orphans stop being orphans at all — and its output is overwhelmingly *low*-similarity links that never become conflict candidates. With the drain now capped above the promotion rate (#601), the queue converges regardless of producer volume. Throttling would sacrifice orphan connectivity for no gain.

The measurement decides that, not the intuition I started with.

## Verification

**Mutation-verified:** disabling the closer fails the new test.

`mix precommit` green — **6875 tests, 0 failures**. One side-table `left: []` flake on the first run: that's the documented rare residual, this diff touches none of `vector_search.ex` / `heavy_read.ex` / `lib/loopctl/embeddings`, and the re-run was clean.

Also re-pointed three shifted `file:line` citations in the knowledge-wiki skill — `CheckSkillCitationsTest` caught them, for the second time today.
