### PR TITLE
Let the nightly drain the duplicate backlog instead of holding a floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Operator-facing changes for deployments outside the hosted instance.
 
   The bounds themselves stay — a bug that mis-picks winners must be visible after one night
   rather than after the whole corpus — and unpublish being reversible by publishing is what
-  licenses a bound this size. Evidence for the new sizing: on 2026-08-06 the class unpublished
+  licenses a bound this size. Evidence for the new sizing: on 2026-08-05 the class unpublished
   112 loser articles on the hosted corpus, and **all 112 were verified to still have a
   surviving published twin**, with zero private articles touched.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ Operator-facing changes for deployments outside the hosted instance.
 
 ### Changed
 
+- **The nightly consolidation drain rates are raised so the duplicate backlog converges to
+  zero instead of to a floor (#611).** Three settings, all previously pinned to module
+  defaults sized for a class that had never applied anything in production:
+  `knowledge_consolidation_max_per_class` (100 → **500**, the existing hard ceiling),
+  `knowledge_consolidation_max_applies` (**new**, default 500) and
+  `knowledge_consolidation_max_unpublishes` (**new**, default 500).
+
+  The per-class cap is the one that mattered. Auto-apply requires a proposal in **both** of
+  the last two reports, so a standing backlog larger than the report cap could never drain
+  however long the pass ran — the hosted corpus sat at 290 proposals with 100 visible, a
+  queue converging to a floor rather than to zero. The two apply caps were additionally
+  UNREACHABLE: `apply_confirmed_duplicates/2` accepted them as options and the worker passed
+  none, so operator configuration had no effect and draining a backlog required calling the
+  context directly.
+
+  The bounds themselves stay — a bug that mis-picks winners must be visible after one night
+  rather than after the whole corpus — and unpublish being reversible by publishing is what
+  licenses a bound this size. Evidence for the new sizing: on 2026-08-06 the class unpublished
+  112 loser articles on the hosted corpus, and **all 112 were verified to still have a
+  surviving published twin**, with zero private articles touched.
+
 - **The nightly knowledge pass now PRUNES the `relates_to` graph to a bounded degree, which
   DELETES rows (#611 stage 0).** Read this before upgrading if you run a large corpus: on
   first run the pass will delete a large number of `article_links` rows, and it is the only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Operator-facing changes for deployments outside the hosted instance.
 
   The bounds themselves stay — a bug that mis-picks winners must be visible after one night
   rather than after the whole corpus — and unpublish being reversible by publishing is what
-  licenses a bound this size. Evidence for the new sizing: on 2026-08-05 the class unpublished
+  licenses a bound this size. Evidence for the new sizing: on 2026-08-06 (UTC) the class unpublished
   112 loser articles on the hosted corpus, and **all 112 were verified to still have a
   surviving published twin**, with zero private articles touched.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ Operator-facing changes for deployments outside the hosted instance.
   112 loser articles on the hosted corpus, and **all 112 were verified to still have a
   surviving published twin**, with zero private articles touched.
 
+  Both apply caps are clamped to **0..500**: 500 is a hard ceiling, so raising a value above
+  it has no effect, and a non-integer value is ignored in favour of the built-in default.
+  Setting either to **0 pauses the auto-unpublish drain** — nothing is applied and the audit
+  event records `duplicate_apply_gate=drain_disabled`, so a paused night is distinguishable
+  from a clean one. That is the supported way to halt the drain during an incident. A
+  duplicate group with more losers than the cap is now drained as far as the cap allows
+  (the surviving winner is never touched) instead of being skipped whole, which had made any
+  group larger than the cap permanently unappliable.
+
 - **The nightly knowledge pass now PRUNES the `relates_to` graph to a bounded degree, which
   DELETES rows (#611 stage 0).** Read this before upgrading if you run a large corpus: on
   first run the pass will delete a large number of `article_links` rows, and it is the only

--- a/config/config.exs
+++ b/config/config.exs
@@ -758,7 +758,7 @@ config :loopctl,
 
 # Consolidation drain rates (#611). All three were previously pinned to module defaults sized
 # for a class that had never applied anything in production. It has now: 112 loser articles
-# unpublished on 2026-08-06, and ALL 112 were verified to still have a surviving published
+# unpublished on 2026-08-05, and ALL 112 were verified to still have a surviving published
 # twin. The bounds stay — a bug that mis-picks winners must be visible after one night rather
 # than after the whole corpus — but they are sized to CONVERGE rather than to hold a line.
 #

--- a/config/config.exs
+++ b/config/config.exs
@@ -769,6 +769,12 @@ config :loopctl,
 # than to zero.
 #
 # Unpublish is reversible by publishing, which is what licenses a bound this size at all.
+#
+# Both apply caps are clamped to 0..500 (500 is the hard ceiling — raising a value above it
+# has no effect), and a non-integer value is ignored in favour of the module default. Setting
+# either to 0 PAUSES the auto-unpublish drain for that run: nothing is applied and the audit
+# event records duplicate_apply_gate=drain_disabled, so a paused night is not mistaken for a
+# clean one. That is the supported way to halt the drain during an incident.
 config :loopctl,
   knowledge_consolidation_max_per_class: 500,
   knowledge_consolidation_max_applies: 500,

--- a/config/config.exs
+++ b/config/config.exs
@@ -758,7 +758,7 @@ config :loopctl,
 
 # Consolidation drain rates (#611). All three were previously pinned to module defaults sized
 # for a class that had never applied anything in production. It has now: 112 loser articles
-# unpublished on 2026-08-05, and ALL 112 were verified to still have a surviving published
+# unpublished on 2026-08-06 UTC, and ALL 112 were verified to still have a surviving published
 # twin. The bounds stay — a bug that mis-picks winners must be visible after one night rather
 # than after the whole corpus — but they are sized to CONVERGE rather than to hold a line.
 #

--- a/config/config.exs
+++ b/config/config.exs
@@ -756,6 +756,24 @@ config :loopctl,
   knowledge_lint_orphan_link_threshold: 0.5,
   knowledge_lint_max_orphan_relink: 500
 
+# Consolidation drain rates (#611). All three were previously pinned to module defaults sized
+# for a class that had never applied anything in production. It has now: 112 loser articles
+# unpublished on 2026-08-06, and ALL 112 were verified to still have a surviving published
+# twin. The bounds stay — a bug that mis-picks winners must be visible after one night rather
+# than after the whole corpus — but they are sized to CONVERGE rather than to hold a line.
+#
+# `max_per_class` at the hard ceiling means the report stops being permanently `truncated`,
+# which matters because the two-run agreement gate can only confirm what BOTH reports carry:
+# a standing backlog larger than the cap could never drain, however long it ran. At 100 the
+# corpus sat at 290 proposals with 100 visible, i.e. a queue that converged to a floor rather
+# than to zero.
+#
+# Unpublish is reversible by publishing, which is what licenses a bound this size at all.
+config :loopctl,
+  knowledge_consolidation_max_per_class: 500,
+  knowledge_consolidation_max_applies: 500,
+  knowledge_consolidation_max_unpublishes: 500
+
 # LinkPruning (#611 stage 0): how many over-degree `relates_to` edges one nightly run may
 # DELETE, worst-first. Sized to converge in a few nights rather than a few months — the
 # standing backlog on the hosted corpus was ~903,600 edges (1,402,699 total, 499,058

--- a/config/test.exs
+++ b/config/test.exs
@@ -771,12 +771,17 @@ config :loopctl, :embedding_legacy_retirement,
 # "already covered elsewhere".
 config :loopctl, :hnsw_iterative_scan_default, 1
 
-# Consolidation apply caps, held DELIBERATELY LOW in test (#611). Both were unreachable from
-# `KnowledgeLintWorker` for a while — `apply_confirmed_duplicates/2` took them as opts and the
-# worker passed none, so the nightly ran on module defaults whatever an operator configured,
-# and nothing failed when that was true. A cap of 1 here makes the wiring observable: the
-# worker test creates several confirmed duplicate groups and asserts exactly ONE applies, so
-# dropping the opts again turns into a failure rather than a silent reversion to 25.
+# Consolidation apply caps, held DELIBERATELY LOW and ASYMMETRIC in test (#611). Both were
+# unreachable from `KnowledgeLintWorker` for a while — `apply_confirmed_duplicates/2` took
+# them as opts and the worker passed none, so the nightly ran on module defaults whatever an
+# operator configured, and nothing failed when that was true.
+#
+# The two values must DIFFER, and both must be below the module defaults (25 / 100), or the
+# regression test cannot see which opt was dropped: with both pinned at 1 the worker test's
+# three groups yield one applied loser whichever cap binds, so dropping EITHER opt still
+# passed. At 2/1 the group cap decides how many proposals are FETCHED (skipped=1, not 2) and
+# the article cap decides how many of those apply (applied=1, not 2), so each opt has its own
+# failing assertion.
 config :loopctl,
-  knowledge_consolidation_max_applies: 1,
+  knowledge_consolidation_max_applies: 2,
   knowledge_consolidation_max_unpublishes: 1

--- a/config/test.exs
+++ b/config/test.exs
@@ -770,3 +770,13 @@ config :loopctl, :embedding_legacy_retirement,
 # at all — a mis-cited compensating control is how the real one gets deleted later as
 # "already covered elsewhere".
 config :loopctl, :hnsw_iterative_scan_default, 1
+
+# Consolidation apply caps, held DELIBERATELY LOW in test (#611). Both were unreachable from
+# `KnowledgeLintWorker` for a while — `apply_confirmed_duplicates/2` took them as opts and the
+# worker passed none, so the nightly ran on module defaults whatever an operator configured,
+# and nothing failed when that was true. A cap of 1 here makes the wiring observable: the
+# worker test creates several confirmed duplicate groups and asserts exactly ONE applies, so
+# dropping the opts again turns into a failure rather than a silent reversion to 25.
+config :loopctl,
+  knowledge_consolidation_max_applies: 1,
+  knowledge_consolidation_max_unpublishes: 1

--- a/lib/loopctl/knowledge/consolidation.ex
+++ b/lib/loopctl/knowledge/consolidation.ex
@@ -147,6 +147,14 @@ defmodule Loopctl.Knowledge.Consolidation do
   # skipped run); anything wider is not the "two consecutive runs" the gate advertises.
   @max_confirmation_gap 2
 
+  @doc "Default cap on duplicate GROUPS one run may apply."
+  @spec default_max_applies() :: pos_integer()
+  def default_max_applies, do: @default_max_applies
+
+  @doc "Default cap on loser ARTICLES one run may unpublish."
+  @spec default_max_unpublishes() :: pos_integer()
+  def default_max_unpublishes, do: @default_max_unpublishes
+
   @doc "Default per-class proposal cap."
   @spec default_max_per_class() :: pos_integer()
   def default_max_per_class, do: @default_max_per_class

--- a/lib/loopctl/knowledge/consolidation.ex
+++ b/lib/loopctl/knowledge/consolidation.ex
@@ -139,10 +139,13 @@ defmodule Loopctl.Knowledge.Consolidation do
   @default_max_unpublishes 100
 
   # Hard ceilings for the two operator-configurable apply caps, mirroring
-  # `@hard_max_per_class`. Both knobs are clamped to `1..ceiling`: an unclamped negative
-  # `:max_applies` reached `limit: ^cap` as a Postgrex error, and an unclamped `0`/negative
-  # `:max_unpublishes` skipped every group every night while the audit event read like a
-  # quiet one. Pausing the drain is the schedule's job, not a zero here.
+  # `@hard_max_per_class`. Both knobs are clamped to `0..ceiling`, and only an INTEGER is
+  # clamped: an unclamped negative `:max_applies` reached `limit: ^cap` as a Postgrex error,
+  # while Erlang term order puts a `nil` or a `"500"` ABOVE every integer, so `min/2` would
+  # resolve a config typo to the ceiling — the largest blast radius available — instead of to
+  # the default. `0` is honoured as an explicit PAUSE (`gate: :drain_disabled`) rather than
+  # rounded up to 1: an operator halting the drain mid-incident must not still get a night of
+  # unpublishes out of it.
   @hard_max_applies 500
   @hard_max_unpublishes 500
 
@@ -305,13 +308,24 @@ defmodule Loopctl.Knowledge.Consolidation do
 
   ## What bounds one night
 
-  Two caps, in different units, each clamped to `1..500`. `:max_applies` (default
-  `#{@default_max_applies}`) bounds how many PROPOSALS are considered;
-  `:max_unpublishes` (default `#{@default_max_unpublishes}`)
-  bounds how many loser ARTICLES actually leave the published set. The second is the one that
-  matters — a group can carry many members, so a group cap alone is not an article cap — and
-  a group that would cross it is skipped WHOLE, never applied part-way, because a group with
-  no winner is the one state neither the next run nor a reader can interpret.
+  Two caps, in different units, each clamped to `0..500` — `0` PAUSES the drain and records
+  `gate: :drain_disabled`, and a non-integer falls back to the module default rather than to
+  the ceiling. `:max_applies` bounds how many PROPOSALS are considered; `:max_unpublishes`
+  bounds how many loser ARTICLES actually leave the published set, and it is the one that
+  matters, because a group can carry many members. The EFFECTIVE defaults are the shipped
+  `config/config.exs` values (`knowledge_consolidation_max_applies` /
+  `_max_unpublishes`, both 500); `#{@default_max_applies}` / `#{@default_max_unpublishes}`
+  are only the module fallbacks for a config that omits them.
+
+  A group larger than the remaining budget is drained AS FAR AS the budget goes, not skipped
+  whole. The winner is never a candidate for unpublishing, so a part-drained group is
+  winner-plus-leftovers — the shape the next scan re-derives — never the winnerless state a
+  whole-group rule was written to avoid. Skipping whole made any group with more losers than
+  the cap permanently unappliable, and with the cap itself ceilinged at 500 the "raise the
+  cap" remedy was unreachable: the backlog converged to a floor, which is the failure this
+  pass exists to fix. The budget is charged on the LIVE loser count at write time and only
+  for articles that actually LEFT the published set — a rejected unpublish is counted in
+  `failed`, never spent.
 
   It is deliberately NOT a confidence score. Confidence is the machine grading its own
   homework; agreement across two independent observations of a moving corpus is evidence.
@@ -333,18 +347,46 @@ defmodule Loopctl.Knowledge.Consolidation do
           applied: non_neg_integer(),
           skipped: non_neg_integer(),
           failed: non_neg_integer(),
-          gate: :open | :report_gap | :insufficient_history
+          gate: :open | :report_gap | :insufficient_history | :drain_disabled
         }
   def apply_confirmed_duplicates(tenant_id, opts \\ []) do
     cap =
-      opts |> Keyword.get(:max_applies, @default_max_applies) |> max(1) |> min(@hard_max_applies)
+      clamp_cap(
+        Keyword.get(opts, :max_applies, @default_max_applies),
+        @default_max_applies,
+        @hard_max_applies
+      )
 
     unpublish_cap =
-      opts
-      |> Keyword.get(:max_unpublishes, @default_max_unpublishes)
-      |> max(1)
-      |> min(@hard_max_unpublishes)
+      clamp_cap(
+        Keyword.get(opts, :max_unpublishes, @default_max_unpublishes),
+        @default_max_unpublishes,
+        @hard_max_unpublishes
+      )
 
+    if min(cap, unpublish_cap) == 0 do
+      log_gate_blocked(tenant_id, :drain_disabled)
+      %{applied: 0, skipped: 0, failed: 0, gate: :drain_disabled}
+    else
+      run_confirmed_duplicates(tenant_id, cap, unpublish_cap)
+    end
+  end
+
+  # Only an integer is clamped. A `nil` or a `"500"` from a hand-rolled env read sorts ABOVE
+  # every integer in Erlang term order, so `min/2` would hand a config typo the ceiling — the
+  # largest blast radius available — rather than the default it meant to fall back to.
+  defp clamp_cap(value, _default, hard_max) when is_integer(value),
+    do: value |> max(0) |> min(hard_max)
+
+  defp clamp_cap(value, default, _hard_max) do
+    Logger.warning(
+      "Consolidation: ignoring non-integer apply cap #{inspect(value)}; using #{default}."
+    )
+
+    default
+  end
+
+  defp run_confirmed_duplicates(tenant_id, cap, unpublish_cap) do
     case confirmed_duplicate_proposals(tenant_id, cap) do
       {:error, reason} ->
         log_gate_blocked(tenant_id, reason)
@@ -380,26 +422,15 @@ defmodule Loopctl.Knowledge.Consolidation do
   # to the worker discarded the tally of groups that had ALREADY committed and reported zero
   # unpublishes that really happened. A crashed group applied nothing, so it counts as one
   # failure and the reduce carries on.
+  #
+  # The remaining budget is spent INSIDE `apply_duplicate_group/3`, after the live re-fetch,
+  # and only `acc.applied` is charged. Two reasons, both of which cost the pass real drain:
+  # `acc.failed` counts loser articles that STAYED published, and this cap counts articles
+  # that LEAVE the published set; and the proposal's `article_ids` is a scan-time snapshot, so
+  # charging its length skipped groups for budget they would never have spent (the same reason
+  # the winner is recomputed from live rows).
   defp tally_apply(tenant_id, proposal, acc, unpublish_cap) do
-    # The group cap bounds how many PROPOSALS are considered; this bounds how many ARTICLES
-    # actually leave the published set tonight. A group is skipped WHOLE rather than applied
-    # part-way, because a half-applied group has no winner and is the one state neither the
-    # next run nor a reader can interpret.
-    #
-    # The group's OWN loser count is charged against the remaining budget, not just the
-    # budget spent so far: testing only "already exhausted" let the last admitted group run
-    # unbounded, so the effective ceiling was `cap - 1 + group_size` and the operator knob
-    # was advisory rather than a bound. A group whose losers exceed the whole budget is
-    # therefore never applied — raise the cap above the largest group to drain it.
-    if acc.applied + acc.failed + losers(proposal) > unpublish_cap do
-      %{acc | skipped: acc.skipped + 1}
-    else
-      do_tally_apply(tenant_id, proposal, acc)
-    end
-  end
-
-  defp do_tally_apply(tenant_id, proposal, acc) do
-    case apply_duplicate_group(tenant_id, proposal) do
+    case apply_duplicate_group(tenant_id, proposal, unpublish_cap - acc.applied) do
       {:ok, applied, failed} ->
         %{acc | applied: acc.applied + applied, failed: acc.failed + failed}
 
@@ -427,8 +458,9 @@ defmodule Loopctl.Knowledge.Consolidation do
     %{acc | failed: acc.failed + losers}
   end
 
-  # Every member but the winner. Floored at 1 so a malformed single-member group still
-  # charges the budget and still counts as one failure rather than as nothing.
+  # Every member but the winner, from the SCAN-time id set — a crashed group never reached
+  # the live re-fetch, so this is the only count it has. Floored at 1 so a malformed
+  # single-member group still counts as one failure rather than as nothing.
   defp losers(proposal), do: max(length(proposal.article_ids) - 1, 1)
 
   # Proposals present in BOTH the newest report and the one before it, matched on
@@ -489,7 +521,7 @@ defmodule Loopctl.Knowledge.Consolidation do
     |> AdminRepo.all()
   end
 
-  defp apply_duplicate_group(tenant_id, proposal) do
+  defp apply_duplicate_group(tenant_id, proposal, budget) do
     live =
       from(a in Article,
         where: a.tenant_id == ^tenant_id,
@@ -506,21 +538,27 @@ defmodule Loopctl.Knowledge.Consolidation do
 
     # Re-verification, not trust. The group must STILL be a group: fewer than two live
     # published members means it resolved itself between the scan and now, and applying
-    # would unpublish the last copy of something.
-    if length(live) < 2 do
+    # would unpublish the last copy of something. No budget left is the other skip.
+    if length(live) < 2 or budget < 1 do
       :skip
     else
-      [winner | losers] =
+      [winner | all_losers] =
         Enum.sort_by(live, fn a ->
           {-a.body_len, -DateTime.to_unix(a.updated_at, :microsecond), a.id}
         end)
 
+      # Drained as far as the budget goes, not skipped whole: the winner is never a candidate
+      # here, so what is left behind is winner-plus-leftovers — the group the next scan
+      # re-derives — never a winnerless set. Skipping whole made a group with more losers
+      # than the cap unappliable on EVERY run, with no reachable remedy once the cap itself
+      # is ceilinged.
+      losers = Enum.take(all_losers, budget)
       applied = Enum.count(losers, &unpublish_duplicate(tenant_id, &1))
 
       Logger.info(
         "Consolidation: tenant=#{tenant_id} applied duplicate_capture proposal " <>
           "##{proposal.number} — kept #{winner.id}, unpublished #{applied} of " <>
-          "#{length(losers)} duplicate(s). Reversible via publish."
+          "#{length(all_losers)} duplicate(s) (budget #{budget}). Reversible via publish."
       )
 
       {:ok, applied, length(losers) - applied}
@@ -631,7 +669,7 @@ defmodule Loopctl.Knowledge.Consolidation do
   # Excludes agent-PRIVATE articles from everything this pass does. Composed into EVERY
   # place that decides whether an article of this tenant is in scope — the scans
   # (`published_base/1`), the evidence fetch (`evidence_map/2`), the apply-time live
-  # re-check (`apply_duplicate_group/2`) and the read-time redaction liveness
+  # re-check (`apply_duplicate_group/3`) and the read-time redaction liveness
   # (`live_evidence_ids/2`) — because a guard that lives in only some of them is a guard
   # the next reader adds one more path around.
   #

--- a/lib/loopctl/knowledge/consolidation.ex
+++ b/lib/loopctl/knowledge/consolidation.ex
@@ -138,6 +138,14 @@ defmodule Loopctl.Knowledge.Consolidation do
   # irreversible-adjacent — loser articles pulled out of the published set in one night.
   @default_max_unpublishes 100
 
+  # Hard ceilings for the two operator-configurable apply caps, mirroring
+  # `@hard_max_per_class`. Both knobs are clamped to `1..ceiling`: an unclamped negative
+  # `:max_applies` reached `limit: ^cap` as a Postgrex error, and an unclamped `0`/negative
+  # `:max_unpublishes` skipped every group every night while the audit event read like a
+  # quiet one. Pausing the drain is the schedule's job, not a zero here.
+  @hard_max_applies 500
+  @hard_max_unpublishes 500
+
   # The classes `analyze/2` still PRODUCES, in the order proposals are numbered in. Distinct
   # from `ConsolidationProposal.classes()`, which is the schema enum and additionally carries
   # the retired values so historical rows load. Assembly iterates THIS list.
@@ -297,8 +305,9 @@ defmodule Loopctl.Knowledge.Consolidation do
 
   ## What bounds one night
 
-  Two caps, in different units. `:max_applies` (default `#{@default_max_applies}`) bounds how
-  many PROPOSALS are considered; `:max_unpublishes` (default `#{@default_max_unpublishes}`)
+  Two caps, in different units, each clamped to `1..500`. `:max_applies` (default
+  `#{@default_max_applies}`) bounds how many PROPOSALS are considered;
+  `:max_unpublishes` (default `#{@default_max_unpublishes}`)
   bounds how many loser ARTICLES actually leave the published set. The second is the one that
   matters — a group can carry many members, so a group cap alone is not an article cap — and
   a group that would cross it is skipped WHOLE, never applied part-way, because a group with
@@ -327,8 +336,14 @@ defmodule Loopctl.Knowledge.Consolidation do
           gate: :open | :report_gap | :insufficient_history
         }
   def apply_confirmed_duplicates(tenant_id, opts \\ []) do
-    cap = Keyword.get(opts, :max_applies, @default_max_applies)
-    unpublish_cap = Keyword.get(opts, :max_unpublishes, @default_max_unpublishes)
+    cap =
+      opts |> Keyword.get(:max_applies, @default_max_applies) |> max(1) |> min(@hard_max_applies)
+
+    unpublish_cap =
+      opts
+      |> Keyword.get(:max_unpublishes, @default_max_unpublishes)
+      |> max(1)
+      |> min(@hard_max_unpublishes)
 
     case confirmed_duplicate_proposals(tenant_id, cap) do
       {:error, reason} ->
@@ -370,7 +385,13 @@ defmodule Loopctl.Knowledge.Consolidation do
     # actually leave the published set tonight. A group is skipped WHOLE rather than applied
     # part-way, because a half-applied group has no winner and is the one state neither the
     # next run nor a reader can interpret.
-    if acc.applied + acc.failed >= unpublish_cap do
+    #
+    # The group's OWN loser count is charged against the remaining budget, not just the
+    # budget spent so far: testing only "already exhausted" let the last admitted group run
+    # unbounded, so the effective ceiling was `cap - 1 + group_size` and the operator knob
+    # was advisory rather than a bound. A group whose losers exceed the whole budget is
+    # therefore never applied — raise the cap above the largest group to drain it.
+    if acc.applied + acc.failed + losers(proposal) > unpublish_cap do
       %{acc | skipped: acc.skipped + 1}
     else
       do_tally_apply(tenant_id, proposal, acc)
@@ -396,7 +417,7 @@ defmodule Loopctl.Knowledge.Consolidation do
   # field makes the number unreadable on exactly the night it matters: a systematic failure
   # across 25 groups of four would have reported 25 while 75 articles stayed published.
   defp group_failed(tenant_id, proposal, tag, acc) do
-    losers = max(length(proposal.article_ids) - 1, 1)
+    losers = losers(proposal)
 
     Logger.error(
       "Consolidation: tenant=#{tenant_id} duplicate_capture proposal ##{proposal.number} " <>
@@ -405,6 +426,10 @@ defmodule Loopctl.Knowledge.Consolidation do
 
     %{acc | failed: acc.failed + losers}
   end
+
+  # Every member but the winner. Floored at 1 so a malformed single-member group still
+  # charges the budget and still counts as one failure rather than as nothing.
+  defp losers(proposal), do: max(length(proposal.article_ids) - 1, 1)
 
   # Proposals present in BOTH the newest report and the one before it, matched on
   # `fingerprint` — which is derived from the class plus the sorted article-id set, so it is
@@ -603,11 +628,12 @@ defmodule Loopctl.Knowledge.Consolidation do
   end
 
   @doc false
-  # Excludes agent-PRIVATE articles from everything this pass does. Composed into all THREE
-  # places that build a "published article of this tenant" predicate — the scans
-  # (`published_base/1`), the evidence fetch (`evidence_map/2`) and the apply-time live
-  # re-check (`apply_duplicate_group/2`) — because a guard that lives in only one of them is
-  # a guard the next reader adds a fourth path around.
+  # Excludes agent-PRIVATE articles from everything this pass does. Composed into EVERY
+  # place that decides whether an article of this tenant is in scope — the scans
+  # (`published_base/1`), the evidence fetch (`evidence_map/2`), the apply-time live
+  # re-check (`apply_duplicate_group/2`) and the read-time redaction liveness
+  # (`live_evidence_ids/2`) — because a guard that lives in only some of them is a guard
+  # the next reader adds one more path around.
   #
   # Two distinct harms, and the quieter one is worse. The LOUD one: `:duplicate_capture`
   # auto-applies (#608), so without this the pass could unpublish one agent's private memory
@@ -959,6 +985,11 @@ defmodule Loopctl.Knowledge.Consolidation do
   # erasing the quoted excerpt that says WHY the article was unpublished on the morning an
   # operator goes looking for it. Archive and hard delete are the one-way doors this
   # redaction exists for, and they still redact.
+  #
+  # `shared_only/1` is composed here for the same reason it is composed into the three scan
+  # predicates: an article that turned private AFTER the scan is a readability change, and
+  # without it a quoted body kept being served to any orchestrator key from a prior-day
+  # report forever. Turning private redacts exactly like archiving.
   defp live_evidence_ids(_tenant_id, []), do: MapSet.new()
 
   defp live_evidence_ids(tenant_id, article_ids) do
@@ -970,6 +1001,7 @@ defmodule Loopctl.Knowledge.Consolidation do
       where: a.id in ^ids,
       select: a.id
     )
+    |> shared_only()
     |> AdminRepo.all()
     |> MapSet.new()
   end

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -574,8 +574,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     %{pruned: 0, remaining: -1}
   end
 
-  defp apply_consolidation(_tenant_id, {:error, _tag}),
-    do: %{applied: 0, skipped: 0, failed: 0, gate: :scan_failed}
+  defp apply_consolidation(_tenant_id, {:error, _tag}), do: empty_tally(:scan_failed)
 
   defp apply_consolidation(tenant_id, {:ok, _report}) do
     Consolidation.apply_confirmed_duplicates(tenant_id,
@@ -614,12 +613,18 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         "(#{tag}); no duplicates unpublished this run."
     )
 
-    # `:gate` is NOT optional: `lint_tenant/1` interpolates `applied.gate` in its summary
-    # line, so a map without the key raised a KeyError one line after this rescue swallowed
-    # the original error — cancelling the fail-soft it exists for and making Oban re-run
-    # every effectful step of the night.
-    %{applied: 0, skipped: 0, failed: 0, gate: :apply_failed, error: tag}
+    empty_tally(:apply_failed, tag)
   end
+
+  # ONE constructor for every zero tally this worker synthesises, so no fail-soft path can
+  # ship a map missing `:gate`: `lint_tenant/1` interpolates `applied.gate` in its summary
+  # line, so a map without the key raised a KeyError one line after the rescue had swallowed
+  # the original error — cancelling the fail-soft it exists for and making Oban re-run every
+  # effectful step of the night. Sharing the constructor is what lets the reachable
+  # `:scan_failed` path guard the `:apply_failed` one, which needs a repo-level failure to
+  # provoke.
+  defp empty_tally(gate, error \\ nil),
+    do: %{applied: 0, skipped: 0, failed: 0, gate: gate, error: error}
 
   # Writes the consolidation report + its proposal rows and nothing else. The APPLY is a
   # separate step (`apply_consolidation/2`, above) on purpose: this one must run first so
@@ -693,19 +698,26 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
       "duplicate_groups_skipped" => applied.skipped,
       "duplicates_unpublish_failed" => applied.failed,
       # WHY nothing was applied, when nothing was. `:open` with zeroes is a clean corpus;
-      # `:report_gap` / `:insufficient_history` mean the agreement gate refused to run and
-      # `:apply_failed` means it ran and crashed. All four used to be the same three zeroes.
-      # Read with `.gate`, never a defaulted `Map.get`: an `:open` default would record a
-      # crashed run as a clean night, which is the exact distinction this key exists for.
+      # `:report_gap` / `:insufficient_history` mean the agreement gate refused to run,
+      # `:drain_disabled` means an operator set a cap to 0, and `:apply_failed` means it ran
+      # and crashed. All of them used to be the same three zeroes. Read with `.gate`, never a
+      # defaulted `Map.get`: an `:open` default would record a crashed run as a clean night,
+      # which is the exact distinction this key exists for.
       "duplicate_apply_gate" => to_string(applied.gate),
       "apply_error" => Map.get(applied, :error)
     }
   end
 
   # No report tonight means no apply ran at all (`apply_consolidation/2` is gated on the
-  # `{:ok, _}`), so there is no tally to record here.
-  defp consolidation_state({:error, tag}, _applied),
-    do: %{"status" => "failed", "error" => tag}
+  # `{:ok, _}`), so there are no counts to record here — but `duplicate_apply_gate` is
+  # recorded anyway. It is the key an auditor parses to learn WHY nothing applied, and an
+  # absent key on exactly the nights the pass failed is the one answer it must not give.
+  defp consolidation_state({:error, tag}, applied),
+    do: %{
+      "status" => "failed",
+      "error" => tag,
+      "duplicate_apply_gate" => to_string(applied.gate)
+    }
 
   # The per-step results arrive as ONE map rather than nine positionals. That is not only
   # arity hygiene: every step this worker gains adds a parameter here, and a positional list

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -614,7 +614,11 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         "(#{tag}); no duplicates unpublished this run."
     )
 
