### PR TITLE
Bound embedding input by bytes, not characters, and shrink on rejection

### DIFF
--- a/lib/loopctl/embeddings/text_budget.ex
+++ b/lib/loopctl/embeddings/text_budget.ex
@@ -1,16 +1,15 @@
 defmodule Loopctl.Embeddings.TextBudget do
   @moduledoc """
-  The size budget for text sent to an embedding provider, expressed in BYTES, plus
-  the shrink ladder the embedding workers walk when the provider rejects an input
-  as too long.
+  The shrink ladder the embedding workers walk when a provider rejects an input as
+  too long, expressed in BYTES — plus the first attempt's cap, which is not.
 
-  ## Why bytes, and why a ladder
+  ## Why a ladder, and why its rungs are bytes
 
   Embedding models bound their input in TOKENS (OpenAI's `text-embedding-3-*`:
-  8192). The workers used to bound it in CHARACTERS — 32,000 of them — and the
-  ratio between the two is not a constant. English prose runs ~4 chars/token, so
-  32,000 chars lands just under the limit; Cyrillic, CJK, dense index pages and
-  code run 2-3x worse, so the same 32,000 chars is several times over it.
+  8192). The workers bounded it in CHARACTERS — 32,000 of them — and the ratio
+  between the two is not a constant. English prose runs ~4 chars/token, so 32,000
+  chars lands just under the limit; Cyrillic, CJK, dense index pages and code run
+  2-3x worse, so the same 32,000 chars is several times over it.
 
   Measured on the hosted corpus 2026-08-06: 80 published articles could NEVER be
   embedded. Every one returned
@@ -19,61 +18,81 @@ defmodule Loopctl.Embeddings.TextBudget do
 
   and the hourly `EmbeddingReconciliationWorker` re-enqueued all 80 every hour,
   forever, because a permanently-discarded job leaves the gap it was meant to
-  close. Those articles had been invisible to semantic search since June. A
-  character cap is not a token bound.
+  close. Those articles had been invisible to semantic search since June.
 
-  Bytes are not a token bound either — but they are a token BOUND FROM ABOVE, which
-  characters are not. A BPE token is a merge of one or more bytes, so
+  The LADDER is the fix. Its rungs are bytes because bytes bound tokens FROM ABOVE —
+  a BPE token is a merge of one or more bytes, so
 
       tokens(text) <= byte_size(text)
 
-  always, for any script. That inequality is what makes `floor_bytes/0` a proof
-  rather than an estimate: 8,000 bytes cannot tokenize to more than 8,000 tokens,
-  which is under every limit we send to. So the ladder is guaranteed to terminate
-  in a value the provider accepts, without a tokenizer dependency.
+  always, for any script. Each rung is therefore a strictly tighter TOKEN bound than
+  the attempt that was just rejected, without a tokenizer dependency.
 
-  Starting AT the floor would be the simple fix and it is the wrong one: 8,000
-  bytes of English is ~2,000 tokens, so every article in the corpus would embed a
-  quarter of its content to accommodate the 0.1% that overflow. Instead the first
-  attempt stays generous (`initial_bytes/0`) and only an input the provider
-  actually rejects pays for a retry. The bound is discovered, not assumed — the
-  provider's 400 is the measurement.
+  ## The first attempt is deliberately NOT byte-capped
+
+  `initial/1` cuts at 32,000 CHARACTERS, exactly as before the ladder existed.
+  Capping the first attempt in bytes instead would silently shorten multi-byte
+  articles that were ALREADY embedding fine: Russian prose runs ~6 bytes/token, so a
+  45,000-byte article is only ~7,500 tokens — under the limit — and a 32,000-byte cap
+  would drop a third of it with no error and no log line, degrading its search recall
+  invisibly. Truncation is paid only by an input the provider actually rejected; the
+  bound is discovered, not assumed.
 
   ## The ladder
 
-      32,000 -> 16,000 -> 8,000 -> :exhausted
+      <bytes actually sent> -> 32,000 -> 16,000 -> 8,000 -> :exhausted
 
-  Two retries at most, and only for text that overflowed. `:exhausted` is a real
-  outcome, not a loop guard for show: it means the floor itself was rejected, which
-  can only be a DIFFERENT defect (a changed model, a much smaller limit) and must
-  surface as a discard rather than as endless halving.
+  Every rung is derived from the bytes ACTUALLY SENT, never from a nominal budget: a
+  budget above the text's own size truncates nothing, so halving the budget alone can
+  re-send a byte-identical request and buy an identical rejection.
+
+  `:exhausted` is a real outcome, not a loop guard for show. `floor_bytes/0` is 8,000,
+  under the 8,192-token window of the models loopctl ships against — but that window
+  is a property of THOSE models, not of every endpoint. `EmbeddingClient` resolves
+  model and base_url per tenant, and a self-hosted 512-token embedder (bge-*, e5-*)
+  rejects the floor too. `:exhausted` is how that surfaces: the caller discards it
+  legibly as a different defect, rather than halving forever or storing a prefix.
   """
 
-  # Unchanged from the character cap it replaces, so an ASCII article — the bulk of
-  # the corpus — sends exactly what it sent before. Multi-byte text is bounded more
-  # tightly at the same number, which is the population that was failing.
-  @initial_bytes 32_000
+  # The FIRST attempt, in characters — unchanged from the cap that predates the
+  # ladder, so nothing the provider was already accepting is silently shortened.
+  @initial_chars 32_000
+
+  # The largest BYTE rung the ladder drops to once an attempt has been rejected.
+  @top_rung_bytes 32_000
 
   # Provably <= 8,000 tokens for any input, under any BPE tokenizer (see moduledoc).
   @floor_bytes 8_000
 
-  @doc "Bytes the first embedding attempt may send."
-  @spec initial_bytes() :: pos_integer()
-  def initial_bytes, do: @initial_bytes
+  @doc "Characters the first embedding attempt may send."
+  @spec initial_chars() :: pos_integer()
+  def initial_chars, do: @initial_chars
 
-  @doc "The smallest budget the ladder will try; provably under every token limit."
+  @doc "The first attempt's text: the pre-ladder character cap, applied verbatim."
+  @spec initial(String.t()) :: String.t()
+  def initial(text) when is_binary(text), do: String.slice(text, 0, @initial_chars)
+
+  @doc "The largest byte rung the ladder drops to after a rejection."
+  @spec top_rung_bytes() :: pos_integer()
+  def top_rung_bytes, do: @top_rung_bytes
+
+  @doc "The smallest budget the ladder will try."
   @spec floor_bytes() :: pos_integer()
   def floor_bytes, do: @floor_bytes
 
   @doc """
-  The next budget down, or `:exhausted` once the floor has already been tried.
+  The next budget below `sent_bytes`, or `:exhausted` once the floor has been tried.
 
-  Halves, clamped at the floor — so the ladder visits the floor exactly once and
-  then stops, rather than converging on it forever.
+  Keyed to what was ACTUALLY SENT, so every rung is strictly smaller than the attempt
+  it replaces. Halves, capped at the top rung and clamped at the floor — so the ladder
+  visits the floor exactly once and then stops, rather than converging on it forever.
   """
