### PR TITLE
Scope four predicates that were correct only by accident

### DIFF
--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -44,9 +44,9 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:509-515`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:463-466`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8579`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:8595`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
-   (`absolute_score/1`, `:8706-8711`) clears a scale-matched threshold AND beats the best retrieved
+   (`absolute_score/1`, `:8722-8727`) clears a scale-matched threshold AND beats the best retrieved
    candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:8646-8656`; the pure decision is
    `resolve_provenance/4`, `:8699-8710`) AND is authoritative (not superseded/conflicted — the caller
    passes only `list_curated_sources/2`-filtered scores). Otherwise `:retrieved`. Both branches return identical `results`/`meta`
@@ -67,7 +67,7 @@ never pass `tenant_id`/`subject_id`.
    `drafts`/`publish` are `:orchestrator` (`:33`).
    Agent edits are visibility-scoped: an agent can only touch an article it can see. (See `chain-of-custody`.)
 5. **Heat must not rank on a signal heat produces** — `Knowledge.heat_index/2`
-   (`knowledge.ex:9220`; the counted set is `@heat_read_access_types`, `:8979`). The heat index is the one retrieval route that
+   (`knowledge.ex:9236`; the counted set is `@heat_read_access_types`, `:8979`). The heat index is the one retrieval route that
    takes NO query, so its misses are uncorrelated with embedding similarity — which is worth nothing
    if its ordering is something a caller or the route itself generates. It has been violated FOUR
    times, each differently — and once by a FIX for one of the others — so treat any new input to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,10 @@ mix ecto.reset         # Drop, create, migrate
 ## Key Documents
 
 - **PRD**: `docs/prd.md` — full product requirements
+- **Research notes**: `docs/research/*.md` — the reasoning behind a design, kept because it
+  outlives the code. Prior art, what was measured, and what was rejected and why. Read the
+  relevant one before redesigning a subsystem it covers; a decision reversed without its
+  rationale tends to get re-reversed.
 - **User Stories**: `docs/user_stories/epic_N_name/us_N.M.json` — one file per story, one folder per epic
 - **Orchestration skills**: `skills/loopctl-*.md` — the orchestration LOOP itself (dispatch, review, verify)
 - **Domain skills**: `.claude/skills/<domain>/SKILL.md` — code-map + invariants skills, loaded when you touch that domain (routing table below). Distinct from the `skills/loopctl-*.md` orchestration skills above.

--- a/docs/research/autonomous-corpus-consolidation.md
+++ b/docs/research/autonomous-corpus-consolidation.md
@@ -1,0 +1,240 @@
+# Autonomous corpus consolidation: the prior art, and what loopctl actually built
+
+Research notes behind the nightly consolidation pass (#584, #605) — the "dream." Written
+after the 2026-08-05 session that made the machinery self-draining, and kept because the
+reasoning is more reusable than the code.
+
+The short version: **the idea is old, the failure mode is specific, and the escape from it
+is reversibility rather than intelligence.**
+
+---
+
+## 1. Why a corpus needs a dream at all
+
+A knowledge base written by many agents, continuously, degrades in ways none of the writers
+can see. Each write is locally correct. The damage is emergent:
+
+- the same knowledge captured twice under slightly different titles
+- a wrong rationale attached to a right conclusion, which reads as correct until the two are
+  quoted side by side
+- entries that were true and quietly stopped being true
+- placeholder titles that block structure from forming
+
+None of these is detectable at write time, which is exactly why an offline pass exists.
+Anthropic ships consolidation as an offline batch for managed agents for the same reason.
+
+---
+
+## 2. The prior art, oldest first
+
+### Complementary Learning Systems (1995)
+
+McClelland, McNaughton & O'Reilly. The hippocampus learns fast and episodically; the
+neocortex learns slowly and structurally; **replay during sleep** transfers between them.
+This is the direct biological ancestor of "dream," and it exists to answer a specific
+problem: McCloskey & Cohen's **catastrophic forgetting** (1989), where naive sequential
+learning destroys what came before.
+
+The load-bearing detail people skip: CLS replay is not cleanup. It is *interleaved replay to
+extract structure* — the neocortex generalises across episodes. A pass that only removes
+duplicates is doing hygiene, not consolidation.
+
+### Wake-Sleep (1995)
+
+Hinton, Dayan, Frey & Neal named the two phases outright. A wake phase that acts, a sleep
+phase that reorganises what the wake phase produced.
+
+### Experience replay (1992 → present)
+
+Lin (1992), then DQN (Mnih et al., 2015). **Prioritised experience replay** (Schaul et al.,
+2016) adds the rule a nightly pass should steal: *replay what is surprising*, not everything.
+Our pass currently scans the whole corpus every night, which is the un-prioritised version.
+
+### Generative replay (2017)
+
+Shin et al. — replay generated samples rather than stored ones, to consolidate without
+keeping the raw data. Relevant to the transcript question below.
+
+### Agent memory (2023 → present)
+
+- **Generative Agents** (Park et al.) — a memory stream plus a periodic **reflection** step
+  that synthesises higher-level insights. This is the closest published analogue to what
+  loopctl calls consolidation.
+- **MemGPT** (Packer et al.) — hierarchical memory with paging between context and store.
+- **Reflexion** (Shinn et al.) — self-critique written back into episodic memory.
+
+### The two older fields that matter more
+
+**Record linkage — Fellegi & Sunter (1969).** The formal treatment of duplicate detection,
+and it makes a *three-way* decision: match, non-match, and **possible match requiring
+clerical review**. Thresholds are tuned to bound both error rates, and the middle zone is
+where a human goes.
+
+That middle zone is exactly loopctl's 16,117 flagged pairs. We have no clerical reviewer, so
+we escape the zone a different way — see §4.
+
+**Belief revision — Doyle's Truth Maintenance Systems (1979) and the AGM postulates
+(Alchourrón, Gärdenfors & Makinson, 1985).** The formal theory of what to do when new
+information contradicts what you already hold. AGM's *minimal change* principle is arguably
+what a `:supersede` disposition should obey, and currently does not.
+
+**Wikipedia's bot policy** — the operational precedent nobody cites. Autonomous corpus
+maintenance at scale, solved empirically: bots must be approved, rate-limited, run a trial
+period, and **every action must be revertible by the community**. They arrived at
+reversibility-as-licence independently, from experience rather than theory.
+
+---
+
+## 3. The failure mode we actually hit
+
+Every defect found in the 2026-08-05 audit was the same shape: **a producer with no
+consumer.**
+
+| Queue | Producers | Automatic consumers |
+|---|---|---|
+| drafts | 7 | 0 |
+| `potential_conflict` | 2 | 0 — monotone by construction |
+| `:supersede` below `:high` confidence | 1 | 0 — invisible *and* unexecutable |
+
+In all three the imagined consumer was a human, and the human never came. Measured
+consequences: 16,117 open conflicts that had **never** produced a single resolution in the
+corpus's lifetime; 81 published articles unsearchable for six weeks while an hourly
+reconciler reported healthy; 26 stranded drafts, two of which arrived *during* the audit.
+
+The lesson is not "humans are needed." It is the opposite: **the human was already absent,
+and the system was designed as though they weren't.** "Approve before write" was not a safety
+property, it was an unfunded liability, and the corpus degraded precisely *because* it was
+waiting.
+
+---
+
+## 4. What replaces the reviewer
+
+Three substitutions, in the order they matter.
+
+### Reversibility instead of approval
+
+A reviewer's real job in "approve before write" is to be the safety mechanism for an
+**irreversible** act. Make the act reversible and the requirement dissolves.
+
+This is why the archive-vs-unpublish distinction turned out to be the load-bearing detail of
+the whole design, not the proposal logic: `:archived` is terminal for an article, so nothing
+automated can undo it; `{:published, :draft}` is reversible, so an unattended pass may use
+it. **A class earns auto-apply by being reversible, not by being confident.**
+
+It is also the same conclusion Wikipedia's bot policy reaches.
+
+### Agreement instead of confidence
+
+A proposal applies only when **two consecutive runs** independently produce it. Anything
+transient — a duplicate created and cleaned up between runs, a title edited mid-scan, a
+half-finished import — is gone by the next night and is never acted on.
+
+This is deliberately *not* a confidence score. Confidence is the machine grading its own
+homework. Agreement across two independent observations of a moving corpus is evidence. It
+costs one night of latency and removes most of what a reviewer actually catches.
+
+### Honesty instead of fabricated verdicts
+
+The worst defect found was not a missing human. It was the machine **claiming a judgement it
+could not make**.
+
+`potential_conflict` was promoted on cosine similarity ≥ 0.93. Similarity says *"these say
+the same thing."* Contradiction says *"these disagree."* Those are orthogonal — a flat
+contradiction scores high, but so does every honest restatement — so a similarity threshold
+cannot separate them.
+
+Measured across all 16,117 flagged pairs: 0 identical bodies, 261 identical normalised
+titles, 54% within 10% body length. A 20-pair sample spanning 0.93–0.99 contained **zero**
+contradictions. The top matches differed by a colon, a hyphen, a percent sign and a plural.
+
+It was **redundancy**, mislabelled as disagreement — and the consequence was inverted: an
+open conflict suppressed *both* its articles from curated answers, so the system withheld its
+most-corroborated content. The fix was to record `classification: :redundant`, which the
+schema already had vocabulary for and the promoter had never used.
+
+**An autonomous system fails when it fabricates verdicts. It works when it records what it
+actually measured.**
+
+### Convergence as arithmetic
+
+The drain is capped *above* the producer (2,000 judged vs 500 promoted per night), so the
+backlog falls rather than holding at whatever level it reached. That is subtraction, not
+judgement, and it is the only part of the design that needs no reasoning to verify.
+
+---
+
+## 5. The transcript question, and why it stayed client-side
+
+Consolidation can only reconcile what is *in* the corpus, but session transcripts live on
+the machines that produce them. Two options:
+
+(a) capture keeps extracting client-side; the pass consolidates published articles only
+(b) capture ships raw transcript excerpts server-side; the server does extraction *and*
+    consolidation
+
+**(a), decided deliberately.** A 2026-08-04 harvest found live API keys sitting in raw
+source material, so shipping transcripts server-side is an egress decision to be made on its
+own merits — not inherited as a side effect of a consolidation feature. (a) is also the
+reversible direction: (b) remains available later, while an accidental (b) cannot be undone.
+
+Generative replay (§2) is the research answer to wanting (b)'s benefits without its risk.
+
+---
+
+## 6. Where this is still thin
+
+**The classes that are cheap to detect are the ones that matter least.** Duplicates dominate
+by volume and are trivially findable. The defect that motivated the whole feature — a *wrong
+rationale attached to a right conclusion* — has **no detector at all**, because it reads as
+perfectly consistent prose and similarity cannot see it.
+
+**Nothing generalises.** Per CLS, consolidation's real function is extracting structure
+across episodes. Our pass removes duplicates and closes conflicts; nothing reads N related
+articles and produces the abstraction they share. That is the actual dream, still unbuilt.
+
+**The scan is un-prioritised.** 79,250 articles scanned nightly to find ~750 things, two of
+the three scans `GROUP BY regexp_replace(...)` and therefore unindexable. Prioritised replay
+says scan the *delta* and what is surprising — which would turn a 79k scan into roughly 250
+rows and stop the cost growing with the corpus.
+
+**A time threshold is not a correctness signal.** `:stale_entry` produces hundreds of
+proposals a night that nothing can ever act on: "nobody edited this in N days" says nothing
+about whether it is wrong, and auto-archiving on age would silently delete the corpus. It is
+a fourth queue with no consumer, just slower to notice.
+
+---
+
+## 7. What to steal from this
+
+1. **Count your producers and consumers.** A queue whose only consumer is a human nobody
+   staffs is not a safety mechanism, it is a leak. This codebase had three simultaneously.
+2. **Check what your signal actually measures** before naming the class it produces. The
+   name outlives the check.
+3. **Make the act reversible and the approval becomes optional.** Reach for the reversible
+   primitive even when the terminal one is more satisfying.
+4. **Two independent observations beat one confident one**, and cost only latency.
+5. **Measure before fixing.** In one session, measurement killed three fixes that were
+   confidently designed and would have been shipped: a lint result-set bound (the "unbounded"
+   scan was ~500 rows), a producer throttle (its output never reached the consumer), and a
+   claim that 32k article-slots were being actively withheld (the curated set was empty, so
+   the harm was latent rather than live).
+
+---
+
+## References
+
+- McCloskey & Cohen (1989), *Catastrophic Interference in Connectionist Networks*
+- Doyle (1979), *A Truth Maintenance System*
+- Alchourrón, Gärdenfors & Makinson (1985), the AGM postulates for belief revision
+- Fellegi & Sunter (1969), *A Theory for Record Linkage*
+- McClelland, McNaughton & O'Reilly (1995), *Why there are complementary learning systems in
+  the hippocampus and neocortex*
+- Hinton, Dayan, Frey & Neal (1995), *The Wake-Sleep Algorithm for Unsupervised Neural
+  Networks*
+- Lin (1992), experience replay; Mnih et al. (2015), DQN; Schaul et al. (2016), *Prioritized
+  Experience Replay*
+- Shin et al. (2017), *Continual Learning with Deep Generative Replay*
+- Park et al. (2023), *Generative Agents* — the reflection mechanism
+- Packer et al. (2023), *MemGPT*; Shinn et al. (2023), *Reflexion*
+- Wikipedia: Bot policy / Bot Approvals Group — the operational precedent

--- a/lib/loopctl/embeddings.ex
+++ b/lib/loopctl/embeddings.ex
@@ -1917,6 +1917,11 @@ defmodule Loopctl.Embeddings do
         where:
           not exists(
             from(ae in ArticleEmbedding,
+              # Tenant-scoped like every sibling anti-join here. Not exploitable today (the
+              # outer scan is already tenant-owned articles), but the failure direction is a
+              # FALSE NEGATIVE — an article wrongly classed "already embedded" and left
+              # unsearchable, which is the exact defect this function exists to close.
+              where: ae.tenant_id == ^tenant_id,
               where: ae.article_id == parent_as(:article).id,
               select: 1
             )

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -3162,18 +3162,22 @@ defmodule Loopctl.Knowledge do
   end
 
   @doc """
-  Authoritative-curated check for a single article (AC-31.1.4).
+  Authoritative-curated check for a single article (AC-31.1.4), from ONE tenant's view.
 
-  Unlike the pure `curated?/1` (status + marker only), this additionally excludes
-  an article that is in an OPEN `:potential_conflict` — such an article is NOT
-  treated as authoritative until the conflict is surfaced/resolved. Does a DB lookup
-  for the open conflict, correlated on the article's globally-unique id. Works for
-  BOTH tenant articles and system canonicals (`tenant_id == nil`) — the latter is the
-  exact input AC-31.1.3 requires to participate as curated.
+  Unlike the pure `curated?/1` (status + marker only), this additionally excludes an article
+  that is in an OPEN `:potential_conflict` — such an article is NOT treated as authoritative
+  until the conflict is resolved. Works for BOTH tenant articles and system canonicals
+  (`tenant_id == nil`), which AC-31.1.3 requires to participate as curated.
+
+  `tenant_id` is the tenant ASKING, and it is required rather than derived from the article
+  because for a system canonical there is nothing to derive it from — the canonical is shared
+  and its own `tenant_id` is NULL. "Is this authoritative?" is only answerable relative to a
+  viewer: a conflict raised by one tenant must never change what another tenant sees of the
+  shared canon.
   """
-  @spec authoritative_curated?(Article.t()) :: boolean()
-  def authoritative_curated?(%Article{} = article) do
-    curated?(article) and not article_in_open_conflict?(article)
+  @spec authoritative_curated?(Article.t(), Ecto.UUID.t()) :: boolean()
+  def authoritative_curated?(%Article{} = article, tenant_id) when is_binary(tenant_id) do
+    curated?(article) and not article_in_open_conflict?(article, tenant_id)
   end
 
   # TRUE when the article is a member of an unresolved auto-generated
@@ -3184,7 +3188,7 @@ defmodule Loopctl.Knowledge do
   # unique across tenants, so id-only correlation is exactly as scoped as an id+tenant
   # filter would be while also participating for system articles (AC-31.1.3). Mirrors
   # open_conflict_subquery/0 and shares conflict_unresolved_subquery/0.
-  defp article_in_open_conflict?(%Article{id: article_id}) do
+  defp article_in_open_conflict?(%Article{id: article_id}, tenant_id) do
     # The SAME fail-open window as `open_conflict_subquery/1` — see the long note there for
     # why suppression expires. These are two separate predicates serving one invariant (the
     # per-article authority check and the list query), so the window MUST be applied to both
@@ -3196,6 +3200,18 @@ defmodule Loopctl.Knowledge do
     query =
       from(l in ArticleLink,
         as: :link,
+        # SCOPED TO THE ASKING TENANT, matching `open_conflict_subquery/1`. Article ids are
+        # GLOBAL, so correlating on the id alone let ANY tenant's conflict link answer this
+        # question — and for a shared system canonical that is a live cross-tenant
+        # suppression: one tenant flags the canonical, every other tenant loses it from
+        # authoritative answers for the whole window, silently and with no audit event.
+        #
+        # The earlier comment claimed the scope could not be added because pinning a nil
+        # `tenant_id` trips Ecto's nil-comparison guard. That confused two different things:
+        # the NULL is on the shared ARTICLE, never on the LINK. A link always belongs to
+        # exactly one tenant, so scoping the link is unblocked — which is why the sibling
+        # subquery has always done it.
+        where: l.tenant_id == ^tenant_id,
         where: l.relationship_type == :potential_conflict,
         where: fragment("(?->>'auto_generated') = 'true'", l.metadata),
         where: l.source_article_id == ^article_id or l.target_article_id == ^article_id,

--- a/lib/loopctl/workers/article_embedding_worker.ex
+++ b/lib/loopctl/workers/article_embedding_worker.ex
@@ -54,7 +54,12 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
   use Oban.Worker,
     queue: :embeddings,
     max_attempts: 4,
-    unique: [keys: [:article_id], period: 300],
+    # `:tenant_id` is part of the key, not just `:article_id`. Article ids are GLOBAL, and a
+    # SYSTEM canonical is enumerated for re-embedding by EVERY tenant — so keying on the id
+    # alone made two tenants' repair jobs collide inside the 300s window, deduping one away
+    # or (with `replace:` below) overwriting its args. `SystemCorpusEmbeddingWorker` already
+    # keys on `[:tenant_id, :dim]` for the same reason.
+    unique: [keys: [:tenant_id, :article_id], period: 300],
     replace: [scheduled: [:args, :scheduled_at]]
 
   require Logger

--- a/lib/loopctl/workers/embedding_reconciliation_worker.ex
+++ b/lib/loopctl/workers/embedding_reconciliation_worker.ex
@@ -136,8 +136,33 @@ defmodule Loopctl.Workers.EmbeddingReconciliationWorker do
     active = Embeddings.active_dimension(tenant_id)
     batch = 100
 
-    articles = Embeddings.pending_reembed_articles(tenant_id, active, batch)
+    # System canonicals are FILTERED OUT, not enqueued. `pending_reembed_articles/3`
+    # deliberately returns them (a canonical is materialized per tenant on the EMBEDDING
+    # row, so it is genuinely this tenant's gap) — but `ArticleEmbeddingWorker` resolves its
+    # article with `a.tenant_id == ^tenant_id`, which a canonical's NULL tenant can never
+    # satisfy. It returned `{:error, :not_found}`, which `embed/2` maps to `:ok` as "article
+    # deleted", so the job SUCCEEDED, repaired nothing, and re-enqueued every hour forever.
+    #
+    # That is precisely the failure this worker's own moduledoc describes closing — ran
+    # hourly, reported healthy, fixed nothing — reproduced one class over. Canonicals have
+    # their own repair path (`SystemCorpusEmbeddingWorker` /
+    # `Embeddings.stale_system_articles/3`); routing them there is correct, and widening
+    # `get_article_with_embedding/2` instead would re-open the global-slot clobber that
+    # `own_tenant_article?/2` exists to prevent.
+    {articles, canonicals} =
+      tenant_id
+      |> Embeddings.pending_reembed_articles(active, batch)
+      |> Enum.split_with(&(&1.scope != :system))
+
     memories = Embeddings.pending_reembed_memories(tenant_id, active, batch)
+
+    if canonicals != [] do
+      Logger.info(
+        "EmbeddingReconciliationWorker: tenant=#{tenant_id} skipped #{length(canonicals)} " <>
+          "system canonical(s) at the active-dimension gap — they are repaired by " <>
+          "SystemCorpusEmbeddingWorker, not by the per-tenant article worker."
+      )
+    end
 
     Enum.each(articles, fn article ->
       %{tenant_id: tenant_id, article_id: article.id}

--- a/test/loopctl/knowledge_curated_test.exs
+++ b/test/loopctl/knowledge_curated_test.exs
@@ -289,7 +289,7 @@ defmodule Loopctl.KnowledgeCuratedTest do
 
       # Pure predicate still true (status + marker), but authoritative check excludes it.
       assert Knowledge.curated?(curated)
-      refute Knowledge.authoritative_curated?(curated)
+      refute Knowledge.authoritative_curated?(curated, tenant.id)
       refute curated.id in ids(Knowledge.list_curated_sources(tenant.id))
     end
 
@@ -316,7 +316,7 @@ defmodule Loopctl.KnowledgeCuratedTest do
         })
 
       # Fresh: suppressed, exactly as the sibling test above asserts.
-      refute Knowledge.authoritative_curated?(curated)
+      refute Knowledge.authoritative_curated?(curated, tenant.id)
       refute curated.id in ids(Knowledge.list_curated_sources(tenant.id))
 
       # Age it one day past the window. `article_links` is deliberately immutable (no update
@@ -333,14 +333,45 @@ defmodule Loopctl.KnowledgeCuratedTest do
       |> AdminRepo.update!()
 
       # Still unjudged — no conflict_resolutions row was written — but no longer suppressing.
-      assert Knowledge.authoritative_curated?(curated),
+      assert Knowledge.authoritative_curated?(curated, tenant.id),
              "an aged unjudged conflict must stop suppressing the per-article authority check"
 
       assert curated.id in ids(Knowledge.list_curated_sources(tenant.id)),
              "an aged unjudged conflict must stop suppressing the curated-sources list"
     end
 
-    test "authoritative_curated?/1 does not crash on a system canonical (tenant_id nil)" do
+    test "one tenant's conflict on a SHARED CANONICAL cannot suppress it for another tenant" do
+      # Article ids are GLOBAL, so correlating the open-conflict lookup on the id alone let
+      # ANY tenant's link answer the question. For a shared system canonical that is a live
+      # cross-tenant suppression: tenant A flags it, tenant B silently loses it from every
+      # authoritative answer for the whole window, with no audit event and no error.
+      #
+      # The sibling `open_conflict_subquery/1` has always been tenant-scoped, and its comment
+      # says exactly why. This is the same invariant, enforced in the other predicate.
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      canon = curated_system_article(%{title: "Shared Canon"}, tenant_a.id)
+      rival = fixture(:article, %{tenant_id: tenant_a.id, status: :published, title: "Rival"})
+
+      # Tenant A raises a conflict against the shared canonical.
+      fixture(:article_link, %{
+        tenant_id: tenant_a.id,
+        source_article_id: canon.id,
+        target_article_id: rival.id,
+        relationship_type: :potential_conflict,
+        metadata: %{"auto_generated" => true, "similarity_score" => 0.95}
+      })
+
+      # A sees the suppression — that is A's own dispute, correctly applied.
+      refute Knowledge.authoritative_curated?(canon, tenant_a.id)
+
+      # B must be entirely unaffected. Without the tenant predicate this returns false and
+      # the shared canon silently disappears from B's authoritative answers.
+      assert Knowledge.authoritative_curated?(canon, tenant_b.id),
+             "a conflict raised by one tenant must never retract the shared canon from another"
+    end
+
+    test "authoritative_curated?/2 does not crash on a system canonical (tenant_id nil)" do
       tenant = fixture(:tenant)
       system = curated_system_article(%{title: "System Canonical"}, tenant.id)
 
@@ -349,7 +380,7 @@ defmodule Loopctl.KnowledgeCuratedTest do
       # be authoritative (AC-31.1.3) rather than raising.
       assert is_nil(system.tenant_id)
       assert Knowledge.curated?(system)
-      assert Knowledge.authoritative_curated?(system)
+      assert Knowledge.authoritative_curated?(system, tenant.id)
     end
 
     test "a system canonical in an OPEN potential_conflict is not authoritative" do
@@ -370,7 +401,7 @@ defmodule Loopctl.KnowledgeCuratedTest do
       })
 
       assert Knowledge.curated?(system)
-      refute Knowledge.authoritative_curated?(system)
+      refute Knowledge.authoritative_curated?(system, tenant.id)
       refute system.id in ids(Knowledge.list_curated_sources(tenant.id))
     end
 


### PR DESCRIPTION
An adversarial tenant-isolation audit of today's nightly-job changes. **No live leak** — the judge, the duplicate auto-apply, the reconciler and the widened analytics joins are each closed by multiple independent predicates, verified against the actual SQL rather than the comments.

It also found four places that are correct **by accident, not by construction**: their safety rests on invariants enforced in other modules, with no test that fails when one of those invariants moves. Two are already under pressure.

## 1. `article_in_open_conflict?/1` had no tenant predicate — HIGH structurally, zero blast radius today

Article ids are **global**, so correlating on the id alone let *any* tenant's conflict link answer the question. For a shared system canonical that's a live cross-tenant suppression: one tenant flags it, **every other tenant loses it from authoritative answers for the whole window** — silently, no audit event, no error.

Its sibling `open_conflict_subquery/1` has always been tenant-scoped, and its comment says exactly why.

Unreachable today on two counts (no production caller; no `auto_generated` conflict link can name a canonical because the kNN pool excludes them). Both are one commit away from changing — `pending_reembed_articles/3` already enumerates canonicals deliberately.

**The old comment's reasoning was wrong**, and that's why it survived: it claimed the scope couldn't be added because pinning a nil `tenant_id` trips Ecto's nil-comparison guard. That conflates two things — **the NULL is on the shared ARTICLE, never on the LINK.** A link always belongs to exactly one tenant, so scoping it was always available.

`authoritative_curated?/2` now takes the **asking** tenant, because for a canonical there's nothing to derive it from and "is this authoritative?" is only answerable relative to a viewer.

## 2. `ArticleEmbeddingWorker`'s Oban unique key omitted `tenant_id`

A system canonical is enumerated for re-embedding by *every* tenant, so two tenants' repair jobs collided inside the 300s window — one deduped away, or its args overwritten by `replace:`. `SystemCorpusEmbeddingWorker` already keys on `[:tenant_id, :dim]` for this exact reason.

## 3. The reconciler enqueued canonicals into a worker that can't process them

`ArticleEmbeddingWorker` resolves its article with `a.tenant_id == ^tenant_id`, which a canonical's NULL tenant never satisfies → `{:error, :not_found}` → `embed/2` maps it to `:ok` as *"article deleted"* → **job succeeds, repairs nothing, re-enqueues hourly forever.**

That is the precise failure this worker's own moduledoc describes closing — *ran hourly, reported healthy, fixed nothing* — reproduced one class over. Canonicals are now filtered out and logged; their repair path is `SystemCorpusEmbeddingWorker`. Widening `get_article_with_embedding/2` instead would re-open the global-slot clobber `own_tenant_article?/2` exists to prevent.

## 4. `unembedded_articles/2`'s anti-join wasn't tenant-scoped

Unlike every sibling. Not exploitable, but the failure direction is a **false negative** — an article wrongly classed "already embedded" and left unsearchable, which is the exact defect that function exists to close.

## Verification

**Mutation-verified:** removing the tenant predicate again fails the new cross-tenant test — *"a conflict raised by one tenant must never retract the shared canon from another."*

`mix precommit` green — **6887 tests, 0 failures**.