-    %{applied: 0, skipped: 0, failed: 0, error: tag}
+    # `:gate` is NOT optional: `lint_tenant/1` interpolates `applied.gate` in its summary
+    # line, so a map without the key raised a KeyError one line after this rescue swallowed
+    # the original error — cancelling the fail-soft it exists for and making Oban re-run
+    # every effectful step of the night.
+    %{applied: 0, skipped: 0, failed: 0, gate: :apply_failed, error: tag}
   end
 
   # Writes the consolidation report + its proposal rows and nothing else. The APPLY is a
@@ -691,7 +695,9 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
       # WHY nothing was applied, when nothing was. `:open` with zeroes is a clean corpus;
       # `:report_gap` / `:insufficient_history` mean the agreement gate refused to run and
       # `:apply_failed` means it ran and crashed. All four used to be the same three zeroes.
-      "duplicate_apply_gate" => to_string(Map.get(applied, :gate, :open)),
+      # Read with `.gate`, never a defaulted `Map.get`: an `:open` default would record a
+      # crashed run as a clean night, which is the exact distinction this key exists for.
+      "duplicate_apply_gate" => to_string(applied.gate),
       "apply_error" => Map.get(applied, :error)
     }
   end

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -578,11 +578,34 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     do: %{applied: 0, skipped: 0, failed: 0, gate: :scan_failed}
 
   defp apply_consolidation(tenant_id, {:ok, _report}) do
