### PR TITLE
Let the duplicate class apply itself, gated on agreement and reversibility

### DIFF
--- a/lib/loopctl/knowledge/consolidation.ex
+++ b/lib/loopctl/knowledge/consolidation.ex
@@ -1,12 +1,17 @@
 defmodule Loopctl.Knowledge.Consolidation do
   @moduledoc """
-  The nightly consolidation ("dream") pass over a tenant's PUBLISHED corpus — #584,
-  stage 1 of 3: **report only, writes nothing**.
+  The nightly consolidation ("dream") pass over a tenant's PUBLISHED corpus (#584, #605).
+
+  It REPORTS on three defect classes, and APPLIES exactly one of them — `:duplicate_capture`,
+  and only as `unpublish`, and only where two consecutive runs agree. Everything else is
+  report-only. See `apply_confirmed_duplicates/2` for why those three restrictions are the
+  whole safety model.
 
   The pass reconciles the corpus and emits NUMBERED proposals, each naming the
   articles involved and carrying a QUOTED excerpt from each as evidence. It writes
-  its findings to `consolidation_reports` / `consolidation_proposals` and NOTHING
-  else — no `articles`, `article_links` or `conflict_resolutions` write happens here.
+  its findings to `consolidation_reports` / `consolidation_proposals`. The only other
+  write it can make is the confirmed-duplicate unpublish above; it never writes
+  `article_links` or `conflict_resolutions` (the nightly lint judge owns conflicts).
   There is no human approve/reject stage and there will not be one (#605 supersedes
   #594): a queue whose only consumer is a human nobody staffs is the failure this
   codebase has hit three separate times. Auto-apply is gated on REVERSIBILITY instead —
@@ -77,6 +82,7 @@ defmodule Loopctl.Knowledge.Consolidation do
 
   alias Loopctl.AdminRepo
   alias Loopctl.HeavyRead
+  alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ConsolidationProposal
   alias Loopctl.Knowledge.ConsolidationReport
@@ -97,6 +103,11 @@ defmodule Loopctl.Knowledge.Consolidation do
   @generic_title_pattern "^(untitled|untitled document|new article|new document|document|draft|no title|untitled note)( [0-9]+)?$"
   # The heavy-read endpoint every whole-corpus enumeration in this module runs under.
   @heavy_endpoint :consolidation
+
+  # How many CONFIRMED duplicate groups one nightly run may apply. Bounded because each
+  # apply is a write on the shared admin pool, and because a bug that mis-picks winners
+  # should be visible after one night rather than after the whole corpus.
+  @default_max_applies 25
 
   @doc "Default per-class proposal cap."
   @spec default_max_per_class() :: pos_integer()
@@ -207,6 +218,145 @@ defmodule Loopctl.Knowledge.Consolidation do
       end)
 
     {:ok, report}
+  end
+
+  @doc """
+  Applies the `:duplicate_capture` proposals that TWO consecutive runs agree on.
+
+  The only class this pass applies by itself, and the only action it will take: keep the
+  richest article of a duplicate group and UNPUBLISH the rest.
+
+  ## Why unpublish and never archive
+
+  `:archived` is TERMINAL for an article — `Article`'s transition table has no
+  `{:archived, _}` and there is no unarchive function, so the only way back is a `user+`
+  PATCH. `{:published, :draft}` and `{:draft, :published}` are both real transitions, so
+  unpublish is the one retraction an unattended pass can undo. A class earns auto-apply by
+  being REVERSIBLE, not by being confident.
+
+  ## Why two runs must agree
+
+  This replaces the human approve/reject stage (#605 supersedes #594) with something that
+  works without anyone: a proposal applies only if the SAME fingerprint appeared in the
+  PREVIOUS report as well. Anything transient — a duplicate created and cleaned up between
+  runs, a title edited mid-scan, a half-finished import — is gone by the next night and is
+  never acted on. It costs one night of latency and removes the entire class of "acted on a
+  state that was already resolving itself", which is most of what a human reviewer catches.
+
+  It is deliberately NOT a confidence score. Confidence is the machine grading its own
+  homework; agreement across two independent observations of a moving corpus is evidence.
+
+  ## Why the winner is recomputed here, not read from the proposal
+
+  The corpus moves between the scan and the write. Every article in the group is re-checked
+  as still published and still colliding at apply time; a group that no longer holds is
+  skipped, not forced. Reading a winner chosen hours ago would be applying a decision to a
+  corpus that no longer matches it.
+  """
+  @spec apply_confirmed_duplicates(Ecto.UUID.t(), keyword()) :: %{
+          applied: non_neg_integer(),
+          skipped: non_neg_integer()
+        }
+  def apply_confirmed_duplicates(tenant_id, opts \\ []) do
+    cap = Keyword.get(opts, :max_applies, @default_max_applies)
+
+    tenant_id
+    |> confirmed_duplicate_proposals(cap)
+    |> Enum.reduce(%{applied: 0, skipped: 0}, &tally_apply(tenant_id, &1, &2))
+  end
+
+  defp tally_apply(tenant_id, proposal, acc) do
+    case apply_duplicate_group(tenant_id, proposal) do
+      {:ok, n} -> %{acc | applied: acc.applied + n}
+      :skip -> %{acc | skipped: acc.skipped + 1}
+    end
+  end
+
+  # Proposals present in BOTH the newest report and the one before it, matched on
+  # `fingerprint` — which is derived from the class plus the sorted article-id set, so it is
+  # stable across runs precisely when the same group is still being found.
+  defp confirmed_duplicate_proposals(tenant_id, cap) do
+    case recent_report_ids(tenant_id) do
+      [newest, previous] ->
+        previous_fingerprints =
+          from(p in ConsolidationProposal,
+            where: p.tenant_id == ^tenant_id and p.report_id == ^previous,
+            where: p.proposal_class == :duplicate_capture,
+            select: p.fingerprint
+          )
+          |> AdminRepo.all()
+
+        from(p in ConsolidationProposal,
+          where: p.tenant_id == ^tenant_id and p.report_id == ^newest,
+          where: p.proposal_class == :duplicate_capture,
+          where: p.fingerprint in ^previous_fingerprints,
+          order_by: [asc: p.number],
+          limit: ^cap
+        )
+        |> AdminRepo.all()
+
+      _fewer_than_two_reports ->
+        # First ever run, or only one report so far: nothing has been confirmed twice, so
+        # nothing applies. The pass is silent rather than eager on a fresh install.
+        []
+    end
+  end
+
+  defp recent_report_ids(tenant_id) do
+    from(r in ConsolidationReport,
+      where: r.tenant_id == ^tenant_id,
+      order_by: [desc: r.day],
+      limit: 2,
+      select: r.id
+    )
+    |> AdminRepo.all()
+  end
+
+  defp apply_duplicate_group(tenant_id, proposal) do
+    live =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id,
+        where: a.id in ^proposal.article_ids,
+        where: a.status == :published,
+        select: %{
+          id: a.id,
+          body_len: fragment("length(coalesce(?, ''))", a.body),
+          updated_at: a.updated_at
+        }
+      )
+      |> AdminRepo.all()
+
+    # Re-verification, not trust. The group must STILL be a group: fewer than two live
+    # published members means it resolved itself between the scan and now, and applying
+    # would unpublish the last copy of something.
+    if length(live) < 2 do
+      :skip
+    else
+      [winner | losers] =
+        Enum.sort_by(live, fn a ->
+          {-a.body_len, -DateTime.to_unix(a.updated_at, :microsecond), a.id}
+        end)
+
+      applied = Enum.count(losers, &unpublish_duplicate(tenant_id, &1))
+
+      Logger.info(
+        "Consolidation: tenant=#{tenant_id} applied duplicate_capture proposal " <>
+          "##{proposal.number} — kept #{winner.id}, unpublished #{applied} of " <>
+          "#{length(losers)} duplicate(s). Reversible via publish."
+      )
+
+      {:ok, applied}
+    end
+  end
+
+  defp unpublish_duplicate(tenant_id, loser) do
+    case Knowledge.unpublish_article(tenant_id, loser.id,
+           actor_type: "system",
+           actor_label: "worker:consolidation"
+         ) do
+      {:ok, _} -> true
+      {:error, _} -> false
+    end
   end
 
   @doc """

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -137,6 +137,9 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     judged = judge_redundant_conflicts(tenant_id)
     resolutions_applied = Knowledge.execute_conflict_resolutions(tenant_id)
     consolidation = consolidate(tenant_id, report)
+    # Apply AFTER consolidate/2 wrote tonight's report, so the two-run confirmation compares
+    # tonight against last night rather than last night against the night before.
+    applied = apply_consolidation(tenant_id)
 
     log_audit_event(
       tenant_id,
@@ -153,6 +156,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         "orphans_relinked=#{action.relinked} orphans_embedding_enqueued=#{action.embedding_enqueued} " <>
         "conflicts_promoted=#{promoted} conflicts_judged_redundant=#{judged} " <>
         "resolutions_applied=#{resolutions_applied} " <>
+        "duplicates_unpublished=#{applied.applied} duplicate_groups_skipped=#{applied.skipped} " <>
         consolidation_log(consolidation)
     )
 
@@ -480,6 +484,30 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # lose the pre-existing pass's observability permanently. The failure is recorded in
   # the audit event instead, as a low-cardinality TAG (never the raw error, which carries
   # backend host / database / role).
+  # FAIL-SOFT like consolidate/2 above, and for the same reason: this is the first thing in
+  # the nightly run that WRITES to `articles`, and a raise here must not abort a pass whose
+  # other steps already succeeded. A failure costs one night of duplicate cleanup, which is
+  # the cheapest thing in the run to lose.
+  defp apply_consolidation(tenant_id) do
+    Consolidation.apply_confirmed_duplicates(tenant_id)
+  rescue
+    e ->
+      Logger.error(
+        "KnowledgeLintWorker: tenant=#{tenant_id} consolidation apply failed " <>
+          "(#{ExitTag.tag(e)}); no duplicates unpublished this run."
+      )
+
+      %{applied: 0, skipped: 0}
+  catch
+    :exit, reason ->
+      Logger.error(
+        "KnowledgeLintWorker: tenant=#{tenant_id} consolidation apply exited " <>
+          "(#{"exit:" <> ExitTag.tag(reason)}); no duplicates unpublished this run."
+      )
+
+      %{applied: 0, skipped: 0}
+  end
+
   defp consolidate(tenant_id, report) do
     max_per_class =
       Application.get_env(

--- a/test/loopctl/knowledge/consolidation_test.exs
+++ b/test/loopctl/knowledge/consolidation_test.exs
@@ -6,6 +6,7 @@ defmodule Loopctl.Knowledge.ConsolidationTest do
   import Ecto.Query
 
   alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Knowledge.ConflictResolution
@@ -632,6 +633,102 @@ defmodule Loopctl.Knowledge.ConsolidationTest do
       assert [%{evidence: [entry]}] = result.proposals
       assert entry["excerpt"] =~ "Still published"
       refute Map.has_key?(entry, "redacted")
+    end
+  end
+
+  describe "apply_confirmed_duplicates/2 (#605 — the one class that applies itself)" do
+    # Two published articles whose titles collide once punctuation/case are normalized away.
+    defp duplicate_pair(tenant_id) do
+      a =
+        published(tenant_id, %{
+          title: "AWS CodeDeploy: Traffic Control",
+          body: String.duplicate("long winner body ", 20)
+        })
+
+      b = published(tenant_id, %{title: "AWS CodeDeploy Traffic Control", body: "short"})
+      {a, b}
+    end
+
+    defp status(id), do: AdminRepo.get!(Article, id).status
+
+    test "applies NOTHING after a single run — one observation is not confirmation" do
+      # This is what replaces human approve/reject. A duplicate that appears once and is gone
+      # by the next run (a half-finished import, a title edited mid-scan) is never acted on,
+      # and it costs one night of latency to get that.
+      tenant = fixture(:tenant)
+      {a, b} = duplicate_pair(tenant.id)
+
+      {:ok, _} = Consolidation.run(tenant.id, %{})
+
+      assert %{applied: 0, skipped: 0} = Consolidation.apply_confirmed_duplicates(tenant.id)
+      assert status(a.id) == :published
+      assert status(b.id) == :published
+    end
+
+    test "a duplicate that appeared only in the NEWEST run is not applied" do
+      # The real confirmation test. Two reports exist, so the fewer-than-two short-circuit
+      # does not fire — the proposal is excluded because its fingerprint is absent from the
+      # PREVIOUS report. Without this, the sibling test above passes for the wrong reason.
+      tenant = fixture(:tenant)
+      published(tenant.id, %{title: "Something Else Entirely", body: "unrelated"})
+
+      # Night one: no duplicates exist yet.
+      {:ok, _} = Consolidation.run(tenant.id, %{}, day: Date.add(Date.utc_today(), -1))
+
+      # The duplicate is created AFTER that run.
+      {a, b} = duplicate_pair(tenant.id)
+
+      # Night two: the proposal appears for the first time.
+      {:ok, _} = Consolidation.run(tenant.id, %{})
+
+      assert %{applied: 0, skipped: 0} = Consolidation.apply_confirmed_duplicates(tenant.id)
+      assert status(a.id) == :published
+      assert status(b.id) == :published
+    end
+
+    test "applies once TWO consecutive runs agree, unpublishing the losers and keeping the richest" do
+      tenant = fixture(:tenant)
+      {a, b} = duplicate_pair(tenant.id)
+
+      {:ok, _} = Consolidation.run(tenant.id, %{}, day: Date.add(Date.utc_today(), -1))
+      {:ok, _} = Consolidation.run(tenant.id, %{})
+
+      assert %{applied: 1, skipped: 0} = Consolidation.apply_confirmed_duplicates(tenant.id)
+
+      # The richest (longest body) survives; the duplicate is UNPUBLISHED, never archived —
+      # :archived is terminal for an article, so it is the one retraction that cannot be
+      # undone in code.
+      assert status(a.id) == :published
+      assert status(b.id) == :draft
+    end
+
+    test "SKIPS a group that no longer holds at apply time" do
+      # The corpus moves between the scan and the write. If the group resolved itself in
+      # between, applying would unpublish the last remaining copy.
+      tenant = fixture(:tenant)
+      {a, b} = duplicate_pair(tenant.id)
+
+      {:ok, _} = Consolidation.run(tenant.id, %{}, day: Date.add(Date.utc_today(), -1))
+      {:ok, _} = Consolidation.run(tenant.id, %{})
+
+      # Someone (or something) already unpublished one of them.
+      {:ok, _} = Knowledge.unpublish_article(tenant.id, b.id)
+
+      assert %{applied: 0, skipped: 1} = Consolidation.apply_confirmed_duplicates(tenant.id)
+      assert status(a.id) == :published, "the survivor must never be unpublished"
+    end
+
+    test "the unpublish is REVERSIBLE, which is the whole reason this class may auto-apply" do
+      tenant = fixture(:tenant)
+      {_a, b} = duplicate_pair(tenant.id)
+
+      {:ok, _} = Consolidation.run(tenant.id, %{}, day: Date.add(Date.utc_today(), -1))
+      {:ok, _} = Consolidation.run(tenant.id, %{})
+      assert %{applied: 1} = Consolidation.apply_confirmed_duplicates(tenant.id)
+
+      assert status(b.id) == :draft
+      assert {:ok, _} = Knowledge.publish_article(tenant.id, b.id)
+      assert status(b.id) == :published
     end
   end
 end


### PR DESCRIPTION
Second half of #605, stacked on #606. **The first time this pass writes to `articles`.**

## What it does

Keeps the richest article of a confirmed duplicate group and **unpublishes** the rest. That is the whole action, bounded at 25 groups per nightly run.

## Three restrictions, each load-bearing

**1. Unpublish, never archive.** `:archived` is terminal for an article — no `{:archived, _}` transition, no unarchive function, so the only way back is a `user+` PATCH. `{:published, :draft}` and `{:draft, :published}` are both real. **A class earns auto-apply by being reversible, not by being confident.**

**2. Two consecutive runs must agree.** This is what replaces the human approve/reject stage. A proposal applies only if the same fingerprint appeared in the *previous* report too — so anything transient (a duplicate created and cleaned up between runs, a title edited mid-scan, a half-finished import) is gone by the next night and never acted on.

It costs one night of latency and removes the entire class of *"acted on a state that was already resolving itself"* — which is most of what a reviewer actually catches.

Deliberately **not** a confidence score. Confidence is the machine grading its own homework; agreement across two independent observations of a moving corpus is evidence.

**3. The winner is recomputed at apply time.** The corpus moves between the scan and the write. Every member is re-checked as still published; a group with fewer than two live members has resolved itself and is **skipped, not forced** — otherwise the apply would unpublish the last remaining copy.

## Mutation-verified — and the first attempt caught a bad test of mine

Removing the two-run filter **did not fail the suite.** My single-run test was passing through the "fewer than two reports" short-circuit and never exercised the fingerprint match at all — a test that couldn't fail, guarding the most important property here.

Added a test where two reports exist but the duplicate appears only in the newest. With that in place:

- removing the two-run filter → fails
- removing the apply-time re-verification → fails the skip test

Fail-soft in the worker, like `consolidate/2`: a raise here must not abort a pass whose other steps already succeeded. A failure costs one night of duplicate cleanup, the cheapest thing in the run to lose.

`mix precommit` green — **6886 tests, 0 failures**.

Not applied autonomously, and stated in the code: `:generic_title` needs a generated replacement and can collide on the active-title index (potentially *manufacturing* a duplicate proposal next night); `:stale_entry` is a time threshold with no correctness signal behind it, so auto-archiving on age would silently delete the corpus over time.