-  @spec shrink(pos_integer()) :: pos_integer() | :exhausted
-  def shrink(bytes) when is_integer(bytes) and bytes <= @floor_bytes, do: :exhausted
-  def shrink(bytes) when is_integer(bytes), do: max(div(bytes, 2), @floor_bytes)
+  @spec next_budget(non_neg_integer()) :: pos_integer() | :exhausted
+  def next_budget(sent_bytes) when is_integer(sent_bytes) and sent_bytes <= @floor_bytes,
+    do: :exhausted
+
+  def next_budget(sent_bytes) when is_integer(sent_bytes),
+    do: sent_bytes |> div(2) |> min(@top_rung_bytes) |> max(@floor_bytes)
 
   @doc """
   Truncate `text` to at most `max_bytes`, never splitting a UTF-8 codepoint.

--- a/lib/loopctl/embeddings/text_budget.ex
+++ b/lib/loopctl/embeddings/text_budget.ex
@@ -1,0 +1,103 @@
+defmodule Loopctl.Embeddings.TextBudget do
+  @moduledoc """
+  The size budget for text sent to an embedding provider, expressed in BYTES, plus
+  the shrink ladder the embedding workers walk when the provider rejects an input
+  as too long.
+
+  ## Why bytes, and why a ladder
+
+  Embedding models bound their input in TOKENS (OpenAI's `text-embedding-3-*`:
+  8192). The workers used to bound it in CHARACTERS — 32,000 of them — and the
+  ratio between the two is not a constant. English prose runs ~4 chars/token, so
+  32,000 chars lands just under the limit; Cyrillic, CJK, dense index pages and
+  code run 2-3x worse, so the same 32,000 chars is several times over it.
+
+  Measured on the hosted corpus 2026-08-06: 80 published articles could NEVER be
+  embedded. Every one returned
+
+      400 Invalid 'input': maximum context length is 8192 tokens.
+
+  and the hourly `EmbeddingReconciliationWorker` re-enqueued all 80 every hour,
+  forever, because a permanently-discarded job leaves the gap it was meant to
+  close. Those articles had been invisible to semantic search since June. A
+  character cap is not a token bound.
+
+  Bytes are not a token bound either — but they are a token BOUND FROM ABOVE, which
+  characters are not. A BPE token is a merge of one or more bytes, so
+
+      tokens(text) <= byte_size(text)
+
+  always, for any script. That inequality is what makes `floor_bytes/0` a proof
+  rather than an estimate: 8,000 bytes cannot tokenize to more than 8,000 tokens,
+  which is under every limit we send to. So the ladder is guaranteed to terminate
+  in a value the provider accepts, without a tokenizer dependency.
+
+  Starting AT the floor would be the simple fix and it is the wrong one: 8,000
+  bytes of English is ~2,000 tokens, so every article in the corpus would embed a
+  quarter of its content to accommodate the 0.1% that overflow. Instead the first
+  attempt stays generous (`initial_bytes/0`) and only an input the provider
+  actually rejects pays for a retry. The bound is discovered, not assumed — the
+  provider's 400 is the measurement.
+
+  ## The ladder
+
+      32,000 -> 16,000 -> 8,000 -> :exhausted
+
+  Two retries at most, and only for text that overflowed. `:exhausted` is a real
+  outcome, not a loop guard for show: it means the floor itself was rejected, which
+  can only be a DIFFERENT defect (a changed model, a much smaller limit) and must
+  surface as a discard rather than as endless halving.
+  """
+
+  # Unchanged from the character cap it replaces, so an ASCII article — the bulk of
+  # the corpus — sends exactly what it sent before. Multi-byte text is bounded more
+  # tightly at the same number, which is the population that was failing.
+  @initial_bytes 32_000
+
+  # Provably <= 8,000 tokens for any input, under any BPE tokenizer (see moduledoc).
+  @floor_bytes 8_000
+
+  @doc "Bytes the first embedding attempt may send."
+  @spec initial_bytes() :: pos_integer()
+  def initial_bytes, do: @initial_bytes
+
+  @doc "The smallest budget the ladder will try; provably under every token limit."
+  @spec floor_bytes() :: pos_integer()
+  def floor_bytes, do: @floor_bytes
+
+  @doc """
+  The next budget down, or `:exhausted` once the floor has already been tried.
+
+  Halves, clamped at the floor — so the ladder visits the floor exactly once and
+  then stops, rather than converging on it forever.
+  """
+  @spec shrink(pos_integer()) :: pos_integer() | :exhausted
+  def shrink(bytes) when is_integer(bytes) and bytes <= @floor_bytes, do: :exhausted
+  def shrink(bytes) when is_integer(bytes), do: max(div(bytes, 2), @floor_bytes)
+
+  @doc """
+  Truncate `text` to at most `max_bytes`, never splitting a UTF-8 codepoint.
+
+  `binary_part/3` cuts on a byte boundary, which for multi-byte text can leave a
+  partial codepoint that is not a valid string — the exact input class this module
+  exists for. The tail is trimmed until the result is valid again (at most 3 bytes,
+  since no UTF-8 codepoint is longer than 4).
+  """
+  @spec truncate(String.t(), pos_integer()) :: String.t()
+  def truncate(text, max_bytes) when is_binary(text) and byte_size(text) <= max_bytes, do: text
+
+  def truncate(text, max_bytes)
+      when is_binary(text) and is_integer(max_bytes) and max_bytes > 0 do
+    text |> binary_part(0, max_bytes) |> trim_partial_codepoint()
+  end
+
+  defp trim_partial_codepoint(<<>>), do: <<>>
+
+  defp trim_partial_codepoint(bin) do
+    if String.valid?(bin) do
+      bin
+    else
+      trim_partial_codepoint(binary_part(bin, 0, byte_size(bin) - 1))
+    end
+  end
+end

--- a/lib/loopctl/embeddings/text_budget.ex
+++ b/lib/loopctl/embeddings/text_budget.ex
@@ -40,7 +40,10 @@ defmodule Loopctl.Embeddings.TextBudget do
 
   ## The ladder
 
-      <bytes actually sent> -> 32,000 -> 16,000 -> 8,000 -> :exhausted
+  Each rung is HALF the bytes the rejected attempt ACTUALLY SENT, capped at 32,000 and
+  clamped at 8,000; the floor is tried exactly once, then `:exhausted`. So a
+  59,400-byte first attempt walks 29,714 -> 14,857 -> 8,000 -> `:exhausted`, and the
+  fixed 32,000 rung is reached only from an attempt above 64,000 bytes.
 
   Every rung is derived from the bytes ACTUALLY SENT, never from a nominal budget: a
   budget above the text's own size truncates nothing, so halving the budget alone can

--- a/lib/loopctl/llm/provider_error.ex
+++ b/lib/loopctl/llm/provider_error.ex
@@ -86,14 +86,19 @@ defmodule Loopctl.Llm.ProviderError do
     end
   end
 
-  # The classifiable surface of a body: a bare string, or the `message`/`code` of a
-  # decoded `{"error" => ...}` envelope. Anything else is unclassifiable, NOT an
-  # error — it just falls back to the generic tag.
+  # The classifiable surface of a body. Vendor-agnostic in SHAPE as well as in
+  # spelling: OpenAI nests the text under `{"error" => %{"message" => ...}}`, but
+  # OpenAI-COMPATIBLE servers a tenant may point `base_url` at answer with a bare
+  # string body, a string-valued `"error"`, or a top-level `"detail"`/`"message"`
+  # (vLLM, TEI, FastAPI gateways). Reading only the nested map left those providers
+  # classified `:provider_error`, which discards a length rejection as permanent and
+  # never runs the shrink ladder — the same hourly re-enqueue loop, one provider over.
+  # Widening what is READ cannot widen what is KEPT: the output is still a fixed atom.
   defp body_signal(body) when is_binary(body), do: String.downcase(body)
 
-  defp body_signal(%{"error" => %{} = err}) do
-    [err["message"], err["code"]]
-    |> Enum.filter(&is_binary/1)
+  defp body_signal(body) when is_map(body) and not is_struct(body) do
+    [body["error"], body["message"], body["detail"], body["code"]]
+    |> Enum.flat_map(&signal_parts/1)
     |> case do
       [] -> nil
       parts -> parts |> Enum.join(" ") |> String.downcase()
@@ -101,6 +106,13 @@ defmodule Loopctl.Llm.ProviderError do
   end
 
   defp body_signal(_other), do: nil
+
+  defp signal_parts(text) when is_binary(text), do: [text]
+
+  defp signal_parts(err) when is_map(err) and not is_struct(err),
+    do: Enum.filter([err["message"], err["code"]], &is_binary/1)
+
+  defp signal_parts(_other), do: []
 
   @doc """
   Strip any provider response body/secret. Collapses the key-bearing provider
@@ -153,9 +165,13 @@ defmodule Loopctl.Llm.ProviderError do
   @spec sanitize(term(), non_neg_integer() | nil) :: t()
   def sanitize(reason, nil), do: sanitize(reason)
 
-  def sanitize({:api_error, status, _body}, retry_after)
+  # `classify(body)`, not a literal `:provider_error`: a gateway can answer a throttle
+  # with a body that still echoes the provider's length complaint, and flattening the
+  # tag on THIS path would silently disable the shrink ladder while sanitize/1 keeps
+  # it — the same downgrade the idempotency clause above exists to prevent.
+  def sanitize({:api_error, status, body}, retry_after)
       when is_integer(status) and is_integer(retry_after),
-      do: {:api_error, status, :provider_error, retry_after}
+      do: {:api_error, status, classify(body), retry_after}
 
   def sanitize({:api_error, status}, retry_after)
       when is_integer(status) and is_integer(retry_after),

--- a/lib/loopctl/llm/provider_error.ex
+++ b/lib/loopctl/llm/provider_error.ex
@@ -59,6 +59,16 @@ defmodule Loopctl.Llm.ProviderError do
     "input is too long"
   ]
 
+  # Statuses whose BODY is never read as a length rejection: a throttle says WAIT,
+  # not SHORTEN. OpenAI-compatible gateways answer a per-minute TOKEN throttle with
+  # exactly the phrasings above ("too many tokens", "reduce the length"), and taking
+  # them at face value sends the worker down the shrink ladder — which spends extra
+  # paid calls and then, once the provider's window clears, STORES an embedding of a
+  # prefix under the FULL text's content hash. The idempotency guard makes every
+  # later enqueue a no-op, so that truncated vector is permanent. The status is
+  # authoritative about which remedy applies; the body is not.
+  @throttle_statuses [408, 429, 503]
+
   @doc """
   Classify a provider error body as one of the value-free `t:tag/0` atoms.
 
@@ -85,6 +95,12 @@ defmodule Loopctl.Llm.ProviderError do
           else: :provider_error
     end
   end
+
+  # Status-aware classification: a throttle is a throttle whatever its body says
+  # (see `@throttle_statuses`), so only a non-throttle status may be classified as a
+  # length rejection. Every classification that reaches a caller goes through here.
+  defp classify(status, _body) when status in @throttle_statuses, do: :provider_error
+  defp classify(_status, body), do: classify(body)
 
   # The classifiable surface of a body. Vendor-agnostic in SHAPE as well as in
   # spelling: OpenAI nests the text under `{"error" => %{"message" => ...}}`, but
@@ -132,7 +148,7 @@ defmodule Loopctl.Llm.ProviderError do
   # boundary preserves `:context_length_exceeded` instead of flattening it — the
   # retry ladder in the embedding workers dispatches on exactly that atom.
   def sanitize({:api_error, status, body}) when is_integer(status),
-    do: {:api_error, status, classify(body)}
+    do: {:api_error, status, classify(status, body)}
 
   def sanitize({:api_error, status}) when is_integer(status),
     do: {:api_error, status, :provider_error}
@@ -165,13 +181,16 @@ defmodule Loopctl.Llm.ProviderError do
   @spec sanitize(term(), non_neg_integer() | nil) :: t()
   def sanitize(reason, nil), do: sanitize(reason)
 
-  # `classify(body)`, not a literal `:provider_error`: a gateway can answer a throttle
-  # with a body that still echoes the provider's length complaint, and flattening the
-  # tag on THIS path would silently disable the shrink ladder while sanitize/1 keeps
-  # it — the same downgrade the idempotency clause above exists to prevent.
-  def sanitize({:api_error, status, body}, retry_after)
+  # A literal `:provider_error`, never `classify(body)`: a Retry-After IS the
+  # provider telling us the remedy is to WAIT, so it outranks whatever its body says
+  # about length. Keeping the tag fixed is also what the throttle 4-tuple's consumers
+  # rely on — every worker's loss-free snooze clause matches
+  # `{:api_error, _status, :provider_error, retry_after}` literally, and a tag they do
+  # not match falls through to the generic branch, which burns an Oban attempt on the
+  # blind `attempt^4` backoff against a provider that just asked us to back off.
+  def sanitize({:api_error, status, _body}, retry_after)
       when is_integer(status) and is_integer(retry_after),
-      do: {:api_error, status, classify(body), retry_after}
+      do: {:api_error, status, :provider_error, retry_after}
 
   def sanitize({:api_error, status}, retry_after)
       when is_integer(status) and is_integer(retry_after),
@@ -186,8 +205,13 @@ defmodule Loopctl.Llm.ProviderError do
   """
   @spec log_tag(term()) :: String.t()
   def log_tag({:error, inner}), do: log_tag(inner)
-  def log_tag({:api_error, status, body, _}), do: "api_error status=#{status} #{classify(body)}"
-  def log_tag({:api_error, status, body}), do: "api_error status=#{status} #{classify(body)}"
+
+  def log_tag({:api_error, status, body, _}),
+    do: "api_error status=#{status} #{classify(status, body)}"
+
+  def log_tag({:api_error, status, body}),
+    do: "api_error status=#{status} #{classify(status, body)}"
+
   def log_tag({:api_error, status}), do: "api_error status=#{status}"
   def log_tag({:request_failed, _}), do: "request_failed"
   def log_tag({:embedding_crash, _}), do: "embedding_crash"

--- a/lib/loopctl/llm/provider_error.ex
+++ b/lib/loopctl/llm/provider_error.ex
@@ -29,12 +29,78 @@ defmodule Loopctl.Llm.ProviderError do
 
   @typedoc "A sanitized provider error term (never carries a response body)."
   @type t ::
-          {:api_error, integer(), :provider_error}
-          | {:api_error, integer(), :provider_error, non_neg_integer() | nil}
+          {:api_error, integer(), tag()}
+          | {:api_error, integer(), tag(), non_neg_integer() | nil}
           | {:request_failed, atom()}
           | {:embedding_crash, :exception}
           | atom()
           | tuple()