-    Consolidation.apply_confirmed_duplicates(tenant_id)
+    Consolidation.apply_confirmed_duplicates(tenant_id,
+      max_applies: applies_cap(),
+      max_unpublishes: unpublishes_cap()
+    )
   rescue
     e -> apply_failed(tenant_id, ExitTag.tag(e))
   catch
     :exit, reason -> apply_failed(tenant_id, "exit:" <> ExitTag.tag(reason))
+  end
+
+  # Both caps were previously unreachable from here — `apply_confirmed_duplicates/2` accepted
+  # them as opts and the worker passed none, so the nightly was pinned to the module defaults
+  # whatever an operator configured. That is why draining the standing backlog required
+  # calling the context directly, which is not a thing a self-maintaining pass should need.
+  defp applies_cap do
+    Application.get_env(
+      :loopctl,
+      :knowledge_consolidation_max_applies,
+      Consolidation.default_max_applies()
+    )
+  end
+
+  defp unpublishes_cap do
+    Application.get_env(
+      :loopctl,
+      :knowledge_consolidation_max_unpublishes,
+      Consolidation.default_max_unpublishes()
+    )
   end
 
   defp apply_failed(tenant_id, tag) do

--- a/test/loopctl/knowledge/consolidation_apply_caps_test.exs
+++ b/test/loopctl/knowledge/consolidation_apply_caps_test.exs
@@ -1,0 +1,129 @@
+defmodule Loopctl.Knowledge.ConsolidationApplyCapsTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.Consolidation
+
+  # Published articles are written as draft-then-update so the inline embedding -> linking
+  # cascade never fires: every signal exercised here is lexical, never vector.
+  defp published(tenant_id, attrs) do
+    base = %{category: :pattern, tags: [], body: "Body #{System.unique_integer([:positive])}."}
+
+    fixture(:article, Map.merge(base, Map.put(attrs, :tenant_id, tenant_id)))
+    |> Ecto.Changeset.change(%{status: :published})
+    |> AdminRepo.update!()
+  end
+
+  defp status(id), do: AdminRepo.get!(Article, id).status
+
+  defp confirm_over_two_nights(tenant_id) do
+    {:ok, _} = Consolidation.run(tenant_id, day: Date.add(Date.utc_today(), -1))
+    {:ok, _} = Consolidation.run(tenant_id)
+  end
+
+  # One confirmed group of three: a winner and two losers, so the article budget can bind
+  # WITHIN a group rather than only between groups.
+  defp confirmed_trio(tenant_id) do
+    winner =
+      published(tenant_id, %{
+        title: "Cap Group Doc",
+        body: String.duplicate("long winner body ", 20)
+      })
+
+    middle = published(tenant_id, %{title: "cap-group-doc!", body: String.duplicate("mid ", 5)})
+    shortest = published(tenant_id, %{title: "CAP GROUP DOC.", body: "s"})
+
+    confirm_over_two_nights(tenant_id)
+    {winner, [middle, shortest]}
+  end
+
+  describe "apply_confirmed_duplicates/2 — the article budget (#611 review round 2)" do
+    test "drains a group larger than the budget as far as the budget goes, and converges" do
+      # Skipping such a group WHOLE made any group with more losers than the cap unappliable
+      # on every run forever, and with the cap itself ceilinged at 500 the "raise the cap"
+      # remedy was unreachable — the backlog held a floor. Draining part-way is safe because
+      # the winner is never a candidate: what is left behind is winner-plus-leftovers, the
+      # same group the next scan re-derives.
+      tenant = fixture(:tenant)
+      {winner, losers} = confirmed_trio(tenant.id)
+
+      assert %{applied: 1, skipped: 0, failed: 0, gate: :open} =
+               Consolidation.apply_confirmed_duplicates(tenant.id, max_unpublishes: 1)
+
+      assert status(winner.id) == :published
+      assert Enum.count(losers, &(status(&1.id) == :published)) == 1
+
+      # And the cap is still a real BOUND: exactly one loser left the published set, not both.
+      # The next run's budget finishes the group off.
+      assert %{applied: 1} =
+               Consolidation.apply_confirmed_duplicates(tenant.id, max_unpublishes: 1)
+
+      assert status(winner.id) == :published
+      refute Enum.any?(losers, &(status(&1.id) == :published))
+    end
+
+    test "a cap of 0 PAUSES the drain instead of being rounded up to one group's worth" do
+      # Halting the drain mid-incident is the reason an operator sets 0. Clamping it to 1
+      # kept unpublishing, and the audit event read like a clean night while doing it.
+      tenant = fixture(:tenant)
+      {winner, losers} = confirmed_trio(tenant.id)
+
+      assert %{applied: 0, skipped: 0, failed: 0, gate: :drain_disabled} =
+               Consolidation.apply_confirmed_duplicates(tenant.id, max_unpublishes: 0)
+
+      assert status(winner.id) == :published
+      assert Enum.all?(losers, &(status(&1.id) == :published))
+    end
+
+    test "a negative or non-integer cap never reaches the query" do
+      # A negative `:max_applies` reached `limit: ^cap` as a Postgrex error. A binary is the
+      # worse half: Erlang term order sorts it ABOVE every integer, so an unguarded
+      # `min(cap, 500)` handed a config typo the ceiling — the largest blast radius there is.
+      tenant = fixture(:tenant)
+      {winner, losers} = confirmed_trio(tenant.id)
+
+      assert %{applied: 0, gate: :drain_disabled} =
+               Consolidation.apply_confirmed_duplicates(tenant.id, max_applies: -1)
+
+      assert Enum.all?(losers, &(status(&1.id) == :published))
+
+      # "1" falls back to the module default (100), NOT to the 500 ceiling.
+      assert %{applied: 2, gate: :open} =
+               Consolidation.apply_confirmed_duplicates(tenant.id, max_unpublishes: "1")
+
+      assert status(winner.id) == :published
+    end
+  end
+
+  describe "latest/2 — an article turned PRIVATE after the scan" do
+    test "redacts the excerpt a prior report quoted from it" do
+      # The quiet harm the visibility guard exists for: the report carries a quoted body and
+      # any orchestrator key can read it, so a published article that later becomes an agent's
+      # private memory must redact exactly like an archived one.
+      tenant = fixture(:tenant)
+
+      article =
+        published(tenant.id, %{title: "Untitled Document", body: "SECRET harvested material."})
+
+      {:ok, _} = Consolidation.run(tenant.id)
+
+      {:ok, before} = Consolidation.latest(tenant.id)
+      assert [%{evidence: [entry]}] = before.proposals
+      assert entry["excerpt"] =~ "SECRET harvested"
+
+      article
+      |> Ecto.Changeset.change(%{
+        metadata: %{"visibility" => "private", "agent_id" => Ecto.UUID.generate()}
+      })
+      |> AdminRepo.update!()
+
+      {:ok, result} = Consolidation.latest(tenant.id)
+      assert [%{evidence: [redacted]}] = result.proposals
+      assert redacted["redacted"] == true
+      assert redacted["excerpt"] == ""
+    end
+  end
+end

