### PR TITLE
Give the conflict pile one owner, and stop calling archive reversible

### DIFF
--- a/lib/loopctl/knowledge/bulk_ops.ex
+++ b/lib/loopctl/knowledge/bulk_ops.ex
@@ -27,9 +27,16 @@ defmodule Loopctl.Knowledge.BulkOps do
 
   ## Operations
 
-  - `archive/3` — `:draft`/`:published` → `:archived` (reversible; links left
-    intact but inert in published-only graph traversal, AC-27.12.3).
-  - `unpublish/3` — `:published` → `:draft` (reversible).
+  - `archive/3` — `:draft`/`:published` → `:archived`. **NOT reversible in code.** The row
+    is retained and links are left intact but inert in published-only graph traversal
+    (AC-27.12.3), so nothing is destroyed — but `Article`'s `@valid_transitions` has no
+    `{:archived, _}` entry and there is no unarchive function, so the ONLY way back is a
+    `user+` PATCH carrying an explicit status. An earlier version of this line called it
+    "reversible"; that was wrong for articles and is exactly the sentence an unattended
+    caller would rely on before archiving something it cannot restore.
+  - `unpublish/3` — `:published` → `:draft`. Genuinely reversible: `{:draft, :published}`
+    is a valid transition, so `publish/3` restores it. This is the primitive to reach for
+    when something automated needs to retract an article.
   - `delete/3` / `delete_with_token/3` — irreversible HARD delete. FK-correct:
     `article_links` (both directions, tenant-scoped) are deleted FIRST in the
     same transaction or the `:restrict` FK aborts; `article_access_events`

--- a/lib/loopctl/knowledge/consolidation.ex
+++ b/lib/loopctl/knowledge/consolidation.ex
@@ -7,8 +7,11 @@ defmodule Loopctl.Knowledge.Consolidation do
   articles involved and carrying a QUOTED excerpt from each as evidence. It writes
   its findings to `consolidation_reports` / `consolidation_proposals` and NOTHING
   else — no `articles`, `article_links` or `conflict_resolutions` write happens here.
-  Stage 2 runs it nightly with human approve/reject for calibration; stage 3 will
-  auto-apply only the class with a clean record.
+  There is no human approve/reject stage and there will not be one (#605 supersedes
+  #594): a queue whose only consumer is a human nobody staffs is the failure this
+  codebase has hit three separate times. Auto-apply is gated on REVERSIBILITY instead —
+  a class may apply itself when its write can be undone in code, which is checkable
+  without accumulating anyone's approvals.
 
   ## Why it consolidates published ARTICLES, not transcripts
 
@@ -26,12 +29,11 @@ defmodule Loopctl.Knowledge.Consolidation do
   re-scanning, and it never runs in a request path: the API endpoint reads the
   persisted rows.
 
-  ## The four defect classes
+  ## The three defect classes
 
   | Class | Signal |
   |---|---|
   | `:duplicate_capture` | two published articles whose titles collide once case/punctuation are normalized away, or whose `idempotency_key`s collide under the same normalization while differing verbatim (tag-format drift — novelty scoring and idempotency are separate paths, so the novelty gate does not catch it) |
-  | `:contradiction_candidate` | a SYSTEM-flagged (`auto_generated`) `potential_conflict` link between two PUBLISHED articles with no `conflict_resolutions` verdict yet — reported INTO the existing conflict machinery, never a parallel store |
   | `:generic_title` | a placeholder title, which collides on per-tenant active-title uniqueness and blocks hub creation |
   | `:stale_entry` | past the lint staleness threshold and never reconciled |
 
@@ -58,7 +60,7 @@ defmodule Loopctl.Knowledge.Consolidation do
   ## Where the reads run
 
   Every whole-corpus ENUMERATION here (the corpus count, the two normalization GROUP BYs,
-  the conflict-link scan, the judged-pair set, the placeholder-title regex scan) goes
+  the placeholder-title regex scan) goes
   through `Loopctl.HeavyRead` on the `:consolidation` endpoint, not straight through
   `AdminRepo`: those scans are unindexable by construction (they group on a
   `regexp_replace` expression) and `AdminRepo`'s pool is 3 connections shared with every