+
+  @typedoc """
+  The closed set of value-free classifications a provider body may collapse to.
+
+  A tag is a FIXED atom chosen by `classify/1`, never a fragment of the body — so
+  keeping one is as safe as the bare `:provider_error` it replaces, and unlike it,
+  says WHY.
+  """
+  @type tag :: :provider_error | :context_length_exceeded
+
+  @tags [:provider_error, :context_length_exceeded]
+
+  # Substrings that identify an input-too-long rejection. Matched case-insensitively
+  # against the body's `error.message` and `error.code` only. Vendor-agnostic by
+  # listing several spellings rather than by parsing a single provider's schema.
+  @context_length_signatures [
+    "maximum context length",
+    "context_length_exceeded",
+    "reduce the length",
+    "string too long",
+    "too many tokens",
+    "input is too long"
+  ]
+
+  @doc """
+  Classify a provider error body as one of the value-free `t:tag/0` atoms.
+
+  This is the ONLY thing read out of a body and kept. It returns an atom from
+  `@tags`, so no byte of the body (and therefore no masked key fragment) can reach
+  a log line or `oban_jobs.errors` through it.
+
+  Total and idempotent: an already-classified tag is returned unchanged, which is
+  what lets `sanitize/1` run again at a worker boundary without downgrading a
+  classification back to the generic `:provider_error` (the same idempotency the
+  throttle 4-tuple needs).
+  """
+  @spec classify(term()) :: tag()
+  def classify(tag) when tag in @tags, do: tag
+
+  def classify(body) do
+    case body_signal(body) do
+      nil ->
+        :provider_error
+
+      text ->
+        if Enum.any?(@context_length_signatures, &String.contains?(text, &1)),
+          do: :context_length_exceeded,
+          else: :provider_error
+    end
+  end
+
+  # The classifiable surface of a body: a bare string, or the `message`/`code` of a
+  # decoded `{"error" => ...}` envelope. Anything else is unclassifiable, NOT an
+  # error — it just falls back to the generic tag.
+  defp body_signal(body) when is_binary(body), do: String.downcase(body)
+
+  defp body_signal(%{"error" => %{} = err}) do
+    [err["message"], err["code"]]
+    |> Enum.filter(&is_binary/1)
+    |> case do
+      [] -> nil
+      parts -> parts |> Enum.join(" ") |> String.downcase()
+    end
+  end
+
+  defp body_signal(_other), do: nil
 
   @doc """
   Strip any provider response body/secret. Collapses the key-bearing provider
@@ -45,12 +111,16 @@ defmodule Loopctl.Llm.ProviderError do
   # US-37.3: an already-sanitized throttle 4-tuple carries only a status + a
   # parsed Retry-After integer (both value-free) — preserve it idempotently so a
   # second sanitize pass at a worker boundary never drops the Retry-After.
-  def sanitize({:api_error, status, :provider_error, retry_after})
-      when is_integer(status) and (is_integer(retry_after) or is_nil(retry_after)),
-      do: {:api_error, status, :provider_error, retry_after}
+  def sanitize({:api_error, status, tag, retry_after})
+      when is_integer(status) and tag in @tags and
+             (is_integer(retry_after) or is_nil(retry_after)),
+      do: {:api_error, status, tag, retry_after}
 
-  def sanitize({:api_error, status, _body}) when is_integer(status),
-    do: {:api_error, status, :provider_error}
+  # `classify/1` is idempotent on a tag, so a second sanitize pass at a worker
+  # boundary preserves `:context_length_exceeded` instead of flattening it — the
+  # retry ladder in the embedding workers dispatches on exactly that atom.
+  def sanitize({:api_error, status, body}) when is_integer(status),
+    do: {:api_error, status, classify(body)}
 
   def sanitize({:api_error, status}) when is_integer(status),
     do: {:api_error, status, :provider_error}
@@ -100,8 +170,8 @@ defmodule Loopctl.Llm.ProviderError do
   """
   @spec log_tag(term()) :: String.t()
   def log_tag({:error, inner}), do: log_tag(inner)
-  def log_tag({:api_error, status, _, _}), do: "api_error status=#{status}"
-  def log_tag({:api_error, status, _}), do: "api_error status=#{status}"
+  def log_tag({:api_error, status, body, _}), do: "api_error status=#{status} #{classify(body)}"
+  def log_tag({:api_error, status, body}), do: "api_error status=#{status} #{classify(body)}"
   def log_tag({:api_error, status}), do: "api_error status=#{status}"
   def log_tag({:request_failed, _}), do: "request_failed"
   def log_tag({:embedding_crash, _}), do: "embedding_crash"

--- a/lib/loopctl/workers/article_embedding_worker.ex
+++ b/lib/loopctl/workers/article_embedding_worker.ex
@@ -11,7 +11,11 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
 
   1. Fetch the article (with its embedding + content-hash) by `article_id` + `tenant_id`
   2. If article was deleted, return `:ok` (no-op)