--- a/test/loopctl/workers/knowledge_lint_worker_test.exs
+++ b/test/loopctl/workers/knowledge_lint_worker_test.exs
@@ -590,10 +590,14 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
       |> AdminRepo.update!()
     end
 
-    test "honours :knowledge_consolidation_max_applies instead of the module default" do
-      # config/test.exs pins the cap at 1. Three confirmed duplicate groups exist, so the
-      # module default (25) and the configured cap (1) give visibly different answers — which
-      # is the only way this test can notice the worker dropping the opts again.
+    test "honours BOTH configured apply caps instead of the module defaults" do
+      # config/test.exs pins the caps ASYMMETRICALLY (max_applies: 2, max_unpublishes: 1)
+      # against three confirmed one-loser groups, so each opt owns its own assertion:
+      #   * both wired      -> 2 proposals fetched, 1 applies, 1 skipped
+      #   * max_applies gone (25)     -> 3 fetched  -> skipped == 2, not 1
+      #   * max_unpublishes gone (100) -> both fetched apply -> applied == 2, not 1
+      # With both caps at 1 the answer was one applied loser either way, which is how the
+      # unreachable-opts bug could have half-regressed unnoticed.
       tenant = fixture(:tenant)
 
       groups =
@@ -626,8 +630,16 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
         end)
 
       assert still_published == 2,