@@ -76,8 +78,6 @@ defmodule Loopctl.Knowledge.Consolidation do
   alias Loopctl.AdminRepo
   alias Loopctl.HeavyRead
   alias Loopctl.Knowledge.Article
-  alias Loopctl.Knowledge.ArticleLink
-  alias Loopctl.Knowledge.ConflictResolution
   alias Loopctl.Knowledge.ConsolidationProposal
   alias Loopctl.Knowledge.ConsolidationReport
 
@@ -142,7 +142,6 @@ defmodule Loopctl.Knowledge.Consolidation do
         {corpus_size(tenant_id),
          %{
            duplicate_capture: duplicate_captures(tenant_id, cap),
-           contradiction_candidate: contradiction_candidates(tenant_id, cap),
            generic_title: generic_titles(tenant_id, cap),
            stale_entry: stale_entries(tenant_id, lint_report, cap)
          }}
@@ -153,8 +152,15 @@ defmodule Loopctl.Knowledge.Consolidation do
     truncated =
       Map.new(found, fn {class, {total, items}} -> {to_string(class), total > length(items)} end)
 
+    # Drive the ORDER from the schema enum, but only over classes this pass still PRODUCES.
+    # The enum deliberately retains `:contradiction_candidate` so historical rows still load
+    # (see `ConsolidationProposal`), and a `Map.fetch!` over the full enum would raise on
+    # every run now that the class is retired. `Map.fetch!` is kept for the classes that ARE
+    # present, so a genuinely missing producer still fails loudly rather than silently
+    # emitting a short report.
     proposals =
       ConsolidationProposal.classes()
+      |> Enum.filter(&Map.has_key?(found, &1))
       |> Enum.flat_map(fn class -> found |> Map.fetch!(class) |> elem(1) end)
       |> Enum.with_index(1)
       |> Enum.map(fn {proposal, number} -> Map.put(proposal, :number, number) end)
@@ -301,7 +307,12 @@ defmodule Loopctl.Knowledge.Consolidation do
             "#{length(ids)} published articles are the same capture under #{reason} drift. " <>
               "The novelty gate does not catch this: novelty scoring and idempotency are separate paths.",
           suggested_action:
-            "Review the excerpts; keep the richest article and archive the rest, or merge them."
+            "Keep the richest article and UNPUBLISH the rest — do not archive them. " <>
+              "`:archived` is TERMINAL for an article: `Article`'s transition table has no " <>
+              "`{:archived, _}` and there is no unarchive function, so the only way back is a " <>
+              "`user+` PATCH carrying an explicit status. `{:published, :draft}` and " <>
+              "`{:draft, :published}` are both real transitions, so unpublish is the " <>
+              "reversible primitive and the only one an unattended pass may ever apply."
         )
       end)
 
@@ -359,80 +370,26 @@ defmodule Loopctl.Knowledge.Consolidation do
     |> Enum.map(fn %{ids: ids} -> {"idempotency-tag", ids} end)
   end
 
-  # Conflict-flagged pairs no agent has judged yet. Canonical (sorted) pair, matching
-  # how `conflict_resolutions` stores its verdicts, so an existing verdict in either
-  # link direction suppresses the proposal.
+  # `:contradiction_candidate` WAS a class here. It is not any more, and the reason is
+  # ownership rather than value.
   #
-  # The predicates MIRROR the conflict-resolution surface this proposal points at, because
-  # a proposal whose `suggested_action` the surface would refuse is a dead end the pass
-  # re-derives every night (nothing can record a verdict for it, so `judged_pairs/1` never
-  # suppresses it, and it permanently occupies one of the per-class slots):
+  # `Loopctl.Workers.KnowledgeLintWorker.judge_redundant_conflicts/1` now resolves exactly
+  # these pairs automatically, recording `classification: :redundant, disposition: :dismiss`
+  # — capped ABOVE the promotion rate so the queue converges. Proposing them here as well
+  # put two subsystems on one pile: one resolving it, the other re-reporting it nightly.
+  # That is the "second scheduler over the same corpus" failure #584 named, arrived at from
+  # the other direction.
   #
