### PR TITLE
Bound relates_to degree: cap the writer, drain the backlog (#611 stage 0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ All notable changes to loopctl are documented here.
 
 Operator-facing changes for deployments outside the hosted instance.
 
+### Changed
+
+- **The nightly knowledge pass now PRUNES the `relates_to` graph to a bounded degree, which
+  DELETES rows (#611 stage 0).** Read this before upgrading if you run a large corpus: on
+  first run the pass will delete a large number of `article_links` rows, and it is the only
+  step in that worker that deletes anything.
+
+  Why: a similarity threshold was never a bound. Above `article_link_threshold` (0.6) the
+  linking worker created a `relates_to` edge for *every* kNN candidate — up to
+  `article_link_max_comparisons` (50) outbound per article, plus one inbound from every other
+  article that reached it. On the hosted corpus that produced **1,402,699 edges over 79,276
+  published articles**, with 56% of articles carrying 21+ and 59% of edges sitting between
+  0.60 and 0.70. At that density a traversal from any article reaches most of the corpus in
+  two hops, so the graph asserts a relationship between nearly everything and distinguishes
+  nothing — which also means the one-hop enrichment in progressive disclosure was spending
+  its budget on noise.
+
+  What changes: `ArticleLinkingWorker` now writes at most `article_max_relates_to_links`
+  (**new setting, default 10**) edges per article, and `Loopctl.Knowledge.LinkPruning` drains
+  the existing backlog at up to `knowledge_link_prune_max_per_run` (**new setting, default
+  250,000**) edges per nightly run, worst-first, reporting the remainder on the
+  `knowledge.lint_completed` audit event as `links_pruned` / `links_prunable_remaining`.
+  On the hosted corpus the target state is 499,058 edges (~12.6 average degree).
+
+  What is NOT touched: `potential_conflict` edges (own threshold, own draining consumer),
+  any `relates_to` link without `auto_generated: true`, and any link without a recorded
+  `similarity_score`. A hand-made link is structurally out of reach, and an edge that cannot
+  be ranked cannot be shown to be prunable.
+
+  Why deleting is safe unattended, when every other automated step in that worker is gated on
+  reversibility: an auto-generated edge is a *derived artifact*, not a record — a pure
+  function of two embeddings and a threshold, which the linking worker recomputes from the
+  same vectors. Pruning uses **union-kNN** (an edge survives if it is in *either* endpoint's
+  top-K), which guarantees every article keeps its own K nearest and therefore **cannot create
+  an orphan**. No migration, no manual step; the pass is idempotent and converges.
+
 ### Added
 
 - **`GET /api/v1/knowledge/consolidation` — the nightly consolidation ("dream") report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,17 +23,20 @@ Operator-facing changes for deployments outside the hosted instance.
   nothing — which also means the one-hop enrichment in progressive disclosure was spending
   its budget on noise.
 
-  What changes: `ArticleLinkingWorker` now writes at most `article_max_relates_to_links`
-  (**new setting, default 10**) edges per article, and `Loopctl.Knowledge.LinkPruning` drains
+  What changes: `ArticleLinkingWorker` now holds each article at `article_max_relates_to_links`
+  (**new setting, default 10**) STORED `relates_to` edges — a re-link tops it up to that number
+  rather than adding that many more — and `Loopctl.Knowledge.LinkPruning` drains
   the existing backlog at up to `knowledge_link_prune_max_per_run` (**new setting, default
   250,000**) edges per nightly run, worst-first, reporting the remainder on the
   `knowledge.lint_completed` audit event as `links_pruned` / `links_prunable_remaining`.
   On the hosted corpus the target state is 499,058 edges (~12.6 average degree).
 
   What is NOT touched: `potential_conflict` edges (own threshold, own draining consumer),
-  any `relates_to` link without `auto_generated: true`, and any link without a recorded
-  `similarity_score`. A hand-made link is structurally out of reach, and an edge that cannot
-  be ranked cannot be shown to be prunable.
+  any `relates_to` link without `auto_generated: true`, any link without a recorded
+  `similarity_score`, and any `relates_to` edge at or above `knowledge_conflict_threshold`
+  (those rows are the conflict promoter's only input, and it drains them far slower than the
+  prune would delete them). A hand-made link is structurally out of reach, and an edge that
+  cannot be ranked cannot be shown to be prunable.
 
   Why deleting is safe unattended, when every other automated step in that worker is gated on
   reversibility: an auto-generated edge is a *derived artifact*, not a record — a pure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,12 @@ Operator-facing changes for deployments outside the hosted instance.
   nothing — which also means the one-hop enrichment in progressive disclosure was spending
   its budget on noise.
 
-  What changes: `ArticleLinkingWorker` now holds each article at `article_max_relates_to_links`
-  (**new setting, default 10**) STORED `relates_to` edges — a re-link tops it up to that number
-  rather than adding that many more — and `Loopctl.Knowledge.LinkPruning` drains
+  What changes: `ArticleLinkingWorker` now writes `relates_to` edges only up to
+  `article_max_relates_to_links` (**new setting, default 10**) minus the prunable edges an
+  article already holds — a re-link tops it up to that number rather than adding that many
+  more. That bounds what the worker writes for the article it is linking; edges other articles
+  write INTO it are bounded by the prune below, not by this setting.
+  `Loopctl.Knowledge.LinkPruning` drains
   the existing backlog at up to `knowledge_link_prune_max_per_run` (**new setting, default
   250,000**) edges per nightly run, worst-first, reporting the remainder on the
   `knowledge.lint_completed` audit event as `links_pruned` / `links_prunable_remaining`.
@@ -34,9 +37,11 @@ Operator-facing changes for deployments outside the hosted instance.
   What is NOT touched: `potential_conflict` edges (own threshold, own draining consumer),
   any `relates_to` link without `auto_generated: true`, any link without a recorded
   `similarity_score`, and any `relates_to` edge at or above `knowledge_conflict_threshold`
-  (those rows are the conflict promoter's only input, and it drains them far slower than the
-  prune would delete them). A hand-made link is structurally out of reach, and an edge that
-  cannot be ranked cannot be shown to be prunable.
+  whose pair the conflict promoter has not flagged yet (those rows are the promoter's only
+  input, and it drains them far slower than the prune would delete them; once a pair is
+  flagged it is no longer promoter input and the edge is prunable like any other). A hand-made
+  link is structurally out of reach, and an edge that cannot be ranked cannot be shown to be
+  prunable.
 
   Why deleting is safe unattended, when every other automated step in that worker is gated on
   reversibility: an auto-generated edge is a *derived artifact*, not a record — a pure

--- a/config/config.exs
+++ b/config/config.exs
@@ -79,6 +79,14 @@ config :loopctl,
   # 0.8+ is only useful for near-duplicate detection.
   article_link_threshold: 0.6,
   article_link_max_comparisons: 50,
+  # #611 stage 0: a threshold is NOT a bound. Above 0.6 the linking worker took every kNN
+  # candidate, so an article contributed up to `article_link_max_comparisons` (50) outbound
+  # edges and accrued one inbound edge per article that reached it. The hosted corpus hit
+  # 1,402,699 `relates_to` edges over 79,276 articles, 56% of them carrying 21+, at which
+  # density any node reaches most of the corpus in two hops and the graph distinguishes
+  # nothing. Keep this WELL under max_comparisons — a cap at or above the candidate count
+  # is not a cap.
+  article_max_relates_to_links: 10,
   # US-27.8 (AC-27.8.4/.6): ADVISORY end-to-end wall-clock budget (ms) for the vector
   # scale gate's timed HTTP requests (suggested_links / semantic search) at the prod
   # floor. SECONDARY to the deterministic plan assertion (index-backed, no full-corpus
@@ -747,6 +755,14 @@ config :loopctl,
 config :loopctl,
   knowledge_lint_orphan_link_threshold: 0.5,
   knowledge_lint_max_orphan_relink: 500
+
+# LinkPruning (#611 stage 0): how many over-degree `relates_to` edges one nightly run may
+# DELETE, worst-first. Sized to converge in a few nights rather than a few months — the
+# standing backlog on the hosted corpus was ~903,600 edges (1,402,699 total, 499,058
+# surviving union-kNN top-10) and the write-side cap means the producer no longer outruns
+# the drain. The remainder is reported on the audit event and logged, never dropped
+# silently. Only machine-derived, rankable `relates_to` rows are ever in scope.
+config :loopctl, :knowledge_link_prune_max_per_run, 250_000
 
 # KnowledgeMocWorker: corpus-specific tags to exclude from Map-of-Content
 # generation (on top of the worker's generic structural/format/provenance list).

--- a/lib/loopctl/knowledge/link_pruning.ex
+++ b/lib/loopctl/knowledge/link_pruning.ex
@@ -59,12 +59,22 @@ defmodule Loopctl.Knowledge.LinkPruning do
   - `metadata->>'similarity_score' IS NOT NULL` — an edge with no recorded similarity cannot be
     ranked, so it cannot be shown to be outside anyone's top-K. Unrankable means unprunable.
 
+  One further class is RANKED but never DELETED: a `relates_to` edge at or above
+  `:knowledge_conflict_threshold`. `KnowledgeLintWorker.promote_conflicts/1` sources its
+  candidates EXCLUSIVELY from those rows, capped at 500/night against a much larger backlog, so
+  deleting one before the promoter reaches it makes that pair permanently invisible to conflict
+  detection. They still occupy top-K slots, so protecting them costs the degree bound nothing.
+
   ## Bounding
 
   One run deletes at most `:knowledge_link_prune_max_per_run` (default 250,000) edges,
-  WORST-FIRST by similarity, inside a `SET LOCAL statement_timeout` transaction. The remainder
-  is returned and logged rather than silently dropped, and the pass converges: the write-side
-  cap means the producer no longer outruns it.
+  WORST-FIRST by similarity, in BATCHES — each its own short transaction whose CLIENT deadline
+  is set ABOVE its `SET LOCAL statement_timeout`, so the server bound is the one that fires
+  and no single AdminRepo connection (pool of 3) is held for minutes while the nightly fan-out
+  runs. Each batch deletes and counts the remainder in ONE statement, so the ranking is never
+  re-derived for a number the delete already knows. A batch that fails after earlier ones
+  committed still reports what they deleted (`remaining: -1`). The pass converges: the
+  write-side cap means the producer no longer outruns it.
   """
 
   import Ecto.Query
@@ -72,13 +82,18 @@ defmodule Loopctl.Knowledge.LinkPruning do
   require Logger
 
   alias Loopctl.AdminRepo
+  alias Loopctl.ExitTag
   alias Loopctl.LocalGuc
 
   @default_max_per_run 250_000
-  # Generous: the ranking CTE over the whole hosted corpus measured 3.7 s, and the delete is
-  # keyed on primary keys. The timeout exists so a pathological plan cannot hold an AdminRepo
-  # connection (pool of 3) for the rest of the night, not to bound the normal case.
-  @statement_timeout_ms 120_000
+  # Rows per statement: re-deriving the ranking per batch (3.7 s on the hosted corpus) is the
+  # price of RELEASING one of AdminRepo's three connections between batches.
+  @batch_size 50_000
+  # SERVER bound on one batch. The CLIENT deadline must EXCEED it or DBConnection aborts the
+  # checkout first and the server bound can never fire — the pairing that
+  # `:bulk_op_transaction_timeout_ms` exists for elsewhere.
+  @statement_timeout_ms 30_000
+  @transaction_timeout_ms @statement_timeout_ms + 5_000
 
   @doc "Per-article `relates_to` degree target — the K in top-K."
   @spec target_degree() :: pos_integer()
@@ -95,108 +110,133 @@ defmodule Loopctl.Knowledge.LinkPruning do
   @doc """
   Prunes this tenant's `relates_to` edges to union-kNN top-K.
 
-  Returns `{:ok, %{pruned: n, remaining: n}}`. `remaining` is how many prunable edges were
-  still over the cap when the run stopped — zero means the graph is at its target degree.
+  Returns `{:ok, %{pruned: n, remaining: n}}`, or `{:error, reason}` when the FIRST batch
+  failed and nothing committed. `remaining` is how many prunable edges were still over the cap
+  when the run stopped — zero means the graph is at its target degree, `-1` means unmeasured.
 
   Opts: `:target_degree`, `:max_per_run` (both default to the config values above).
   """
   @spec prune(Ecto.UUID.t(), keyword()) ::
-          {:ok, %{pruned: non_neg_integer(), remaining: integer()}}
+          {:ok, %{pruned: non_neg_integer(), remaining: integer()}} | {:error, term()}
   def prune(tenant_id, opts \\ []) do
     k = Keyword.get(opts, :target_degree, target_degree())
     cap = Keyword.get(opts, :max_per_run, max_per_run())
 
-    {:ok, pruned} =
-      LocalGuc.timed_transaction(AdminRepo, @statement_timeout_ms, fn ->
-        delete_prunable(tenant_id, k, cap)
-      end)
-
-    remaining = count_prunable(tenant_id, k)
-
-    if pruned > 0 or remaining > 0 do
-      Logger.info(
-        "LinkPruning: tenant=#{tenant_id} relates_to pruned=#{pruned} remaining=#{remaining} " <>
-          "target_degree=#{k} cap=#{cap}"
-      )
-    end
-
-    {:ok, %{pruned: pruned, remaining: remaining}}
-  end
-
-  # The ranking is over edges INCIDENT to a node, which means each edge is ranked twice —
-  # once from each endpoint. `union all` materializes both sides; `rn <= k` on either keeps
-  # the edge. Deleting worst-first (`order by sim`) makes a capped run drop the least
-  # defensible edges first, so a partially-drained graph is always better than it was.
-  defp delete_prunable(tenant_id, k, cap) do
-    %{num_rows: n} =
-      AdminRepo.query!(
-        """
-        WITH e AS (
-          SELECT id, source_article_id AS a, target_article_id AS b,
-                 (metadata->>'similarity_score')::float AS sim
-          FROM article_links
-          WHERE tenant_id = $1 #{prunable_predicate()}
-        ),
-        sided AS (
-          SELECT id, a AS node, sim FROM e
-          UNION ALL
-          SELECT id, b AS node, sim FROM e
-        ),
-        ranked AS (
-          SELECT id, row_number() OVER (PARTITION BY node ORDER BY sim DESC, id) AS rn
-          FROM sided
-        ),
-        keep AS (SELECT DISTINCT id FROM ranked WHERE rn <= $2),
-        doomed AS (
-          SELECT e.id FROM e
-          LEFT JOIN keep ON keep.id = e.id
-          WHERE keep.id IS NULL
-          ORDER BY e.sim ASC, e.id
-          LIMIT $3
+    with {:ok, %{pruned: pruned, remaining: remaining} = result} <- drain(tenant_id, k, cap, 0) do
+      if pruned > 0 or remaining != 0 do
+        Logger.info(
+          "LinkPruning: tenant=#{tenant_id} relates_to pruned=#{pruned} remaining=#{remaining} " <>
+            "target_degree=#{k} cap=#{cap}"
         )
-        DELETE FROM article_links WHERE id IN (SELECT id FROM doomed)
-        """,
-        [Ecto.UUID.dump!(tenant_id), k, cap]
-      )
+      end
 
-    n
+      {:ok, result}
+    end
   end
 
-  defp count_prunable(tenant_id, k) do
-    %{rows: [[n]]} =
-      AdminRepo.query!(
-        """
-        WITH e AS (
-          SELECT id, source_article_id AS a, target_article_id AS b,
-                 (metadata->>'similarity_score')::float AS sim
-          FROM article_links
-          WHERE tenant_id = $1 #{prunable_predicate()}
-        ),
-        sided AS (
-          SELECT id, a AS node, sim FROM e
-          UNION ALL
-          SELECT id, b AS node, sim FROM e
-        ),
-        ranked AS (
-          SELECT id, row_number() OVER (PARTITION BY node ORDER BY sim DESC, id) AS rn
-          FROM sided
-        ),
-        keep AS (SELECT DISTINCT id FROM ranked WHERE rn <= $2)
-        SELECT count(*) FROM e LEFT JOIN keep ON keep.id = e.id WHERE keep.id IS NULL
-        """,
-        [Ecto.UUID.dump!(tenant_id), k]
-      )
+  # A batch that fails AFTER earlier ones committed must not discard their tally: the caller
+  # would then record `pruned: 0` for a night that really deleted rows, and this is the one
+  # step in the nightly pass that deletes anything.
+  defp drain(tenant_id, k, cap, pruned) do
+    case delete_batch(tenant_id, k, min(@batch_size, cap - pruned)) do
+      {:ok, {deleted, prunable}} ->
+        pruned = pruned + deleted
+        remaining = prunable - deleted
 
-    n
+        if deleted == 0 or remaining == 0 or pruned >= cap do
+          {:ok, %{pruned: pruned, remaining: remaining}}
+        else
+          drain(tenant_id, k, cap, pruned)
+        end
+
+      {:error, reason} ->
+        partial(tenant_id, pruned, reason)
+    end
   end
+
+  defp partial(_tenant_id, 0, reason), do: {:error, reason}
+
+  defp partial(tenant_id, pruned, reason) do
+    Logger.error(
+      "LinkPruning: tenant=#{tenant_id} batch failed (#{ExitTag.tag(reason)}) after #{pruned} " <>
+        "edges were already committed; reporting those, with remaining=-1 (unmeasured)."
+    )
+
+    {:ok, %{pruned: pruned, remaining: -1}}
+  end
+
+  # The ranking is over edges INCIDENT to a node, so each edge is ranked twice — once from each
+  # endpoint. `union all` materializes both sides; `rn <= k` on either keeps the edge. Deleting
+  # worst-first makes a capped run drop the least defensible edges first.
+  #
+  # Delete AND remainder in ONE statement: the ranking is the expensive part (3.7 s over the
+  # whole hosted corpus) and a separate count re-ran all of it for a number this statement
+  # already holds. `doomed` is evaluated on the statement's snapshot, so `prunable - deleted`
+  # is exact — every deleted edge was outside EVERY partition's top-K, so removing it cannot
+  # promote another doomed edge into one.
+  #
+  # `NULLS LAST` and the `coalesce` are not decoration: `DESC` defaults to NULLS FIRST and
+  # `NULL < 0.93` is NULL, so if the scoreless guard were ever loosened an UNRANKABLE edge
+  # would rank BEST and be spared by the band — the most protected row rather than the least.
+  defp delete_batch(tenant_id, k, limit) do
+    LocalGuc.timed_transaction(
+      AdminRepo,
+      @statement_timeout_ms,
+      fn ->
+        %{rows: [[deleted, prunable]]} =
+          AdminRepo.query!(
+            """
+            WITH e AS (
+              SELECT id, source_article_id AS a, target_article_id AS b,
+                     (metadata->>'similarity_score')::float AS sim
+              FROM article_links
+              WHERE tenant_id = $1 #{prunable_predicate()}
+            ),
+            sided AS (
+              SELECT id, a AS node, sim FROM e
+              UNION ALL
+              SELECT id, b AS node, sim FROM e
+            ),
+            ranked AS (
+              SELECT id, row_number() OVER (PARTITION BY node ORDER BY sim DESC NULLS LAST, id) AS rn
+              FROM sided
+            ),
+            keep AS (SELECT DISTINCT id FROM ranked WHERE rn <= $2),
+            doomed AS (
+              SELECT e.id, e.sim FROM e
+              LEFT JOIN keep ON keep.id = e.id
+              WHERE keep.id IS NULL AND coalesce(e.sim, 0) < #{conflict_band()}
+            ),
+            deleted AS (
+              DELETE FROM article_links
+              WHERE id IN (SELECT id FROM doomed ORDER BY sim ASC, id LIMIT $3)
+              RETURNING 1
+            )
+            SELECT (SELECT count(*) FROM deleted), (SELECT count(*) FROM doomed)
+            """,
+            [Ecto.UUID.dump!(tenant_id), k, limit]
+          )
+
+        {deleted, prunable}
+      end,
+      timeout: @transaction_timeout_ms
+    )
+  rescue
+    e -> {:error, e}
+  catch
+    :exit, reason -> {:error, reason}
+  end
+
+  # A numeric SQL literal by construction, never caller input.
+  defp conflict_band, do: Float.to_string(conflict_threshold())
+
+  defp conflict_threshold,
+    do: Application.get_env(:loopctl, :knowledge_conflict_threshold, 0.93) * 1.0
 
   @doc """
-  The SQL predicate selecting edges this module may delete — machine-derived, rankable
-  `relates_to` only.
-
-  Exposed so the test can assert the guard is present in BOTH statements above rather than
-  in whichever one it happened to read: a predicate that drifts between the delete and the
-  count would report a backlog it is not allowed to drain, forever.
+  The SQL predicate selecting the edges this module RANKS — machine-derived, rankable
+  `relates_to` only; the delete additionally spares the conflict band (see the moduledoc).
+  Exposed so the test can assert the guard is in the STATEMENT, not in whichever prose it read.
   """
   @spec prunable_predicate() :: String.t()
   def prunable_predicate do
@@ -211,11 +251,14 @@ defmodule Loopctl.Knowledge.LinkPruning do
   """
   @spec prunable_query(Ecto.UUID.t()) :: Ecto.Query.t()
   def prunable_query(tenant_id) do
+    band = conflict_threshold()
+
     from(l in Loopctl.Knowledge.ArticleLink,
       where: l.tenant_id == ^tenant_id,
       where: l.relationship_type == :relates_to,
       where: fragment("?->>'auto_generated' = 'true'", l.metadata),
-      where: not is_nil(fragment("?->>'similarity_score'", l.metadata))
+      where: not is_nil(fragment("?->>'similarity_score'", l.metadata)),
+      where: fragment("(?->>'similarity_score')::float < ?", l.metadata, ^band)
     )
   end
 end

--- a/lib/loopctl/knowledge/link_pruning.ex
+++ b/lib/loopctl/knowledge/link_pruning.ex
@@ -1,0 +1,221 @@
+defmodule Loopctl.Knowledge.LinkPruning do
+  @moduledoc """
+  Bounds `relates_to` degree by pruning the standing edge backlog to top-K (#611 stage 0).
+
+  `ArticleLinkingWorker` now caps what it WRITES at `:article_max_relates_to_links`, but that
+  cap is on outbound edges only and it arrived after the graph was already built. This module
+  drains what is already there.
+
+  ## Why the graph needed a bound at all
+
+  A similarity threshold is not a bound. Above 0.6, `relates_to` admitted every kNN candidate,
+  so each article contributed up to `max_comparisons` (50) outbound edges and accrued one
+  inbound edge from every other article that reached it.
+
+  MEASURED on the hosted corpus 2026-08-05, before any pruning:
+
+  | | |
+  |---|---|
+  | published articles | 79,276 |
+  | `relates_to` edges | 1,402,699 |
+  | in the 0.60–0.70 band | 833,418 (59%) |
+  | articles with 21+ edges | 44,496 (56%) |
+  | edges surviving union-kNN top-10 | 499,058 |
+
+  At that density any node reaches most of the corpus in two hops, so the graph asserts a
+  relationship between nearly everything and therefore distinguishes nothing — the structural
+  half of the same symptom `precision@20 = 0.038` reports from the retrieval side.
+
+  ## Union-kNN, not mutual
+
+  An edge survives if it is in the top-K of **either** endpoint. Mutual-kNN (both endpoints)
+  would delete an edge that is A's single best relationship merely because it is not in B's
+  top-K, which breaks the one guarantee that makes this safe to run unattended: **every
+  article keeps its own K nearest.**
+
+  That guarantee has a structural consequence worth stating, because it is what stops this
+  interacting with the orphan re-linker: an article with at least one edge necessarily holds
+  that edge at rank 1 of its own partition, and rank 1 is always inside top-K. **Pruning can
+  never create an orphan.** `prune_would_orphan_nobody/1` is not a runtime check because it is
+  a property of the ranking, but the test asserts it against real rows.
+
+  ## Why deleting these rows is safe without a human
+
+  Everything else in the nightly machinery is gated on reversibility (#605), and a DELETE is
+  not reversible. The distinction that licenses it: a `relates_to` edge is a **derived
+  artifact**, not a record. It is a pure function of two embeddings and a threshold, so
+  `ArticleLinkingWorker` regenerates it — the same computation, against the same vectors. No
+  human wrote any of them: measured on the hosted corpus, **zero** `relates_to` edges lack a
+  machine-written `similarity_score`.
+
+  That reasoning applies only to edges that carry their derivation, so the predicate is
+  narrow and fails CLOSED. `prunable_predicate/0` requires ALL of:
+
+  - `relationship_type = 'relates_to'` — `:potential_conflict` has its own threshold and its
+    own draining consumer (`KnowledgeLintWorker.judge_redundant_conflicts/1`, capped above the
+    promotion rate). Pruning it would withhold pairs from a queue designed to empty itself.
+  - `metadata->>'auto_generated' = 'true'` — a hand-made link is not regenerable and is never
+    touched. None exist today; this is what keeps that true if one is ever added.
+  - `metadata->>'similarity_score' IS NOT NULL` — an edge with no recorded similarity cannot be
+    ranked, so it cannot be shown to be outside anyone's top-K. Unrankable means unprunable.
+
+  ## Bounding
+
+  One run deletes at most `:knowledge_link_prune_max_per_run` (default 250,000) edges,
+  WORST-FIRST by similarity, inside a `SET LOCAL statement_timeout` transaction. The remainder
+  is returned and logged rather than silently dropped, and the pass converges: the write-side
+  cap means the producer no longer outruns it.
+  """
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.LocalGuc
+
+  @default_max_per_run 250_000
+  # Generous: the ranking CTE over the whole hosted corpus measured 3.7 s, and the delete is
+  # keyed on primary keys. The timeout exists so a pathological plan cannot hold an AdminRepo
+  # connection (pool of 3) for the rest of the night, not to bound the normal case.
+  @statement_timeout_ms 120_000
+
+  @doc "Per-article `relates_to` degree target — the K in top-K."
+  @spec target_degree() :: pos_integer()
+  def target_degree do
+    Application.get_env(:loopctl, :article_max_relates_to_links, 10)
+  end
+
+  @doc "Maximum edges one run may delete."
+  @spec max_per_run() :: pos_integer()
+  def max_per_run do
+    Application.get_env(:loopctl, :knowledge_link_prune_max_per_run, @default_max_per_run)
+  end
+
+  @doc """
+  Prunes this tenant's `relates_to` edges to union-kNN top-K.
+
+  Returns `{:ok, %{pruned: n, remaining: n}}`. `remaining` is how many prunable edges were
+  still over the cap when the run stopped — zero means the graph is at its target degree.
+
+  Opts: `:target_degree`, `:max_per_run` (both default to the config values above).
+  """
+  @spec prune(Ecto.UUID.t(), keyword()) ::
+          {:ok, %{pruned: non_neg_integer(), remaining: integer()}}
+  def prune(tenant_id, opts \\ []) do
+    k = Keyword.get(opts, :target_degree, target_degree())
+    cap = Keyword.get(opts, :max_per_run, max_per_run())
+
+    {:ok, pruned} =
+      LocalGuc.timed_transaction(AdminRepo, @statement_timeout_ms, fn ->
+        delete_prunable(tenant_id, k, cap)
+      end)
+
+    remaining = count_prunable(tenant_id, k)
+
+    if pruned > 0 or remaining > 0 do
+      Logger.info(
+        "LinkPruning: tenant=#{tenant_id} relates_to pruned=#{pruned} remaining=#{remaining} " <>
+          "target_degree=#{k} cap=#{cap}"
+      )
+    end
+
+    {:ok, %{pruned: pruned, remaining: remaining}}
+  end
+
+  # The ranking is over edges INCIDENT to a node, which means each edge is ranked twice —
+  # once from each endpoint. `union all` materializes both sides; `rn <= k` on either keeps
+  # the edge. Deleting worst-first (`order by sim`) makes a capped run drop the least
+  # defensible edges first, so a partially-drained graph is always better than it was.
+  defp delete_prunable(tenant_id, k, cap) do
+    %{num_rows: n} =
+      AdminRepo.query!(
+        """
+        WITH e AS (
+          SELECT id, source_article_id AS a, target_article_id AS b,
+                 (metadata->>'similarity_score')::float AS sim
+          FROM article_links
+          WHERE tenant_id = $1 #{prunable_predicate()}
+        ),
+        sided AS (
+          SELECT id, a AS node, sim FROM e
+          UNION ALL
+          SELECT id, b AS node, sim FROM e
+        ),
+        ranked AS (
+          SELECT id, row_number() OVER (PARTITION BY node ORDER BY sim DESC, id) AS rn
+          FROM sided
+        ),
+        keep AS (SELECT DISTINCT id FROM ranked WHERE rn <= $2),
+        doomed AS (
+          SELECT e.id FROM e
+          LEFT JOIN keep ON keep.id = e.id
+          WHERE keep.id IS NULL
+          ORDER BY e.sim ASC, e.id
+          LIMIT $3
+        )
+        DELETE FROM article_links WHERE id IN (SELECT id FROM doomed)
+        """,
+        [Ecto.UUID.dump!(tenant_id), k, cap]
+      )
+
+    n
+  end
+
+  defp count_prunable(tenant_id, k) do
+    %{rows: [[n]]} =
+      AdminRepo.query!(
+        """
+        WITH e AS (
+          SELECT id, source_article_id AS a, target_article_id AS b,
+                 (metadata->>'similarity_score')::float AS sim
+          FROM article_links
+          WHERE tenant_id = $1 #{prunable_predicate()}
+        ),
+        sided AS (
+          SELECT id, a AS node, sim FROM e
+          UNION ALL
+          SELECT id, b AS node, sim FROM e
+        ),
+        ranked AS (
+          SELECT id, row_number() OVER (PARTITION BY node ORDER BY sim DESC, id) AS rn
+          FROM sided
+        ),
+        keep AS (SELECT DISTINCT id FROM ranked WHERE rn <= $2)
+        SELECT count(*) FROM e LEFT JOIN keep ON keep.id = e.id WHERE keep.id IS NULL
+        """,
+        [Ecto.UUID.dump!(tenant_id), k]
+      )
+
+    n
+  end
+
+  @doc """
+  The SQL predicate selecting edges this module may delete — machine-derived, rankable
+  `relates_to` only.
+
+  Exposed so the test can assert the guard is present in BOTH statements above rather than
+  in whichever one it happened to read: a predicate that drifts between the delete and the
+  count would report a backlog it is not allowed to drain, forever.
+  """
+  @spec prunable_predicate() :: String.t()
+  def prunable_predicate do
+    "AND relationship_type = 'relates_to' " <>
+      "AND metadata->>'auto_generated' = 'true' " <>
+      "AND metadata->>'similarity_score' IS NOT NULL"
+  end
+
+  @doc """
+  Ecto query over the edges this module may delete, for callers that need to count or
+  inspect them without hand-writing the predicate.
+  """
+  @spec prunable_query(Ecto.UUID.t()) :: Ecto.Query.t()
+  def prunable_query(tenant_id) do
+    from(l in Loopctl.Knowledge.ArticleLink,
+      where: l.tenant_id == ^tenant_id,
+      where: l.relationship_type == :relates_to,
+      where: fragment("?->>'auto_generated' = 'true'", l.metadata),
+      where: not is_nil(fragment("?->>'similarity_score'", l.metadata))
+    )
+  end
+end

--- a/lib/loopctl/knowledge/link_pruning.ex
+++ b/lib/loopctl/knowledge/link_pruning.ex
@@ -59,11 +59,18 @@ defmodule Loopctl.Knowledge.LinkPruning do
   - `metadata->>'similarity_score' IS NOT NULL` — an edge with no recorded similarity cannot be
     ranked, so it cannot be shown to be outside anyone's top-K. Unrankable means unprunable.
 
-  One further class is RANKED but never DELETED: a `relates_to` edge at or above
-  `:knowledge_conflict_threshold`. `KnowledgeLintWorker.promote_conflicts/1` sources its
-  candidates EXCLUSIVELY from those rows, capped at 500/night against a much larger backlog, so
-  deleting one before the promoter reaches it makes that pair permanently invisible to conflict
-  detection. They still occupy top-K slots, so protecting them costs the degree bound nothing.
+  One further class is RANKED but SPARED WHILE IT IS STILL PROMOTER INPUT: a `relates_to` edge
+  at or above `:knowledge_conflict_threshold` whose pair carries NO `:potential_conflict` edge
+  yet. `KnowledgeLintWorker.promote_conflicts/1` sources its candidates EXCLUSIVELY from those
+  rows, capped at 500/night against a much larger backlog, so deleting one before the promoter
+  reaches it makes that pair permanently invisible to conflict detection.
+
+  The spare mirrors BOTH halves of the promoter's own candidate query — the similarity floor
+  AND its `not exists` clause — so it is RELEASED the moment the pair is flagged. Copying only
+  the similarity half left every promoted pair permanently unprunable while it was no longer
+  promoter input at all, accumulating in exactly the high-similarity region this pass exists to
+  thin. While a spare holds, that edge may sit outside both endpoints' top-K: the degree bound
+  is not reached for it, and it is NOT counted in `remaining`.
 
   ## Bounding
 
@@ -91,7 +98,11 @@ defmodule Loopctl.Knowledge.LinkPruning do
   @batch_size 50_000
   # SERVER bound on one batch. The CLIENT deadline must EXCEED it or DBConnection aborts the
   # checkout first and the server bound can never fire — the pairing that
-  # `:bulk_op_transaction_timeout_ms` exists for elsewhere.
+  # `:bulk_op_transaction_timeout_ms` exists for elsewhere. It has to be passed TWICE, on the
+  # transaction AND on the statement: Ecto stores only the CONNECTION in the process dictionary,
+  # never the transaction's opts, so a query inside the transaction otherwise falls back to the
+  # repo's DEFAULT 15 s `:timeout` — below the server bound, which is the same inversion one
+  # level down (`Knowledge.BulkOps` avoids it the other way, with a 10 s server bound).
   @statement_timeout_ms 30_000
   @transaction_timeout_ms @statement_timeout_ms + 5_000
 
@@ -111,8 +122,10 @@ defmodule Loopctl.Knowledge.LinkPruning do
   Prunes this tenant's `relates_to` edges to union-kNN top-K.
 
   Returns `{:ok, %{pruned: n, remaining: n}}`, or `{:error, reason}` when the FIRST batch
-  failed and nothing committed. `remaining` is how many prunable edges were still over the cap
-  when the run stopped — zero means the graph is at its target degree, `-1` means unmeasured.
+  failed and nothing committed. `remaining` is how many DELETABLE edges were still over the cap
+  when the run stopped — zero means nothing is left that this pass is ALLOWED to delete, which
+  is weaker than "the graph is at its target degree": an edge spared as promoter input (see the
+  moduledoc) is over-degree and uncounted. `-1` means unmeasured.
 
   Opts: `:target_degree`, `:max_per_run` (both default to the config values above).
   """
@@ -205,7 +218,14 @@ defmodule Loopctl.Knowledge.LinkPruning do
             doomed AS (
               SELECT e.id, e.sim FROM e
               LEFT JOIN keep ON keep.id = e.id
-              WHERE keep.id IS NULL AND coalesce(e.sim, 0) < #{conflict_band()}
+              WHERE keep.id IS NULL
+                AND (coalesce(e.sim, 0) < #{conflict_band()} OR EXISTS (
+                  SELECT 1 FROM article_links pc
+                  WHERE pc.tenant_id = $1
+                    AND pc.relationship_type = 'potential_conflict'
+                    AND ((pc.source_article_id = e.a AND pc.target_article_id = e.b)
+                      OR (pc.source_article_id = e.b AND pc.target_article_id = e.a))
+                ))
             ),
             deleted AS (
               DELETE FROM article_links
@@ -214,7 +234,8 @@ defmodule Loopctl.Knowledge.LinkPruning do
             )
             SELECT (SELECT count(*) FROM deleted), (SELECT count(*) FROM doomed)
             """,
-            [Ecto.UUID.dump!(tenant_id), k, limit]
+            [Ecto.UUID.dump!(tenant_id), k, limit],
+            timeout: @transaction_timeout_ms
           )
 
         {deleted, prunable}
@@ -235,7 +256,8 @@ defmodule Loopctl.Knowledge.LinkPruning do
 
   @doc """
   The SQL predicate selecting the edges this module RANKS — machine-derived, rankable
-  `relates_to` only; the delete additionally spares the conflict band (see the moduledoc).
+  `relates_to` only; the delete additionally spares a conflict-band pair the promoter has not
+  reached yet (see the moduledoc).
   Exposed so the test can assert the guard is in the STATEMENT, not in whichever prose it read.
   """
   @spec prunable_predicate() :: String.t()
@@ -246,19 +268,23 @@ defmodule Loopctl.Knowledge.LinkPruning do
   end
 
   @doc """
-  Ecto query over the edges this module may delete, for callers that need to count or
-  inspect them without hand-writing the predicate.
-  """
-  @spec prunable_query(Ecto.UUID.t()) :: Ecto.Query.t()
-  def prunable_query(tenant_id) do
-    band = conflict_threshold()
+  Ecto query over the edges this module can RECLAIM from `tenant_id` — machine-derived,
+  rankable `relates_to`. The conflict-band spare is deliberately not applied here: it is
+  transient, released as soon as the promoter flags the pair, so a band edge is reclaimable in
+  the long run.
 
+  `ArticleLinkingWorker` derives its per-article write headroom from this, so the writer's
+  bound and the pruner's target are ONE definition of degree. Where they differed, an edge this
+  module can never free (hand-made, or scoreless and so unrankable) consumed a write slot
+  forever and switched that article's auto-linking off with no path back.
+  """
+  @spec reclaimable_query(Ecto.UUID.t()) :: Ecto.Query.t()
+  def reclaimable_query(tenant_id) do
     from(l in Loopctl.Knowledge.ArticleLink,
       where: l.tenant_id == ^tenant_id,
       where: l.relationship_type == :relates_to,
       where: fragment("?->>'auto_generated' = 'true'", l.metadata),
-      where: not is_nil(fragment("?->>'similarity_score'", l.metadata)),
-      where: fragment("(?->>'similarity_score')::float < ?", l.metadata, ^band)
+      where: not is_nil(fragment("?->>'similarity_score'", l.metadata))
     )
   end
 end

--- a/lib/loopctl/workers/article_linking_worker.ex
+++ b/lib/loopctl/workers/article_linking_worker.ex
@@ -56,6 +56,24 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
   Configurable via `Application.get_env(:loopctl, :article_link_threshold, 0.6)`.
   Only articles with cosine similarity >= threshold get linked.
 
+  ## Degree cap (#611 stage 0)
+
+  A threshold alone is not a bound. Above it, `relates_to` took EVERY candidate — up to
+  `max_comparisons` (50) outbound edges per article, and degree is bidirectional, so an
+  article also accrues one inbound edge per other article that reaches it. Measured on the
+  hosted corpus before the cap: **1,402,699 `relates_to` edges over 79,276 published
+  articles**, 59% of them between 0.60 and 0.70, and 56% of articles carrying 21+ edges.
+  A graph that dense relates nearly everything to everything and so distinguishes nothing.
+
+  `relates_to` is now capped at the top `:article_max_relates_to_links` (default 10) nearest
+  candidates per article. `:potential_conflict` is NOT capped — it has its own threshold and
+  its own draining consumer, and a second cap there would withhold pairs from a queue
+  designed to converge.
+
+  The cap bounds what this worker WRITES. Total degree is still unbounded from the inbound
+  side, which is why #611 stage 0 also prunes the standing backlog; see
+  `Loopctl.Knowledge.LinkPruning`.
+
   ## Retry Strategy (AC-21.2.13)
 
   Custom polynomial backoff: `attempt^4 + 15 + rand(0..30*attempt)`.
@@ -180,12 +198,29 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
       candidates when is_list(candidates) ->
         conflict_threshold = conflict_threshold()
 
-        # A `relates_to` ambient link for everything >= the link threshold, PLUS a
+        # A `relates_to` ambient link for the TOP-K nearest above the link threshold, PLUS a
         # `:potential_conflict` flag (route-the-findings #4) for pairs >= the conflict
         # threshold — too similar to comfortably coexist, for the consumer to resolve.
         # Dedup is type-aware so the two link types don't crowd each other out.
+        #
+        # The top-K cut is #611 stage 0, and it replaces an unconditional keep. Admitting
+        # every candidate over the threshold made this an unbounded producer: `max_comparisons`
+        # is 50, so each article could contribute 50 outbound edges, and degree is BIDIRECTIONAL
+        # — an article also accrues an inbound edge from every other article that reaches it.
+        # MEASURED before the cap: 1,402,699 `relates_to` edges over 79,276 published articles,
+        # 59% of them in the 0.60–0.70 band (barely over the floor) and 56% of articles carrying
+        # 21+ edges. At that density any node reaches most of the corpus in two hops, so the
+        # graph asserts a relationship between nearly everything and therefore distinguishes
+        # nothing — which is what `Knowledge.progressive_index/2`'s one-hop enrichment was
+        # spending its budget on.
+        #
+        # `:potential_conflict` is deliberately NOT capped here. It has its own (much higher)
+        # threshold and its own consumer — `KnowledgeLintWorker.judge_redundant_conflicts/1`
+        # drains it, capped above the promotion rate — so a second cap would silently withhold
+        # pairs from a queue that is already designed to converge.
         relates =
-          build_links(article.id, candidates, tenant_id, :relates_to, fn _sim -> true end)
+          article.id
+          |> build_links(top_k(candidates), tenant_id, :relates_to, fn _sim -> true end)
 
         conflicts =
           build_links(article.id, candidates, tenant_id, :potential_conflict, fn sim ->
@@ -196,6 +231,24 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
         log_audit_event(article.id, tenant_id, created_count)
         :ok
     end
+  end
+
+  # The K nearest candidates, by similarity. `find_similar_articles/4` returns them in
+  # kNN order already, but that ordering is the vector index's and this cut must not depend
+  # on it: an explicit sort makes the bound a property of THIS function, so a future change
+  # to the search path cannot silently turn "the best K" into "whichever K arrived first".
+  # Ties break on id so the cut is deterministic across re-runs — a re-link that kept a
+  # different arbitrary half each night would churn the graph forever.
+  defp top_k(candidates) do
+    candidates
+    |> Enum.sort_by(fn %{similarity: sim, id: id} -> {-sim, id} end)
+    |> Enum.take(max_relates_to_links())
+  end
+
+  # Per-article outbound cap for `relates_to`. Kept well under `max_comparisons` (50) —
+  # a cap at or above the candidate count is not a cap.
+  defp max_relates_to_links do
+    Application.get_env(:loopctl, :article_max_relates_to_links, 10)
   end
 
   defp build_links(article_id, candidates, tenant_id, type, keep?) do

--- a/lib/loopctl/workers/article_linking_worker.ex
+++ b/lib/loopctl/workers/article_linking_worker.ex
@@ -65,13 +65,15 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
   articles**, 59% of them between 0.60 and 0.70, and 56% of articles carrying 21+ edges.
   A graph that dense relates nearly everything to everything and so distinguishes nothing.
 
-  `relates_to` is now capped at the top `:article_max_relates_to_links` (default 10) nearest
-  candidates per article. `:potential_conflict` is NOT capped — it has its own threshold and
-  its own draining consumer, and a second cap there would withhold pairs from a queue
-  designed to converge.
+  `relates_to` is now capped at `:article_max_relates_to_links` (default 10) STORED edges per
+  article, counting edges INCIDENT to it in either direction: the cut runs AFTER the
+  already-linked rejection, so a re-link (nightly orphan pass, a re-embed) tops the article up
+  to K rather than adding K more. `:potential_conflict` is NOT capped — it has its own
+  threshold and its own draining consumer, and a second cap there would withhold pairs from a
+  queue designed to converge.
 
-  The cap bounds what this worker WRITES. Total degree is still unbounded from the inbound
-  side, which is why #611 stage 0 also prunes the standing backlog; see
+  The cap bounds what this worker WRITES; it cannot retract the edges written before it
+  existed, which is why #611 stage 0 also prunes the standing backlog. See
   `Loopctl.Knowledge.LinkPruning`.
 
   ## Retry Strategy (AC-21.2.13)
@@ -219,13 +221,24 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
         # drains it, capped above the promotion rate — so a second cap would silently withhold
         # pairs from a queue that is already designed to converge.
         relates =
-          article.id
-          |> build_links(top_k(candidates), tenant_id, :relates_to, fn _sim -> true end)
+          build_links(
+            article.id,
+            candidates,
+            tenant_id,
+            :relates_to,
+            fn _sim -> true end,
+            max_relates_to_links()
+          )
 
         conflicts =
-          build_links(article.id, candidates, tenant_id, :potential_conflict, fn sim ->
-            sim >= conflict_threshold
-          end)
+          build_links(
+            article.id,
+            candidates,
+            tenant_id,
+            :potential_conflict,
+            fn sim -> sim >= conflict_threshold end,
+            :infinity
+          )
 
         created_count = create_links(relates ++ conflicts, tenant_id)
         log_audit_event(article.id, tenant_id, created_count)
@@ -233,25 +246,35 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
     end
   end
 
-  # The K nearest candidates, by similarity. `find_similar_articles/4` returns them in
-  # kNN order already, but that ordering is the vector index's and this cut must not depend
+  # The `headroom` nearest candidates, by similarity. `find_similar_articles/4` returns them
+  # in kNN order already, but that ordering is the vector index's and this cut must not depend
   # on it: an explicit sort makes the bound a property of THIS function, so a future change
   # to the search path cannot silently turn "the best K" into "whichever K arrived first".
   # Ties break on id so the cut is deterministic across re-runs — a re-link that kept a
   # different arbitrary half each night would churn the graph forever.
-  defp top_k(candidates) do
+  defp top_k(candidates, :infinity), do: candidates
+
+  defp top_k(candidates, headroom) do
     candidates
     |> Enum.sort_by(fn %{similarity: sim, id: id} -> {-sim, id} end)
-    |> Enum.take(max_relates_to_links())
+    |> Enum.take(headroom)
   end
 
-  # Per-article outbound cap for `relates_to`. Kept well under `max_comparisons` (50) —
+  # K minus what this article ALREADY holds, which is what makes the cap a bound on STORED
+  # degree rather than on one run's writes. The cut used to run on the candidate list BEFORE
+  # the already-linked rejection below, so existing edges cost nothing against K and every
+  # re-link (nightly orphan pass, a re-embed) could add K MORE — degree grew without bound
+  # between prunes, and the write-side cap the moduledoc claims held per run only.
+  defp headroom(:infinity, _existing), do: :infinity
+  defp headroom(cap, existing), do: max(cap - existing, 0)
+
+  # Per-article cap for `relates_to`. Kept well under `max_comparisons` (50) —
   # a cap at or above the candidate count is not a cap.
   defp max_relates_to_links do
     Application.get_env(:loopctl, :article_max_relates_to_links, 10)
   end
 
-  defp build_links(article_id, candidates, tenant_id, type, keep?) do
+  defp build_links(article_id, candidates, tenant_id, type, keep?, cap) do
     existing = get_existing_link_pairs(article_id, tenant_id, type)
 
     candidates
@@ -266,6 +289,8 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
       cid == article_id or MapSet.member?(existing, {article_id, cid}) or
         MapSet.member?(existing, {cid, article_id})
     end)
+    # AFTER the rejection, so an already-linked pair does not consume a slot it already holds.
+    |> top_k(headroom(cap, MapSet.size(existing)))
     |> Enum.map(fn %{id: target_id, similarity: score} ->
       %{
         source_article_id: article_id,

--- a/lib/loopctl/workers/article_linking_worker.ex
+++ b/lib/loopctl/workers/article_linking_worker.ex
@@ -65,16 +65,27 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
   articles**, 59% of them between 0.60 and 0.70, and 56% of articles carrying 21+ edges.
   A graph that dense relates nearly everything to everything and so distinguishes nothing.
 
-  `relates_to` is now capped at `:article_max_relates_to_links` (default 10) STORED edges per
-  article, counting edges INCIDENT to it in either direction: the cut runs AFTER the
+  `relates_to` writes are now bounded by HEADROOM: `:article_max_relates_to_links` (default 10)
+  minus the edges already incident to this article, in either direction, that
+  `LinkPruning.reclaimable_query/1` says the prune can free. The cut runs AFTER the
   already-linked rejection, so a re-link (nightly orphan pass, a re-embed) tops the article up
   to K rather than adding K more. `:potential_conflict` is NOT capped — it has its own
   threshold and its own draining consumer, and a second cap there would withhold pairs from a
   queue designed to converge.
 
-  The cap bounds what this worker WRITES; it cannot retract the edges written before it
-  existed, which is why #611 stage 0 also prunes the standing backlog. See
-  `Loopctl.Knowledge.LinkPruning`.
+  Two things this bound is NOT, stated because both are easy to read into it:
+
+  - **Not a bound on TOTAL degree.** Only the article being linked has its headroom checked;
+    another article writing an edge INTO this one never consults this one's degree, so a hub
+    still accrues inbound edges without limit here. Total degree is bounded by the nightly
+    prune's union-kNN target, not by this cap.
+  - **Not "the best K".** A stored edge is never displaced: at headroom 0 a strictly nearer
+    candidate is discarded rather than replacing a weaker stored edge, so the set is
+    first-K-acquired until the prune frees a slot. `top_k/2`'s sort decides which of THIS run's
+    candidates win, not which of all time's.
+
+  And it cannot retract the edges written before it existed, which is why #611 stage 0 also
+  prunes the standing backlog. See `Loopctl.Knowledge.LinkPruning`.
 
   ## Retry Strategy (AC-21.2.13)
 
@@ -102,6 +113,7 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleEmbedding
   alias Loopctl.Knowledge.ArticleLink
+  alias Loopctl.Knowledge.LinkPruning
   alias Loopctl.Knowledge.VectorSearch
   alias Loopctl.LocalGuc
   alias Loopctl.Oban.FairShare
@@ -248,8 +260,10 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
 
   # The `headroom` nearest candidates, by similarity. `find_similar_articles/4` returns them
   # in kNN order already, but that ordering is the vector index's and this cut must not depend
-  # on it: an explicit sort makes the bound a property of THIS function, so a future change
-  # to the search path cannot silently turn "the best K" into "whichever K arrived first".
+  # on it: an explicit sort makes the bound a property of THIS function, so a future change to
+  # the search path cannot silently turn "the best K of this run's candidates" into "whichever
+  # K arrived first". It does NOT reorder already-STORED edges — those are never displaced, so
+  # across runs the stored set is first-K-acquired (see the moduledoc).
   # Ties break on id so the cut is deterministic across re-runs — a re-link that kept a
   # different arbitrary half each night would churn the graph forever.
   defp top_k(candidates, :infinity), do: candidates
@@ -260,13 +274,28 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
     |> Enum.take(headroom)
   end
 
-  # K minus what this article ALREADY holds, which is what makes the cap a bound on STORED
-  # degree rather than on one run's writes. The cut used to run on the candidate list BEFORE
-  # the already-linked rejection below, so existing edges cost nothing against K and every
-  # re-link (nightly orphan pass, a re-embed) could add K MORE — degree grew without bound
-  # between prunes, and the write-side cap the moduledoc claims held per run only.
-  defp headroom(:infinity, _existing), do: :infinity
-  defp headroom(cap, existing), do: max(cap - existing, 0)
+  # K minus the edges this article already holds THAT THE PRUNE CAN RECLAIM. Two halves:
+  #
+  # * STORED, not per-run: the cut runs AFTER the already-linked rejection below. It used to run
+  #   before it, so existing edges cost nothing against K and every re-link (nightly orphan
+  #   pass, a re-embed) could add K MORE — degree grew without bound between prunes.
+  # * RECLAIMABLE, not merely incident: counting EVERY incident edge counted rows `LinkPruning`
+  #   may never delete (hand-made links, and scoreless ones it cannot rank), so K of those
+  #   switched this article's auto-linking off with no pass able to free a slot again. The count
+  #   comes from `LinkPruning.reclaimable_query/1` so the writer's bound and the pruner's target
+  #   are one definition of degree rather than two that can disagree — which also means a finite
+  #   cap applies to `:relates_to` only, the sole type either of them bounds.
+  defp headroom(:infinity, _article_id, _tenant_id), do: :infinity
+
+  defp headroom(cap, article_id, tenant_id) do
+    reclaimable =
+      tenant_id
+      |> LinkPruning.reclaimable_query()
+      |> where([l], l.source_article_id == ^article_id or l.target_article_id == ^article_id)
+      |> AdminRepo.aggregate(:count)
+
+    max(cap - reclaimable, 0)
+  end
 
   # Per-article cap for `relates_to`. Kept well under `max_comparisons` (50) —
   # a cap at or above the candidate count is not a cap.
@@ -290,7 +319,7 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
         MapSet.member?(existing, {cid, article_id})
     end)
     # AFTER the rejection, so an already-linked pair does not consume a slot it already holds.
-    |> top_k(headroom(cap, MapSet.size(existing)))
+    |> top_k(headroom(cap, article_id, tenant_id))
     |> Enum.map(fn %{id: target_id, similarity: score} ->
       %{
         source_article_id: article_id,

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -52,9 +52,9 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
      graph relates nearly everything to everything and distinguishes nothing.
      Union-kNN (an edge survives if it is in EITHER endpoint's top-K) guarantees
      every article keeps its own K nearest, which is also why the prune can never
-     create an orphan. An edge at or above the conflict threshold is ranked but never
-     deleted, so step 4's promoter keeps every candidate it has not reached yet.
-     Bounded per run, worst-first, and FAIL-SOFT.
+     create an orphan. An edge at or above the conflict threshold is ranked but spared
+     until step 4's promoter has flagged the pair, so the promoter keeps every candidate
+     it has not reached yet. Bounded per run, worst-first, and FAIL-SOFT.
   4. **Promotes, judges and executes conflicts**, in that order and in one pass
      (#601, #606). `promote_conflicts/1` flags high-similarity pairs;
      `judge_redundant_conflicts/1` then records a verdict on them —
@@ -180,9 +180,11 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     # halves of that are structural rather than positional. Union-kNN keeps every article's own
     # top-K, so an article holding at least one edge holds it at rank 1 and the prune cannot
     # create an orphan. And a `relates_to` edge at or above the conflict threshold is RANKED but
-    # never DELETED, so the prune cannot take a candidate out from under `promote_conflicts/1`
-    # below — which is capped at 500/night against a much larger backlog, so a pair deleted
-    # before it was reached would be lost to conflict detection permanently.
+    # SPARED while the pair carries no `:potential_conflict` edge, so the prune cannot take a
+    # candidate out from under `promote_conflicts/1` below — which is capped at 500/night
+    # against a much larger backlog, so a pair deleted before it was reached would be lost to
+    # conflict detection permanently. The spare lifts once the pair is flagged: it is no longer
+    # promoter input, and an unconditional exemption would make it permanently unprunable.
     pruned = prune_links(tenant_id)
     promoted = promote_conflicts(tenant_id)
     # The judge runs AFTER promotion so a pair flagged tonight is also judged tonight and
@@ -700,9 +702,10 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         # revisiting — that is not visible from either number alone.
         "conflicts_judged_redundant" => judged,
         # Same convergence reading as the pair above, for the graph. `links_prunable_remaining`
-        # is what a capped run could not reach; 0 means the graph is at its target degree.
-        # A -1 means the prune FAILED and is deliberately not 0 — a zero there would read as
-        # converged, which is the one wrong conclusion available.
+        # is what a capped run could not reach; 0 means nothing DELETABLE is left, which is
+        # weaker than "at target degree" — an edge spared as conflict-promoter input is
+        # over-degree and uncounted. A -1 means the prune FAILED and is deliberately not 0 — a
+        # zero there would read as drained, which is the one wrong conclusion available.
         "links_pruned" => pruned.pruned,
         "links_prunable_remaining" => pruned.remaining,
         "resolutions_applied" => resolutions_applied,

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -10,9 +10,18 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
 
   What makes a repair safe here is REVERSIBILITY, not confidence (#605). Every
   automated write below can be undone in code — a re-linked orphan, a conflict
-  verdict re-annotated, an unpublished duplicate re-published. Nothing on this
-  path archives, deletes, or otherwise takes a one-way door, and no step waits
-  on a human verdict that will never arrive.
+  verdict re-annotated, an unpublished duplicate re-published. No step archives
+  an article or waits on a human verdict that will never arrive.
+
+  ONE step deletes, and the exception is deliberate: link pruning (#611) removes
+  `relates_to` rows. An undo would be meaningless there and a soft-delete column
+  would be worse, because such an edge is a DERIVED ARTIFACT rather than a record
+  — a pure function of two embeddings and a threshold, which
+  `ArticleLinkingWorker` recomputes from the same vectors. `LinkPruning` will only
+  touch a row that carries its own derivation (`auto_generated` plus a
+  `similarity_score`), so a hand-made link is structurally out of reach. Read that
+  as the rule it is: *regenerable* is the property that licenses a delete, and it
+  is narrower than "we can rebuild something like it".
 
   ## Scheduling
 
@@ -35,7 +44,16 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
      cheap, and makes **no** embedding-API calls (orphans missing an embedding
      simply no-op in the linking worker — backfilling those is a separate
      concern, out of scope here).
-  3. **Promotes, judges and executes conflicts**, in that order and in one pass
+  3. **Prunes the `relates_to` graph to top-K degree** (#611 stage 0) via
+     `Loopctl.Knowledge.LinkPruning`. A similarity threshold is not a bound: above
+     0.6 the linking worker admitted every kNN candidate, and the hosted corpus
+     reached 1,402,699 edges over 79,276 articles with 56% of articles carrying
+     21+. At that density any node reaches most of the corpus in two hops, so the
+     graph relates nearly everything to everything and distinguishes nothing.
+     Union-kNN (an edge survives if it is in EITHER endpoint's top-K) guarantees
+     every article keeps its own K nearest, which is also why the prune can never
+     create an orphan. Bounded per run, worst-first, and FAIL-SOFT.
+  4. **Promotes, judges and executes conflicts**, in that order and in one pass
      (#601, #606). `promote_conflicts/1` flags high-similarity pairs;
      `judge_redundant_conflicts/1` then records a verdict on them —
      `classification: :redundant, disposition: :dismiss`, because cosine
@@ -46,24 +64,24 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
      pile shrinks by arithmetic rather than by hoping the inflow stops. The judge
      runs after the promoter within the same night so a pair flagged tonight
      never spends a night suppressing both its articles from curated answers.
-  4. **Consolidates the corpus** (#584, #605) — runs
+  5. **Consolidates the corpus** (#584, #605) — runs
      `Loopctl.Knowledge.Consolidation.run/2`, which emits numbered,
      evidence-carrying proposals for the two live defect classes and persists them
      as the tenant's report for the day. It scans the corpus itself and takes no
      input from the lint report above. It writes nothing to `article_links` or
      `conflict_resolutions`; the ONLY article write it can make is the reversible
-     confirmed-duplicate unpublish in step 5. This runs inside the existing
+     confirmed-duplicate unpublish in step 6. This runs inside the existing
      nightly pass on purpose: a second scheduler over the same corpus is the
      specific failure #584 names. It is also FAIL-SOFT: a raise or a pool exit
      inside it is recorded in the audit event and never aborts the run
      (see `consolidate/1`).
-  5. **Applies the confirmed duplicates** — `apply_confirmed_duplicates/2`
+  6. **Applies the confirmed duplicates** — `apply_confirmed_duplicates/2`
      unpublishes the losers of each `:duplicate_capture` group that TONIGHT's
-     report and the PREVIOUS one both propose. It runs after step 4 on purpose,
+     report and the PREVIOUS one both propose. It runs after step 5 on purpose,
      so the two-run comparison is tonight-against-last-night. Unpublish, never
      archive: `:archived` is terminal for an article and nothing unattended may
      take a one-way door.
-  6. **Surfaces all findings** via an immutable audit event
+  7. **Surfaces all findings** via an immutable audit event
      (`knowledge.lint_completed`) carrying the full lint summary, so coverage
      gaps / broken sources / stale counts are observable in the change feed even
      though nothing repairs them — each would need a correctness signal this
@@ -97,6 +115,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Knowledge.ConflictResolution
   alias Loopctl.Knowledge.Consolidation
+  alias Loopctl.Knowledge.LinkPruning
   alias Loopctl.Oban.FairShare
   alias Loopctl.Tenants.Tenant
   alias Loopctl.Workers.ArticleLinkingWorker
@@ -155,6 +174,12 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     {:ok, report} = Knowledge.lint(tenant_id, max_per_category: @lint_max_per_category)
 
     action = act_on_orphans(tenant_id, report)
+    # Prune BEFORE the orphan count above is acted on? No — deliberately after. Union-kNN
+    # keeps every article's own top-K, so an article holding at least one edge holds it at
+    # rank 1 and the prune cannot create an orphan; ordering the two is therefore a matter
+    # of cost, not correctness, and pruning second keeps the lint report describing the
+    # graph the rest of this run reasons about.
+    pruned = prune_links(tenant_id)
     promoted = promote_conflicts(tenant_id)
     # The judge runs AFTER promotion so a pair flagged tonight is also judged tonight and
     # never spends a night suppressing its two articles. It is bounded above the promotion
@@ -171,21 +196,21 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     # failing.
     applied = apply_consolidation(tenant_id, consolidation)
 
-    log_audit_event(
-      tenant_id,
-      report,
-      action,
-      promoted,
-      judged,
-      resolutions_applied,
-      consolidation,
-      applied
-    )
+    log_audit_event(tenant_id, report, %{
+      action: action,
+      pruned: pruned,
+      promoted: promoted,
+      judged: judged,
+      resolutions_applied: resolutions_applied,
+      consolidation: consolidation,
+      applied: applied
+    })
 
     Logger.info(
       "KnowledgeLintWorker: tenant=#{tenant_id} issues=#{report.summary.total_issues} " <>
         "orphans_relinked=#{action.relinked} orphans_embedding_enqueued=#{action.embedding_enqueued} " <>
         "conflicts_promoted=#{promoted} conflicts_judged_redundant=#{judged} " <>
+        "links_pruned=#{pruned.pruned} links_prunable_remaining=#{pruned.remaining} " <>
         "resolutions_applied=#{resolutions_applied} " <>
         "duplicates_unpublished=#{applied.applied} duplicate_groups_skipped=#{applied.skipped} " <>
         "duplicates_unpublish_failed=#{applied.failed} " <>
@@ -514,6 +539,29 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # whose unpublishes had already committed). What reaches this rescue is a failure BEFORE
   # any write — the confirmed-set SELECT — so a zero tally here is true; it carries an
   # `:error` tag so the audit event still separates it from a night with nothing to apply.
+  # FAIL-SOFT for the same reason `consolidate/1` is: by the time this runs the pass has
+  # already taken effectful steps and has not yet written its audit event, so letting a
+  # statement timeout or a pool exit out of here would lose the whole night's record.
+  # A failed prune is reported as `remaining: -1` — distinguishable from "nothing left to
+  # prune" (0), because a zero here would read as a converged graph.
+  defp prune_links(tenant_id) do
+    {:ok, result} = LinkPruning.prune(tenant_id)
+    result
+  rescue
+    e -> prune_failed(tenant_id, ExitTag.tag(e))
+  catch
+    :exit, reason -> prune_failed(tenant_id, "exit:" <> ExitTag.tag(reason))
+  end
+
+  defp prune_failed(tenant_id, tag) do
+    Logger.error(
+      "KnowledgeLintWorker: tenant=#{tenant_id} relates_to link pruning failed (#{tag}); " <>
+        "the graph keeps its current degree this run."
+    )
+
+    %{pruned: 0, remaining: -1}
+  end
+
   defp apply_consolidation(_tenant_id, {:error, _tag}), do: %{applied: 0, skipped: 0, failed: 0}
 
   defp apply_consolidation(tenant_id, {:ok, _report}) do
@@ -613,16 +661,18 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   defp consolidation_state({:error, tag}, _applied),
     do: %{"status" => "failed", "error" => tag}
 
-  defp log_audit_event(
-         tenant_id,
-         report,
-         action,
-         promoted,
-         judged,
-         resolutions_applied,
-         consolidation,
-         applied
-       ) do
+  # The per-step results arrive as ONE map rather than nine positionals. That is not only
+  # arity hygiene: every step this worker gains adds a parameter here, and a positional list
+  # that long silently accepts two same-typed counts swapped at the call site.
+  defp log_audit_event(tenant_id, report, %{
+         action: action,
+         pruned: pruned,
+         promoted: promoted,
+         judged: judged,
+         resolutions_applied: resolutions_applied,
+         consolidation: consolidation,
+         applied: applied
+       }) do
     Audit.create_log_entry(tenant_id, %{
       entity_type: "knowledge_lint",
       entity_id: tenant_id,
@@ -640,6 +690,12 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         # over several nights, the drain is merely holding the line and the caps need
         # revisiting — that is not visible from either number alone.
         "conflicts_judged_redundant" => judged,
+        # Same convergence reading as the pair above, for the graph. `links_prunable_remaining`
+        # is what a capped run could not reach; 0 means the graph is at its target degree.
+        # A -1 means the prune FAILED and is deliberately not 0 — a zero there would read as
+        # converged, which is the one wrong conclusion available.
+        "links_pruned" => pruned.pruned,
+        "links_prunable_remaining" => pruned.remaining,
         "resolutions_applied" => resolutions_applied,
         "consolidation" => consolidation_state(consolidation, applied)
       }

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -52,7 +52,9 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
      graph relates nearly everything to everything and distinguishes nothing.
      Union-kNN (an edge survives if it is in EITHER endpoint's top-K) guarantees
      every article keeps its own K nearest, which is also why the prune can never
-     create an orphan. Bounded per run, worst-first, and FAIL-SOFT.
+     create an orphan. An edge at or above the conflict threshold is ranked but never
+     deleted, so step 4's promoter keeps every candidate it has not reached yet.
+     Bounded per run, worst-first, and FAIL-SOFT.
   4. **Promotes, judges and executes conflicts**, in that order and in one pass
      (#601, #606). `promote_conflicts/1` flags high-similarity pairs;
      `judge_redundant_conflicts/1` then records a verdict on them —
@@ -174,11 +176,13 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     {:ok, report} = Knowledge.lint(tenant_id, max_per_category: @lint_max_per_category)
 
     action = act_on_orphans(tenant_id, report)
-    # Prune BEFORE the orphan count above is acted on? No — deliberately after. Union-kNN
-    # keeps every article's own top-K, so an article holding at least one edge holds it at
-    # rank 1 and the prune cannot create an orphan; ordering the two is therefore a matter
-    # of cost, not correctness, and pruning second keeps the lint report describing the
-    # graph the rest of this run reasons about.
+    # Ordering the prune against its neighbours is a matter of cost, not correctness, and both
+    # halves of that are structural rather than positional. Union-kNN keeps every article's own
+    # top-K, so an article holding at least one edge holds it at rank 1 and the prune cannot
+    # create an orphan. And a `relates_to` edge at or above the conflict threshold is RANKED but
+    # never DELETED, so the prune cannot take a candidate out from under `promote_conflicts/1`
+    # below — which is capped at 500/night against a much larger backlog, so a pair deleted
+    # before it was reached would be lost to conflict detection permanently.
     pruned = prune_links(tenant_id)
     promoted = promote_conflicts(tenant_id)
     # The judge runs AFTER promotion so a pair flagged tonight is also judged tonight and
@@ -545,8 +549,13 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # A failed prune is reported as `remaining: -1` — distinguishable from "nothing left to
   # prune" (0), because a zero here would read as a converged graph.
   defp prune_links(tenant_id) do
-    {:ok, result} = LinkPruning.prune(tenant_id)
-    result
+    case LinkPruning.prune(tenant_id) do
+      {:ok, result} -> result
+      # NOT a bare `{:ok, _} =` match: `prune/2` returns `{:error, _}` when a batch rolls back
+      # before anything committed, and a MatchError there would reach the rescue below as a
+      # made-up exception class rather than the reason the prune actually failed.
+      {:error, reason} -> prune_failed(tenant_id, ExitTag.tag(reason))
+    end
   rescue
     e -> prune_failed(tenant_id, ExitTag.tag(e))
   catch

--- a/test/loopctl/knowledge/link_pruning_test.exs
+++ b/test/loopctl/knowledge/link_pruning_test.exs
@@ -1,0 +1,330 @@
+defmodule Loopctl.Knowledge.LinkPruningTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.ArticleLink
+  alias Loopctl.Knowledge.LinkPruning
+
+  defp published(tenant_id, attrs \\ %{}) do
+    base = %{
+      title: "Article #{System.unique_integer([:positive])}",
+      body: "Body.",
+      category: :pattern,
+      status: :draft,
+      tags: []
+    }
+
+    fixture(:article, Map.merge(base, Map.put(attrs, :tenant_id, tenant_id)))
+    |> Ecto.Changeset.change(%{status: :published})
+    |> AdminRepo.update!()
+  end
+
+  defp link(tenant_id, source, target, sim) do
+    typed_link(tenant_id, source, target, sim, :relates_to)
+  end
+
+  defp typed_link(tenant_id, source, target, sim, type) do
+    fixture(:article_link, %{
+      tenant_id: tenant_id,
+      source_article_id: source.id,
+      target_article_id: target.id,
+      relationship_type: type,
+      metadata: %{"auto_generated" => true, "similarity_score" => sim}
+    })
+  end
+
+  defp edge_ids(tenant_id, type \\ :relates_to) do
+    from(l in ArticleLink,
+      where: l.tenant_id == ^tenant_id,
+      where: l.relationship_type == ^type,
+      select: l.id
+    )
+    |> AdminRepo.all()
+    |> MapSet.new()
+  end
+
+  defp degree(tenant_id, article) do
+    from(l in ArticleLink,
+      where: l.tenant_id == ^tenant_id,
+      where: l.relationship_type == :relates_to,
+      where: l.source_article_id == ^article.id or l.target_article_id == ^article.id
+    )
+    |> AdminRepo.aggregate(:count)
+  end
+
+  describe "prune/2 — top-K by similarity" do
+    test "drops the edges outside top-K and keeps the NEAREST ones" do
+      tenant = fixture(:tenant)
+      hub = published(tenant.id)
+      # 6 spokes at descending similarity, all attached only to the hub. With K=2 the hub
+      # keeps its 2 best; the other 4 spokes each keep their single edge (rank 1 of their
+      # own partition), so union-kNN keeps all 6 — which is the property the next test
+      # isolates. Here the spokes are cross-linked to give them better edges of their own,
+      # so the hub's weak edges genuinely fall outside BOTH endpoints' top-K.
+      spokes = for _i <- 1..6, do: published(tenant.id)
+
+      hub_edges =
+        spokes
+        |> Enum.with_index()
+        |> Enum.map(fn {s, i} -> {s, link(tenant.id, hub, s, 0.90 - i * 0.05)} end)
+
+      # Give every spoke two strong mutual edges so its own top-2 is never the hub edge.
+      for {s, _} <- Enum.drop(hub_edges, 2) do
+        a = published(tenant.id)
+        b = published(tenant.id)
+        link(tenant.id, s, a, 0.99)
+        link(tenant.id, s, b, 0.98)
+      end
+
+      assert {:ok, %{pruned: pruned, remaining: 0}} =
+               LinkPruning.prune(tenant.id, target_degree: 2, max_per_run: 1000)
+
+      assert pruned > 0
+      surviving = edge_ids(tenant.id)
+
+      # The hub's two BEST edges survive.
+      for {_s, edge} <- Enum.take(hub_edges, 2) do
+        assert MapSet.member?(surviving, edge.id)
+      end
+
+      # Its four weakest do not — each spoke's own top-2 is the 0.99/0.98 pair.
+      for {_s, edge} <- Enum.drop(hub_edges, 2) do
+        refute MapSet.member?(surviving, edge.id)
+      end
+    end
+
+    test "UNION-kNN: an edge survives on EITHER endpoint's top-K, not both" do
+      # This is the guarantee that makes unattended pruning safe. Under mutual-kNN the
+      # hub's weak edge would be deleted even though it is the spoke's ONLY relationship.
+      tenant = fixture(:tenant)
+      hub = published(tenant.id)
+      strong_a = published(tenant.id)
+      strong_b = published(tenant.id)
+      lonely = published(tenant.id)
+
+      link(tenant.id, hub, strong_a, 0.99)
+      link(tenant.id, hub, strong_b, 0.98)
+      weak = link(tenant.id, hub, lonely, 0.61)
+
+      assert {:ok, %{pruned: 0, remaining: 0}} =
+               LinkPruning.prune(tenant.id, target_degree: 2, max_per_run: 1000)
+
+      assert MapSet.member?(edge_ids(tenant.id), weak.id),
+             "the hub's 3rd-best edge is the lonely article's ONLY edge — union-kNN must keep it"
+    end
+
+    test "pruning can never create an orphan" do
+      # An article holding at least one edge holds it at rank 1 of its own partition, and
+      # rank 1 is always inside top-K. Asserted rather than assumed because the orphan
+      # re-linker would otherwise silently re-create whatever this deleted, every night.
+      tenant = fixture(:tenant)
+      articles = for _i <- 1..12, do: published(tenant.id)
+      [hub | spokes] = articles
+
+      for {s, i} <- Enum.with_index(spokes) do
+        link(tenant.id, hub, s, 0.95 - i * 0.03)
+      end
+
+      assert {:ok, _} = LinkPruning.prune(tenant.id, target_degree: 2, max_per_run: 1000)
+
+      for a <- articles do
+        assert degree(tenant.id, a) >= 1,
+               "article #{a.id} was orphaned by pruning"
+      end
+    end
+  end
+
+  describe "prune/2 — what it refuses to touch" do
+    test "never deletes a potential_conflict edge" do
+      # That pile has its own threshold and its own draining consumer
+      # (`judge_redundant_conflicts/1`, capped above the promotion rate). Pruning it would
+      # withhold pairs from a queue designed to empty itself.
+      tenant = fixture(:tenant)
+      hub = published(tenant.id)
+      targets = for _i <- 1..5, do: published(tenant.id)
+
+      conflicts =
+        for {t, i} <- Enum.with_index(targets) do
+          typed_link(tenant.id, hub, t, 0.99 - i * 0.001, :potential_conflict)
+        end
+
+      assert {:ok, _} = LinkPruning.prune(tenant.id, target_degree: 1, max_per_run: 1000)
+
+      surviving = edge_ids(tenant.id, :potential_conflict)
+
+      for c <- conflicts do
+        assert MapSet.member?(surviving, c.id)
+      end
+    end
+
+    test "never deletes a hand-made relates_to link (no auto_generated flag)" do
+      # A hand-made edge is not regenerable, so the whole justification for deleting rather
+      # than soft-deleting does not apply to it. None exist on the corpus today; this guard
+      # is what keeps that safe if one is ever added.
+      tenant = fixture(:tenant)
+      hub = published(tenant.id)
+      strong_a = published(tenant.id)
+      strong_b = published(tenant.id)
+      hand_target = published(tenant.id)
+      other = published(tenant.id)
+
+      link(tenant.id, hub, strong_a, 0.99)
+      link(tenant.id, hub, strong_b, 0.98)
+      # Give hand_target strong edges of its own so the hand-made edge is outside BOTH
+      # endpoints' top-K — the only condition under which it could be deleted.
+      link(tenant.id, hand_target, other, 0.99)
+      link(tenant.id, hand_target, published(tenant.id), 0.985)
+
+      handmade =
+        fixture(:article_link, %{
+          tenant_id: tenant.id,
+          source_article_id: hub.id,
+          target_article_id: hand_target.id,
+          relationship_type: :relates_to,
+          metadata: %{"note" => "curated by hand"}
+        })
+
+      assert {:ok, _} = LinkPruning.prune(tenant.id, target_degree: 2, max_per_run: 1000)
+
+      assert MapSet.member?(edge_ids(tenant.id), handmade.id),
+             "a link with no auto_generated flag is not regenerable and must never be pruned"
+    end
+
+    test "never deletes an edge with no similarity_score — unrankable means unprunable" do
+      tenant = fixture(:tenant)
+      hub = published(tenant.id)
+      strong_a = published(tenant.id)
+      strong_b = published(tenant.id)
+      scoreless_target = published(tenant.id)
+
+      link(tenant.id, hub, strong_a, 0.99)
+      link(tenant.id, hub, strong_b, 0.98)
+      link(tenant.id, scoreless_target, published(tenant.id), 0.99)
+      link(tenant.id, scoreless_target, published(tenant.id), 0.985)
+
+      scoreless =
+        fixture(:article_link, %{
+          tenant_id: tenant.id,
+          source_article_id: hub.id,
+          target_article_id: scoreless_target.id,
+          relationship_type: :relates_to,
+          metadata: %{"auto_generated" => true}
+        })
+
+      assert {:ok, _} = LinkPruning.prune(tenant.id, target_degree: 2, max_per_run: 1000)
+
+      assert MapSet.member?(edge_ids(tenant.id), scoreless.id)
+    end
+
+    test "the delete and the count share ONE predicate" do
+      # If they drifted, the worker would report a backlog it is structurally unable to
+      # drain — a `remaining` that never reaches zero and no way to tell why.
+      predicate = LinkPruning.prunable_predicate()
+
+      assert predicate =~ "relates_to"
+      assert predicate =~ "auto_generated"
+      assert predicate =~ "similarity_score"
+
+      source = File.read!("lib/loopctl/knowledge/link_pruning.ex")
+
+      # Exactly two SQL statements exist (the delete and the count) and BOTH interpolate
+      # the shared function rather than inlining a copy. Anchored to code, not prose: a
+      # third statement, or one that hand-writes its own WHERE, fails here.
+      interpolations =
+        source
+        |> String.split("WHERE tenant_id = $1 \#{prunable_predicate()}")
+        |> length()
+        |> Kernel.-(1)
+
+      assert interpolations == 2,
+             "expected both SQL statements to interpolate prunable_predicate/0, found " <>
+               "#{interpolations}"
+
+      # That count is the whole check: inlining the guard into either statement drops the
+      # interpolation count to 1, and adding a third statement raises it to 3. There is no
+      # separate "no inline copy" assertion because a literal in the moduledoc — which
+      # documents exactly this predicate — is not a copy, and a check that cannot tell
+      # those apart fails on correct code.
+    end
+  end
+
+  describe "prune/2 — bounding and convergence" do
+    test "respects max_per_run and reports the remainder" do
+      tenant = fixture(:tenant)
+      hub = published(tenant.id)
+
+      for i <- 1..10 do
+        s = published(tenant.id)
+        link(tenant.id, hub, s, 0.90 - i * 0.02)
+        link(tenant.id, s, published(tenant.id), 0.99)
+        link(tenant.id, s, published(tenant.id), 0.98)
+      end
+
+      assert {:ok, %{pruned: 2, remaining: rest}} =
+               LinkPruning.prune(tenant.id, target_degree: 2, max_per_run: 2)
+
+      assert rest > 0, "a capped run must report what it could not reach"
+
+      # Draining converges: run until nothing is prunable.
+      final =
+        Enum.reduce_while(1..20, nil, fn _i, _acc ->
+          {:ok, r} = LinkPruning.prune(tenant.id, target_degree: 2, max_per_run: 2)
+          if r.remaining == 0, do: {:halt, r}, else: {:cont, r}
+        end)
+
+      assert final.remaining == 0
+    end
+
+    test "is idempotent — a second run on a pruned graph deletes nothing" do
+      tenant = fixture(:tenant)
+      hub = published(tenant.id)
+
+      for i <- 1..6 do
+        s = published(tenant.id)
+        link(tenant.id, hub, s, 0.90 - i * 0.02)
+        link(tenant.id, s, published(tenant.id), 0.99)
+        link(tenant.id, s, published(tenant.id), 0.98)
+      end
+
+      assert {:ok, %{remaining: 0}} =
+               LinkPruning.prune(tenant.id, target_degree: 2, max_per_run: 1000)
+
+      before = edge_ids(tenant.id)
+
+      assert {:ok, %{pruned: 0, remaining: 0}} =
+               LinkPruning.prune(tenant.id, target_degree: 2, max_per_run: 1000)
+
+      assert edge_ids(tenant.id) == before
+    end
+  end
+
+  describe "tenant isolation" do
+    test "pruning tenant A leaves tenant B's edges untouched" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      for tenant <- [tenant_a, tenant_b] do
+        hub = published(tenant.id)
+
+        for i <- 1..6 do
+          s = published(tenant.id)
+          link(tenant.id, hub, s, 0.90 - i * 0.02)
+          link(tenant.id, s, published(tenant.id), 0.99)
+          link(tenant.id, s, published(tenant.id), 0.98)
+        end
+      end
+
+      b_before = edge_ids(tenant_b.id)
+
+      assert {:ok, %{pruned: pruned}} =
+               LinkPruning.prune(tenant_a.id, target_degree: 2, max_per_run: 1000)
+
+      assert pruned > 0
+      assert edge_ids(tenant_b.id) == b_before
+    end
+  end
+end

--- a/test/loopctl/knowledge/link_pruning_test.exs
+++ b/test/loopctl/knowledge/link_pruning_test.exs
@@ -139,20 +139,32 @@ defmodule Loopctl.Knowledge.LinkPruningTest do
   end
 
   describe "prune/2 — what it refuses to touch" do
+    # Each test below varies EXACTLY ONE clause of `prunable_predicate/0` away from a
+    # doomed edge, so deleting that clause makes the test fail. A guarded edge that a
+    # SECOND guard would also have saved proves nothing about the first — that is how all
+    # three of these passed vacuously before.
     test "never deletes a potential_conflict edge" do
       # That pile has its own threshold and its own draining consumer
       # (`judge_redundant_conflicts/1`, capped above the promotion rate). Pruning it would
       # withhold pairs from a queue designed to empty itself.
       tenant = fixture(:tenant)
       hub = published(tenant.id)
-      targets = for _i <- 1..5, do: published(tenant.id)
+      targets = for _i <- 1..3, do: published(tenant.id)
+
+      link(tenant.id, hub, published(tenant.id), 0.92)
+      link(tenant.id, hub, published(tenant.id), 0.91)
 
       conflicts =
         for {t, i} <- Enum.with_index(targets) do
-          typed_link(tenant.id, hub, t, 0.99 - i * 0.001, :potential_conflict)
+          # Deliberately BELOW the conflict threshold. A promoted conflict link sits above
+          # it and would be spared by the conflict-band guard too, so a test built from one
+          # could not tell the `relationship_type` clause from that one.
+          link(tenant.id, t, published(tenant.id), 0.92)
+          link(tenant.id, t, published(tenant.id), 0.91)
+          typed_link(tenant.id, hub, t, 0.70 - i * 0.01, :potential_conflict)
         end
 
-      assert {:ok, _} = LinkPruning.prune(tenant.id, target_degree: 1, max_per_run: 1000)
+      assert {:ok, _} = LinkPruning.prune(tenant.id, target_degree: 2, max_per_run: 1000)
 
       surviving = edge_ids(tenant.id, :potential_conflict)
 
@@ -172,12 +184,12 @@ defmodule Loopctl.Knowledge.LinkPruningTest do
       hand_target = published(tenant.id)
       other = published(tenant.id)
 
-      link(tenant.id, hub, strong_a, 0.99)
-      link(tenant.id, hub, strong_b, 0.98)
+      link(tenant.id, hub, strong_a, 0.92)
+      link(tenant.id, hub, strong_b, 0.91)
       # Give hand_target strong edges of its own so the hand-made edge is outside BOTH
       # endpoints' top-K — the only condition under which it could be deleted.
-      link(tenant.id, hand_target, other, 0.99)
-      link(tenant.id, hand_target, published(tenant.id), 0.985)
+      link(tenant.id, hand_target, other, 0.92)
+      link(tenant.id, hand_target, published(tenant.id), 0.915)
 
       handmade =
         fixture(:article_link, %{
@@ -185,7 +197,10 @@ defmodule Loopctl.Knowledge.LinkPruningTest do
           source_article_id: hub.id,
           target_article_id: hand_target.id,
           relationship_type: :relates_to,
-          metadata: %{"note" => "curated by hand"}
+          # Carries a SCORE but no `auto_generated` flag, so the `auto_generated` clause is
+          # the only thing between it and deletion. With no score the scoreless clause would
+          # have saved it too and this test would pass with the guard removed.
+          metadata: %{"note" => "curated by hand", "similarity_score" => 0.61}
         })
 
       assert {:ok, _} = LinkPruning.prune(tenant.id, target_degree: 2, max_per_run: 1000)
@@ -195,16 +210,19 @@ defmodule Loopctl.Knowledge.LinkPruningTest do
     end
 
     test "never deletes an edge with no similarity_score — unrankable means unprunable" do
+      # The ranking sorts `DESC NULLS LAST` and the conflict band compares
+      # `coalesce(sim, 0)`, so a scoreless edge ranks WORST and is not band-protected: this
+      # clause is the only one holding it, and removing it deletes the edge below.
       tenant = fixture(:tenant)
       hub = published(tenant.id)
       strong_a = published(tenant.id)
       strong_b = published(tenant.id)
       scoreless_target = published(tenant.id)
 
-      link(tenant.id, hub, strong_a, 0.99)
-      link(tenant.id, hub, strong_b, 0.98)
-      link(tenant.id, scoreless_target, published(tenant.id), 0.99)
-      link(tenant.id, scoreless_target, published(tenant.id), 0.985)
+      link(tenant.id, hub, strong_a, 0.92)
+      link(tenant.id, hub, strong_b, 0.91)
+      link(tenant.id, scoreless_target, published(tenant.id), 0.92)
+      link(tenant.id, scoreless_target, published(tenant.id), 0.915)
 
       scoreless =
         fixture(:article_link, %{
@@ -220,9 +238,36 @@ defmodule Loopctl.Knowledge.LinkPruningTest do
       assert MapSet.member?(edge_ids(tenant.id), scoreless.id)
     end
 
-    test "the delete and the count share ONE predicate" do
-      # If they drifted, the worker would report a backlog it is structurally unable to
-      # drain — a `remaining` that never reaches zero and no way to tell why.
+    test "never deletes a relates_to edge in the conflict band" do
+      # `KnowledgeLintWorker.promote_conflicts/1` sources its candidates EXCLUSIVELY from
+      # these rows and is capped at 500/night against a much larger backlog, and the prune
+      # runs in the same nightly pass. Deleting one before the promoter reached it would
+      # make that pair permanently invisible to conflict detection — a cap on the conflict
+      # queue's inflow, imposed sideways.
+      tenant = fixture(:tenant)
+      band = Application.get_env(:loopctl, :knowledge_conflict_threshold, 0.93)
+      hub = published(tenant.id)
+      target = published(tenant.id)
+
+      # Both endpoints hold two NEARER edges, so the band edge is outside both top-2s and
+      # only the band guard can save it.
+      link(tenant.id, hub, published(tenant.id), band + 0.05)
+      link(tenant.id, hub, published(tenant.id), band + 0.04)
+      link(tenant.id, target, published(tenant.id), band + 0.05)
+      link(tenant.id, target, published(tenant.id), band + 0.04)
+
+      in_band = link(tenant.id, hub, target, band)
+
+      assert {:ok, %{remaining: 0}} =
+               LinkPruning.prune(tenant.id, target_degree: 2, max_per_run: 1000)
+
+      assert MapSet.member?(edge_ids(tenant.id), in_band.id)
+    end
+
+    test "the prune is ONE statement, and it carries the predicate" do
+      # The delete and the remainder count used to be two statements, so the guard could
+      # drift between them and the worker would report a backlog it was structurally unable
+      # to drain. They are one statement now; this is what keeps that true.
       predicate = LinkPruning.prunable_predicate()
 
       assert predicate =~ "relates_to"
@@ -231,24 +276,15 @@ defmodule Loopctl.Knowledge.LinkPruningTest do
 
       source = File.read!("lib/loopctl/knowledge/link_pruning.ex")
 
-      # Exactly two SQL statements exist (the delete and the count) and BOTH interpolate
-      # the shared function rather than inlining a copy. Anchored to code, not prose: a
-      # third statement, or one that hand-writes its own WHERE, fails here.
       interpolations =
         source
         |> String.split("WHERE tenant_id = $1 \#{prunable_predicate()}")
         |> length()
         |> Kernel.-(1)
 
-      assert interpolations == 2,
-             "expected both SQL statements to interpolate prunable_predicate/0, found " <>
+      assert interpolations == 1,
+             "expected exactly ONE SQL statement interpolating prunable_predicate/0, found " <>
                "#{interpolations}"
-
-      # That count is the whole check: inlining the guard into either statement drops the
-      # interpolation count to 1, and adding a third statement raises it to 3. There is no
-      # separate "no inline copy" assertion because a literal in the moduledoc — which
-      # documents exactly this predicate — is not a copy, and a check that cannot tell
-      # those apart fails on correct code.
     end
   end
 

--- a/test/loopctl/knowledge/link_pruning_test.exs
+++ b/test/loopctl/knowledge/link_pruning_test.exs
@@ -258,10 +258,39 @@ defmodule Loopctl.Knowledge.LinkPruningTest do
 
       in_band = link(tenant.id, hub, target, band)
 
+      # `remaining: 0` here is "nothing DELETABLE is left", not "at target degree": the hub is
+      # over K precisely because of the row this guard spared.
       assert {:ok, %{remaining: 0}} =
                LinkPruning.prune(tenant.id, target_degree: 2, max_per_run: 1000)
 
       assert MapSet.member?(edge_ids(tenant.id), in_band.id)
+    end
+
+    test "deletes a band edge once the promoter has already flagged the pair" do
+      # The spare protects PROMOTER INPUT, and `promote_conflicts/1` excludes any pair that
+      # already carries a `:potential_conflict` edge (either direction). An unconditional band
+      # exemption kept this row forever while it could never be promoted again — accumulating
+      # in exactly the high-similarity region this pass exists to thin.
+      tenant = fixture(:tenant)
+      band = Application.get_env(:loopctl, :knowledge_conflict_threshold, 0.93)
+      hub = published(tenant.id)
+      target = published(tenant.id)
+
+      link(tenant.id, hub, published(tenant.id), band + 0.05)
+      link(tenant.id, hub, published(tenant.id), band + 0.04)
+      link(tenant.id, target, published(tenant.id), band + 0.05)
+      link(tenant.id, target, published(tenant.id), band + 0.04)
+
+      in_band = link(tenant.id, hub, target, band)
+      # REVERSE direction, matching the promoter's own pair-wise `not exists`: the spare is
+      # released for the PAIR, not for one row's orientation.
+      flagged = typed_link(tenant.id, target, hub, band, :potential_conflict)
+
+      assert {:ok, %{pruned: 1, remaining: 0}} =
+               LinkPruning.prune(tenant.id, target_degree: 2, max_per_run: 1000)
+
+      refute MapSet.member?(edge_ids(tenant.id), in_band.id)
+      assert MapSet.member?(edge_ids(tenant.id, :potential_conflict), flagged.id)
     end
 
     test "the prune is ONE statement, and it carries the predicate" do
@@ -285,6 +314,17 @@ defmodule Loopctl.Knowledge.LinkPruningTest do
       assert interpolations == 1,
              "expected exactly ONE SQL statement interpolating prunable_predicate/0, found " <>
                "#{interpolations}"
+
+      # ...and it carries the client deadline TWICE. Ecto stores only the connection in the
+      # process dictionary, never the transaction's opts, so a query inside the transaction
+      # falls back to the repo's default 15 s `:timeout` — below the 30 s server bound, which
+      # is the inversion the pairing exists to prevent, one level down.
+      deadlines =
+        source |> String.split("timeout: @transaction_timeout_ms") |> length() |> Kernel.-(1)
+
+      assert deadlines == 2,
+             "expected the client deadline on BOTH the transaction and the statement, found " <>
+               "#{deadlines}"
     end
   end
 

--- a/test/loopctl/workers/article_linking_worker_test.exs
+++ b/test/loopctl/workers/article_linking_worker_test.exs
@@ -457,8 +457,101 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
 
   # --- TC-21.2.5: Links every returned candidate ---
 
+  describe "relates_to degree cap (#611 stage 0)" do
+    # A threshold is not a bound. Before this cap `relates_to` took EVERY candidate over
+    # 0.6 — up to `max_comparisons` (50) per article, bidirectionally — and the hosted
+    # corpus reached 1,402,699 edges over 79,276 articles, 56% of them carrying 21+. At
+    # that density the graph relates nearly everything to everything and distinguishes
+    # nothing. The cap is what makes the producer bounded.
+    test "keeps only the top-K nearest, and keeps the NEAREST ones" do
+      %{tenant: tenant} = setup_tenant()
+      source = create_published_article(tenant.id)
+      # 14 candidates, all comfortably over the relates threshold and all under the
+      # conflict threshold, with strictly descending similarity so "which K" is decidable.
+      scored =
+        for i <- 0..13 do
+          {create_published_article(tenant.id), 0.92 - i * 0.01}
+        end
+
+      expect(MockArticleSimilaritySearch, :nearest, fn _t, _emb, _k, _opts ->
+        # Returned in a deliberately WRONG order: the cut must sort, not trust arrival
+        # order, or it degrades to "whichever K the vector index happened to yield first".
+        scored |> Enum.reverse() |> Enum.map(fn {a, s} -> candidate(a, s) end)
+      end)
+
+      assert :ok =
+               ArticleLinkingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => source.id, "tenant_id" => tenant.id}
+               })
+
+      linked =
+        from(l in ArticleLink,
+          where: l.tenant_id == ^tenant.id,
+          where: l.relationship_type == :relates_to,
+          where: l.source_article_id == ^source.id,
+          select: l.target_article_id
+        )
+        |> AdminRepo.all()
+        |> MapSet.new()
+
+      cap = Application.get_env(:loopctl, :article_max_relates_to_links, 10)
+      assert MapSet.size(linked) == cap
+
+      {kept, dropped} = Enum.split(scored, cap)
+
+      for {article, sim} <- kept do
+        assert MapSet.member?(linked, article.id),
+               "candidate at similarity #{sim} is in the top #{cap} but was not linked"
+      end
+
+      for {article, sim} <- dropped do
+        refute MapSet.member?(linked, article.id),
+               "candidate at similarity #{sim} is outside the top #{cap} but was linked"
+      end
+    end
+
+    test "does NOT cap potential_conflict — that queue has its own draining consumer" do
+      # `judge_redundant_conflicts/1` drains this pile capped ABOVE the promotion rate, so
+      # it converges by arithmetic. Capping the producer here as well would silently
+      # withhold pairs from a queue designed to empty itself.
+      %{tenant: tenant} = setup_tenant()
+      source = create_published_article(tenant.id)
+      targets = for _i <- 1..14, do: create_published_article(tenant.id)
+
+      expect(MockArticleSimilaritySearch, :nearest, fn _t, _emb, _k, _opts ->
+        Enum.map(targets, &candidate(&1, 0.97))
+      end)
+
+      assert :ok =
+               ArticleLinkingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => source.id, "tenant_id" => tenant.id}
+               })
+
+      conflict_count =
+        from(l in ArticleLink,
+          where: l.tenant_id == ^tenant.id,
+          where: l.relationship_type == :potential_conflict,
+          where: l.source_article_id == ^source.id
+        )
+        |> AdminRepo.aggregate(:count)
+
+      assert conflict_count == 14
+
+      # ...while relates_to for the same 14 candidates IS capped.
+      relates_count =
+        from(l in ArticleLink,
+          where: l.tenant_id == ^tenant.id,
+          where: l.relationship_type == :relates_to,
+          where: l.source_article_id == ^source.id
+        )
+        |> AdminRepo.aggregate(:count)
+
+      assert relates_count == Application.get_env(:loopctl, :article_max_relates_to_links, 10)
+    end
+  end
+
   describe "candidate fan-out" do
-    test "creates a relates_to link for each returned candidate" do
+    test "creates a relates_to link for each returned candidate under the degree cap" do
       %{tenant: tenant} = setup_tenant()
       source = create_published_article(tenant.id)
       targets = for _i <- 1..3, do: create_published_article(tenant.id)

--- a/test/loopctl/workers/article_linking_worker_test.exs
+++ b/test/loopctl/workers/article_linking_worker_test.exs
@@ -550,6 +550,42 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
       assert degree == Application.get_env(:loopctl, :article_max_relates_to_links, 10)
     end
 
+    test "an edge the prune can never free does not consume the headroom" do
+      # Headroom used to count EVERY incident relates_to edge, including hand-made ones that
+      # `LinkPruning` may never delete. K of those switched this article's auto-linking off for
+      # good: no pass could free a slot again, so the writer's bound and the pruner's target
+      # were two different definitions of degree and the article lost by the difference.
+      %{tenant: tenant} = setup_tenant()
+      source = create_published_article(tenant.id)
+      cap = Application.get_env(:loopctl, :article_max_relates_to_links, 10)
+
+      for _i <- 1..cap do
+        fixture(:article_link, %{
+          tenant_id: tenant.id,
+          source_article_id: source.id,
+          target_article_id: create_published_article(tenant.id).id,
+          relationship_type: :relates_to,
+          metadata: %{"note" => "curated by hand"}
+        })
+      end
+
+      candidates = for _i <- 1..3, do: create_published_article(tenant.id)
+
+      expect(MockArticleSimilaritySearch, :nearest, fn _t, _emb, _k, _opts ->
+        Enum.map(candidates, &candidate(&1, 0.90))
+      end)
+
+      assert :ok =
+               ArticleLinkingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => source.id, "tenant_id" => tenant.id}
+               })
+
+      for c <- candidates do
+        assert links_of_type(tenant.id, source.id, c.id, :relates_to) != [],
+               "a hand-made link the prune cannot reclaim consumed a write slot forever"
+      end
+    end
+
     test "does NOT cap potential_conflict — that queue has its own draining consumer" do
       # `judge_redundant_conflicts/1` drains this pile capped ABOVE the promotion rate, so
       # it converges by arithmetic. Capping the producer here as well would silently

--- a/test/loopctl/workers/article_linking_worker_test.exs
+++ b/test/loopctl/workers/article_linking_worker_test.exs
@@ -510,6 +510,46 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
       end
     end
 
+    test "tops an already-linked article UP to K rather than adding K more" do
+      # The cut used to run on the candidate list BEFORE the already-linked rejection, so
+      # stored edges cost nothing against K: every re-link (nightly orphan pass, a re-embed)
+      # could add K MORE and outbound degree grew without bound between prunes.
+      %{tenant: tenant} = setup_tenant()
+      source = create_published_article(tenant.id)
+      first = for _i <- 1..14, do: create_published_article(tenant.id)
+      second = for _i <- 1..14, do: create_published_article(tenant.id)
+
+      run = fn ->
+        ArticleLinkingWorker.perform(%Oban.Job{
+          args: %{"article_id" => source.id, "tenant_id" => tenant.id}
+        })
+      end
+
+      expect(MockArticleSimilaritySearch, :nearest, fn _t, _emb, _k, _opts ->
+        Enum.map(first, &candidate(&1, 0.90))
+      end)
+
+      assert :ok = run.()
+
+      # A later run whose candidate set has shifted: all NEW pairs, all nearer than the
+      # stored ones. The article is already at K, so it may write none of them.
+      expect(MockArticleSimilaritySearch, :nearest, fn _t, _emb, _k, _opts ->
+        Enum.map(second, &candidate(&1, 0.92))
+      end)
+
+      assert :ok = run.()
+
+      degree =
+        from(l in ArticleLink,
+          where: l.tenant_id == ^tenant.id,
+          where: l.relationship_type == :relates_to,
+          where: l.source_article_id == ^source.id or l.target_article_id == ^source.id
+        )
+        |> AdminRepo.aggregate(:count)
+
+      assert degree == Application.get_env(:loopctl, :article_max_relates_to_links, 10)
+    end
+
     test "does NOT cap potential_conflict — that queue has its own draining consumer" do
       # `judge_redundant_conflicts/1` drains this pile capped ABOVE the promotion rate, so
       # it converges by arithmetic. Capping the producer here as well would silently


### PR DESCRIPTION
Stage 0 of #611. Bounds `relates_to` degree so the graph carries navigational information instead of asserting that nearly everything relates to everything.

## The measurement that motivated it

| | |
|---|---|
| published articles | 79,276 |
| `relates_to` edges | **1,402,699** |
| written by a human | **0** — every one carries a machine `similarity_score` |
| in the 0.60–0.70 band | 833,418 (59%) |
| articles with 21+ edges | 44,496 (56%) |
| surviving union-kNN top-10 | **499,058** (~12.6 avg degree) |
| precision@20 (14d baseline, #605) | 0.038 |

A similarity threshold is not a bound. Above 0.6 the linking worker created an edge for **every** kNN candidate — up to `article_link_max_comparisons` (50) outbound per article, plus one inbound from every other article that reached it. At the resulting density a traversal from any article reaches most of the corpus in two hops, so the graph distinguishes nothing. That is the structural half of the same symptom precision@20 reports from the retrieval side, and it is what progressive disclosure's one-hop enrichment has been spending its budget on.

## Two halves

**Write side** — `ArticleLinkingWorker` keeps only the top `article_max_relates_to_links` (new, default 10) nearest candidates. Sorted explicitly rather than trusting the vector index's arrival order, so a future change to the search path cannot silently turn "the best K" into "whichever K arrived first"; ties break on id so a re-link does not churn the graph nightly.

`:potential_conflict` is deliberately **not** capped — it has its own threshold and its own draining consumer (`judge_redundant_conflicts/1`, capped above the promotion rate), and a second cap there would withhold pairs from a queue designed to converge.

**Backlog** — `Loopctl.Knowledge.LinkPruning` drains what is already there: bounded per run (`knowledge_link_prune_max_per_run`, new, default 250,000), worst-first, inside a `SET LOCAL statement_timeout` transaction, fail-soft, reporting the remainder on the `knowledge.lint_completed` audit event as `links_pruned` / `links_prunable_remaining`. A failed prune reports `remaining: -1`, not 0 — a zero there would read as a converged graph, which is the one wrong conclusion available.

## Union-kNN, and why it is the whole safety argument

An edge survives if it is in the top-K of **either** endpoint. Mutual-kNN would delete an edge that is A's single best relationship merely because it is not in B's top-K.

Union buys the property everything else rests on: an article holding at least one edge holds it at **rank 1 of its own partition**, and rank 1 is always inside top-K — so **pruning can never create an orphan.** That is asserted against real rows rather than assumed, because otherwise the orphan re-linker would quietly rebuild whatever this deleted, every night, and the two passes would fight forever.

## Why a DELETE is allowed here when nothing else in that worker deletes

Every other automated step is gated on reversibility (#605). This one is not reversible, and the distinction that licenses it is narrow: an auto-generated edge is a **derived artifact**, not a record — a pure function of two embeddings and a threshold, which `ArticleLinkingWorker` recomputes from the same vectors.

That reasoning covers only edges that carry their own derivation, so the predicate fails closed. `prunable_predicate/0` requires **all** of: `relates_to`, `auto_generated: true`, and a non-null `similarity_score`. A hand-made link is structurally out of reach (none exist today — this is what keeps that safe if one is added), and an edge that cannot be ranked cannot be shown to be outside anyone's top-K.

The delete and the count interpolate **one shared predicate**, and a test fails if either inlines its own copy — drift there would report a backlog the pass is structurally unable to drain, forever.

## Verification

`mix precommit` green: 6906 tests, 0 failures.

Mutation-verified — each of these fails tests, none was assumed:

| Mutation | Result |
|---|---|
| remove the top-K cap | 2 failures |
| remove the sort (trust arrival order) | 1 failure |
| inline the predicate into the count statement | 1 failure |
| union-kNN → mutual-kNN | 2 failures, including the orphan invariant |

Also covered: tenant isolation, idempotency (a second run deletes nothing), convergence (repeated capped runs reach `remaining: 0`), and refusal to touch `potential_conflict` / hand-made / unrankable edges.

## Operator note

`CHANGELOG.md` carries this under **Changed**, leading with the fact that the nightly pass now deletes rows and roughly how many on first run. No migration, no manual step; idempotent and convergent.

## What this does NOT do

Stage 1 (typing the surviving edges — `supports` / `contradicts` / `specializes`) is **not** in this PR and is explicitly gated on measurement. Per #611: ship stage 0, then read precision@20 against the 0.038 baseline for a fortnight. If pruning moves it, the graph was the bottleneck and the LLM typing pass is worth the spend. If it does not, the problem is elsewhere and stage 1 would have been expensive noise.