-             "cap of 1 must leave 2 of 3 losers published; the module default of 25 would " <>
-               "have applied all three"
+             "an article cap of 1 must leave 2 of 3 losers published"
+
+      assert [entry] = lint_audit_entries(tenant.id)
+      applied = entry.new_state["consolidation"]
+
+      assert applied["duplicates_unpublished"] == 1,
+             ":max_unpublishes was not honoured — a second group applied"
+
+      assert applied["duplicate_groups_skipped"] == 1,
+             ":max_applies was not honoured — a third proposal was fetched and skipped"
     end
   end
 end

--- a/test/loopctl/workers/knowledge_lint_worker_test.exs
+++ b/test/loopctl/workers/knowledge_lint_worker_test.exs
@@ -578,4 +578,56 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
       0 -> acc
     end
   end
+
+  describe "consolidation apply caps reach the context (#611)" do
+    # No embedding: this describe exercises the LEXICAL duplicate class only, and an embedded
+    # publish would fire the inline linking cascade these tests do not want.
+    defp published_no_embedding(tenant_id, attrs) do
+      base = %{category: :pattern, status: :draft, tags: []}
+
+      fixture(:article, Map.merge(base, Map.put(attrs, :tenant_id, tenant_id)))
+      |> Ecto.Changeset.change(%{status: :published})
+      |> AdminRepo.update!()
+    end
+
+    test "honours :knowledge_consolidation_max_applies instead of the module default" do
+      # config/test.exs pins the cap at 1. Three confirmed duplicate groups exist, so the
+      # module default (25) and the configured cap (1) give visibly different answers — which
+      # is the only way this test can notice the worker dropping the opts again.
+      tenant = fixture(:tenant)
+
+      groups =
+        for n <- 1..3 do
+          winner =
+            published_no_embedding(tenant.id, %{
+              title: "Cap Group #{n} Document",
+              body: String.duplicate("long winner body ", 20)
+            })
+
+          loser =
+            published_no_embedding(tenant.id, %{title: "cap-group-#{n}-document!", body: "s"})
+
+          {winner, loser}
+        end
+
+      # Two adjacent reports so the agreement gate is open on all three groups.
+      {:ok, _} = Consolidation.run(tenant.id, day: Date.add(Date.utc_today(), -1))
+      {:ok, _} = Consolidation.run(tenant.id)
+
+      assert :ok =
+               KnowledgeLintWorker.perform(%Oban.Job{
+                 id: 0,
+                 args: %{"tenant_id" => tenant.id}
+               })
+
+      still_published =
+        Enum.count(groups, fn {_w, loser} ->
+          AdminRepo.get!(Loopctl.Knowledge.Article, loser.id).status == :published
+        end)
+
+      assert still_published == 2,
+             "cap of 1 must leave 2 of 3 losers published; the module default of 25 would " <>
+               "have applied all three"
+    end
+  end
 end