-  #   * `:potential_conflict` ONLY, and only SYSTEM-flagged (`auto_generated`) — the same
-  #     two predicates `Knowledge.validate_potential_conflict_exists/3` requires (else
-  #     `422 no_potential_conflict`) and `Knowledge.list_potential_conflicts/2` applies.
-  #     `:contradicts` is PUBLICLY creatable by an `:agent` key, so including it also let
-  #     an agent manufacture orchestrator-facing proposals at will.
-  #   * BOTH endpoints PUBLISHED — every other class derives from `published_base/1`, and
-  #     `archive_article/3` deliberately retains `article_links`, so without this an
-  #     archived article kept producing proposals (quoting its body) while `corpus_size`
-  #     excluded it: a proposal citing an article outside its own stated denominator.
-  defp contradiction_candidates(tenant_id, cap) do
-    pairs =
-      from(l in ArticleLink,
-        join: s in Article,
-        on: s.id == l.source_article_id,
-        join: t in Article,
-        on: t.id == l.target_article_id,
-        where: l.tenant_id == ^tenant_id,
-        where: s.tenant_id == ^tenant_id,
-        where: t.tenant_id == ^tenant_id,
-        where: l.relationship_type == :potential_conflict,
-        where: fragment("(?->>'auto_generated') = 'true'", l.metadata),
-        where: s.status == :published,
-        where: t.status == :published,
-        select: %{
-          source_article_id: l.source_article_id,
-          target_article_id: l.target_article_id
-        }
-      )
-      |> heavy_all(tenant_id)
-      |> Enum.map(fn %{source_article_id: s, target_article_id: t} -> Enum.sort([s, t]) end)
-      |> Enum.uniq()
-      |> Enum.sort()
-
-    judged = judged_pairs(tenant_id)
-    unjudged = Enum.reject(pairs, &MapSet.member?(judged, &1))
-
-    selected = Enum.take(unjudged, cap)
-    evidence_by_id = evidence_map(tenant_id, List.flatten(selected))
-
-    items =
-      Enum.map(selected, fn ids ->
-        build_proposal(:contradiction_candidate, ids, evidence_by_id,
-          severity: "warning",
-          rationale:
-            "These two articles are flagged as conflicting but carry no recorded verdict. " <>
-              "Compare the excerpts: a wrong rationale attached to a right conclusion reads as " <>
-              "correct until the two are quoted side by side.",
-          suggested_action:
-            "Record a conflict resolution for the pair (dismiss / supersede / merge) via the " <>
-              "existing conflict-resolution surface — this pass records no verdict."
-        )
-      end)
-
-    {length(unjudged), items}
-  end
-
-  defp judged_pairs(tenant_id) do
-    from(r in ConflictResolution,
-      where: r.tenant_id == ^tenant_id,
-      select: {r.source_article_id, r.target_article_id}
-    )
-    |> heavy_all(tenant_id)
-    |> Enum.map(fn {s, t} -> Enum.sort([s, t]) end)
-    |> MapSet.new()
-  end
+  # MEASURED on the hosted corpus 2026-08-05, in the run that settled this: of 16,340
+  # proposals emitted, 15,588 were `:contradiction_candidate` — 95% of the report was a
+  # re-derivation of the set the judge drains, truncated at the per-class cap and
+  # re-derived identically the next night. The remaining classes (390 duplicate_capture,
+  # 361 stale_entry, 1 generic_title) are consolidation's actual work and were being
+  # crowded out of the report by it.
+  #
+  # If a future change wants consolidation to own conflicts again, MOVE the judge here
+  # rather than adding a second proposer: the invariant is one writer per pile, not one
+  # location.
 
   # Same Unicode-aware normalization as the drift groups: under the ASCII-only class
   # "設計ドキュメント Draft" normalized to "draft" and was flagged as a placeholder title.