-  3. Build embedding text: `"{title}\\n\\n{body}"` truncated to 32K chars
+  3. Build embedding text: `"{title}\\n\\n{body}"`, truncated to
+     `Loopctl.Embeddings.TextBudget.initial_bytes/0` BYTES — not characters. A
+     character cap does not bound TOKENS, which is what the provider limits; see
+     that module for why bytes do and for the 80 articles the character cap left
+     permanently un-embeddable.
   4. IDEMPOTENCY (review #12): if the article already carries an embedding whose
      stored content-hash matches the current content, skip the paid provider call
      entirely (re-ensure linking, return `:ok`). This stops an Oban retry after a
@@ -26,6 +30,11 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
      `{:discard, {:embedding_permanent_error, _}}` (review #5): retrying a revoked
      key 3× is pointless. Transient errors (5xx / network / timeout) return
      `{:error, reason}` for Oban retry.
+  7b. EXCEPT `:context_length_exceeded`, which is permanent for the text SENT but
+     not for the article: `embed_with_shrink/6` re-sends it at half the byte budget,
+     down to a floor that provably fits (`TextBudget`). Only an exhausted ladder
+     falls through to the discard in 7 — so an over-long article is embedded from
+     its prefix instead of being retried hourly forever by the reconciler.
   8. On `{:error, :circuit_open}` (the tenant breaker is OPEN — a throttle/latency
      storm) the worker `{:snooze, remaining_cooldown}`s (US-37.3, AC-37.3.5): a
      loss-free reschedule that consumes NO attempt. This is deliberately NOT the
@@ -71,6 +80,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
   import Loopctl.Egress, only: [is_egress_refusal: 1]
   alias Loopctl.Embeddings
   alias Loopctl.Embeddings.Dimensions
+  alias Loopctl.Embeddings.TextBudget
   alias Loopctl.Knowledge
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
@@ -84,7 +94,6 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
   # worker. The client itself caps a single attempt at ~4s (no client retries), so
   # this only adds slack for scheduling/DB.
   @worker_yield_ms 8_000
-  @max_text_length 32_000
 
   @impl Oban.Worker
   def perform(%Oban.Job{id: id, args: %{"article_id" => article_id, "tenant_id" => tenant_id}}) do
@@ -128,6 +137,13 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
     end
   end
 
+  # NOTE the asymmetry between `text` and `content_hash` once the ladder shrinks:
+  # the hash is always of the INITIAL-budget text, never of the shrunk text actually
+  # sent. That is deliberate. `embedding_content_hash` answers "has this article's
+  # content already been embedded?", and keying it to whichever rung succeeded would
+  # make the answer depend on a provider verdict — so every later enqueue would miss
+  # the idempotency check, walk the whole ladder again, and re-bill the tenant for
+  # an embedding it already has.
   defp generate(tenant_id, article, article_id, text, content_hash) do
     # US-41.4 (AC-41.4.2): articles carry a nullable `project_id`, so the egress scope
     # is the ARTICLE's project when it has one and the tenant-wide scope otherwise.
@@ -145,7 +161,15 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
     # timeout, a task yield timeout, a node death mid-call — with no entry AND no
     # gap, and the claim would report no-third-party-egress for a row whose body
     # did egress. AC-41.7.2 names exactly that scenario.
-    result = embed_with_custody(tenant_id, article, article_id, text, opts)
+    result =
+      embed_with_shrink(
+        tenant_id,
+        article,
+        article_id,
+        text,
+        opts,
+        TextBudget.initial_bytes()
+      )
 
     case result do
       {:ok, embedding} ->
@@ -215,6 +239,45 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
         else
           {:error, sanitized}
         end
+    end
+  end
+
+  # The shrink ladder. `text` arrives already truncated to the INITIAL budget, so the
+  # first pass sends exactly what the pre-ladder code sent; each rejection re-truncates
+  # the SAME text to half the bytes and re-sends.
+  #
+  # Terminates unconditionally: `TextBudget.shrink/1` returns `:exhausted` once the
+  # floor has been tried, and the floor is provably under the token limit for any
+  # script. On `:exhausted` the original error is returned untouched, so the caller's
+  # existing permanent-error branch discards it — a floor-sized input that is STILL
+  # rejected is a different defect (a changed model or a much smaller limit) and must
+  # be legible as one, not absorbed by more halving.
+  defp embed_with_shrink(tenant_id, article, article_id, text, opts, budget) do
+    attempt = TextBudget.truncate(text, budget)
+
+    case embed_with_custody(tenant_id, article, article_id, attempt, opts) do
+      {:error, {:api_error, _status, :context_length_exceeded}} = error ->
+        case TextBudget.shrink(budget) do
+          :exhausted ->
+            Logger.warning(
+              "ArticleEmbeddingWorker: tenant=#{tenant_id} article=#{article_id} rejected as " <>
+                "too long even at the #{budget}-byte floor — not a length problem; discarding."
+            )
+
+            error
+
+          smaller ->
+            Logger.warning(
+              "ArticleEmbeddingWorker: tenant=#{tenant_id} article=#{article_id} exceeded the " <>
+                "provider token limit at #{budget} bytes; retrying at #{smaller}. The embedding " <>
+                "will cover a prefix of the article, not all of it."
+            )
+
+            embed_with_shrink(tenant_id, article, article_id, text, opts, smaller)
+        end
+
+      result ->
+        result
     end
   end
 
@@ -354,6 +417,6 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
 
   defp build_embedding_text(article) do
     "#{article.title}\n\n#{article.body}"
-    |> String.slice(0, @max_text_length)
+    |> TextBudget.truncate(TextBudget.initial_bytes())
   end
 end

--- a/lib/loopctl/workers/article_embedding_worker.ex
+++ b/lib/loopctl/workers/article_embedding_worker.ex
@@ -11,11 +11,12 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
 
   1. Fetch the article (with its embedding + content-hash) by `article_id` + `tenant_id`
   2. If article was deleted, return `:ok` (no-op)
-  3. Build embedding text: `"{title}\\n\\n{body}"`, truncated to
-     `Loopctl.Embeddings.TextBudget.initial_bytes/0` BYTES — not characters. A
-     character cap does not bound TOKENS, which is what the provider limits; see
-     that module for why bytes do and for the 80 articles the character cap left
-     permanently un-embeddable.
+  3. Build embedding text: `"{title}\\n\\n{body}"`, cut by
+     `Loopctl.Embeddings.TextBudget.initial/1` — the same 32,000-CHARACTER cap that
+     predates the ladder, so nothing the provider already accepted is shortened.
+     A character cap does not BOUND tokens, which is why step 7b exists; bounding
+     the first attempt in bytes instead would silently gut the multi-byte articles
+     that fit. See `TextBudget` for both halves of that argument.
   4. IDEMPOTENCY (review #12): if the article already carries an embedding whose
      stored content-hash matches the current content, skip the paid provider call
      entirely (re-ensure linking, return `:ok`). This stops an Oban retry after a
@@ -31,8 +32,8 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
      key 3× is pointless. Transient errors (5xx / network / timeout) return
      `{:error, reason}` for Oban retry.
   7b. EXCEPT `:context_length_exceeded`, which is permanent for the text SENT but
-     not for the article: `embed_with_shrink/6` re-sends it at half the byte budget,
-     down to a floor that provably fits (`TextBudget`). Only an exhausted ladder
+     not for the article: `embed_with_shrink/5` re-sends it at half the bytes it just
+     sent, down to a floor that provably fits (`TextBudget`). Only an exhausted ladder
      falls through to the discard in 7 — so an over-long article is embedded from
      its prefix instead of being retried hourly forever by the reconciler.
   8. On `{:error, :circuit_open}` (the tenant breaker is OPEN — a throttle/latency
@@ -138,7 +139,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
   end
 
   # NOTE the asymmetry between `text` and `content_hash` once the ladder shrinks:
-  # the hash is always of the INITIAL-budget text, never of the shrunk text actually
+  # the hash is always of the INITIAL text, never of the shrunk text actually
   # sent. That is deliberate. `embedding_content_hash` answers "has this article's
   # content already been embedded?", and keying it to whichever rung succeeded would
   # make the answer depend on a provider verdict — so every later enqueue would miss
@@ -161,15 +162,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
     # timeout, a task yield timeout, a node death mid-call — with no entry AND no
     # gap, and the claim would report no-third-party-egress for a row whose body
     # did egress. AC-41.7.2 names exactly that scenario.
-    result =
-      embed_with_shrink(
-        tenant_id,
-        article,
-        article_id,
-        text,
-        opts,
-        TextBudget.initial_bytes()
-      )
+    result = embed_with_shrink(tenant_id, article, article_id, text, opts)
 
     case result do
       {:ok, embedding} ->
@@ -242,26 +235,31 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
     end
   end
 
-  # The shrink ladder. `text` arrives already truncated to the INITIAL budget, so the
+  # The shrink ladder. `attempt` arrives as the initial (character-capped) text, so the
   # first pass sends exactly what the pre-ladder code sent; each rejection re-truncates
-  # the SAME text to half the bytes and re-sends.
+  # what was JUST SENT to half its bytes and re-sends.
   #
-  # Terminates unconditionally: `TextBudget.shrink/1` returns `:exhausted` once the
-  # floor has been tried, and the floor is provably under the token limit for any
-  # script. On `:exhausted` the original error is returned untouched, so the caller's
-  # existing permanent-error branch discards it — a floor-sized input that is STILL
-  # rejected is a different defect (a changed model or a much smaller limit) and must
-  # be legible as one, not absorbed by more halving.
-  defp embed_with_shrink(tenant_id, article, article_id, text, opts, budget) do
-    attempt = TextBudget.truncate(text, budget)
-
+  # The next budget is derived from `byte_size(attempt)`, never from a nominal rung:
+  # a rung larger than the text truncates nothing, so halving the rung alone would
+  # re-send byte-identical bytes and buy a guaranteed-identical rejection.
+  #
+  # Terminates unconditionally: `TextBudget.next_budget/1` returns `:exhausted` once
+  # the floor has been tried. On `:exhausted` the original error is returned untouched,
+  # so the caller's existing permanent-error branch discards it — a floor-sized input
+  # that is STILL rejected is a different defect (a much smaller model window, e.g. a
+  # self-hosted 512-token embedder) and must be legible as one, not absorbed by more
+  # halving.
+  defp embed_with_shrink(tenant_id, article, article_id, attempt, opts) do
     case embed_with_custody(tenant_id, article, article_id, attempt, opts) do
       {:error, {:api_error, _status, :context_length_exceeded}} = error ->
-        case TextBudget.shrink(budget) do
+        sent = byte_size(attempt)
+
+        case TextBudget.next_budget(sent) do
           :exhausted ->
             Logger.warning(
               "ArticleEmbeddingWorker: tenant=#{tenant_id} article=#{article_id} rejected as " <>
-                "too long even at the #{budget}-byte floor — not a length problem; discarding."
+                "too long at #{sent} bytes, the ladder's floor — not a length problem " <>
+                "(a smaller model window?); discarding."
             )
 
             error
@@ -269,11 +267,17 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
           smaller ->
             Logger.warning(
               "ArticleEmbeddingWorker: tenant=#{tenant_id} article=#{article_id} exceeded the " <>
-                "provider token limit at #{budget} bytes; retrying at #{smaller}. The embedding " <>
+                "provider token limit at #{sent} bytes; retrying at #{smaller}. The embedding " <>
                 "will cover a prefix of the article, not all of it."
             )
 
-            embed_with_shrink(tenant_id, article, article_id, text, opts, smaller)
+            embed_with_shrink(
+              tenant_id,
+              article,
+              article_id,
+              TextBudget.truncate(attempt, smaller),
+              opts
+            )
         end
 
       result ->
@@ -415,8 +419,12 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
     |> Oban.insert()
   end
 
+  # The initial CHARACTER cap, shared verbatim with `BatchArticleEmbeddingWorker`,
+  # `ReembedWorker` and `SystemCorpusEmbeddingWorker` — they all write
+  # `embedding_content_hash` into the same side table and read each other's back as
+  # the no-re-bill guard, so a divergent unit here makes every hash miss and re-bills
+  # the provider on every enqueue.
   defp build_embedding_text(article) do
-    "#{article.title}\n\n#{article.body}"
-    |> TextBudget.truncate(TextBudget.initial_bytes())
+    TextBudget.initial("#{article.title}\n\n#{article.body}")
   end
 end

--- a/lib/loopctl/workers/article_embedding_worker.ex
+++ b/lib/loopctl/workers/article_embedding_worker.ex
@@ -258,8 +258,8 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
           :exhausted ->
             Logger.warning(
               "ArticleEmbeddingWorker: tenant=#{tenant_id} article=#{article_id} rejected as " <>
-                "too long at #{sent} bytes, the ladder's floor — not a length problem " <>
-                "(a smaller model window?); discarding."
+                "too long at #{sent} bytes, at or below the #{TextBudget.floor_bytes()}-byte " <>
+                "floor — not a length problem (a smaller model window?); discarding."
             )
 
             error

--- a/lib/loopctl/workers/batch_article_embedding_worker.ex
+++ b/lib/loopctl/workers/batch_article_embedding_worker.ex
@@ -151,29 +151,50 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorker do
     # single scope would be the most restrictive one, which would block articles that
     # are not marked. Grouping keeps each decision exact.
     |> Enum.group_by(fn {article, _text, _hash} -> article.project_id end)
-    |> Enum.reduce_while(:ok, fn {project_id, group}, :ok ->
-      case generate_and_store_project_group(tenant_id, project_id, group) do
-        :ok -> {:cont, :ok}
-        other -> {:halt, other}
-      end
-    end)
+    |> Enum.to_list()
+    |> embed_groups(tenant_id)
+  end
+
+  defp embed_groups([], _tenant_id), do: :ok
+
+  defp embed_groups([{project_id, group} | rest], tenant_id) do
+    case generate_and_store_project_group(tenant_id, project_id, group) do
+      :ok ->
+        embed_groups(rest, tenant_id)
+
+      # Once ONE array has been rejected for length, this job stops sending arrays
+      # ENTIRELY: the rejected sub-batch AND everything queued behind it are handed to
+      # the per-article worker. Carrying on would let a later sub-batch's snooze/error
+      # rerun the whole job, which would re-send the rejected array (guaranteed to be
+      # rejected again) — and halting without the handoff would strand the remainder.
+      {:dissolve, remaining} ->
+        dissolve(tenant_id, remaining ++ Enum.flat_map(rest, fn {_pid, group} -> group end))
+
+      other ->
+        other
+    end
   end
 
   defp generate_and_store_project_group(tenant_id, project_id, to_embed) do
     to_embed
     |> chunk_by_char_budget(Knowledge.embedding_batch_max_chars())
-    |> Enum.reduce_while(:ok, fn sub_batch, :ok ->
-      case embed_and_store_sub_batch(tenant_id, project_id, sub_batch) do
-        :ok -> {:cont, :ok}
-        other -> {:halt, other}
-      end
-    end)
+    |> embed_sub_batches(tenant_id, project_id)
+  end
+
+  defp embed_sub_batches([], _tenant_id, _project_id), do: :ok
+
+  defp embed_sub_batches([sub_batch | rest], tenant_id, project_id) do
+    case embed_and_store_sub_batch(tenant_id, project_id, sub_batch) do
+      :ok -> embed_sub_batches(rest, tenant_id, project_id)
+      :dissolve -> {:dissolve, sub_batch ++ Enum.concat(rest)}
+      other -> other
+    end
   end
 
   # Greedy split of `to_embed` tuples into sub-batches whose cumulative text
   # `byte_size` stays at/under `max_chars`. A single input larger than the budget
-  # (already truncated to `TextBudget.initial_bytes/0`) still forms its own sub-batch
-  # rather than wedging into an empty one.
+  # (already cut by `TextBudget.initial/1`) still forms its own sub-batch rather than
+  # wedging into an empty one.
   defp chunk_by_char_budget(to_embed, max_chars) do
     chunk_fun = fn {_article, text, _hash} = item, {acc, size} ->
       len = byte_size(text)
@@ -284,25 +305,10 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorker do
   # (it would be rejected identically forever), and shrinking every text to fit the
   # unknown offender would truncate articles that were never over the limit.
   #
-  # So: dissolve the batch into single-article jobs. `ArticleEmbeddingWorker` walks
-  # the per-article shrink ladder, which pays the truncation cost ONLY on the
-  # article that actually overflows. The batch itself is done — `:ok`, not a
-  # discard, because its work has been handed on rather than dropped.
-  defp handle_batch_error(tenant_id, to_embed, {:api_error, _status, :context_length_exceeded}) do
-    Enum.each(to_embed, fn {article, _text, _hash} ->
-      %{tenant_id: tenant_id, article_id: article.id}
-      |> ArticleEmbeddingWorker.new()
-      |> Oban.insert()
-    end)
-
-    Logger.warning(
-      "BatchArticleEmbeddingWorker: tenant=#{tenant_id} batch=#{length(to_embed)} rejected — " <>
-        "at least one input exceeds the provider token limit. Re-enqueued as single-article " <>
-        "jobs so only the over-long article(s) get truncated."
-    )
-
-    :ok
-  end
+  # So: signal DISSOLVE. The enqueue happens in `dissolve/2`, at the level that also
+  # knows the sub-batches this job would still have sent as arrays.
+  defp handle_batch_error(_tenant_id, _to_embed, {:api_error, _status, :context_length_exceeded}),
+    do: :dissolve
 
   defp handle_batch_error(tenant_id, to_embed, reason) do
     # No partial writes happened (we only store after a full success), so the whole
@@ -319,6 +325,32 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorker do
     else
       {:error, sanitized}
     end
+  end
+
+  # Hand every still-unembedded article to `ArticleEmbeddingWorker`, whose per-article
+  # shrink ladder pays the truncation cost ONLY on the article that actually overflows.
+  #
+  # `:ok` here claims the work was handed on rather than dropped, so every insert is
+  # CHECKED: an unchecked `Oban.insert/1` failure (a changeset rejection, a DB blip)
+  # would report a successful batch while silently losing those articles from the
+  # pipeline. A failed handoff returns `{:error, _}` so Oban retries the batch instead.
+  defp dissolve(tenant_id, to_embed) do
+    failed =
+      to_embed
+      |> Enum.map(fn {article, _text, _hash} ->
+        %{tenant_id: tenant_id, article_id: article.id}
+        |> ArticleEmbeddingWorker.new()
+        |> Oban.insert()
+      end)
+      |> Enum.reject(&match?({:ok, _job}, &1))
+
+    Logger.warning(
+      "BatchArticleEmbeddingWorker: tenant=#{tenant_id} batch=#{length(to_embed)} rejected — " <>
+        "at least one input exceeds the provider token limit. Re-enqueued as single-article " <>
+        "jobs so only the over-long article(s) get truncated (#{length(failed)} enqueue failed)."
+    )
+
+    if failed == [], do: :ok, else: {:error, :dissolve_enqueue_failed}
   end
 
   # Store every vector against its article + enqueue linking. A store failure (other
@@ -453,9 +485,11 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorker do
     |> Oban.insert()
   end
 
+  # The initial CHARACTER cap, shared verbatim with `ArticleEmbeddingWorker` — both
+  # write `embedding_content_hash` into the same side table and read each other's back
+  # as the no-re-bill guard, so a divergent unit here makes every hash miss.
   defp build_embedding_text(article) do
-    "#{article.title}\n\n#{article.body}"
-    |> TextBudget.truncate(TextBudget.initial_bytes())
+    TextBudget.initial("#{article.title}\n\n#{article.body}")
   end
 
   # Task.yield budget (ms) for a sub-batch provider call — live-tunable via

--- a/lib/loopctl/workers/batch_article_embedding_worker.ex
+++ b/lib/loopctl/workers/batch_article_embedding_worker.ex
@@ -69,6 +69,7 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorker do
   alias Loopctl.Egress.Scope
   alias Loopctl.Embeddings
   alias Loopctl.Embeddings.Dimensions
+  alias Loopctl.Embeddings.TextBudget
   alias Loopctl.Knowledge
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
@@ -76,6 +77,7 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorker do
   alias Loopctl.Provider.Admission
   alias Loopctl.Provider.RetryAfter
   alias Loopctl.SystemConfig
+  alias Loopctl.Workers.ArticleEmbeddingWorker
   alias Loopctl.Workers.ArticleLinkingWorker
 
   # Task.yield budget for a batch provider call. Review (MED #3): this was a
@@ -90,7 +92,6 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorker do
   # `EmbeddingClient.batch_receive_timeout_ms/1`.
   @default_yield_base_ms 8_000
   @default_yield_per_item_ms 100
-  @max_text_length 32_000
 
   @impl Oban.Worker
   def perform(%Oban.Job{
@@ -171,8 +172,8 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorker do
 
   # Greedy split of `to_embed` tuples into sub-batches whose cumulative text
   # `byte_size` stays at/under `max_chars`. A single input larger than the budget
-  # (already sliced to `@max_text_length`) still forms its own sub-batch rather than
-  # wedging into an empty one.
+  # (already truncated to `TextBudget.initial_bytes/0`) still forms its own sub-batch
+  # rather than wedging into an empty one.
   defp chunk_by_char_budget(to_embed, max_chars) do
     chunk_fun = fn {_article, text, _hash} = item, {acc, size} ->
       len = byte_size(text)
@@ -277,6 +278,31 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorker do
        )
        when is_integer(retry_after),
        do: {:snooze, RetryAfter.snooze_seconds(retry_after)}
+
+  # An input-too-long rejection is about ONE member of the array, but the provider
+  # fails the whole array and never says which. Re-enqueueing the batch is useless
+  # (it would be rejected identically forever), and shrinking every text to fit the
+  # unknown offender would truncate articles that were never over the limit.
+  #
+  # So: dissolve the batch into single-article jobs. `ArticleEmbeddingWorker` walks
+  # the per-article shrink ladder, which pays the truncation cost ONLY on the
+  # article that actually overflows. The batch itself is done — `:ok`, not a
+  # discard, because its work has been handed on rather than dropped.
+  defp handle_batch_error(tenant_id, to_embed, {:api_error, _status, :context_length_exceeded}) do
+    Enum.each(to_embed, fn {article, _text, _hash} ->
+      %{tenant_id: tenant_id, article_id: article.id}
+      |> ArticleEmbeddingWorker.new()
+      |> Oban.insert()
+    end)
+
+    Logger.warning(
+      "BatchArticleEmbeddingWorker: tenant=#{tenant_id} batch=#{length(to_embed)} rejected — " <>
+        "at least one input exceeds the provider token limit. Re-enqueued as single-article " <>
+        "jobs so only the over-long article(s) get truncated."
+    )
+
+    :ok
+  end
 
   defp handle_batch_error(tenant_id, to_embed, reason) do
     # No partial writes happened (we only store after a full success), so the whole
@@ -429,7 +455,7 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorker do
 
   defp build_embedding_text(article) do
     "#{article.title}\n\n#{article.body}"
-    |> String.slice(0, @max_text_length)
+    |> TextBudget.truncate(TextBudget.initial_bytes())
   end
 
   # Task.yield budget (ms) for a sub-batch provider call — live-tunable via

--- a/test/loopctl/embeddings/text_budget_test.exs
+++ b/test/loopctl/embeddings/text_budget_test.exs
@@ -1,0 +1,109 @@
+defmodule Loopctl.Embeddings.TextBudgetTest do
+  @moduledoc """
+  The budget's contract is a TERMINATION PROOF, not a preference: the ladder must
+  reach a rung that no tokenizer can push over the provider's limit, and it must
+  stop there rather than halving forever.
+
+  These tests are written against the corpus that broke it — 80 published articles
+  the old 32,000-CHARACTER cap could never embed, because characters do not bound
+  tokens. Each one pins a property that, if it regressed, would put those articles
+  back into the hourly retry loop.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Embeddings.TextBudget
+
+  describe "the ladder terminates" do
+    test "shrink/1 reaches the floor and then reports exhaustion" do
+      rungs =
+        Stream.unfold(TextBudget.initial_bytes(), fn
+          :exhausted -> nil
+          budget -> {budget, TextBudget.shrink(budget)}
+        end)
+        |> Enum.take(50)
+
+      assert List.last(rungs) == TextBudget.floor_bytes(),
+             "the ladder must END at the floor, not merely approach it"
+
+      assert TextBudget.shrink(TextBudget.floor_bytes()) == :exhausted
+
+      # The real guarantee: bounded, and small. Two retries, not fifty.
+      assert length(rungs) <= 4, "ladder should be a handful of rungs, got #{length(rungs)}"
+    end
+
+    test "shrink/1 below the floor is exhausted, never a smaller positive budget" do
+      # A budget under the floor can only arise from a caller bug; halving it further
+      # would send ever-tinier prefixes to a paid provider instead of failing loudly.
+      assert TextBudget.shrink(1) == :exhausted
+      assert TextBudget.shrink(TextBudget.floor_bytes() - 1) == :exhausted
+    end
+  end
+
+  describe "the floor is a bound, not an estimate" do
+    test "floor is under the smallest provider limit we send to" do
+      # A BPE token is a merge of one or more BYTES, so tokens <= byte_size always.
+      # That inequality is the whole reason the floor is expressible in bytes.
+      # OpenAI text-embedding-3-* caps at 8192 tokens.
+      assert TextBudget.floor_bytes() < 8192
+    end
+
+    test "the initial budget is generous enough not to gut ordinary articles" do
+      # Starting AT the floor would be the trivial fix and the wrong one: it would
+      # truncate every article in the corpus to fix the 0.1% that overflow.
+      assert TextBudget.initial_bytes() >= 4 * TextBudget.floor_bytes()
+    end
+  end
+
+  describe "truncate/2" do
+    test "returns text under budget untouched" do
+      assert TextBudget.truncate("short", 100) == "short"
+    end
+
+    test "bounds BYTES, not characters — the whole point of the change" do
+      # Cyrillic is 2 bytes/char. Under the old character cap this text counted as
+      # 100 "characters" and sailed through; it is 200 bytes.
+      text = String.duplicate("я", 100)
+      assert String.length(text) == 100
+      assert byte_size(text) == 200
+
+      out = TextBudget.truncate(text, 50)
+      assert byte_size(out) <= 50
+
+      refute String.length(out) == 100,
+             "a character-based cap would have returned this unchanged"
+    end
+
+    test "never splits a UTF-8 codepoint" do
+      # Cut at every byte offset across a mix of 1-, 2-, 3- and 4-byte codepoints.
+      # A naive binary_part/3 produces an invalid string at most of these offsets.
+      text = "aя€🎯" |> String.duplicate(20)
+
+      for max_bytes <- 1..byte_size(text) do
+        out = TextBudget.truncate(text, max_bytes)
+
+        assert String.valid?(out),
+               "truncating to #{max_bytes} bytes produced an invalid UTF-8 string"
+
+        assert byte_size(out) <= max_bytes,
+               "truncating to #{max_bytes} bytes returned #{byte_size(out)} bytes"
+      end
+    end
+
+    test "a 4-byte codepoint at the boundary is dropped whole, not clipped" do
+      # 🎯 is 4 bytes. Asking for 2 must yield "" — not two bytes of a codepoint.
+      assert TextBudget.truncate("🎯", 2) == ""
+      assert TextBudget.truncate("🎯", 4) == "🎯"
+    end
+
+    test "output at the floor cannot exceed the token limit for ANY script" do
+      # The property the floor rests on, asserted directly on the worst input we can
+      # construct: every codepoint 4 bytes.
+      text = String.duplicate("🎯", 10_000)
+      out = TextBudget.truncate(text, TextBudget.floor_bytes())
+
+      assert byte_size(out) <= TextBudget.floor_bytes()
+      assert byte_size(out) < 8192, "tokens <= bytes, so bytes < 8192 implies tokens < 8192"
+    end
+  end
+end

--- a/test/loopctl/embeddings/text_budget_test.exs
+++ b/test/loopctl/embeddings/text_budget_test.exs
@@ -15,28 +15,37 @@ defmodule Loopctl.Embeddings.TextBudgetTest do
   alias Loopctl.Embeddings.TextBudget
 
   describe "the ladder terminates" do
-    test "shrink/1 reaches the floor and then reports exhaustion" do
+    test "next_budget/1 reaches the floor and then reports exhaustion" do
       rungs =
-        Stream.unfold(TextBudget.initial_bytes(), fn
+        Stream.unfold(TextBudget.top_rung_bytes(), fn
           :exhausted -> nil
-          budget -> {budget, TextBudget.shrink(budget)}
+          budget -> {budget, TextBudget.next_budget(budget)}
         end)
         |> Enum.take(50)
 
       assert List.last(rungs) == TextBudget.floor_bytes(),
              "the ladder must END at the floor, not merely approach it"
 
-      assert TextBudget.shrink(TextBudget.floor_bytes()) == :exhausted
+      assert TextBudget.next_budget(TextBudget.floor_bytes()) == :exhausted
 
-      # The real guarantee: bounded, and small. Two retries, not fifty.
+      # The real guarantee: bounded, and small. A handful of rungs, not fifty.
       assert length(rungs) <= 4, "ladder should be a handful of rungs, got #{length(rungs)}"
     end
 
-    test "shrink/1 below the floor is exhausted, never a smaller positive budget" do
-      # A budget under the floor can only arise from a caller bug; halving it further
-      # would send ever-tinier prefixes to a paid provider instead of failing loudly.
-      assert TextBudget.shrink(1) == :exhausted
-      assert TextBudget.shrink(TextBudget.floor_bytes() - 1) == :exhausted
+    test "every rung is STRICTLY smaller than the bytes that were rejected" do
+      # Keyed to what was SENT, not to a nominal budget: a budget above the text's own
+      # size truncates nothing, so halving it would re-send a byte-identical request and
+      # pay for a guaranteed-identical rejection. Below the floor is :exhausted, never a
+      # smaller prefix; far above the top rung drops straight ONTO it, in one hop.
+      assert TextBudget.next_budget(1) == :exhausted
+      assert TextBudget.next_budget(TextBudget.floor_bytes() - 1) == :exhausted
+
+      for sent <- [10_000, 32_000, 59_428, 128_000, TextBudget.floor_bytes() + 1] do
+        assert TextBudget.next_budget(sent) < sent,
+               "next_budget(#{sent}) did not shrink what was actually sent"
+      end
+
+      assert TextBudget.next_budget(128_000) == TextBudget.top_rung_bytes()
     end
   end
 
@@ -48,10 +57,22 @@ defmodule Loopctl.Embeddings.TextBudgetTest do
       assert TextBudget.floor_bytes() < 8192
     end
 
-    test "the initial budget is generous enough not to gut ordinary articles" do
+    test "the top rung is generous enough not to gut ordinary articles" do
       # Starting AT the floor would be the trivial fix and the wrong one: it would
       # truncate every article in the corpus to fix the 0.1% that overflow.
-      assert TextBudget.initial_bytes() >= 4 * TextBudget.floor_bytes()
+      assert TextBudget.top_rung_bytes() >= 4 * TextBudget.floor_bytes()
+    end
+
+    test "initial/1 is NOT byte-capped — it keeps text the provider would accept" do
+      # Bounding the FIRST attempt in bytes shortens articles that were embedding fine:
+      # Russian prose runs ~6 bytes/token, so this is ~39,000 bytes but only ~6,500
+      # tokens, and a byte cap would drop a fifth of it silently. Chars still bound it.
+      text = String.duplicate("привет ", 3_000)
+      assert byte_size(text) > TextBudget.top_rung_bytes()
+      assert TextBudget.initial(text) == text, "truncated text the provider accepts whole"
+
+      huge = String.duplicate("a", TextBudget.initial_chars() * 2)
+      assert String.length(TextBudget.initial(huge)) == TextBudget.initial_chars()
     end
   end
 

--- a/test/loopctl/llm/provider_error_test.exs
+++ b/test/loopctl/llm/provider_error_test.exs
@@ -62,10 +62,112 @@ defmodule Loopctl.Llm.ProviderErrorTest do
   describe "log_tag/1" do
     test "never includes a body and unwraps {:error, _}" do
       body = %{"error" => "Incorrect API key: test-openai-...ZXY9"}
-      assert ProviderError.log_tag({:api_error, 401, body}) == "api_error status=401"
-      assert ProviderError.log_tag({:error, {:api_error, 500, body}}) == "api_error status=500"
+
+      assert ProviderError.log_tag({:api_error, 401, body}) ==
+               "api_error status=401 provider_error"
+
+      assert ProviderError.log_tag({:error, {:api_error, 500, body}}) ==
+               "api_error status=500 provider_error"
+
       assert ProviderError.log_tag({:request_failed, %{secret: "x"}}) == "request_failed"
       refute ProviderError.log_tag({:api_error, 401, body}) =~ "ZXY9"
+    end
+
+    test "names the classification, so an operator can see WHY a 400 happened" do
+      # The defect this closes: 80 articles failed identically for 16 hours and every
+      # record of it — logs AND oban_jobs.errors — said only "status=400". The reason
+      # had to be recovered by bisecting against the live provider.
+      body = %{
+        "error" => %{"message" => "Invalid 'input': maximum context length is 8192 tokens."}
+      }
+
+      assert ProviderError.log_tag({:api_error, 400, body}) ==
+               "api_error status=400 context_length_exceeded"
+    end
+  end
+
+  describe "classify/1" do
+    test "recognises input-too-long across vendor spellings" do
+      for message <- [
+            "Invalid 'input': maximum context length is 8192 tokens.",
+            "This model's maximum context length is 8192 tokens, however you requested 9001.",
+            "Please reduce the length of the messages.",
+            "input is too long for the model",
+            "string too long"
+          ] do
+        body = %{"error" => %{"message" => message}}
+
+        assert ProviderError.classify(body) == :context_length_exceeded,
+               "failed to classify: #{message}"
+      end
+    end
+
+    test "reads the error code as well as the message" do
+      body = %{"error" => %{"code" => "context_length_exceeded", "message" => nil}}
+      assert ProviderError.classify(body) == :context_length_exceeded
+    end
+
+    test "is case-insensitive" do
+      body = %{"error" => %{"message" => "MAXIMUM CONTEXT LENGTH IS 8192 TOKENS"}}
+      assert ProviderError.classify(body) == :context_length_exceeded
+    end
+
+    test "does NOT claim context-length for unrelated failures" do
+      # A false :context_length_exceeded is worse than none: it would send the worker
+      # down the shrink ladder, re-billing the provider two extra times for an error
+      # that shrinking cannot fix.
+      for body <- [
+            %{"error" => %{"message" => "Incorrect API key provided: sk-...ZXY9"}},
+            %{"error" => %{"message" => "Rate limit reached for requests"}},
+            %{"error" => %{"code" => "invalid_api_key"}},
+            %{"error" => "some string body"},
+            "a bare string body",
+            %{"unexpected" => "shape"},
+            nil
+          ] do
+        assert ProviderError.classify(body) == :provider_error,
+               "wrongly classified as context-length: #{inspect(body)}"
+      end
+    end
+
+    test "is idempotent on an already-classified tag" do
+      # sanitize/1 runs again at every worker boundary. If classify/1 flattened a tag
+      # back to :provider_error the workers' retry ladder would never fire — the exact
+      # half-fix that would leave the 80 articles un-embedded while looking fixed.
+      assert ProviderError.classify(:context_length_exceeded) == :context_length_exceeded
+      assert ProviderError.classify(:provider_error) == :provider_error
+    end
+
+    test "keeps no byte of the body — the return is always a fixed atom" do
+      body = %{"error" => %{"message" => "maximum context length exceeded for sk-...ZXY9"}}
+      result = ProviderError.classify(body)
+
+      assert result in [:provider_error, :context_length_exceeded]
+      refute inspect(result) =~ "ZXY9"
+    end
+  end
+
+  describe "sanitize/1 classification round-trip" do
+    test "carries the classification into the Oban error term" do
+      body = %{"error" => %{"message" => "maximum context length is 8192 tokens"}}
+
+      assert ProviderError.sanitize({:api_error, 400, body}) ==
+               {:api_error, 400, :context_length_exceeded}
+    end
+
+    test "a second sanitize pass preserves it (worker boundaries re-sanitize)" do
+      once =
+        ProviderError.sanitize(
+          {:api_error, 400, %{"error" => %{"code" => "context_length_exceeded"}}}
+        )
+
+      assert ProviderError.sanitize(once) == once
+      assert once == {:api_error, 400, :context_length_exceeded}
+    end
+
+    test "preserves the throttle 4-tuple for a classified tag too" do
+      term = {:api_error, 429, :provider_error, 30}
+      assert ProviderError.sanitize(term) == term
     end
   end
 end

--- a/test/loopctl/llm/provider_error_test.exs
+++ b/test/loopctl/llm/provider_error_test.exs
@@ -123,10 +123,29 @@ defmodule Loopctl.Llm.ProviderErrorTest do
             %{"error" => "some string body"},
             "a bare string body",
             %{"unexpected" => "shape"},
+            # A struct has no Access impl — reading it as a map would raise in an
+            # error path.
+            %URI{path: "/v1/embeddings"},
             nil
           ] do
         assert ProviderError.classify(body) == :provider_error,
                "wrongly classified as context-length: #{inspect(body)}"
+      end
+    end
+
+    test "reads the OpenAI-COMPATIBLE envelope shapes, not just OpenAI's own" do
+      # A tenant may point base_url at vLLM / TEI / a FastAPI gateway, which answer a
+      # length rejection with a string-valued "error" or a top-level "detail"/"message".
+      # Reading only %{"error" => %{...}} classified all of them :provider_error, which
+      # discards the 400 as permanent and never runs the ladder.
+      for body <- [
+            %{"error" => "maximum context length is 8192 tokens"},
+            %{"detail" => "Input is too long for this model"},
+            %{"message" => "please reduce the length of the input"},
+            %{"code" => "context_length_exceeded"}
+          ] do
+        assert ProviderError.classify(body) == :context_length_exceeded,
+               "failed to classify: #{inspect(body)}"
       end
     end
 
@@ -168,6 +187,19 @@ defmodule Loopctl.Llm.ProviderErrorTest do
     test "preserves the throttle 4-tuple for a classified tag too" do
       term = {:api_error, 429, :provider_error, 30}
       assert ProviderError.sanitize(term) == term
+    end
+
+    test "sanitize/2 keeps the classification when a Retry-After is attached" do
+      # sanitize/2 hardcoded :provider_error while sanitize/1 preserved the tag, so a
+      # gateway answering with both a Retry-After and a length complaint lost the
+      # classification — disabling the ladder on that path only.
+      body = %{"error" => %{"message" => "maximum context length is 8192 tokens"}}
+
+      assert ProviderError.sanitize({:api_error, 400, body}, 30) ==
+               {:api_error, 400, :context_length_exceeded, 30}
+
+      assert ProviderError.sanitize({:api_error, 429, "slow down"}, 30) ==
+               {:api_error, 429, :provider_error, 30}
     end
   end
 end

--- a/test/loopctl/llm/provider_error_test.exs
+++ b/test/loopctl/llm/provider_error_test.exs
@@ -189,17 +189,40 @@ defmodule Loopctl.Llm.ProviderErrorTest do
       assert ProviderError.sanitize(term) == term
     end
 
-    test "sanitize/2 keeps the classification when a Retry-After is attached" do
-      # sanitize/2 hardcoded :provider_error while sanitize/1 preserved the tag, so a
-      # gateway answering with both a Retry-After and a length complaint lost the
-      # classification — disabling the ladder on that path only.
+    test "sanitize/2 always tags the throttle 4-tuple :provider_error" do
+      # A Retry-After IS the provider naming the remedy: WAIT, not shorten. The tag
+      # must stay fixed because every worker's loss-free snooze clause matches
+      # {:api_error, _status, :provider_error, retry_after} LITERALLY — a classified
+      # tag there falls through to the generic branch and burns an Oban attempt on the
+      # blind attempt^4 backoff against a provider that just asked us to back off.
       body = %{"error" => %{"message" => "maximum context length is 8192 tokens"}}
 
       assert ProviderError.sanitize({:api_error, 400, body}, 30) ==
-               {:api_error, 400, :context_length_exceeded, 30}
+               {:api_error, 400, :provider_error, 30}
 
       assert ProviderError.sanitize({:api_error, 429, "slow down"}, 30) ==
                {:api_error, 429, :provider_error, 30}
+    end
+
+    test "a throttle status is never classified as a length rejection" do
+      # OpenAI-compatible gateways answer a per-minute TOKEN throttle with the same
+      # phrasings a length rejection uses. Taking those at face value ran the shrink
+      # ladder, then — once the provider's window cleared — stored an embedding of a
+      # PREFIX under the FULL text's content hash, which the idempotency guard makes
+      # permanent. The status decides the remedy; the body does not.
+      for {status, body} <- [
+            {429, %{"detail" => "Too many tokens in this request, slow down"}},
+            {429, %{"error" => "please reduce the length of your input"}},
+            {503, %{"message" => "input is too long right now, retry later"}},
+            {408, %{"error" => %{"code" => "context_length_exceeded"}}}
+          ] do
+        assert ProviderError.sanitize({:api_error, status, body}) ==
+                 {:api_error, status, :provider_error},
+               "throttle #{status} wrongly classified as context-length: #{inspect(body)}"
+
+        assert ProviderError.log_tag({:api_error, status, body}) ==
+                 "api_error status=#{status} provider_error"
+      end
     end
   end
 end

--- a/test/loopctl/workers/article_embedding_worker_test.exs
+++ b/test/loopctl/workers/article_embedding_worker_test.exs
@@ -7,6 +7,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
   alias Loopctl.Custody
   alias Loopctl.Egress
   alias Loopctl.Egress.PinCache
+  alias Loopctl.Embeddings.TextBudget
   alias Loopctl.Knowledge
   alias Loopctl.Test.AllowlistSource
   alias Loopctl.Workers.ArticleEmbeddingWorker
@@ -527,6 +528,134 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
       # No embedding was stored (the article stays created, just not vector-searchable).
       {:ok, loaded} = Knowledge.get_article_with_embedding(tenant.id, article.id)
       assert loaded.embedding == nil
+    end
+  end
+
+  # --- Context-length shrink ladder ---
+  #
+  # Measured 2026-08-06: 80 published articles could never be embedded, because the
+  # embedding text was capped at 32,000 CHARACTERS while the provider caps at 8,192
+  # TOKENS, and the ratio is not constant across scripts. Each failure discarded
+  # permanently, and the hourly reconciler re-enqueued all 80 every hour, forever.
+  # These tests pin the escape: a too-long rejection re-sends a shorter prefix rather
+  # than discarding the article.
+
+  describe "context-length shrink ladder" do
+    test "retries at a smaller byte budget and succeeds instead of discarding" do
+      %{tenant: tenant} = setup_tenant()
+      embedding = List.duplicate(0.5, 1536)
+
+      article =
+        create_draft_then_publish(tenant.id, %{
+          title: "Over Long Article",
+          # Cyrillic: 2 bytes/char, so this is well over the initial byte budget —
+          # the exact population the character cap mis-measured.
+          body: String.duplicate("привет ", 6_000)
+        })
+
+      # First call rejected as too long; second (shorter) call succeeds.
+      Loopctl.MockEmbeddingClient
+      |> expect(:generate_embedding, fn _tenant_id, text ->
+        assert byte_size(text) <= TextBudget.initial_bytes()
+        {:error, {:api_error, 400, :context_length_exceeded}}
+      end)
+      |> expect(:generate_embedding, fn _tenant_id, text ->
+        assert byte_size(text) <= TextBudget.shrink(TextBudget.initial_bytes()),
+               "the retry must send STRICTLY LESS than the attempt that was rejected"
+
+        {:ok, embedding}
+      end)
+
+      assert :ok =
+               ArticleEmbeddingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => article.id, "tenant_id" => tenant.id}
+               })
+
+      # The article is embedded — not left in the reconciler's hourly retry loop.
+      {:ok, stored} = Knowledge.get_article_with_embedding(tenant.id, article.id)
+      refute is_nil(stored.embedding)
+    end
+
+    test "gives up with a discard once the floor itself is rejected" do
+      %{tenant: tenant} = setup_tenant()
+
+      article =
+        create_draft_then_publish(tenant.id, %{
+          title: "Always Too Long",
+          body: String.duplicate("привет ", 6_000)
+        })
+
+      # Rejected at every rung. The ladder must TERMINATE — if it did not, this test
+      # would hang rather than fail, which is why the rung count is asserted too.
+      calls = :counters.new(1, [])
+
+      stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        :counters.add(calls, 1, 1)
+        {:error, {:api_error, 400, :context_length_exceeded}}
+      end)
+
+      assert {:discard, {:embedding_permanent_error, {:api_error, 400, :context_length_exceeded}}} =
+               ArticleEmbeddingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => article.id, "tenant_id" => tenant.id}
+               })
+
+      attempts = :counters.get(calls, 1)
+
+      assert attempts >= 2, "expected the ladder to retry at least once, got #{attempts} call(s)"
+
+      assert attempts <= 4,
+             "the ladder must be bounded — #{attempts} provider calls for one article"
+    end
+
+    test "a NON-length 4xx is not shrunk — it discards on the first call" do
+      # The ladder must be driven by the classification, not by the status. Shrinking
+      # a revoked-key 401 would re-bill the provider twice for an error that no amount
+      # of truncation can fix.
+      %{tenant: tenant} = setup_tenant()
+
+      article =
+        create_draft_then_publish(tenant.id, %{
+          title: "Revoked Key Not Shrunk",
+          body: String.duplicate("привет ", 6_000)
+        })
+
+      # `expect` with the default count of 1 fails the test if a second call is made.
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 401, :provider_error}}
+      end)
+
+      assert {:discard, {:embedding_permanent_error, {:api_error, 401, _}}} =
+               ArticleEmbeddingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => article.id, "tenant_id" => tenant.id}
+               })
+    end
+
+    test "the text sent is bounded by BYTES, not characters" do
+      # The mutation that caused the outage: swap TextBudget.truncate/2 back for
+      # String.slice/3 and this assertion is what fails.
+      %{tenant: tenant} = setup_tenant()
+      embedding = List.duplicate(0.5, 1536)
+
+      article =
+        create_draft_then_publish(tenant.id, %{
+          title: "Byte Bounded",
+          # 30,000 Cyrillic chars = 60,000 bytes. A 32,000-CHARACTER cap would send
+          # 32,000 chars (~64,000 bytes); the byte cap sends at most 32,000 bytes.
+          body: String.duplicate("я", 30_000)
+        })
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
+        assert byte_size(text) <= TextBudget.initial_bytes(),
+               "sent #{byte_size(text)} bytes, budget is #{TextBudget.initial_bytes()}"
+
+        assert String.valid?(text), "truncation split a UTF-8 codepoint"
+        {:ok, embedding}
+      end)
+
+      assert :ok =
+               ArticleEmbeddingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => article.id, "tenant_id" => tenant.id}
+               })
     end
   end
 

--- a/test/loopctl/workers/article_embedding_worker_test.exs
+++ b/test/loopctl/workers/article_embedding_worker_test.exs
@@ -548,21 +548,23 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
       article =
         create_draft_then_publish(tenant.id, %{
           title: "Over Long Article",
-          # Cyrillic: 2 bytes/char, so this is well over the initial byte budget —
-          # the exact population the character cap mis-measured.
+          # Cyrillic: 2 bytes/char, so this is well over any byte rung — the exact
+          # population the character cap mis-measured.
           body: String.duplicate("привет ", 6_000)
         })
 
-      # First call rejected as too long; second (shorter) call succeeds.
+      # First call rejected as too long; second (shorter) call succeeds. Sizes are
+      # reported back to the test process — the client runs in its own task, so the
+      # comparison cannot be made inside the stub.
+      test_pid = self()
+
       Loopctl.MockEmbeddingClient
       |> expect(:generate_embedding, fn _tenant_id, text ->
-        assert byte_size(text) <= TextBudget.initial_bytes()
+        send(test_pid, {:attempt, byte_size(text)})
         {:error, {:api_error, 400, :context_length_exceeded}}
       end)
       |> expect(:generate_embedding, fn _tenant_id, text ->
-        assert byte_size(text) <= TextBudget.shrink(TextBudget.initial_bytes()),
-               "the retry must send STRICTLY LESS than the attempt that was rejected"
-
+        send(test_pid, {:attempt, byte_size(text)})
         {:ok, embedding}
       end)
 
@@ -570,6 +572,12 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
                ArticleEmbeddingWorker.perform(%Oban.Job{
                  args: %{"article_id" => article.id, "tenant_id" => tenant.id}
                })
+
+      assert_received {:attempt, first}
+      assert_received {:attempt, second}
+
+      assert second <= TextBudget.next_budget(first),
+             "the retry must send STRICTLY LESS than the attempt that was rejected"
 
       # The article is embedded — not left in the reconciler's hourly retry loop.
       {:ok, stored} = Knowledge.get_article_with_embedding(tenant.id, article.id)
@@ -630,24 +638,28 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
                })
     end
 
-    test "the text sent is bounded by BYTES, not characters" do
+    test "the RETRY is bounded by BYTES, not characters" do
       # The mutation that caused the outage: swap TextBudget.truncate/2 back for
-      # String.slice/3 and this assertion is what fails.
+      # String.slice/3 on the retry and this assertion is what fails — a shrunk
+      # attempt measured in characters is not a smaller number of TOKENS.
       %{tenant: tenant} = setup_tenant()
       embedding = List.duplicate(0.5, 1536)
+      test_pid = self()
 
       article =
         create_draft_then_publish(tenant.id, %{
           title: "Byte Bounded",
-          # 30,000 Cyrillic chars = 60,000 bytes. A 32,000-CHARACTER cap would send
-          # 32,000 chars (~64,000 bytes); the byte cap sends at most 32,000 bytes.
+          # 30,000 Cyrillic chars = 60,000 bytes, under the 32,000-character initial
+          # cut — so the retry, not the first attempt, is where bytes must bind.
           body: String.duplicate("я", 30_000)
         })
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
-        assert byte_size(text) <= TextBudget.initial_bytes(),
-               "sent #{byte_size(text)} bytes, budget is #{TextBudget.initial_bytes()}"
-
+      Loopctl.MockEmbeddingClient
+      |> expect(:generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 400, :context_length_exceeded}}
+      end)
+      |> expect(:generate_embedding, fn _tenant_id, text ->
+        send(test_pid, {:retry_bytes, byte_size(text)})
         assert String.valid?(text), "truncation split a UTF-8 codepoint"
         {:ok, embedding}
       end)
@@ -656,6 +668,41 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
                ArticleEmbeddingWorker.perform(%Oban.Job{
                  args: %{"article_id" => article.id, "tenant_id" => tenant.id}
                })
+
+      assert_received {:retry_bytes, retried}
+
+      assert retried <= TextBudget.top_rung_bytes(),
+             "retry sent #{retried} bytes, top rung is #{TextBudget.top_rung_bytes()}"
+    end
+
+    test "the first attempt keeps multi-byte content the provider would accept" do
+      # The regression a BYTE cap on the first attempt introduces: an article that was
+      # embedding fine loses a third of its text, with no error and no log line, and
+      # its search recall degrades silently. Nothing marks it, so nothing finds it.
+      %{tenant: tenant} = setup_tenant()
+      embedding = List.duplicate(0.5, 1536)
+      test_pid = self()
+
+      # ~45,000 bytes of Cyrillic: over every byte rung, under the token limit.
+      body = String.duplicate("привет ", 3_000)
+      article = create_draft_then_publish(tenant.id, %{title: "Fits Whole", body: body})
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
+        send(test_pid, {:sent, text})
+        {:ok, embedding}
+      end)
+
+      assert :ok =
+               ArticleEmbeddingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => article.id, "tenant_id" => tenant.id}
+               })
+
+      assert_received {:sent, sent}
+      assert byte_size(body) > TextBudget.top_rung_bytes(), "fixture no longer exercises the bug"
+
+      assert sent == "#{article.title}\n\n#{body}",
+             "the first attempt dropped #{byte_size(article.title) + byte_size(body) + 2 - byte_size(sent)} " <>
+               "bytes of an article the provider accepted whole"
     end
   end
 

--- a/test/loopctl/workers/batch_article_embedding_worker_test.exs
+++ b/test/loopctl/workers/batch_article_embedding_worker_test.exs
@@ -260,18 +260,20 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorkerTest do
       assert is_nil(stored.embedding)
     end
 
-    test "batch text is bounded by BYTES, not characters" do
+    test "batch text is cut by the SAME initial rule as the single-article path" do
       # There is no ladder on the batch path — build_embedding_text/1 IS what gets
-      # sent, so its unit is the whole guard here.
+      # sent. Both workers write `embedding_content_hash` into one side table and read
+      # each other's back as the no-re-bill guard, so a divergent cut here makes every
+      # hash miss and re-bills the provider on every enqueue.
       tenant = fixture(:tenant)
+      body = String.duplicate("я", 30_000)
 
-      article =
-        create_published_article(tenant.id, %{body: String.duplicate("я", 30_000)})
+      article = create_published_article(tenant.id, %{body: body})
 
       Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _t, texts ->
         for text <- texts do
-          assert byte_size(text) <= TextBudget.initial_bytes(),
-                 "sent #{byte_size(text)} bytes"
+          assert text == TextBudget.initial("#{article.title}\n\n#{body}"),
+                 "batch text diverged from the single-article cut"
 
           assert String.valid?(text), "truncation split a UTF-8 codepoint"
         end
@@ -280,6 +282,45 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorkerTest do
       end)
 
       assert :ok = perform(tenant.id, [article.id])
+    end
+
+    test "a length rejection hands on the sub-batches BEHIND it too, not just its own" do
+      # Continuing after a dissolve let a later sub-batch's snooze/error rerun the whole
+      # job, which re-sent the rejected array — guaranteed to be rejected again, for a
+      # second paid round trip. Once one array is rejected for length, this job stops
+      # sending arrays: everything left goes to the per-article ladder.
+      tenant = fixture(:tenant)
+      test_pid = self()
+
+      # One article per sub-batch: a tiny cumulative byte budget forces the split.
+      pt_key = {Loopctl.SystemConfig, "embedding_batch_max_chars"}
+      :persistent_term.put(pt_key, 1)
+      on_exit(fn -> :persistent_term.erase(pt_key) end)
+
+      articles = for _ <- 1..3, do: create_published_article(tenant.id)
+      ids = Enum.map(articles, & &1.id)
+
+      # Only the FIRST array call is rejected; the rest must never be sent as arrays.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _t, texts ->
+        send(test_pid, {:batch_call, length(texts)})
+        {:error, {:api_error, 400, :context_length_exceeded}}
+      end)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, text ->
+        {:ok, vec_for(text)}
+      end)
+
+      assert :ok = perform(tenant.id, ids)
+
+      assert_received {:batch_call, 1}
+      refute_received {:batch_call, _}
+
+      for id <- ids do
+        {:ok, stored} = Knowledge.get_article_with_embedding(tenant.id, id)
+
+        refute is_nil(stored.embedding),
+               "article #{id} was stranded when the batch stopped sending arrays"
+      end
     end
 
     test "throttle with Retry-After → snooze ~that interval", %{tenant: tenant, ids: ids} do

--- a/test/loopctl/workers/batch_article_embedding_worker_test.exs
+++ b/test/loopctl/workers/batch_article_embedding_worker_test.exs
@@ -20,6 +20,7 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorkerTest do
 
   setup :verify_on_exit!
 
+  alias Loopctl.Embeddings.TextBudget
   alias Loopctl.Knowledge
   alias Loopctl.Workers.BatchArticleEmbeddingWorker
 
@@ -204,6 +205,81 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorkerTest do
 
       assert {:discard, {:embedding_permanent_error, {:api_error, 401, _}}} =
                perform(tenant.id, ids)
+    end
+
+    test "context_length_exceeded → dissolved into single-article jobs, not discarded" do
+      # The provider fails the WHOLE array and never says which input was too long.
+      # Discarding would strand every article in the batch; shrinking every text
+      # would truncate the innocent ones. So the batch is re-enqueued per article and
+      # the per-article ladder pays the cost only where it is owed.
+      tenant = fixture(:tenant)
+      articles = for _ <- 1..3, do: create_published_article(tenant.id)
+      ids = Enum.map(articles, & &1.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _t, _texts ->
+        {:error, {:api_error, 400, :context_length_exceeded}}
+      end)
+
+      # Oban runs `testing: :inline`, so the re-enqueued single jobs execute here.
+      # Asserting the OUTCOME is stronger than asserting the enqueue anyway: it
+      # proves the dissolve actually rescues the articles rather than just moving
+      # them to another queue.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, text ->
+        {:ok, vec_for(text)}
+      end)
+
+      assert :ok = perform(tenant.id, ids)
+
+      for id <- ids do
+        {:ok, stored} = Knowledge.get_article_with_embedding(tenant.id, id)
+
+        refute is_nil(stored.embedding),
+               "article #{id} was stranded by the batch rejection instead of being re-embedded"
+      end
+    end
+
+    test "a NON-length 400 still discards — it is not dissolved into singles" do
+      # Guards the classification, not the status: dissolving a malformed-request 400
+      # would re-run every article individually against the same rejection.
+      tenant = fixture(:tenant)
+      article = create_published_article(tenant.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _t, _texts ->
+        {:error, {:api_error, 400, :provider_error}}
+      end)
+
+      # No single-article fallout: if the batch dissolved, these inline jobs would
+      # call generate_embedding/2 and this expectation would blow up on arity/count.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        flunk("a non-length 400 must NOT be dissolved into single-article jobs")
+      end)
+
+      assert {:discard, {:embedding_permanent_error, _}} = perform(tenant.id, [article.id])
+
+      {:ok, stored} = Knowledge.get_article_with_embedding(tenant.id, article.id)
+      assert is_nil(stored.embedding)
+    end
+
+    test "batch text is bounded by BYTES, not characters" do
+      # There is no ladder on the batch path — build_embedding_text/1 IS what gets
+      # sent, so its unit is the whole guard here.
+      tenant = fixture(:tenant)
+
+      article =
+        create_published_article(tenant.id, %{body: String.duplicate("я", 30_000)})
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _t, texts ->
+        for text <- texts do
+          assert byte_size(text) <= TextBudget.initial_bytes(),
+                 "sent #{byte_size(text)} bytes"
+
+          assert String.valid?(text), "truncation split a UTF-8 codepoint"
+        end
+
+        {:ok, Enum.map(texts, &vec_for/1)}
+      end)
+
+      assert :ok = perform(tenant.id, [article.id])
     end
 
     test "throttle with Retry-After → snooze ~that interval", %{tenant: tenant, ids: ids} do


### PR DESCRIPTION
## What last night's jobs showed

Reviewing the 04:00 UTC nightly turned up an hourly failure loop that had been
running unnoticed since 22:00 on 08-05: **80 published articles that can never be
embedded**, re-enqueued by `EmbeddingReconciliationWorker` every hour, forever.
Roughly 1,920 wasted provider calls and Oban rows per day, and those 80 articles
have been invisible to semantic search since June.

Reproduced against the live provider, the cause was unambiguous:

```
400 Invalid 'input': maximum context length is 8192 tokens.
```

The embedding text was capped at **32,000 characters**; the model caps at **8,192
tokens**. Chars-per-token is not a constant — English prose runs ~4, so 32,000
chars lands just under; Cyrillic, CJK, dense index pages and code run 2-3x worse
and blow straight past it. A cap in the wrong unit is not a bound.

## The fix

Bytes *are* a bound. A BPE token is a merge of one or more bytes, so
`tokens(text) <= byte_size(text)` for any script. That inequality makes an
8,000-byte floor a proof rather than an estimate, and it is what lets the ladder
terminate without a tokenizer dependency.

Starting *at* that floor would have been the one-line fix and the wrong one: it
would truncate every article in the corpus to a quarter of its content to
accommodate the 0.1% that overflow. So the first attempt stays generous at 32,000
bytes and only an input the provider actually rejects pays for a retry:

```
32,000 -> 16,000 -> 8,000 -> :exhausted
```

At most two extra calls, and only for text that overflowed. The bound is
discovered, not assumed.

| Change | Why |
|---|---|
| `Loopctl.Embeddings.TextBudget` (new) | the byte budget, the ladder, UTF-8-safe truncation that never splits a codepoint |
| `ProviderError.classify/1` | maps a body to a fixed atom from a closed set, so `:context_length_exceeded` reaches the worker and the log without any byte of the body. **Idempotent** — `sanitize/1` runs again at every worker boundary, and a flattened tag would silently disable the ladder |
| `ArticleEmbeddingWorker` | walks the ladder; only an exhausted ladder discards |
| `BatchArticleEmbeddingWorker` | one over-long input fails the whole array and the provider never says which — so the batch dissolves into single-article jobs rather than truncating its innocent members |

Two decisions worth flagging for review:

- **The content hash stays keyed to the initial-budget text**, not to whichever
  rung succeeded. Keying it to the provider's verdict would make every later
  enqueue miss the idempotency check, re-walk the ladder, and re-bill the tenant
  for an embedding it already has.
- **The reconciler is deliberately unchanged.** Its hourly warning is the alarm
  that found this, and its own moduledoc argues for it; it stops on its own once
  the jobs succeed. Suppressing it would mute the instrumentation that just proved
  its worth.

## Diagnosability

The sanitizer dropped the provider body (correctly — it can echo a masked key
fragment), and the log line said only `status=400`. So a systematic permanent
failure on 80 articles left **no record anywhere** of why; the reason had to be
recovered by bisecting against the live provider. `classify/1` closes that without
reopening the leak: the return is always a fixed atom.

## Verification

Full gate green: 6,945 tests, 0 failures; credo `--strict`, dialyzer, format clean.

Every new guard was **mutation-tested** — reverting the byte bound, removing
either ladder branch, or breaking `classify/1` idempotency each fails a named
test. The first mutation attempt passed and was traced to a masked line rather
than accepted; the real send-path line is the one now covered.

Not verified: the fix has not yet run against the 80 production articles. That is
the post-merge check.