--- a/test/loopctl/workers/knowledge_lint_worker_test.exs
+++ b/test/loopctl/workers/knowledge_lint_worker_test.exs
@@ -258,6 +258,13 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
       assert entry.new_state["summary"]["total_articles"] == 2
       assert entry.new_state["consolidation"]["status"] == "failed"
       assert is_binary(entry.new_state["consolidation"]["error"])
+
+      # The gate key is the one an auditor parses to learn WHY nothing applied, so it is
+      # recorded on the failing nights too — absent-on-failure is the one answer it must not
+      # give. This also guards the `:apply_failed` tally: both come from the same zero-tally
+      # constructor, and it was a constructor missing `:gate` that raised a KeyError one line
+      # after the rescue swallowed the original error, making Oban re-run the whole night.
+      assert entry.new_state["consolidation"]["duplicate_apply_gate"] == "scan_failed"
     end
 
     # The apply reads the two most recent reports. If a failed scan could fall through to it,


### PR DESCRIPTION
The consolidation drain converged to a **floor** rather than to zero. Two causes, both only visible once the class actually started applying.

## The per-class report cap is the one that mattered

Auto-apply requires a proposal in **both** of the last two reports. The intersection of two capped reports is bounded by the cap — so a standing backlog larger than the cap can never drain, however long the pass runs.