--- a/lib/loopctl/knowledge/consolidation_proposal.ex
+++ b/lib/loopctl/knowledge/consolidation_proposal.ex
@@ -43,6 +43,12 @@ defmodule Loopctl.Knowledge.ConsolidationProposal do
 
   @type t :: %__MODULE__{}
 
+  # `:contradiction_candidate` is RETIRED as of #605 — no longer produced by
+  # `Consolidation.analyze/3`, because `KnowledgeLintWorker.judge_redundant_conflicts/1`
+  # now owns that pile and resolves it automatically. The value STAYS in this enum: reports
+  # persisted before the change carry proposals with that class, and dropping the value
+  # would make `Ecto.Enum` fail to LOAD those historical rows. A retired class and a deleted
+  # one are different things, and only one of them is safe on a table with history.
   @classes [:duplicate_capture, :contradiction_candidate, :generic_title, :stale_entry]
   @review_statuses [:pending, :approved, :rejected]
 

--- a/lib/loopctl_web/controllers/knowledge_consolidation_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_consolidation_controller.ex
@@ -40,10 +40,9 @@ defmodule LoopctlWeb.KnowledgeConsolidationController do
         "normalized away, or idempotency keys that collide under the same normalization " <>
         "while differing verbatim: capture tag-format drift, which the novelty gate does " <>
         "not catch because novelty scoring and idempotency are separate paths); " <>
-        "`contradiction_candidate` (a SYSTEM-flagged `potential_conflict` pair of PUBLISHED " <>
-        "articles with no recorded verdict — the same predicates the conflict-resolution " <>
-        "surface itself requires, so a proposal never names a pair that surface would " <>
-        "refuse; reported into that surface, not a parallel store); " <>
+        "`contradiction_candidate` (RETIRED as of #605 and no longer produced — the nightly " <>
+        "lint now judges those pairs automatically; historical reports may still carry the " <>
+        "class); " <>
         "`generic_title` (a placeholder title that collides on active-title uniqueness " <>
         "and blocks hub creation); `stale_entry` (past the lint staleness threshold and " <>
         "never reconciled).\n\n" <>

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -5201,11 +5201,15 @@ const TOOLS = [
   {
     name: "knowledge_archive",
     description:
-      "Archive an article (soft delete). The article is hidden from search, context, " +
-      "and the index but the row is retained for audit/history (reversible — re-publish " +
-      "or edit it back). Works for drafts and published articles. Agent role — KB-content " +
-      "curation. Visibility-scoped: you can only archive an article you can see, so " +
-      "another agent's private/owner memory returns 404.",
+      "Archive an article (soft delete). The article is hidden from search, context, and " +
+      "the index but the row is retained for audit/history. NOT reversible by you: " +
+      "`:archived` is a TERMINAL article status — there is no unarchive call and no " +
+      "{archived -> anything} transition, so restoring one needs a user-role PATCH with an " +
+      "explicit status. Nothing is destroyed, but do not reach for this as an undoable " +
+      "action. If you want a RETRACTION you can undo, use knowledge_unpublish (published " +
+      "-> draft) and knowledge_publish to put it back. Works for drafts and published " +
+      "articles. Agent role — KB-content curation. Visibility-scoped: you can only archive " +
+      "an article you can see, so another agent's private/owner memory returns 404.",
     inputSchema: {
       type: "object",
       properties: {

--- a/test/loopctl/knowledge/consolidation_test.exs
+++ b/test/loopctl/knowledge/consolidation_test.exs
@@ -226,116 +226,34 @@ defmodule Loopctl.Knowledge.ConsolidationTest do
     end
   end
 
-  describe "analyze/3 — contradiction_candidate" do
-    test "proposes a conflict-flagged pair that carries no recorded verdict" do
+  describe "analyze/3 — contradiction_candidate is RETIRED (#605)" do
+    test "a conflict-flagged pair with no verdict is NOT proposed — the lint judge owns it" do
+      # This class used to be produced here. It is not any more: the nightly lint now
+      # resolves these pairs automatically (`judge_redundant_conflicts/1`, capped above the
+      # promotion rate so the queue converges), and proposing them here as well put two
+      # subsystems on one pile — one resolving it, the other re-reporting it nightly.
+      #
+      # Measured on the hosted corpus in the run that settled it: 15,588 of 16,340 proposals
+      # were this class, crowding the report's other 752 out of the per-class caps.
       tenant = fixture(:tenant)
       a = published(tenant.id, %{title: "Use Ecto.Multi", body: "Always wrap writes in Multi."})
-
-      b =
-        published(tenant.id, %{title: "Avoid Ecto.Multi", body: "Never wrap writes in Multi."})
-
+      b = published(tenant.id, %{title: "Avoid Ecto.Multi", body: "Multi is usually overkill."})
       system_conflict_link(tenant.id, a, b)
 
       {:ok, analysis} = Consolidation.analyze(tenant.id, %{})
 
-      assert [proposal] = proposals_of(analysis, :contradiction_candidate)
-      assert Enum.sort(proposal.article_ids) == Enum.sort([a.id, b.id])
-      excerpts = Enum.map(proposal.evidence, & &1["excerpt"])
-      assert Enum.any?(excerpts, &(&1 =~ "Always wrap writes"))
-      assert Enum.any?(excerpts, &(&1 =~ "Never wrap writes"))
-      assert proposal.suggested_action =~ "conflict resolution"
+      assert proposals_of(analysis, :contradiction_candidate) == [],
+             "the lint judge owns this pile; a second proposer re-reports what it resolves"
+
+      refute Map.has_key?(analysis.summary.by_class, "contradiction_candidate"),
+             "a retired class must not keep occupying a slot in by_class"
     end
 
-    test "does not propose a pair an agent already judged (either link direction)" do
-      tenant = fixture(:tenant)
-      a = published(tenant.id, %{title: "Use Ecto.Multi"})
-      b = published(tenant.id, %{title: "Avoid Ecto.Multi"})
-
-      system_conflict_link(tenant.id, a, b)
-
-      [source_id, target_id] = Enum.sort([a.id, b.id])
-
-      %ConflictResolution{tenant_id: tenant.id}
-      |> ConflictResolution.changeset(%{
-        source_article_id: source_id,
-        target_article_id: target_id,
-        classification: :contradictory,
-        disposition: :dismiss,
-        confidence: :high,
-        evidence: "Judged already.",
-        annotated_by: "agent-1",
-        annotated_at: DateTime.utc_now()
-      })
-      |> AdminRepo.insert!()
-
-      {:ok, analysis} = Consolidation.analyze(tenant.id, %{})
-
-      assert proposals_of(analysis, :contradiction_candidate) == []
-    end
-
-    # An agent-created `contradicts` link is NOT a pair the conflict-resolution surface
-    # accepts (`validate_potential_conflict_exists/3` 422s it), so a proposal naming it
-    # would instruct the reviewer to make a call that always fails — and, since no verdict
-    # can ever be recorded, would be re-derived every night forever.
-    test "does not propose an agent-creatable contradicts link" do
-      tenant = fixture(:tenant)
-      a = published(tenant.id, %{title: "Use Ecto.Multi"})
-      b = published(tenant.id, %{title: "Avoid Ecto.Multi"})
-
-      fixture(:article_link, %{
-        tenant_id: tenant.id,
-        source_article_id: a.id,
-        target_article_id: b.id,
-        relationship_type: :contradicts
-      })
-
-      {:ok, analysis} = Consolidation.analyze(tenant.id, %{})
-
-      assert proposals_of(analysis, :contradiction_candidate) == []
-      assert analysis.summary.by_class["contradiction_candidate"] == 0
-    end
-
-    # Same dead end for a stray / legacy potential_conflict with no system stamp — which is
-    # exactly what `Knowledge.list_potential_conflicts/2` refuses to surface (kb-02).
-    test "does not propose a potential_conflict link that is not SYSTEM-flagged" do
-      tenant = fixture(:tenant)
-      a = published(tenant.id, %{title: "Use Ecto.Multi"})
-      b = published(tenant.id, %{title: "Avoid Ecto.Multi"})
-
-      fixture(:article_link, %{
-        tenant_id: tenant.id,
-        source_article_id: a.id,
-        target_article_id: b.id,
-        relationship_type: :potential_conflict,
-        metadata: %{}
-      })
-
-      {:ok, analysis} = Consolidation.analyze(tenant.id, %{})
-
-      assert proposals_of(analysis, :contradiction_candidate) == []
-    end
-
-    # Archiving retains article_links by design, so without a status join the pass kept
-    # proposing over an archived article — and quoting its body — while `corpus_size`
-    # excluded it from the denominator the same report states.
-    test "does not propose a pair whose endpoint is archived, and never quotes its body" do
-      tenant = fixture(:tenant)
-      a = published(tenant.id, %{title: "Use Ecto.Multi", body: "Always wrap writes in Multi."})
-
-      b =
-        published(tenant.id, %{title: "Avoid Ecto.Multi", body: "SECRET archived reasoning."})
-
-      system_conflict_link(tenant.id, a, b)
-
-      b |> Ecto.Changeset.change(%{status: :archived}) |> AdminRepo.update!()
-
-      {:ok, analysis} = Consolidation.analyze(tenant.id, %{})
-
-      assert proposals_of(analysis, :contradiction_candidate) == []
-
-      refute Enum.any?(analysis.proposals, fn p ->
-               Enum.any?(p.evidence, &(&1["excerpt"] =~ "SECRET archived"))
-             end)
+    test "the class VALUE survives in the schema enum, so historical rows still load" do
+      # Retiring a class and deleting it are different things. Reports persisted before #605
+      # carry proposals with this class, and dropping the value from the Ecto.Enum would make
+      # those rows fail to LOAD — turning a docs change into a read outage on history.
+      assert :contradiction_candidate in ConsolidationProposal.classes()
     end
   end
 


### PR DESCRIPTION
First half of #605. Two corrections, both settled by a **manual run against the real corpus** rather than by reading the code.

## One owner per pile

Consolidation no longer proposes `:contradiction_candidate`. The nightly lint judge (#601) resolves exactly those pairs automatically, capped above the promotion rate so the queue converges. Proposing them here as well put **two subsystems on one pile** — one resolving it, the other re-reporting it nightly. That's the "second scheduler over one corpus" failure #584 named, arrived at from the other direction.

Measured in the run that settled it:

```
16,340 proposals emitted
  contradiction_candidate  15,588   ← 95%, truncated, re-derived identically every night
  duplicate_capture           390
  stale_entry                 361
  generic_title                 1
```

**95% of the report was a re-derivation of the set the judge drains** — and consolidation's actual work was being crowded out of its own per-class caps by it.

### The enum value stays

Reports persisted before this change carry proposals with that class. Dropping the value from the `Ecto.Enum` would make those rows fail to **load** — turning a docs change into a read outage on history. Retiring a class and deleting one are different things, and only one is safe on a table that has history.

The assembly loop now filters to classes the pass still produces, keeping `Map.fetch!` for the rest so a genuinely missing producer still fails loudly rather than silently emitting a short report.

## Archive is not reversible, and three places said it was

`Article`'s `@valid_transitions` has no `{:archived, _}` and there is no unarchive function. The only way back is a `user+` PATCH with an explicit status. Nothing is destroyed — but nothing **automated** can restore it either, which is the part that matters now.

Corrected in:
- `BulkOps`' moduledoc (`archive/3 — reversible`)
- the `knowledge_archive` MCP tool description (*"reversible — re-publish or edit it back"*)
- `:duplicate_capture`'s `suggested_action`, which now says **unpublish** — the genuinely reversible primitive — and says why

That last one is the sentence an unattended caller would rely on before archiving something it cannot bring back.

This also reverses consolidation's own stated bet that `:duplicate_capture` would be the first auto-apply candidate. It still can be — **but only as unpublish**, which is the second half of #605.

## Tests

Replaced, not deleted: one asserts the class is **no longer produced** (so re-adding a second proposer fails), one asserts the **enum value survives** (so dropping it fails).

`mix precommit` green — **6881 tests, 0 failures**. Net −109 lines.