Measured tonight: the hosted corpus held **290 proposals with 100 visible**, and the confirmed-in-both set was exactly 100. Raised to **500** (the existing hard ceiling), so the report stops being permanently `truncated` and the class can reach zero.

## The two apply caps were worse — unreachable

`apply_confirmed_duplicates/2` accepted `:max_applies` and `:max_unpublishes` as options; `KnowledgeLintWorker` passed **none**. So the nightly ran on module defaults whatever an operator configured, and draining tonight's backlog required calling the context directly from a console. A self-maintaining pass should not need a human at a REPL to reach its own tuning.

Both now read from config. `config/test.exs` pins them at **1** so the wiring is observable: three confirmed groups, exactly one applies. Dropping the opts again fails a test instead of silently reverting to 25.

## The bounds stay — only the sizing changed

A bug that mis-picks winners must still be visible after one night rather than after the whole corpus, and unpublish being **reversible by publishing** is what licenses a bound this size at all.

The new sizing is evidence-backed rather than guessed. On the hosted corpus tonight the class unpublished **112 loser articles**, and:

- **112 of 112** were verified to still have a surviving published twin — checked across the whole set, not sampled;
- **zero** private articles were touched (#613's visibility guard, confirmed on real data);
- 25 groups already applied were correctly re-detected as resolved and skipped, 0 failed.

## Verification

`mix precommit` green: **6915 tests, 0 failures.**

Mutation-verified: reverting `apply_consolidation/2` to pass no opts — the exact prior state — fails the new test. That regression had no coverage before, which is how it survived.
