### PR TITLE
Finish the shrink ladder, and stop the nightly applying a group it no longer derives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ Operator-facing changes for deployments outside the hosted instance.
 
 ### Changed
 
-- **The three consolidation drain caps are now live-tunable without a deploy (#617).**
-  `knowledge_consolidation_max_applies`, `knowledge_consolidation_max_unpublishes` and
-  `knowledge_consolidation_max_per_class` are read from `SystemConfig` DB rows first, falling
+- **The consolidation drain caps AND the duplicate-similarity threshold are now live-tunable
+  without a deploy (#617).** `knowledge_consolidation_max_applies`,
+  `knowledge_consolidation_max_unpublishes`, `knowledge_consolidation_max_per_class` and
+  `knowledge_consolidation_min_duplicate_similarity_pct` (an INTEGER percent — `80` means
+  0.80 — which is the threshold a title collision's members must corroborate at in content
+  before the nightly may unpublish one) are read from `SystemConfig` DB rows first, falling
   back to the compile-time application config and then to the built-in default. Setting
   `knowledge_consolidation_max_unpublishes` to **0** halts the auto-unpublish drain, and that
   halt now takes effect on the next nightly rather than on the next deploy — which is the
@@ -32,9 +35,12 @@ Operator-facing changes for deployments outside the hosted instance.
   published. Retitling the articles is the remedy for a false grouping, and a retitled group
   passed that check — it was saved only because a fresh derivation happened to drop the group
   first. The grouping signal (normalized title, or normalized idempotency key, whichever
-  formed the group) is now re-evaluated at apply time; a group that has dissolved or split is
-  skipped and re-derived. A duplicate group also carries at most 50 members onto one proposal,
-  with the remainder re-derived on the next run.
+  formed the group) is now re-evaluated at apply time; a group that no longer collides as one
+  whole — dissolved, split, or any live member dropped — is skipped and re-derived. A
+  duplicate group also carries at most 50 members onto one proposal. The remainder is
+  re-derived on the next run and applies the run AFTER that: the survivors are a different id
+  set, so their fingerprint has to appear in two consecutive reports before the agreement gate
+  will confirm it. A very large group therefore drains 50 members every two nights.
 
 - **The nightly consolidation drain rates are raised so the duplicate backlog converges to
   zero instead of to a floor (#611).** Three settings, all previously pinned to module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ Operator-facing changes for deployments outside the hosted instance.
   `knowledge_consolidation_max_unpublishes`, `knowledge_consolidation_max_per_class` and
   `knowledge_consolidation_min_duplicate_similarity_pct` (an INTEGER percent — `80` means
   0.80 — which is the threshold a title collision's members must corroborate at in content
-  before the nightly may unpublish one) are read from `SystemConfig` DB rows first, falling
-  back to the compile-time application config and then to the built-in default. Setting
+  before the nightly may unpublish one; only **1..99** is accepted, because `0` on this knob
+  would satisfy the corroboration check for every pair rather than disabling it, and any
+  other value falls back to the config layer) are read from `SystemConfig` DB rows first,
+  falling back to the compile-time application config and then to the built-in default. The
+  drain caps still read `0` as "halt", which this threshold deliberately does not. Setting
   `knowledge_consolidation_max_unpublishes` to **0** halts the auto-unpublish drain, and that
   halt now takes effect on the next nightly rather than on the next deploy — which is the
   whole point, since the caps are the only lever an operator has while an apply is going
@@ -28,7 +31,10 @@ Operator-facing changes for deployments outside the hosted instance.
   memory was permanently absent from semantic recall. All four now walk the same ladder,
   embedding a prefix rather than nothing. Array calls bisect first, so only the member that
   actually overflows is truncated. No configuration change; the effect is fewer rows silently
-  missing from semantic search.
+  missing from semantic search. A vector that covers only a prefix is MARKED where it is
+  stored, and the three readers that compare vectors treat it accordingly: the novelty gate
+  will not call a proposal a duplicate on one, the nightly will not corroborate a title
+  collision on one, and agent-memory promotion will not retire a memory on one.
 
 - **The nightly re-checks that a confirmed duplicate group still COLLIDES before unpublishing
   it (#617).** The apply path previously re-checked only that the group's members were still
@@ -36,7 +42,10 @@ Operator-facing changes for deployments outside the hosted instance.
   passed that check — it was saved only because a fresh derivation happened to drop the group
   first. The grouping signal (normalized title, or normalized idempotency key, whichever
   formed the group) is now re-evaluated at apply time; a group that no longer collides as one
-  whole — dissolved, split, or any live member dropped — is skipped and re-derived. A
+  whole — dissolved, split, or any live member dropped — is skipped and re-derived. The same
+  holds when the group is SHRUNK rather than split: if a confirmed member was archived,
+  deleted or made private, the survivors are a set no report ever confirmed and the pass
+  skips them (its own part-drain, which leaves the member a shared draft, still converges). A
   duplicate group also carries at most 50 members onto one proposal. The remainder is
   re-derived on the next run and applies the run AFTER that: the survivors are a different id
   set, so their fingerprint has to appear in two consecutive reports before the agreement gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ Operator-facing changes for deployments outside the hosted instance.
 
 ### Changed
 
+- **The three consolidation drain caps are now live-tunable without a deploy (#617).**
+  `knowledge_consolidation_max_applies`, `knowledge_consolidation_max_unpublishes` and
+  `knowledge_consolidation_max_per_class` are read from `SystemConfig` DB rows first, falling
+  back to the compile-time application config and then to the built-in default. Setting
+  `knowledge_consolidation_max_unpublishes` to **0** halts the auto-unpublish drain, and that
+  halt now takes effect on the next nightly rather than on the next deploy — which is the
+  whole point, since the caps are the only lever an operator has while an apply is going
+  wrong. The existing config values keep working unchanged; nothing needs to be set.
+
+- **An over-long input no longer permanently strands a row un-embedded (#617).** #615 added
+  the byte budget and shrink ladder to the two article-embedding workers. The same rejection
+  on the re-embed, system-corpus, agent-memory and novelty-gate paths still mapped to a
+  permanent 4xx and DISCARDED the job — so a single over-long article could wedge a whole
+  tenant re-embed mid-run (leaving recall pinned at the old dimension), and an over-long
+  memory was permanently absent from semantic recall. All four now walk the same ladder,
+  embedding a prefix rather than nothing. Array calls bisect first, so only the member that
+  actually overflows is truncated. No configuration change; the effect is fewer rows silently
+  missing from semantic search.
+
+- **The nightly re-checks that a confirmed duplicate group still COLLIDES before unpublishing
+  it (#617).** The apply path previously re-checked only that the group's members were still
+  published. Retitling the articles is the remedy for a false grouping, and a retitled group
+  passed that check — it was saved only because a fresh derivation happened to drop the group
+  first. The grouping signal (normalized title, or normalized idempotency key, whichever
+  formed the group) is now re-evaluated at apply time; a group that has dissolved or split is
+  skipped and re-derived. A duplicate group also carries at most 50 members onto one proposal,
+  with the remainder re-derived on the next run.
+
 - **The nightly consolidation drain rates are raised so the duplicate backlog converges to
   zero instead of to a floor (#611).** Three settings, all previously pinned to module
   defaults sized for a class that had never applied anything in production:

--- a/config/config.exs
+++ b/config/config.exs
@@ -775,10 +775,23 @@ config :loopctl,
 # either to 0 PAUSES the auto-unpublish drain for that run: nothing is applied and the audit
 # event records duplicate_apply_gate=drain_disabled, so a paused night is not mistaken for a
 # clean one. That is the supported way to halt the drain during an incident.
+#
+# knowledge_consolidation_min_duplicate_similarity is the CONTENT gate on the same class:
+# the minimum pairwise cosine a title-collision group must reach before it may auto-apply.
+# It lives here so all four levers on that pass are discoverable in one place. All four
+# also resolve through a SystemConfig DB row first (the similarity one as the integer-percent
+# key knowledge_consolidation_min_duplicate_similarity_pct, since SystemConfig stores
+# integers), so an operator can move any of them without a deploy.
+#
+# NOTE the asymmetry on 0: for the three caps 0 is an explicit PAUSE, but for the similarity
+# threshold 0 is REFUSED rather than honoured — min_sim >= 0.0 holds for every pair, so it
+# would turn the only content check on the auto-applying class fully off, which is the
+# opposite of what an operator typing 0 means.
 config :loopctl,
   knowledge_consolidation_max_per_class: 500,
   knowledge_consolidation_max_applies: 500,
-  knowledge_consolidation_max_unpublishes: 500
+  knowledge_consolidation_max_unpublishes: 500,
+  knowledge_consolidation_min_duplicate_similarity: 0.80
 
 # LinkPruning (#611 stage 0): how many over-degree `relates_to` edges one nightly run may
 # DELETE, worst-first. Sized to converge in a few nights rather than a few months — the

--- a/lib/loopctl/embeddings/shrink_ladder.ex
+++ b/lib/loopctl/embeddings/shrink_ladder.ex
@@ -63,8 +63,19 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
 
   @type vector :: [float()]
   @type one_result :: {:ok, vector()} | {:ok, vector(), :truncated} | {:error, term()}
+
+  # A member the bisect embedded successfully before a SIBLING half failed: its index in
+  # the ORIGINAL array, its vector, and whether the ladder had to truncate it.
+  @type partial :: {non_neg_integer(), vector(), boolean()}
+
+  # What `embed_fun` may return (the guarded client's own shape).
+  @type provider_result :: {:ok, [vector()]} | {:error, term()}
+
   @type batch_result ::
-          {:ok, [vector()]} | {:ok, [vector()], [non_neg_integer()]} | {:error, term()}
+          {:ok, [vector()]}
+          | {:ok, [vector()], [non_neg_integer()]}
+          | {:error, term()}
+          | {:error, term(), [partial()]}
 
   @doc """
   Embed ONE text through `embed_fun`, shrinking on a context-length rejection.
@@ -152,8 +163,22 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
   those rows or the corpus fills with prefixes the comparing side is told cannot exist.
   `:max_calls` bounds the provider calls one batch may spend across the whole bisect
   (default `max(#{@min_max_calls}, #{@calls_per_text} * length(texts))`).
+
+  ## A failure does not throw away what was already paid for
+
+  When the bisect has embedded one half and the other then fails, the error comes back as
+  `{:error, reason, partial}` — `partial` being `[{index, vector, truncated?}]` for the
+  members that DID succeed, at their original-array indexes. Those vectors are already
+  billed; discarding them made the caller's retry re-send and re-pay for the whole array,
+  and against a deterministic failure (an egress refusal, a revoked key) it re-paid on
+  every attempt while never making progress.
+
+  A caller should store `partial` and THEN propagate the error, so the retry's pending set
+  no longer names those rows. A caller that does not care may match `{:error, reason, _}`;
+  the plain `{:error, reason}` shape is still returned whenever nothing was salvaged.
   """
-  @spec embed_batch([String.t()], ([String.t()] -> batch_result()), keyword()) :: batch_result()
+  @spec embed_batch([String.t()], ([String.t()] -> provider_result()), keyword()) ::
+          batch_result()
   def embed_batch(texts, embed_fun, opts \\ [])
 
   def embed_batch([], _embed_fun, _opts), do: {:ok, []}
@@ -168,6 +193,8 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
     case result do
       {:ok, vectors, []} -> {:ok, vectors}
       {:ok, vectors, truncated} -> {:ok, vectors, Enum.sort(truncated)}
+      {:error, reason, []} -> {:error, reason}
+      {:error, reason, partial} -> {:error, reason, Enum.sort_by(partial, &elem(&1, 0))}
       error -> error
     end
   end
@@ -181,17 +208,20 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
         {{:ok, v, []}, budget - 1}
 
       {:ok, _mismatch} ->
-        {{:error, :embedding_batch_length_mismatch}, budget - 1}
+        {{:error, :embedding_batch_length_mismatch, []}, budget - 1}
 
       {:error, {:api_error, _s, :context_length_exceeded}} = e ->
         shrink(texts, embed_fun, opts, e, budget - 1, offset)
+
+      {:error, reason} ->
+        {{:error, reason, []}, budget - 1}
 
       other ->
         {other, budget - 1}
     end
   end
 
-  defp shrink(texts, _embed_fun, opts, error, budget, _offset) when budget <= 0 do
+  defp shrink(texts, _embed_fun, opts, {:error, reason}, budget, _offset) when budget <= 0 do
     Logger.warning(
       "#{label(opts)}: giving up on a batch of #{length(texts)} after " <>
         "#{Keyword.fetch!(opts, :max_calls)} provider calls — most of it is over-long, " <>
@@ -199,17 +229,17 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
         "(`chunk_by_bytes/3`) before sending."
     )
 
-    {error, 0}
+    {{:error, reason, []}, 0}
   end
 
   # Isolated to ONE text: this is the member the provider was rejecting, so ladder it.
-  defp shrink([text], embed_fun, opts, error, budget, offset) do
+  defp shrink([text], embed_fun, opts, {:error, reason}, budget, offset) do
     sent = byte_size(text)
 
     case TextBudget.next_budget(sent) do
       :exhausted ->
         log_exhausted(opts, sent)
-        {error, budget}
+        {{:error, reason, []}, budget}
 
       smaller ->
         log_shrink(opts, sent, smaller)
@@ -223,8 +253,17 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
 
   # More than one member: the provider named none of them, so split and let each
   # half answer for itself. `div(length, 2)` is >= 1 here (length >= 2), so both
-  # halves are strictly smaller and the recursion terminates. A `with` else-less
-  # fallthrough returns the failing `{result, budget}` pair unchanged.
+  # halves are strictly smaller and the recursion terminates.
+  #
+  # A half that SUCCEEDED is never thrown away when its sibling fails (#617 review
+  # follow-up). Those vectors are already billed; discarding them meant the caller's
+  # retry re-sent and re-paid for the whole array, and on a batch whose failure is
+  # deterministic — an egress refusal, a revoked key — it re-paid on every attempt while
+  # never making progress. The error now carries the successes as
+  # `[{index, vector, truncated?}]`, and the caller stores them before it propagates.
+  #
+  # Indexes are ORIGINAL-array offsets, so a caller can zip them against its own entries
+  # exactly as it does the success path's vectors.
   defp shrink(texts, embed_fun, opts, _error, budget, offset) do
     {left, right} = Enum.split(texts, div(length(texts), 2))
 
@@ -234,11 +273,36 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
         "isolate it. Only the over-long text will be truncated."
     )
 
-    with {{:ok, lv, lt}, left_budget} <- run_batch(left, embed_fun, opts, budget, offset),
-         {{:ok, rv, rt}, spent} <-
-           run_batch(right, embed_fun, opts, left_budget, offset + length(left)) do
-      {{:ok, lv ++ rv, lt ++ rt}, spent}
+    case run_batch(left, embed_fun, opts, budget, offset) do
+      {{:ok, lv, lt}, left_budget} ->
+        right_offset = offset + length(left)
+
+        case run_batch(right, embed_fun, opts, left_budget, right_offset) do
+          {{:ok, rv, rt}, spent} ->
+            {{:ok, lv ++ rv, lt ++ rt}, spent}
+
+          {{:error, reason, right_partial}, spent} ->
+            {{:error, reason, indexed(lv, lt, offset) ++ right_partial}, spent}
+        end
+
+      # The left half failed. Its own bisect may still have salvaged part of itself, so
+      # its partial is propagated rather than replaced with an empty one. The right half
+      # is deliberately NOT attempted: the budget is shared, and a half that failed for a
+      # non-length reason (breaker open, egress refusal) means the next call fails too.
+      {{:error, reason, left_partial}, spent} ->
+        {{:error, reason, left_partial}, spent}
     end
+  end
+
+  # A successful half, expressed in the partial-result shape so it survives its sibling's
+  # failure. `truncated` holds ORIGINAL-array indexes already, hence the membership test
+  # rather than a positional one.
+  defp indexed(vectors, truncated, offset) do
+    marked = MapSet.new(truncated)
+
+    vectors
+    |> Enum.with_index(offset)
+    |> Enum.map(fn {vector, index} -> {index, vector, MapSet.member?(marked, index)} end)
   end
 
   # Tagged ONCE per member: a deeper rung already tagged the same index, hence the uniq.

--- a/lib/loopctl/embeddings/shrink_ladder.ex
+++ b/lib/loopctl/embeddings/shrink_ladder.ex
@@ -4,55 +4,56 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
   `:context_length_exceeded` rejection, for BOTH the single-text and the array
   embedding paths.
 
-  #615 added the ladder to `ArticleEmbeddingWorker` and (via dissolve)
-  `BatchArticleEmbeddingWorker`. Every OTHER embedding write path still mapped an
-  input-too-long rejection onto `Llm.permanent_provider_error?/1`, which is `true`
-  for any 4xx — so the job DISCARDED and the row stayed permanently un-embedded.
-  That is the same shape as the outage #615 fixed, one call site over:
-
-    * `ReembedWorker` — discards mid-run, so the tenant's re-embed never reaches
-      `complete_reembed` and recall stays pinned at the old dimension forever.
-    * `SystemCorpusEmbeddingWorker` — the canonical stays keyword-only for that
-      tenant, with `system_corpus_meta/2` still reporting "semantic".
-    * `MemoryEmbeddingWorker` and the synchronous promotion near-dup read in
-      `Loopctl.Memory` — the memory is invisible to semantic recall, and the
-      near-dup check that guards against duplicate promotions silently degrades.
-    * `Knowledge.ProposalGate` — the novelty gate falls OPEN, so the over-long
-      article skips dedup entirely and lands as the duplicate the nightly
-      consolidation pass then has to catch.
+  #615 added the ladder to the two article workers. Every OTHER embedding write path —
+  `ReembedWorker`, `SystemCorpusEmbeddingWorker`, `MemoryEmbeddingWorker`,
+  `Loopctl.Memory`'s promotion near-dup read, `Knowledge.ProposalGate` — still mapped an
+  input-too-long rejection onto `Llm.permanent_provider_error?/1`, which is `true` for
+  any 4xx, so the job DISCARDED and the row stayed permanently un-embedded.
 
   ## Single text: halve what was SENT
 
   `embed_one/3` re-truncates the bytes ACTUALLY SENT and re-sends, exactly as
-  `ArticleEmbeddingWorker` does. Deriving the next rung from a nominal budget
-  instead would let a budget larger than the text truncate nothing and buy a
-  byte-identical rejection.
+  `ArticleEmbeddingWorker` does — deriving the next rung from a nominal budget would let
+  a budget larger than the text truncate nothing and buy a byte-identical rejection.
+
+  A shrunk result comes back as `{:ok, vector, :truncated}`, never as a bare
+  `{:ok, vector}`. The vector covers a PREFIX, so it is NOT comparable with corpus
+  vectors built from whole texts — `ProposalGate` may not call a proposal a duplicate
+  on one, and `Memory` may not supersede a prior memory on one. A truncation the
+  caller cannot see is a truncation it silently judges against.
 
   ## An array: BISECT, then ladder the singleton
 
   A provider rejects the whole array and never says which member was over-long.
   Shrinking every text would truncate articles that were never over the limit;
-  re-sending the array buys an identical rejection forever.
+  re-sending the array buys an identical rejection forever. So `embed_batch/3` splits
+  the array in half and embeds each half independently, recursing until the rejection
+  isolates to ONE text — which then walks the ladder. Only the offender is truncated.
+  (`BatchArticleEmbeddingWorker` DISSOLVES to per-article jobs instead, which is the
+  better answer only where such a worker shares this one's dimension and model.)
 
-  So `embed_batch/3` splits the array in half and embeds each half independently,
-  recursing until the rejection isolates to ONE text — which then walks the ladder.
-  Only the offending text is truncated; its innocent neighbours are re-sent whole.
-  This costs extra provider calls (~2·log2(n)), but ONLY on a batch that already
-  failed, and only in place of a discard.
-
-  `BatchArticleEmbeddingWorker` solves the same problem by DISSOLVING to
-  per-article jobs. That is the better answer where a per-item worker exists at the
-  same dimension and model; it does not here — `ReembedWorker` embeds at a PENDING
-  dimension with a pinned model, and re-enqueueing through `ArticleEmbeddingWorker`
-  would write the ACTIVE dimension instead.
+  That costs ~2·log2(n) extra calls only when exactly ONE member is over-long; with k
+  offenders it is ~2k·log2(n/k), degenerating towards 2n-1 when most of the batch
+  overflows — the measured #615 corpus, not a hypothetical. A batch is therefore
+  bounded twice: the caller pre-splits with `chunk_by_bytes/3` (an AGGREGATE rejection
+  must never be answered by bisecting — every half fails too, so the batch pays the
+  whole tree on every run instead of once), and `:max_calls` bounds what one
+  already-failing batch may spend.
   """
 
   require Logger
 
   alias Loopctl.Embeddings.TextBudget
 
+  # What ONE `embed_batch/3` may spend in provider calls. The bisect's own bound is ~2n
+  # with n up to `Knowledge.embedding_batch_max/0` — hundreds of sequential calls, each
+  # with its own yield budget, inside one Oban job. A batch that blows this is no longer
+  # a length problem the bisect can fix, so it surfaces the provider error exactly as an
+  # exhausted rung does.
+  @default_max_calls 64
+
   @type vector :: [float()]
-  @type one_result :: {:ok, vector()} | {:error, term()}
+  @type one_result :: {:ok, vector()} | {:ok, vector(), :truncated} | {:error, term()}
   @type batch_result :: {:ok, [vector()]} | {:error, term()}
 
   @doc """
@@ -62,6 +63,10 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
   guarded embedding client returns. Every non-`:context_length_exceeded` result —
   success, egress refusal, circuit-open, throttle — is passed through untouched, so
   the caller's existing error handling is unchanged.
+
+  A result the ladder had to shrink is `{:ok, vector, :truncated}`: the vector covers
+  a prefix, and a caller that COMPARES it against whole-text vectors must not treat it
+  as authoritative (see the moduledoc).
 
   On an exhausted ladder the ORIGINAL error is returned, so the caller discards it
   as the different defect it is (a much smaller model window, e.g. a self-hosted
@@ -79,19 +84,44 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
     end
   end
 
+  # `:max_rungs` (default unbounded) caps how many times ONE text may be halved. A
+  # SYNCHRONOUS caller pays each rung in request latency and in an embedding admission
+  # slot that interactive search shares, so `ProposalGate` spends one and then accepts
+  # its own fail-open — the background worker walks the full ladder for that row anyway.
   defp shrink_one(text, embed_fun, opts, error) do
     sent = byte_size(text)
+    rungs = Keyword.get(opts, :max_rungs, :infinity)
 
     case TextBudget.next_budget(sent) do
       :exhausted ->
         log_exhausted(opts, sent)
         error
 
+      _smaller when rungs == 0 ->
+        Logger.warning(
+          "#{label(opts)}: still too long at #{sent} bytes with the rung budget spent; " <>
+            "surfacing the provider error rather than spending another round trip."
+        )
+
+        error
+
       smaller ->
         log_shrink(opts, sent, smaller)
-        embed_one(TextBudget.truncate(text, smaller), embed_fun, opts)
+
+        text
+        |> TextBudget.truncate(smaller)
+        |> embed_one(embed_fun, spend_rung(opts, rungs))
+        |> mark_truncated()
     end
   end
+
+  defp spend_rung(opts, :infinity), do: opts
+  defp spend_rung(opts, rungs), do: Keyword.put(opts, :max_rungs, rungs - 1)
+
+  # A vector produced from a shrunk text is tagged ONCE, at the rung that shrank it; a
+  # deeper rung has already tagged its own, so the pass-through clause keeps it.
+  defp mark_truncated({:ok, vector}), do: {:ok, vector, :truncated}
+  defp mark_truncated(other), do: other
 
   @doc """
   Embed an ARRAY of texts through `embed_fun`, bisecting on a context-length
@@ -106,6 +136,9 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
   `{:error, :embedding_batch_length_mismatch}`, matching what the call sites
   already did inline, so a contract violation cannot be zipped into misattributed
   vectors.
+
+  `:max_calls` (default #{@default_max_calls}) bounds the provider calls one batch
+  may spend across the whole bisect.
   """
   @spec embed_batch([String.t()], ([String.t()] -> batch_result()), keyword()) :: batch_result()
   def embed_batch(texts, embed_fun, opts \\ [])
@@ -114,40 +147,59 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
 
   def embed_batch(texts, embed_fun, opts)
       when is_list(texts) and is_function(embed_fun, 1) do
+    budget = Keyword.get(opts, :max_calls, @default_max_calls)
+    {result, _left} = run_batch(texts, embed_fun, opts, budget)
+    result
+  end
+
+  # Every result carries the REMAINING call budget, so the two halves of a bisect share
+  # one budget: a per-branch one would multiply with the depth and bound nothing.
+  defp run_batch(texts, embed_fun, opts, budget) do
     case embed_fun.(texts) do
-      {:ok, vectors} when length(vectors) == length(texts) ->
-        {:ok, vectors}
+      {:ok, v} when length(v) == length(texts) ->
+        {{:ok, v}, budget - 1}
 
       {:ok, _mismatch} ->
-        {:error, :embedding_batch_length_mismatch}
+        {{:error, :embedding_batch_length_mismatch}, budget - 1}
 
-      {:error, {:api_error, _status, :context_length_exceeded}} = error ->
-        shrink_batch(texts, embed_fun, opts, error)
+      {:error, {:api_error, _s, :context_length_exceeded}} = e ->
+        shrink(texts, embed_fun, opts, e, budget - 1)
 
       other ->
-        other
+        {other, budget - 1}
     end
   end
 
+  defp shrink(texts, _embed_fun, opts, error, budget) when budget <= 0 do
+    Logger.warning(
+      "#{label(opts)}: giving up on a batch of #{length(texts)} after #{@default_max_calls} " <>
+        "provider calls — most of it is over-long, which no bisect can fix; surfacing the " <>
+        "provider error. Split by bytes (`chunk_by_bytes/3`) before sending."
+    )
+
+    {error, 0}
+  end
+
   # Isolated to ONE text: this is the member the provider was rejecting, so ladder it.
-  defp shrink_batch([text], embed_fun, opts, error) do
+  defp shrink([text], embed_fun, opts, error, budget) do
     sent = byte_size(text)
 
     case TextBudget.next_budget(sent) do
       :exhausted ->
         log_exhausted(opts, sent)
-        error
+        {error, budget}
 
       smaller ->
         log_shrink(opts, sent, smaller)
-        embed_batch([TextBudget.truncate(text, smaller)], embed_fun, opts)
+        run_batch([TextBudget.truncate(text, smaller)], embed_fun, opts, budget)
     end
   end
 
   # More than one member: the provider named none of them, so split and let each
   # half answer for itself. `div(length, 2)` is >= 1 here (length >= 2), so both
-  # halves are strictly smaller and the recursion terminates.
-  defp shrink_batch(texts, embed_fun, opts, _error) do
+  # halves are strictly smaller and the recursion terminates. A `with` else-less
+  # fallthrough returns the failing `{result, budget}` pair unchanged.
+  defp shrink(texts, embed_fun, opts, _error, budget) do
     {left, right} = Enum.split(texts, div(length(texts), 2))
 
     Logger.warning(
@@ -156,10 +208,35 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
         "isolate it. Only the over-long text will be truncated."
     )
 
-    with {:ok, left_vectors} <- embed_batch(left, embed_fun, opts),
-         {:ok, right_vectors} <- embed_batch(right, embed_fun, opts) do
-      {:ok, left_vectors ++ right_vectors}
+    with {{:ok, lv}, left_budget} <- run_batch(left, embed_fun, opts, budget),
+         {{:ok, rv}, spent} <- run_batch(right, embed_fun, opts, left_budget) do
+      {{:ok, lv ++ rv}, spent}
     end
+  end
+
+  @doc """
+  Split `items` into groups whose cumulative text stays at/under `max_bytes`, so the
+  ladder is reserved for a genuinely over-long MEMBER (see the moduledoc). An item
+  larger than the budget forms its own group rather than wedging into an empty one.
+  """
+  @spec chunk_by_bytes([item], pos_integer(), (item -> String.t())) :: [[item]] when item: term()
+  def chunk_by_bytes(items, max_bytes, text_fun) do
+    chunk_fun = fn item, {acc, size} ->
+      len = byte_size(text_fun.(item))
+
+      cond do
+        acc == [] -> {:cont, {[item], len}}
+        size + len > max_bytes -> {:cont, Enum.reverse(acc), {[item], len}}
+        true -> {:cont, {[item | acc], size + len}}
+      end
+    end
+
+    after_fun = fn
+      {[], _size} -> {:cont, [], {[], 0}}
+      {acc, _size} -> {:cont, Enum.reverse(acc), {[], 0}}
+    end
+
+    Enum.chunk_while(items, {[], 0}, chunk_fun, after_fun)
   end
 
   defp log_shrink(opts, sent, smaller) do

--- a/lib/loopctl/embeddings/shrink_ladder.ex
+++ b/lib/loopctl/embeddings/shrink_ladder.ex
@@ -20,7 +20,11 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
   `{:ok, vector}`. The vector covers a PREFIX, so it is NOT comparable with corpus
   vectors built from whole texts — `ProposalGate` may not call a proposal a duplicate
   on one, and `Memory` may not supersede a prior memory on one. A truncation the
-  caller cannot see is a truncation it silently judges against.
+  caller cannot see is a truncation it silently judges against. Refusing to JUDGE on one is
+  only half of it: a prefix STORED unmarked is indistinguishable from a whole-text vector,
+  and the next comparison runs the forbidden compare from the other side — this time
+  retiring the longer text. No side table has a column for the fact, so the marker rides
+  `embedding_content_hash` (`truncated_hash/1`).
 
   ## An array: BISECT, then ladder the singleton
 
@@ -45,16 +49,22 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
 
   alias Loopctl.Embeddings.TextBudget
 
-  # What ONE `embed_batch/3` may spend in provider calls. The bisect's own bound is ~2n
-  # with n up to `Knowledge.embedding_batch_max/0` — hundreds of sequential calls, each
-  # with its own yield budget, inside one Oban job. A batch that blows this is no longer
-  # a length problem the bisect can fix, so it surfaces the provider error exactly as an
-  # exhausted rung does.
-  @default_max_calls 64
+  # What ONE `embed_batch/3` may spend: `max(@min_max_calls, @calls_per_text * n)`. A budget
+  # below the bisect's own worst case (~5n: n-1 internal nodes, plus per leaf its own call
+  # and at most 3 rungs) abandons work the bisect could have finished, and the callers read
+  # the surfaced 4xx through `permanent_provider_error?/1` — the job DISCARDS and the rows
+  # stay un-embedded, the outage this module exists to end. So it guards against runaway
+  # recursion, never caps a legitimate batch; callers bound COST via `chunk_by_bytes/3`.
+  @min_max_calls 64
+  @calls_per_text 6
+
+  # See the moduledoc: no side table has a column for "this vector is a prefix".
+  @truncated_hash_prefix "t:"
 
   @type vector :: [float()]
   @type one_result :: {:ok, vector()} | {:ok, vector(), :truncated} | {:error, term()}
-  @type batch_result :: {:ok, [vector()]} | {:error, term()}
+  @type batch_result ::
+          {:ok, [vector()]} | {:ok, [vector()], [non_neg_integer()]} | {:error, term()}
 
   @doc """
   Embed ONE text through `embed_fun`, shrinking on a context-length rejection.
@@ -137,8 +147,11 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
   already did inline, so a contract violation cannot be zipped into misattributed
   vectors.
 
-  `:max_calls` (default #{@default_max_calls}) bounds the provider calls one batch
-  may spend across the whole bisect.
+  A batch the ladder had to shrink comes back as `{:ok, vectors, truncated_indexes}` — the
+  SAME contract `embed_one/3` carries, and for the same reason: a storing caller must mark
+  those rows or the corpus fills with prefixes the comparing side is told cannot exist.
+  `:max_calls` bounds the provider calls one batch may spend across the whole bisect
+  (default `max(#{@min_max_calls}, #{@calls_per_text} * length(texts))`).
   """
   @spec embed_batch([String.t()], ([String.t()] -> batch_result()), keyword()) :: batch_result()
   def embed_batch(texts, embed_fun, opts \\ [])
@@ -147,41 +160,50 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
 
   def embed_batch(texts, embed_fun, opts)
       when is_list(texts) and is_function(embed_fun, 1) do
-    budget = Keyword.get(opts, :max_calls, @default_max_calls)
-    {result, _left} = run_batch(texts, embed_fun, opts, budget)
-    result
+    budget = Keyword.get(opts, :max_calls, max(@min_max_calls, @calls_per_text * length(texts)))
+    # Back into `opts` so the give-up log names the budget ACTUALLY in force.
+    opts = Keyword.put(opts, :max_calls, budget)
+    {result, _left} = run_batch(texts, embed_fun, opts, budget, 0)
+
+    case result do
+      {:ok, vectors, []} -> {:ok, vectors}
+      {:ok, vectors, truncated} -> {:ok, vectors, Enum.sort(truncated)}
+      error -> error
+    end
   end
 
-  # Every result carries the REMAINING call budget, so the two halves of a bisect share
-  # one budget: a per-branch one would multiply with the depth and bound nothing.
-  defp run_batch(texts, embed_fun, opts, budget) do
+  # Every result carries the REMAINING call budget, so the two halves of a bisect share one:
+  # a per-branch budget would multiply with the depth and bound nothing. `offset` is the
+  # index of `texts` in the ORIGINAL array, i.e. the index the caller zips its entries at.
+  defp run_batch(texts, embed_fun, opts, budget, offset) do
     case embed_fun.(texts) do
       {:ok, v} when length(v) == length(texts) ->
-        {{:ok, v}, budget - 1}
+        {{:ok, v, []}, budget - 1}
 
       {:ok, _mismatch} ->
         {{:error, :embedding_batch_length_mismatch}, budget - 1}
 
       {:error, {:api_error, _s, :context_length_exceeded}} = e ->
-        shrink(texts, embed_fun, opts, e, budget - 1)
+        shrink(texts, embed_fun, opts, e, budget - 1, offset)
 
       other ->
         {other, budget - 1}
     end
   end
 
-  defp shrink(texts, _embed_fun, opts, error, budget) when budget <= 0 do
+  defp shrink(texts, _embed_fun, opts, error, budget, _offset) when budget <= 0 do
     Logger.warning(
-      "#{label(opts)}: giving up on a batch of #{length(texts)} after #{@default_max_calls} " <>
-        "provider calls — most of it is over-long, which no bisect can fix; surfacing the " <>
-        "provider error. Split by bytes (`chunk_by_bytes/3`) before sending."
+      "#{label(opts)}: giving up on a batch of #{length(texts)} after " <>
+        "#{Keyword.fetch!(opts, :max_calls)} provider calls — most of it is over-long, " <>
+        "which no bisect can fix; surfacing the provider error. Split by bytes " <>
+        "(`chunk_by_bytes/3`) before sending."
     )
 
     {error, 0}
   end
 
   # Isolated to ONE text: this is the member the provider was rejecting, so ladder it.
-  defp shrink([text], embed_fun, opts, error, budget) do
+  defp shrink([text], embed_fun, opts, error, budget, offset) do
     sent = byte_size(text)
 
     case TextBudget.next_budget(sent) do
@@ -191,7 +213,11 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
 
       smaller ->
         log_shrink(opts, sent, smaller)
-        run_batch([TextBudget.truncate(text, smaller)], embed_fun, opts, budget)
+
+        {result, left} =
+          run_batch([TextBudget.truncate(text, smaller)], embed_fun, opts, budget, offset)
+
+        {mark_index(result, offset), left}
     end
   end
 
@@ -199,7 +225,7 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
   # half answer for itself. `div(length, 2)` is >= 1 here (length >= 2), so both
   # halves are strictly smaller and the recursion terminates. A `with` else-less
   # fallthrough returns the failing `{result, budget}` pair unchanged.
-  defp shrink(texts, embed_fun, opts, _error, budget) do
+  defp shrink(texts, embed_fun, opts, _error, budget, offset) do
     {left, right} = Enum.split(texts, div(length(texts), 2))
 
     Logger.warning(
@@ -208,11 +234,36 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
         "isolate it. Only the over-long text will be truncated."
     )
 
-    with {{:ok, lv}, left_budget} <- run_batch(left, embed_fun, opts, budget),
-         {{:ok, rv}, spent} <- run_batch(right, embed_fun, opts, left_budget) do
-      {{:ok, lv ++ rv}, spent}
+    with {{:ok, lv, lt}, left_budget} <- run_batch(left, embed_fun, opts, budget, offset),
+         {{:ok, rv, rt}, spent} <-
+           run_batch(right, embed_fun, opts, left_budget, offset + length(left)) do
+      {{:ok, lv ++ rv, lt ++ rt}, spent}
     end
   end
+
+  # Tagged ONCE per member: a deeper rung already tagged the same index, hence the uniq.
+  defp mark_index({:ok, v, truncated}, offset), do: {:ok, v, Enum.uniq([offset | truncated])}
+  defp mark_index(other, _offset), do: other
+
+  @doc """
+  Mark a stored `embedding_content_hash` whose vector covers only a PREFIX of the text.
+  The hash still identifies the FULL text — idempotency guards compare `whole_hash/1` —
+  so the mark records truncation without re-billing the provider on every enqueue.
+  `truncated_hash?/1` reads it back; `truncated_hash_pattern/0` is its SQL `LIKE` form.
+  """
+  @spec truncated_hash(String.t()) :: String.t()
+  def truncated_hash(hash) when is_binary(hash), do: @truncated_hash_prefix <> hash
+
+  @doc false
+  def truncated_hash?(hash),
+    do: is_binary(hash) and String.starts_with?(hash, @truncated_hash_prefix)
+
+  @doc false
+  def whole_hash(@truncated_hash_prefix <> hash), do: hash
+  def whole_hash(hash), do: hash
+
+  @doc false
+  def truncated_hash_pattern, do: @truncated_hash_prefix <> "%"
 
   @doc """
   Split `items` into groups whose cumulative text stays at/under `max_bytes`, so the
@@ -231,8 +282,9 @@ defmodule Loopctl.Embeddings.ShrinkLadder do
       end
     end
 
+    # `{:cont, acc}` — NOT `{:cont, [], acc}`, which emits an empty chunk for empty input.
     after_fun = fn
-      {[], _size} -> {:cont, [], {[], 0}}
+      {[], _size} -> {:cont, {[], 0}}
       {acc, _size} -> {:cont, Enum.reverse(acc), {[], 0}}
     end
 

--- a/lib/loopctl/embeddings/shrink_ladder.ex
+++ b/lib/loopctl/embeddings/shrink_ladder.ex
@@ -1,0 +1,181 @@
+defmodule Loopctl.Embeddings.ShrinkLadder do
+  @moduledoc """
+  Walks `Loopctl.Embeddings.TextBudget`'s byte ladder on a provider
+  `:context_length_exceeded` rejection, for BOTH the single-text and the array
+  embedding paths.
+
+  #615 added the ladder to `ArticleEmbeddingWorker` and (via dissolve)
+  `BatchArticleEmbeddingWorker`. Every OTHER embedding write path still mapped an
+  input-too-long rejection onto `Llm.permanent_provider_error?/1`, which is `true`
+  for any 4xx — so the job DISCARDED and the row stayed permanently un-embedded.
+  That is the same shape as the outage #615 fixed, one call site over:
+
+    * `ReembedWorker` — discards mid-run, so the tenant's re-embed never reaches
+      `complete_reembed` and recall stays pinned at the old dimension forever.
+    * `SystemCorpusEmbeddingWorker` — the canonical stays keyword-only for that
+      tenant, with `system_corpus_meta/2` still reporting "semantic".
+    * `MemoryEmbeddingWorker` and the synchronous promotion near-dup read in
+      `Loopctl.Memory` — the memory is invisible to semantic recall, and the
+      near-dup check that guards against duplicate promotions silently degrades.
+    * `Knowledge.ProposalGate` — the novelty gate falls OPEN, so the over-long
+      article skips dedup entirely and lands as the duplicate the nightly
+      consolidation pass then has to catch.
+
+  ## Single text: halve what was SENT
+
+  `embed_one/3` re-truncates the bytes ACTUALLY SENT and re-sends, exactly as
+  `ArticleEmbeddingWorker` does. Deriving the next rung from a nominal budget
+  instead would let a budget larger than the text truncate nothing and buy a
+  byte-identical rejection.
+
+  ## An array: BISECT, then ladder the singleton
+
+  A provider rejects the whole array and never says which member was over-long.
+  Shrinking every text would truncate articles that were never over the limit;
+  re-sending the array buys an identical rejection forever.
+
+  So `embed_batch/3` splits the array in half and embeds each half independently,
+  recursing until the rejection isolates to ONE text — which then walks the ladder.
+  Only the offending text is truncated; its innocent neighbours are re-sent whole.
+  This costs extra provider calls (~2·log2(n)), but ONLY on a batch that already
+  failed, and only in place of a discard.
+
+  `BatchArticleEmbeddingWorker` solves the same problem by DISSOLVING to
+  per-article jobs. That is the better answer where a per-item worker exists at the
+  same dimension and model; it does not here — `ReembedWorker` embeds at a PENDING
+  dimension with a pinned model, and re-enqueueing through `ArticleEmbeddingWorker`
+  would write the ACTIVE dimension instead.
+  """
+
+  require Logger
+
+  alias Loopctl.Embeddings.TextBudget
+
+  @type vector :: [float()]
+  @type one_result :: {:ok, vector()} | {:error, term()}
+  @type batch_result :: {:ok, [vector()]} | {:error, term()}
+
+  @doc """
+  Embed ONE text through `embed_fun`, shrinking on a context-length rejection.
+
+  `embed_fun` receives the (possibly truncated) text and returns whatever the
+  guarded embedding client returns. Every non-`:context_length_exceeded` result —
+  success, egress refusal, circuit-open, throttle — is passed through untouched, so
+  the caller's existing error handling is unchanged.
+
+  On an exhausted ladder the ORIGINAL error is returned, so the caller discards it
+  as the different defect it is (a much smaller model window, e.g. a self-hosted
+  512-token embedder) rather than absorbing it in more halving.
+  """
+  @spec embed_one(String.t(), (String.t() -> one_result()), keyword()) :: one_result()
+  def embed_one(text, embed_fun, opts \\ [])
+      when is_binary(text) and is_function(embed_fun, 1) do
+    case embed_fun.(text) do
+      {:error, {:api_error, _status, :context_length_exceeded}} = error ->
+        shrink_one(text, embed_fun, opts, error)
+
+      result ->
+        result
+    end
+  end
+
+  defp shrink_one(text, embed_fun, opts, error) do
+    sent = byte_size(text)
+
+    case TextBudget.next_budget(sent) do
+      :exhausted ->
+        log_exhausted(opts, sent)
+        error
+
+      smaller ->
+        log_shrink(opts, sent, smaller)
+        embed_one(TextBudget.truncate(text, smaller), embed_fun, opts)
+    end
+  end
+
+  @doc """
+  Embed an ARRAY of texts through `embed_fun`, bisecting on a context-length
+  rejection until the offender is isolated, then laddering it.
+
+  `embed_fun` receives a list of texts and returns `{:ok, vectors}` or
+  `{:error, reason}`. Vectors come back in the SAME ORDER as `texts` — the bisect
+  concatenates left before right — so the caller can keep zipping them against its
+  own entries.
+
+  A short/misaligned `{:ok, vectors}` is normalized to
+  `{:error, :embedding_batch_length_mismatch}`, matching what the call sites
+  already did inline, so a contract violation cannot be zipped into misattributed
+  vectors.
+  """
+  @spec embed_batch([String.t()], ([String.t()] -> batch_result()), keyword()) :: batch_result()
+  def embed_batch(texts, embed_fun, opts \\ [])
+
+  def embed_batch([], _embed_fun, _opts), do: {:ok, []}
+
+  def embed_batch(texts, embed_fun, opts)
+      when is_list(texts) and is_function(embed_fun, 1) do
+    case embed_fun.(texts) do
+      {:ok, vectors} when length(vectors) == length(texts) ->
+        {:ok, vectors}
+
+      {:ok, _mismatch} ->
+        {:error, :embedding_batch_length_mismatch}
+
+      {:error, {:api_error, _status, :context_length_exceeded}} = error ->
+        shrink_batch(texts, embed_fun, opts, error)
+
+      other ->
+        other
+    end
+  end
+
+  # Isolated to ONE text: this is the member the provider was rejecting, so ladder it.
+  defp shrink_batch([text], embed_fun, opts, error) do
+    sent = byte_size(text)
+
+    case TextBudget.next_budget(sent) do
+      :exhausted ->
+        log_exhausted(opts, sent)
+        error
+
+      smaller ->
+        log_shrink(opts, sent, smaller)
+        embed_batch([TextBudget.truncate(text, smaller)], embed_fun, opts)
+    end
+  end
+
+  # More than one member: the provider named none of them, so split and let each
+  # half answer for itself. `div(length, 2)` is >= 1 here (length >= 2), so both
+  # halves are strictly smaller and the recursion terminates.
+  defp shrink_batch(texts, embed_fun, opts, _error) do
+    {left, right} = Enum.split(texts, div(length(texts), 2))
+
+    Logger.warning(
+      "#{label(opts)}: batch of #{length(texts)} rejected as too long — the provider does " <>
+        "not say which member, so bisecting into #{length(left)} + #{length(right)} to " <>
+        "isolate it. Only the over-long text will be truncated."
+    )
+
+    with {:ok, left_vectors} <- embed_batch(left, embed_fun, opts),
+         {:ok, right_vectors} <- embed_batch(right, embed_fun, opts) do
+      {:ok, left_vectors ++ right_vectors}
+    end
+  end
+
+  defp log_shrink(opts, sent, smaller) do
+    Logger.warning(
+      "#{label(opts)}: input exceeded the provider token limit at #{sent} bytes; retrying " <>
+        "at #{smaller}. The embedding will cover a prefix of the text, not all of it."
+    )
+  end
+
+  defp log_exhausted(opts, sent) do
+    Logger.warning(
+      "#{label(opts)}: input rejected as too long at #{sent} bytes, at or below the " <>
+        "#{TextBudget.floor_bytes()}-byte floor — not a length problem (a smaller model " <>
+        "window?); giving up on the ladder and surfacing the provider error."
+    )
+  end
+
+  defp label(opts), do: Keyword.get(opts, :label, "ShrinkLadder")
+end

--- a/lib/loopctl/knowledge/consolidation.ex
+++ b/lib/loopctl/knowledge/consolidation.ex
@@ -116,6 +116,10 @@ defmodule Loopctl.Knowledge.Consolidation do
 
   @default_max_per_class 100
   @hard_max_per_class 500
+
+  # The most members one duplicate group may carry onto a proposal (#617). See
+  # `cap_members/1` for why truncating is safe and why it must be deterministic.
+  @max_group_members 50
   # Page-depth ceiling. A report holds at most one cap's worth of proposals per class, so
   # this is well past the end of any real page — it exists so an unbounded `offset` cannot
   # reach Postgrex as an out-of-bigint-range integer and 500 the read endpoint.
@@ -128,6 +132,12 @@ defmodule Loopctl.Knowledge.Consolidation do
   # Placeholder titles that block hub creation (the "Untitled Document" 409). ONE
   # definition, referenced by both the query and the endpoint documentation.
   @generic_title_pattern "^(untitled|untitled document|new article|new document|document|draft|no title|untitled note)( [0-9]+)?$"
+
+  # The SAME pattern, compiled once for the apply-time re-check (`title_group_key/1`),
+  # which runs in Elixir rather than in Postgres. Anchors, alternation and `[0-9]+` mean
+  # exactly the same thing in POSIX ERE and in PCRE, so the two evaluations agree; it is
+  # derived from the one string above so they cannot drift.
+  @generic_title_regex Regex.compile!(@generic_title_pattern)
   # The heavy-read endpoint every whole-corpus enumeration in this module runs under.
   @heavy_endpoint :consolidation
 
@@ -135,6 +145,13 @@ defmodule Loopctl.Knowledge.Consolidation do
   # it and `pairwise_similarity_by_group/2` re-derives the same groups to score them; if the
   # two ever disagreed the gate would score the wrong sets and silently pass collisions.
   @title_key_sql "btrim(regexp_replace(lower(?), '[^[:alnum:]]+', ' ', 'g'))"
+
+  # The idempotency-key twin, referenced by `idempotency_drift_groups/1` (which DERIVES the
+  # groups) and by `still_colliding/5` (which RE-CHECKS them at apply time) so the two cannot
+  # drift apart — the same pinning `@title_key_sql` gets, for the same reason. Deliberately
+  # NOT `lower()`-ed: an `idempotency_key` is an opaque writer-chosen token where case can be
+  # the only thing separating two of them, so folding it is a collision, not a normalization.
+  @idempotency_key_sql "btrim(regexp_replace(?, '[^[:alnum:]]+', ' ', 'g'))"
 
   # How many CONFIRMED duplicate groups one nightly run may apply. Bounded because each
   # apply is a write on the shared admin pool, and because a bug that mis-picks winners
@@ -226,11 +243,7 @@ defmodule Loopctl.Knowledge.Consolidation do
   """
   @spec analyze(Ecto.UUID.t(), keyword()) :: {:ok, map()}
   def analyze(tenant_id, opts \\ []) do
-    cap =
-      opts
-      |> Keyword.get(:max_per_class, @default_max_per_class)
-      |> max(1)
-      |> min(@hard_max_per_class)
+    cap = clamp_per_class(Keyword.get(opts, :max_per_class, @default_max_per_class))
 
     # ONE gate slot for the whole read unit: the scans below are logically one pass, and
     # acquiring per query would let the cheap halves run ungated between the expensive ones.
@@ -298,7 +311,7 @@ defmodule Loopctl.Knowledge.Consolidation do
     {:ok, report} =
       AdminRepo.transaction(fn ->
         report = upsert_report(tenant_id, day, analysis)
-        prune_proposals(report.id, analysis.proposals)
+        prune_proposals(tenant_id, report.id, analysis.proposals)
         Enum.each(analysis.proposals, &upsert_proposal(tenant_id, report.id, &1))
         report
       end)
@@ -426,6 +439,30 @@ defmodule Loopctl.Knowledge.Consolidation do
     )
 
     default
+  end
+
+  # The READ cap's twin of `clamp_cap/3`, and it needs the same type check for the same
+  # reason (#617). `analyze/2` used to pipe the raw opt through `max(1) |> min(hard)`,
+  # but a number sorts BELOW every atom and binary in Erlang term order — so a `nil`, an
+  # `:all`, or a `"100"` from a hand-rolled config read survived `max(1)` and came out of
+  # `min/2` as `@hard_max_per_class`. A malformed value resolved to the LARGEST blast
+  # radius available; a typo silently bought five times the intended report. It now falls
+  # back to the default and says so, exactly like the apply caps.
+  #
+  # The floor is 1 rather than `clamp_cap/3`'s 0 because this is the pure-read derivation:
+  # `0` here means "emit no proposals at all", which is not a pause an operator can
+  # meaningfully want from a report, whereas `0` on an APPLY cap is a real mid-incident
+  # halt.
+  defp clamp_per_class(value) when is_integer(value),
+    do: value |> max(1) |> min(@hard_max_per_class)
+
+  defp clamp_per_class(value) do
+    Logger.warning(
+      "Consolidation: ignoring non-integer :max_per_class #{inspect(value)}; using " <>
+        "#{@default_max_per_class}."
+    )
+
+    @default_max_per_class
   end
 
   defp run_confirmed_duplicates(tenant_id, cap, unpublish_cap) do
@@ -608,7 +645,10 @@ defmodule Loopctl.Knowledge.Consolidation do
         select: %{
           id: a.id,
           body_len: fragment("length(coalesce(?, ''))", a.body),
-          updated_at: a.updated_at
+          updated_at: a.updated_at,
+          title_key: fragment(unquote(@title_key_sql), a.title),
+          idempotency_key: a.idempotency_key,
+          idempotency_key_norm: fragment(unquote(@idempotency_key_sql), a.idempotency_key)
         }
       )
       |> shared_only()
@@ -620,16 +660,115 @@ defmodule Loopctl.Knowledge.Consolidation do
     if length(live) < 2 or budget < 1 do
       :skip
     else
-      case corroborated?(proposal, live, scored) do
-        :ok ->
-          apply_live_group(tenant_id, proposal, live, budget)
-
-        {:withheld, entry, unscored} ->
-          log_uncorroborated(tenant_id, proposal, live, entry, unscored)
-          backfill_missing_embeddings(tenant_id, unscored)
-          :uncorroborated
-      end
+      still_colliding(tenant_id, proposal, live, budget, scored)
     end
+  end
+
+  # The group must still be a group ON ITS OWN GROUNDS, not merely alive (#617).
+  #
+  # The liveness re-check above proves every member is still published; it does NOT prove
+  # they still collide. A proposal persists across nights, and the ONE remedy a human has
+  # for a false grouping is to retitle the articles — which is exactly what was done to 23
+  # articles on 2026-08-06 to stop three unrelated `Changelog` documents being auto-
+  # unpublished. Those articles were all still live, so liveness alone would have applied
+  # the stale group on grounds that no longer existed. It was saved only because a fresh
+  # derivation drops the group before it reaches apply, i.e. by a step OUTSIDE this
+  # function. That is a correct outcome resting on an accident of ordering, so the
+  # premise is now re-checked where it is used.
+  #
+  # A group that has SPLIT (two or more surviving keys with >= 2 members each) is skipped
+  # whole rather than applied to the larger half: the persisted proposal describes one
+  # collision, the corpus now holds two, and re-deriving them fresh is both cheap and the
+  # only thing that produces fingerprints matching what they now are.
+  #
+  # The predicate re-checked is the one that FORMED the group — `title_drift?/1` is the
+  # same classifier `corroborated?/3` branches on, so the two cannot disagree about what a
+  # group is. Re-checking titles on an idempotency-drift group would reject every one of
+  # them: those members collide on a writer-supplied key and have no reason to share a
+  # title.
+  defp still_colliding(tenant_id, proposal, live, budget, scored) do
+    subgroups =
+      if title_drift?(proposal),
+        do: colliding_subgroups(live, &title_group_key/1, fn _members -> true end),
+        else: colliding_subgroups(live, &idempotency_group_key/1, &distinct_verbatim_keys?/1)
+
+    case subgroups do
+      [members] ->
+        corroborate(tenant_id, proposal, members, budget, scored)
+
+      other ->
+        log_dissolved(tenant_id, proposal, live, other)
+        :skip
+    end
+  end
+
+  # Members still sharing one normalized key, in subgroups of at least two, subject to the
+  # extra condition the deriving query's `having` imposed. A member whose key no longer
+  # qualifies at all (blank, or — for titles — a placeholder) is dropped BEFORE grouping,
+  # mirroring the deriving query's `where`: it is no longer a member the scan would find.
+  defp colliding_subgroups(live, key_fun, extra) do
+    live
+    |> Enum.reject(&(key_fun.(&1) == :ineligible))
+    |> Enum.group_by(key_fun)
+    |> Map.values()
+    |> Enum.filter(&(length(&1) > 1 and extra.(&1)))
+  end
+
+  # `:ineligible` for anything `title_drift_groups/1`'s `where` would have excluded — a key
+  # that normalizes to nothing, and a PLACEHOLDER title. Placeholders are excluded there
+  # because "Draft"/"Untitled" collide with each other for reasons that have nothing to do
+  # with being the same capture; `generic_titles/2` is the class that owns them. Without
+  # this, a group retitled to two placeholders would re-collide here and auto-unpublish on
+  # a signal the scan deliberately refuses to raise.
+  defp title_group_key(%{title_key: key}) when is_binary(key) do
+    cond do
+      String.trim(key) == "" -> :ineligible
+      Regex.match?(@generic_title_regex, key) -> :ineligible
+      true -> key
+    end
+  end
+
+  defp title_group_key(_member), do: :ineligible
+
+  # `idempotency_drift_groups/1` requires a non-nil key that does not normalize to the
+  # empty string. Without this, every member whose key was cleared since the scan would
+  # share the `nil` key and re-form a "group" out of articles that now have no idempotency
+  # signal at all.
+  defp idempotency_group_key(%{idempotency_key: nil}), do: :ineligible
+
+  defp idempotency_group_key(%{idempotency_key_norm: key}) when is_binary(key) do
+    if String.trim(key) == "", do: :ineligible, else: key
+  end
+
+  defp idempotency_group_key(_member), do: :ineligible
+
+  # `idempotency_drift_groups/1` requires `count(idempotency_key, :distinct) > 1` — the class
+  # is about ONE key written under two FORMATS, not about two rows carrying the byte-identical
+  # key (that is an ordinary re-capture the writer meant). The re-check carries the same
+  # condition, or it would apply to groups the derivation would never have produced.
+  defp distinct_verbatim_keys?(members) do
+    members |> Enum.map(& &1.idempotency_key) |> Enum.uniq() |> length() > 1
+  end
+
+  defp corroborate(tenant_id, proposal, live, budget, scored) do
+    case corroborated?(proposal, live, scored) do
+      :ok ->
+        apply_live_group(tenant_id, proposal, live, budget)
+
+      {:withheld, entry, unscored} ->
+        log_uncorroborated(tenant_id, proposal, live, entry, unscored)
+        backfill_missing_embeddings(tenant_id, unscored)
+        :uncorroborated
+    end
+  end
+
+  defp log_dissolved(tenant_id, proposal, live, surviving) do
+    Logger.info(
+      "Consolidation: tenant=#{tenant_id} skipped duplicate_capture proposal " <>
+        "##{proposal.number} — its #{length(live)} live member(s) no longer share one " <>
+        "normalized title (#{length(surviving)} colliding subgroup(s)). The group was " <>
+        "retitled or split since it was proposed; the next scan re-derives what is left."
+    )
   end
 
   # A group withheld for MISSING evidence would otherwise be withheld on this and every
@@ -825,6 +964,22 @@ defmodule Loopctl.Knowledge.Consolidation do
 
   defp heavy_all(query, tenant_id), do: HeavyRead.all(tenant_id, query, heavy_opts())
 
+  defp heavy_one(tenant_id, query), do: HeavyRead.one(tenant_id, query, heavy_opts())
+
+  # The matching set for `:generic_title`, as a composable query so the COUNT and the
+  # capped PAGE are built from ONE predicate and cannot drift into disagreeing about what
+  # "matching" means.
+  defp generic_title_base(tenant_id) do
+    from(a in published_base(tenant_id),
+      where:
+        fragment(
+          unquote(@title_key_sql <> " ~ ?"),
+          a.title,
+          ^@generic_title_pattern
+        )
+    )
+  end
+
   defp corpus_size(tenant_id) do
     HeavyRead.one(
       tenant_id,
@@ -863,7 +1018,11 @@ defmodule Loopctl.Knowledge.Consolidation do
 
     groups = titles |> interleave(idempotency) |> Enum.uniq_by(by_ids)
 
-    selected = Enum.take(groups, cap)
+    selected =
+      groups
+      |> Enum.take(cap)
+      |> Enum.map(fn {reason, ids} -> {reason, cap_members(ids)} end)
+
     evidence_by_id = evidence_map(tenant_id, Enum.flat_map(selected, fn {_r, ids} -> ids end))
 
     items =
@@ -889,6 +1048,35 @@ defmodule Loopctl.Knowledge.Consolidation do
   defp interleave([], rest), do: rest
   defp interleave(rest, []), do: rest
   defp interleave([a | as], [b | bs]), do: [a, b | interleave(as, bs)]
+
+  # The number of GROUPS was capped; the number of members WITHIN one group was not
+  # (#617). Every member id is carried on the proposal row, echoed in its `evidence`
+  # array, and re-sent as an `id in ^article_ids` parameter list on the apply path — so a
+  # pathological group (one normalized title shared by thousands of captures, which is
+  # exactly what filename-derived titles produce) writes an unbounded row and builds an
+  # unbounded query out of one night's scan.
+  #
+  # Truncation is SAFE here only because it is deterministic: `fingerprint/2` hashes the
+  # SORTED id set, and the two-run agreement gate confirms a group only when the same
+  # fingerprint appears in two consecutive reports. The `array_agg` orders by
+  # `inserted_at, id` — a TOTAL order, the `id` tiebreaker added with this cap — so both
+  # runs truncate to the byte-identical set and the group stays confirmable. Ordering by
+  # `inserted_at` alone left ties resolvable either way, which under a cap would flap the
+  # fingerprint and make such a group permanently unconfirmable.
+  #
+  # The leftovers are not lost: the winner stays published, so the next scan re-derives
+  # the remaining collision as a fresh group. Same drain-don't-stall shape as the apply
+  # budget in `apply_live_group/4`.
+  defp cap_members(ids) when length(ids) <= @max_group_members, do: ids
+
+  defp cap_members(ids) do
+    Logger.info(
+      "Consolidation: duplicate group of #{length(ids)} members truncated to " <>
+        "#{@max_group_members} for this run; the remainder re-derives next run."
+    )
+
+    Enum.take(ids, @max_group_members)
+  end
 
   # Titles that collide once case and punctuation are normalized away. The exact
   # active-title uniqueness check cannot see these — that is why they got published.
@@ -927,7 +1115,7 @@ defmodule Loopctl.Knowledge.Consolidation do
       where: fragment(unquote(@title_key_sql <> " !~ ?"), a.title, ^@generic_title_pattern),
       group_by: fragment(unquote(@title_key_sql), a.title),
       having: count(a.id) > 1,
-      select: %{ids: fragment("array_agg(?::text ORDER BY ?)", a.id, a.inserted_at)}
+      select: %{ids: fragment("array_agg(?::text ORDER BY ?, ?)", a.id, a.inserted_at, a.id)}
     )
     |> heavy_all(tenant_id)
     |> Enum.map(fn %{ids: ids} -> {@title_drift, ids} end)
@@ -1197,15 +1385,10 @@ defmodule Loopctl.Knowledge.Consolidation do
   defp idempotency_drift_groups(tenant_id) do
     from(a in published_base(tenant_id),
       where: not is_nil(a.idempotency_key),
-      where:
-        fragment(
-          "btrim(regexp_replace(?, '[^[:alnum:]]+', ' ', 'g')) <> ''",
-          a.idempotency_key
-        ),
-      group_by:
-        fragment("btrim(regexp_replace(?, '[^[:alnum:]]+', ' ', 'g'))", a.idempotency_key),
+      where: fragment(unquote(@idempotency_key_sql <> " <> ''"), a.idempotency_key),
+      group_by: fragment(unquote(@idempotency_key_sql), a.idempotency_key),
       having: count(a.id) > 1 and count(a.idempotency_key, :distinct) > 1,
-      select: %{ids: fragment("array_agg(?::text ORDER BY ?)", a.id, a.inserted_at)}
+      select: %{ids: fragment("array_agg(?::text ORDER BY ?, ?)", a.id, a.inserted_at, a.id)}
     )
     |> heavy_all(tenant_id)
     |> Enum.map(fn %{ids: ids} -> {@idempotency_drift, ids} end)
@@ -1236,21 +1419,25 @@ defmodule Loopctl.Knowledge.Consolidation do
   # "設計ドキュメント Draft" normalized to "draft" and was flagged as a placeholder title.
   # The ASCII-only `@generic_title_pattern` is anchored, so it still matches exactly the
   # placeholder titles against an `[[:alnum:]]`-normalized key.
+  #
+  # The COUNT and the PAGE are separate queries (#617). This used to `heavy_all` every
+  # matching id and then `Enum.take(ids, cap)` — shipping the whole matching set across the
+  # wire and through the heavy-read gate to keep `cap` of it, purely because `total` is
+  # needed for the truncation flag. A `SELECT count(*)` answers that without materializing
+  # anything, and `limit: ^cap` fetches only what is used.
   defp generic_titles(tenant_id, cap) do
-    ids =
-      from(a in published_base(tenant_id),
-        where:
-          fragment(
-            "btrim(regexp_replace(lower(?), '[^[:alnum:]]+', ' ', 'g')) ~ ?",
-            a.title,
-            ^@generic_title_pattern
-          ),
+    matching = generic_title_base(tenant_id)
+
+    total = heavy_one(tenant_id, from(a in matching, select: count(a.id)))
+
+    selected =
+      from(a in matching,
         order_by: [asc: a.inserted_at, asc: a.id],
+        limit: ^cap,
         select: a.id
       )
       |> heavy_all(tenant_id)
 
-    selected = Enum.take(ids, cap)
     evidence_by_id = evidence_map(tenant_id, selected)
 
     items =
@@ -1265,7 +1452,7 @@ defmodule Loopctl.Knowledge.Consolidation do
         )
       end)
 
-    {length(ids), items}
+    {total, items}
   end
 
   # `:stale_entry` WAS a class here. It is not any more, and the reason is that age is
@@ -1476,10 +1663,20 @@ defmodule Loopctl.Knowledge.Consolidation do
   end
 
   # A proposal the machine no longer derives is withdrawn, not left standing.
-  defp prune_proposals(report_id, proposals) do
+  #
+  # The `tenant_id` predicate is EXPLICIT (#617). This is an unqualified `delete_all`
+  # on AdminRepo, which is BYPASSRLS — so RLS provides no backstop and the WHERE clause
+  # is the ENTIRE tenant boundary. `report_id` happens to imply the tenant today (a
+  # report row belongs to exactly one), so this is defence in depth rather than a live
+  # cross-tenant delete; it is written out because the failure mode if that implication
+  # ever stops holding is silent destruction of another tenant's rows, and a deletion
+  # scoped only by a value derived elsewhere is a boundary you cannot see at the call
+  # site. Every AdminRepo delete in a tenant-scoped context names its tenant.
+  defp prune_proposals(tenant_id, report_id, proposals) do
     keep = Enum.map(proposals, & &1.fingerprint)
 
     from(p in ConsolidationProposal,
+      where: p.tenant_id == ^tenant_id,
       where: p.report_id == ^report_id,
       where: p.fingerprint not in ^keep
     )

--- a/lib/loopctl/knowledge/consolidation.ex
+++ b/lib/loopctl/knowledge/consolidation.ex
@@ -106,6 +106,7 @@ defmodule Loopctl.Knowledge.Consolidation do
 
   alias Loopctl.AdminRepo
   alias Loopctl.Embeddings
+  alias Loopctl.Embeddings.ShrinkLadder
   alias Loopctl.ExitTag
   alias Loopctl.HeavyRead
   alias Loopctl.Knowledge
@@ -196,6 +197,10 @@ defmodule Loopctl.Knowledge.Consolidation do
   # in `0.0..1.0`. Measured band on the hosted corpus 2026-08-06: collisions at/below 0.68,
   # genuine duplicates at/above 0.84.
   @default_min_duplicate_similarity 0.80
+
+  # "No DB row" sentinel for the percent knob. `SystemConfig.get_int/2` requires an
+  # INTEGER default, so absence is signalled by a value no valid percent can take.
+  @no_pct -1
 
   # The visibility guard, in ONE place, usable in a `where` AND in a join `on` — see
   # `shared_only/1` for why it must be composed into every scope decision this pass makes.
@@ -705,6 +710,18 @@ defmodule Loopctl.Knowledge.Consolidation do
   # anything less is re-derived fresh and re-confirmed over two nights, which is cheap and
   # is the only thing that produces a fingerprint matching what the group now is.
   #
+  # And the live set must itself be the whole confirmed set, MINUS only what this pass
+  # retired. Retitling SPLITS a group, so the subgroup check catches it; archiving a
+  # member, deleting it or marking it private SHRINKS the group without splitting it, and
+  # the survivors still share one title — so comparing the subgroup against `live` alone
+  # would apply a two-member fingerprint no report ever carried, on the night an operator
+  # remedied the group by hiding its members.
+  #
+  # The one shrink that is NOT that is this pass's own part-drain (#614): `unpublish` is
+  # the only write it makes, so a member it retired is a still-shared DRAFT, and the group
+  # left behind is winner-plus-leftovers — the same group converging on the outcome that
+  # WAS confirmed. `drained_by_this_pass?/2` is what tells the two apart.
+  #
   # The predicate re-checked is the one that FORMED the group — `title_drift?/1` is the
   # same classifier `corroborated?/3` branches on, so the two cannot disagree about what a
   # group is. Re-checking titles on an idempotency-drift group would reject every one of
@@ -716,14 +733,49 @@ defmodule Loopctl.Knowledge.Consolidation do
         do: {"normalized title", &title_group_key/1},
         else: {"normalized idempotency key", &idempotency_group_key/1}
 
+    confirmed = Enum.uniq(proposal.article_ids)
+
     case colliding_subgroups(live, key_fun) do
       [members] when length(members) == length(live) ->
-        corroborate(tenant_id, proposal, members, budget, scored)
+        whole_group(tenant_id, proposal, members, confirmed, {budget, scored})
 
       other ->
         log_dissolved(tenant_id, proposal, live, other, signal)
         :skip
     end
+  end
+
+  defp whole_group(tenant_id, proposal, live, confirmed, {budget, scored}) do
+    departed = confirmed -- Enum.map(live, & &1.id)
+
+    if departed == [] or drained_by_this_pass?(tenant_id, departed) do
+      corroborate(tenant_id, proposal, live, budget, scored)
+    else
+      log_shrunk(tenant_id, proposal, live, departed)
+      :skip
+    end
+  end
+
+  # Every departed member is a still-shared DRAFT, i.e. exactly what this pass's own
+  # `unpublish` leaves behind. An archived, deleted or now-private member is a shrink by a
+  # hand that never confirmed the smaller group, so the remainder is re-derived instead.
+  defp drained_by_this_pass?(tenant_id, ids) do
+    from(a in Article,
+      where: a.tenant_id == ^tenant_id and a.id in ^ids and a.status == :draft
+    )
+    |> shared_only()
+    |> AdminRepo.aggregate(:count)
+    |> Kernel.==(length(ids))
+  end
+
+  defp log_shrunk(tenant_id, proposal, live, departed) do
+    Logger.info(
+      "Consolidation: tenant=#{tenant_id} skipped duplicate_capture proposal " <>
+        "##{proposal.number} — #{length(departed)} confirmed member(s) left the group by " <>
+        "something other than this pass's own unpublish (archived, deleted or made " <>
+        "private), so its #{length(live)} survivor(s) are a group nothing has confirmed. " <>
+        "The next scan re-derives what is left and the two-run gate re-confirms it."
+    )
   end
 
   # Members still sharing one normalized key, in subgroups of at least two. A member whose
@@ -1322,9 +1374,20 @@ defmodule Loopctl.Knowledge.Consolidation do
       else: :legacy
   end
 
+  # A PREFIX vector is excluded from scoring, not scored (#617). The shrink ladder embeds
+  # an over-long body as its opening only, and two unrelated captures that share a
+  # boilerplate opening (CHANGELOG/API-doc headers — the exact population this gate was
+  # added for) then score near 1.0 against each other. Corroborating a title collision on
+  # that is the auto-unpublish the gate exists to prevent, arriving through the gate
+  # itself. A marked member is therefore treated as MISSING evidence — it drops out of
+  # `scored`, so `judge_similarity/2` withholds the whole group, which fails closed.
   defp score_pairs(query, :legacy) do
     from([a1, a2] in query,
       where: not is_nil(a1.embedding) and not is_nil(a2.embedding),
+      where:
+        not like(coalesce(a1.embedding_content_hash, ""), ^ShrinkLadder.truncated_hash_pattern()),
+      where:
+        not like(coalesce(a2.embedding_content_hash, ""), ^ShrinkLadder.truncated_hash_pattern()),
       group_by: fragment(unquote(@title_key_sql), a1.title),
       select: %{
         min_sim: min(fragment("1 - (? <=> ?)", a1.embedding, a2.embedding)),
@@ -1341,6 +1404,10 @@ defmodule Loopctl.Knowledge.Consolidation do
       on: e1.article_id == a1.id and e1.dim == ^dim and e1.tenant_id == a1.tenant_id,
       join: e2 in "article_embeddings",
       on: e2.article_id == a2.id and e2.dim == ^dim and e2.tenant_id == a2.tenant_id,
+      where:
+        not like(coalesce(e1.embedding_content_hash, ""), ^ShrinkLadder.truncated_hash_pattern()),
+      where:
+        not like(coalesce(e2.embedding_content_hash, ""), ^ShrinkLadder.truncated_hash_pattern()),
       group_by: fragment(unquote(@title_key_sql), a1.title),
       select: %{
         min_sim: min(fragment("1 - (? <=> ?)", e1.embedding, e2.embedding)),
@@ -1384,10 +1451,18 @@ defmodule Loopctl.Knowledge.Consolidation do
   # `KnowledgeLintWorker` — this is the one threshold that decides whether the only
   # self-writing class applies anything at all, and an operator watching it behave wrong
   # must be able to move it without a deploy. The DB key is expressed in PERCENT
-  # (`..._pct`, `80` = 0.80) because `SystemConfig`'s cache is integer-typed; the app
-  # config stays the float layer beneath it. Resolution order: DB row -> app config ->
-  # module default, and an out-of-range value at EITHER layer falls back rather than
-  # clamping (see above).
+  # (`..._pct`, `80` = 0.80) because `SystemConfig`'s cache is integer-typed.
+  #
+  # The DB layer is read with a SENTINEL default and consulted only when a row actually
+  # exists, for two reasons. It keeps the app-config float exact — routing it through
+  # `round(x * 100)` quantized every threshold with more than two decimals (0.925 became
+  # 0.93) even for the deployments that set no DB row at all. And it lets the percent be
+  # range-checked as the INTEGER an operator types: only 1..99 is accepted, because the
+  # sibling drain caps read `0` as "disable" and here `0` does the OPPOSITE of disabling —
+  # `min_sim >= 0.0` holds for every pair, so the one content check on the auto-applying
+  # class is fully OFF and every title collision auto-unpublishes uncorroborated. `100` is
+  # rejected for the mirror-image reason given above. An out-of-range percent is treated
+  # as absent and falls through to the app layer, which is the conservative direction.
   defp min_duplicate_similarity do
     app_layer =
       :loopctl
@@ -1397,10 +1472,22 @@ defmodule Loopctl.Knowledge.Consolidation do
       )
       |> validate_similarity()
 
-    "knowledge_consolidation_min_duplicate_similarity_pct"
-    |> SystemConfig.get_int(round(app_layer * 100))
-    |> Kernel./(100)
-    |> validate_similarity()
+    case SystemConfig.get_int("knowledge_consolidation_min_duplicate_similarity_pct", @no_pct) do
+      pct when pct > 0 and pct < 100 ->
+        pct / 100
+
+      @no_pct ->
+        app_layer
+
+      other ->
+        Logger.warning(
+          "Consolidation: ignoring duplicate similarity percent #{inspect(other)} — not an " <>
+            "integer in 1..99 (0 would turn the corroboration gate OFF, not disable it); " <>
+            "using #{app_layer}."
+        )
+
+        app_layer
+    end
   end
 
   defp validate_similarity(value)

--- a/lib/loopctl/knowledge/consolidation.ex
+++ b/lib/loopctl/knowledge/consolidation.ex
@@ -112,6 +112,7 @@ defmodule Loopctl.Knowledge.Consolidation do
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ConsolidationProposal
   alias Loopctl.Knowledge.ConsolidationReport
+  alias Loopctl.SystemConfig
   alias Loopctl.Workers.BatchArticleEmbeddingWorker
 
   @default_max_per_class 100
@@ -256,10 +257,16 @@ defmodule Loopctl.Knowledge.Consolidation do
          }}
       end)
 
-    by_class = Map.new(found, fn {class, {total, _items}} -> {to_string(class), total} end)
+    by_class = Map.new(found, fn {class, {total, _items, _cut}} -> {to_string(class), total} end)
 
+    # `truncated` answers "did this class see the whole picture", so MEMBER truncation
+    # (`cap_members/1`, which drops members from inside a group without changing either
+    # count) has to flip it too. Group-level `total > length(items)` alone reported `false`
+    # while a proposal silently omitted members and its evidence array came up short.
     truncated =
-      Map.new(found, fn {class, {total, items}} -> {to_string(class), total > length(items)} end)
+      Map.new(found, fn {class, {total, items, members_cut}} ->
+        {to_string(class), total > length(items) or members_cut}
+      end)
 
     # Drive the ORDER from `@live_classes` — the classes this pass still PRODUCES — and
     # `Map.fetch!` over THAT list, so a dropped producer raises.
@@ -382,11 +389,13 @@ defmodule Loopctl.Knowledge.Consolidation do
   group left with fewer than two live published members is skipped, not forced. Reading a
   winner chosen hours ago would be applying a decision to a corpus that no longer matches it.
 
-  What is NOT re-derived here is the COLLISION: the normalized title / idempotency key is
-  not recomputed at apply time. Collision freshness rests entirely on the two-run agreement
-  gate — a group broken up by a rename drops out of tonight's report and can never be
-  confirmed — which is why the worker calls this only after tonight's report was written
-  (`Loopctl.Workers.KnowledgeLintWorker`).
+  The COLLISION is re-derived here too (`still_colliding/5`): the grouping signal that
+  FORMED the group — normalized title, or normalized idempotency key — is recomputed over
+  the live rows, and a group that has dissolved, split, or lost any live member to another
+  key is skipped WHOLE rather than applied to what is left. The two-run agreement gate
+  still runs in front of it (which is why the worker calls this only after tonight's report
+  was written, `Loopctl.Workers.KnowledgeLintWorker`), but agreement confirms a specific id
+  set; it cannot notice that a human retitled three of the five members this morning.
   ## What a TITLE collision must additionally clear
 
   Agreement filters transience, not wrongness: a title two unrelated sources share collides
@@ -496,8 +505,20 @@ defmodule Loopctl.Knowledge.Consolidation do
   # `backfill_missing_embeddings/2` — so a shed on this read would answer a DB outage by
   # enqueueing an embedding job per member of every confirmed group, against the same
   # degraded database, and log it as missing vectors.
+  # Only the TITLE-drift proposals' ids, and each id ONCE. The score is consulted for no
+  # other class (`corroborated?/3` exempts idempotency drift), and `title_pairs/2` binds
+  # the list TWICE (`a1.id in ^ids and a2.id in ^ids`) — so at the shipped ceilings an
+  # undeduplicated list carrying both classes approaches Postgres's 65,535 bind-parameter
+  # limit, where a Postgrex encode failure is rescued into `:unavailable` and withholds
+  # EVERY title-drift group for that tenant, deterministically, every night.
   defp score_groups(tenant_id, proposals) do
-    pairwise_similarity_by_group(tenant_id, Enum.flat_map(proposals, & &1.article_ids))
+    ids =
+      proposals
+      |> Enum.filter(&title_drift?/1)
+      |> Enum.flat_map(& &1.article_ids)
+      |> Enum.uniq()
+
+    pairwise_similarity_by_group(tenant_id, ids)
   rescue
     e -> log_scoring_failed(tenant_id, ExitTag.tag(e))
   catch
@@ -676,10 +697,13 @@ defmodule Loopctl.Knowledge.Consolidation do
   # function. That is a correct outcome resting on an accident of ordering, so the
   # premise is now re-checked where it is used.
   #
-  # A group that has SPLIT (two or more surviving keys with >= 2 members each) is skipped
-  # whole rather than applied to the larger half: the persisted proposal describes one
-  # collision, the corpus now holds two, and re-deriving them fresh is both cheap and the
-  # only thing that produces fingerprints matching what they now are.
+  # A group that no longer collides AS ONE WHOLE is skipped, not applied to what survives.
+  # Not just a SPLIT (two keys of >= 2): a group of five whose members were retitled down
+  # to two is a two-member group nothing has ever confirmed — the two-run gate agreed on
+  # the five-id fingerprint — and applying it completes a partial human remedy the same
+  # night the remedy was made. So the surviving subgroup must be the WHOLE live set;
+  # anything less is re-derived fresh and re-confirmed over two nights, which is cheap and
+  # is the only thing that produces a fingerprint matching what the group now is.
   #
   # The predicate re-checked is the one that FORMED the group — `title_drift?/1` is the
   # same classifier `corroborated?/3` branches on, so the two cannot disagree about what a
@@ -687,31 +711,39 @@ defmodule Loopctl.Knowledge.Consolidation do
   # them: those members collide on a writer-supplied key and have no reason to share a
   # title.
   defp still_colliding(tenant_id, proposal, live, budget, scored) do
-    subgroups =
+    {signal, key_fun} =
       if title_drift?(proposal),
-        do: colliding_subgroups(live, &title_group_key/1, fn _members -> true end),
-        else: colliding_subgroups(live, &idempotency_group_key/1, &distinct_verbatim_keys?/1)
+        do: {"normalized title", &title_group_key/1},
+        else: {"normalized idempotency key", &idempotency_group_key/1}
 
-    case subgroups do
-      [members] ->
+    case colliding_subgroups(live, key_fun) do
+      [members] when length(members) == length(live) ->
         corroborate(tenant_id, proposal, members, budget, scored)
 
       other ->
-        log_dissolved(tenant_id, proposal, live, other)
+        log_dissolved(tenant_id, proposal, live, other, signal)
         :skip
     end
   end
 
-  # Members still sharing one normalized key, in subgroups of at least two, subject to the
-  # extra condition the deriving query's `having` imposed. A member whose key no longer
-  # qualifies at all (blank, or — for titles — a placeholder) is dropped BEFORE grouping,
-  # mirroring the deriving query's `where`: it is no longer a member the scan would find.
-  defp colliding_subgroups(live, key_fun, extra) do
+  # Members still sharing one normalized key, in subgroups of at least two. A member whose
+  # key no longer qualifies at all (blank, or — for titles — a placeholder) is dropped
+  # BEFORE grouping, mirroring the deriving query's `where`: it is no longer a member the
+  # scan would find, and the caller then sees a subgroup shorter than `live` and skips.
+  #
+  # The idempotency derivation's other `having` term — `count(idempotency_key, :distinct)
+  # > 1` — is deliberately NOT re-checked. It is a condition on the WHOLE group, and
+  # `cap_members/1` may hand this only the oldest 50, so re-evaluating it here asks a
+  # different question and could answer "no" forever for a group the derivation keeps
+  # re-deriving. It is also structurally guaranteed: `articles_tenant_idempotency_key_idx`
+  # is UNIQUE on `(tenant_id, idempotency_key)`, so two live members of one tenant cannot
+  # carry the byte-identical key and distinctness follows from there being two of them.
+  defp colliding_subgroups(live, key_fun) do
     live
     |> Enum.reject(&(key_fun.(&1) == :ineligible))
     |> Enum.group_by(key_fun)
     |> Map.values()
-    |> Enum.filter(&(length(&1) > 1 and extra.(&1)))
+    |> Enum.filter(&(length(&1) > 1))
   end
 
   # `:ineligible` for anything `title_drift_groups/1`'s `where` would have excluded — a key
@@ -742,14 +774,6 @@ defmodule Loopctl.Knowledge.Consolidation do
 
   defp idempotency_group_key(_member), do: :ineligible
 
-  # `idempotency_drift_groups/1` requires `count(idempotency_key, :distinct) > 1` — the class
-  # is about ONE key written under two FORMATS, not about two rows carrying the byte-identical
-  # key (that is an ordinary re-capture the writer meant). The re-check carries the same
-  # condition, or it would apply to groups the derivation would never have produced.
-  defp distinct_verbatim_keys?(members) do
-    members |> Enum.map(& &1.idempotency_key) |> Enum.uniq() |> length() > 1
-  end
-
   defp corroborate(tenant_id, proposal, live, budget, scored) do
     case corroborated?(proposal, live, scored) do
       :ok ->
@@ -762,12 +786,17 @@ defmodule Loopctl.Knowledge.Consolidation do
     end
   end
 
-  defp log_dissolved(tenant_id, proposal, live, surviving) do
+  # NAMES the signal that was actually re-checked. This log line is the only surface that
+  # explains a skip, and an idempotency-drift group whose members never had to share a
+  # title would send the operator to inspect (and retitle) the wrong column entirely.
+  defp log_dissolved(tenant_id, proposal, live, surviving, signal) do
     Logger.info(
       "Consolidation: tenant=#{tenant_id} skipped duplicate_capture proposal " <>
         "##{proposal.number} — its #{length(live)} live member(s) no longer share one " <>
-        "normalized title (#{length(surviving)} colliding subgroup(s)). The group was " <>
-        "retitled or split since it was proposed; the next scan re-derives what is left."
+        "#{signal} as one group (#{length(surviving)} colliding subgroup(s), " <>
+        "#{surviving |> List.flatten() |> length()} member(s)). Something changed since it " <>
+        "was proposed; the next scan re-derives what is left, and the two-run gate " <>
+        "re-confirms it before anything is unpublished."
     )
   end
 
@@ -964,8 +993,6 @@ defmodule Loopctl.Knowledge.Consolidation do
 
   defp heavy_all(query, tenant_id), do: HeavyRead.all(tenant_id, query, heavy_opts())
 
-  defp heavy_one(tenant_id, query), do: HeavyRead.one(tenant_id, query, heavy_opts())
-
   # The matching set for `:generic_title`, as a composable query so the COUNT and the
   # capped PAGE are built from ONE predicate and cannot drift into disagreeing about what
   # "matching" means.
@@ -1018,10 +1045,9 @@ defmodule Loopctl.Knowledge.Consolidation do
 
     groups = titles |> interleave(idempotency) |> Enum.uniq_by(by_ids)
 
-    selected =
-      groups
-      |> Enum.take(cap)
-      |> Enum.map(fn {reason, ids} -> {reason, cap_members(ids)} end)
+    taken = Enum.take(groups, cap)
+    members_cut = Enum.any?(taken, fn {_reason, ids} -> length(ids) > @max_group_members end)
+    selected = Enum.map(taken, fn {reason, ids} -> {reason, cap_members(ids)} end)
 
     evidence_by_id = evidence_map(tenant_id, Enum.flat_map(selected, fn {_r, ids} -> ids end))
 
@@ -1042,7 +1068,7 @@ defmodule Loopctl.Knowledge.Consolidation do
         )
       end)
 
-    {length(groups), items}
+    {length(groups), items, members_cut}
   end
 
   defp interleave([], rest), do: rest
@@ -1066,13 +1092,18 @@ defmodule Loopctl.Knowledge.Consolidation do
   #
   # The leftovers are not lost: the winner stays published, so the next scan re-derives
   # the remaining collision as a fresh group. Same drain-don't-stall shape as the apply
-  # budget in `apply_live_group/4`.
+  # budget in `apply_live_group/4` — but SLOWER, and by construction: the survivors are a
+  # different sorted id set, hence a different fingerprint, which the two-run agreement
+  # gate cannot confirm until it has appeared in two consecutive reports. A truncated
+  # group therefore drains one cap's worth every TWO runs (derive, confirm, apply), not
+  # every run.
   defp cap_members(ids) when length(ids) <= @max_group_members, do: ids
 
   defp cap_members(ids) do
     Logger.info(
       "Consolidation: duplicate group of #{length(ids)} members truncated to " <>
-        "#{@max_group_members} for this run; the remainder re-derives next run."
+        "#{@max_group_members} for this run; the remainder is re-derived on the next run " <>
+        "and applies the run after that (its new fingerprint needs two agreeing reports)."
     )
 
     Enum.take(ids, @max_group_members)
@@ -1348,12 +1379,27 @@ defmodule Loopctl.Knowledge.Consolidation do
   # (an operator hard-disabling the class mid-incident) to `1.0` is reachable too: identical
   # vectors score exactly 1.0, so the gate an operator shut re-opens for byte-identical
   # captures. A typo may only make this pass more conservative, so both go to the default.
+  #
+  # Resolved through `SystemConfig` FIRST, like the three drain caps in
+  # `KnowledgeLintWorker` — this is the one threshold that decides whether the only
+  # self-writing class applies anything at all, and an operator watching it behave wrong
+  # must be able to move it without a deploy. The DB key is expressed in PERCENT
+  # (`..._pct`, `80` = 0.80) because `SystemConfig`'s cache is integer-typed; the app
+  # config stays the float layer beneath it. Resolution order: DB row -> app config ->
+  # module default, and an out-of-range value at EITHER layer falls back rather than
+  # clamping (see above).
   defp min_duplicate_similarity do
-    :loopctl
-    |> Application.get_env(
-      :knowledge_consolidation_min_duplicate_similarity,
-      @default_min_duplicate_similarity
-    )
+    app_layer =
+      :loopctl
+      |> Application.get_env(
+        :knowledge_consolidation_min_duplicate_similarity,
+        @default_min_duplicate_similarity
+      )
+      |> validate_similarity()
+
+    "knowledge_consolidation_min_duplicate_similarity_pct"
+    |> SystemConfig.get_int(round(app_layer * 100))
+    |> Kernel./(100)
     |> validate_similarity()
   end
 
@@ -1420,24 +1466,25 @@ defmodule Loopctl.Knowledge.Consolidation do
   # The ASCII-only `@generic_title_pattern` is anchored, so it still matches exactly the
   # placeholder titles against an `[[:alnum:]]`-normalized key.
   #
-  # The COUNT and the PAGE are separate queries (#617). This used to `heavy_all` every
+  # ONE query for both the page and the total (#617). This used to `heavy_all` every
   # matching id and then `Enum.take(ids, cap)` — shipping the whole matching set across the
-  # wire and through the heavy-read gate to keep `cap` of it, purely because `total` is
-  # needed for the truncation flag. A `SELECT count(*)` answers that without materializing
-  # anything, and `limit: ^cap` fetches only what is used.
+  # wire to keep `cap` of it, purely because `total` is needed for the truncation flag.
+  # `count(*) OVER ()` answers that from the same scan: splitting it into a COUNT plus a
+  # LIMIT would evaluate the unindexable regexp-normalized title predicate over every
+  # published row TWICE per run, each under its own 10s statement timeout, and a timeout on
+  # either raises out of `analyze/2` whole — losing the duplicate_capture derivation, which
+  # is the class that actually applies.
   defp generic_titles(tenant_id, cap) do
-    matching = generic_title_base(tenant_id)
-
-    total = heavy_one(tenant_id, from(a in matching, select: count(a.id)))
-
-    selected =
-      from(a in matching,
+    rows =
+      from(a in generic_title_base(tenant_id),
         order_by: [asc: a.inserted_at, asc: a.id],
         limit: ^cap,
-        select: a.id
+        select: %{id: a.id, total: fragment("count(*) OVER ()")}
       )
       |> heavy_all(tenant_id)
 
+    total = rows |> List.first(%{total: 0}) |> Map.fetch!(:total)
+    selected = Enum.map(rows, & &1.id)
     evidence_by_id = evidence_map(tenant_id, selected)
 
     items =
@@ -1452,7 +1499,8 @@ defmodule Loopctl.Knowledge.Consolidation do
         )
       end)
 
-    {total, items}
+    # `false`: this class emits one article per proposal, so there are no members to cut.
+    {total, items, false}
   end
 
   # `:stale_entry` WAS a class here. It is not any more, and the reason is that age is

--- a/lib/loopctl/knowledge/proposal_gate.ex
+++ b/lib/loopctl/knowledge/proposal_gate.ex
@@ -35,6 +35,8 @@ defmodule Loopctl.Knowledge.ProposalGate do
 
   require Logger
 
+  alias Loopctl.Embeddings.ShrinkLadder
+  alias Loopctl.Embeddings.TextBudget
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.VectorSearch
   alias Loopctl.Llm
@@ -43,7 +45,6 @@ defmodule Loopctl.Knowledge.ProposalGate do
   @default_duplicate_threshold 0.97
   @default_overlap_threshold 0.88
   @neighbors_k 5
-  @max_text_length 32_000
 
   @impl true
   def assess(tenant_id, attrs, opts \\ [])
@@ -153,8 +154,18 @@ defmodule Loopctl.Knowledge.ProposalGate do
         # project-only `local_only` marking would not be enforced on a path that
         # runs SYNCHRONOUSLY in the `knowledge_create` write path — and because the
         # gate deliberately falls OPEN, the refusal would be silent.
-        {Knowledge.generate_embedding(tenant_id, build_text(attrs),
-           project_id: attrs["project_id"] || attrs[:project_id]
+        # Through `ShrinkLadder.embed_one/3` (#617). This gate falls OPEN on an
+        # embedding failure, so an input-too-long rejection did not surface as an
+        # error — it silently skipped novelty checking entirely, and the over-long
+        # article landed as exactly the duplicate the nightly consolidation pass then
+        # has to catch. The ladder is paid only by an input the provider rejected, on
+        # a request that was already going to make an extra round trip and fall open.
+        project_id = attrs["project_id"] || attrs[:project_id]
+
+        {ShrinkLadder.embed_one(
+           build_text(attrs),
+           &Knowledge.generate_embedding(tenant_id, &1, project_id: project_id),
+           label: "ProposalGate tenant=#{tenant_id}"
          ), true}
     end
   end
@@ -162,7 +173,7 @@ defmodule Loopctl.Knowledge.ProposalGate do
   defp build_text(attrs) do
     title = attrs["title"] || attrs[:title] || ""
     body = attrs["body"] || attrs[:body] || ""
-    String.slice("#{title}\n\n#{body}", 0, @max_text_length)
+    TextBudget.initial("#{title}\n\n#{body}")
   end
 
   defp open_verdict, do: %{verdict: :unknown, score: nil, neighbors: [], gate_embedded: false}

--- a/lib/loopctl/knowledge/proposal_gate.ex
+++ b/lib/loopctl/knowledge/proposal_gate.ex
@@ -143,12 +143,21 @@ defmodule Loopctl.Knowledge.ProposalGate do
   # The ladder (#617) can only embed an over-long proposal as a PREFIX, and it says so.
   # That vector is scored against corpus vectors built from whole texts, so a shared
   # opening (generated API docs, changelogs, a common frontmatter header) scores as a
-  # near-identity of a document it may differ from entirely after the cut. `:duplicate`
-  # makes `Knowledge.gate_proposal/4` return `created: false` — the proposal is DROPPED
-  # and the caller handed a pre-existing article — so a prefix may not reach that band:
-  # it is capped at `:low_novelty`, which still drafts the article and surfaces the
-  # neighbours for the agent to judge. The gate's job is to flag, never to lose a write.
-  defp cap_truncated(:duplicate, true), do: :low_novelty
+  # near-identity of a document it may differ from entirely after the cut. A prefix
+  # therefore supports NO negative verdict at all — neither band may be reached on one.
+  #
+  # `:low_novelty` is not a safe cap: under `on_low_novelty: :skip` (memory graduation,
+  # channel-post capture, ingestion `skip_low_novelty=true`) `Knowledge.gate_proposal/4`
+  # creates NOTHING for that band, so capping to it relabels the verdict and still drops
+  # the write for exactly the UNATTENDED callers that have no reviewer to recover it.
+  # `:unknown` is not safe either: those same callers pass `on_gate_unavailable: :skip`,
+  # which returns `{:error, :gate_unavailable}` so they can retry once embeddings recover
+  # — but truncation is a permanent property of the text, so the retry never clears.
+  # `:novel` creates on the requested path for EVERY caller class; `score` and `neighbors`
+  # still ride the assessment, so nothing is hidden, and the nightly consolidation pass
+  # remains the backstop for the rare over-long duplicate. The gate's job is to flag,
+  # never to lose a write.
+  defp cap_truncated(verdict, true) when verdict in [:duplicate, :low_novelty], do: :novel
   defp cap_truncated(verdict, _truncated?), do: verdict
 
   defp split_truncation({:ok, vector, :truncated}), do: {{:ok, vector}, true}
@@ -178,18 +187,24 @@ defmodule Loopctl.Knowledge.ProposalGate do
         # embedding failure, so an input-too-long rejection did not surface as an
         # error — it silently skipped novelty checking entirely, and the over-long
         # article landed as exactly the duplicate the nightly consolidation pass then
-        # has to catch. `max_rungs: 1` because this runs SYNCHRONOUSLY in the write
-        # path: the full ladder puts up to four sequential provider round trips (and
-        # four embedding admission slots that interactive search shares) inside one
-        # article create, to buy a verdict this gate deliberately caps anyway. One
-        # rung, then the existing fall-open; `ArticleEmbeddingWorker` walks the rest.
+        # has to catch. `max_rungs` is BOUNDED because this runs SYNCHRONOUSLY in the
+        # write path — each rung is a provider round trip and an embedding admission slot
+        # that interactive search shares — but the bound must still REACH the floor, or
+        # the rung budget reproduces the silent skip it was added to close.
+        #
+        # THREE, because `build_text/1` caps at 32,000 CHARACTERS: a dense-script
+        # (Cyrillic/CJK) or code-heavy proposal arrives at up to 128,000 bytes, and
+        # `next_budget/1` caps the first rung at 32,000 bytes, then 16,000, then the 8,000
+        # floor. At one rung that whole class — exactly the articles #615 measured, and
+        # the ones most likely to be re-captured — landed back at the fall-open having had
+        # NO novelty check at all. Three rungs reach the floor from ANY first attempt.
         project_id = attrs["project_id"] || attrs[:project_id]
 
         {ShrinkLadder.embed_one(
            build_text(attrs),
            &Knowledge.generate_embedding(tenant_id, &1, project_id: project_id),
            label: "ProposalGate tenant=#{tenant_id}",
-           max_rungs: 1
+           max_rungs: 3
          ), true}
     end
   end

--- a/lib/loopctl/knowledge/proposal_gate.ex
+++ b/lib/loopctl/knowledge/proposal_gate.ex
@@ -71,9 +71,10 @@ defmodule Loopctl.Knowledge.ProposalGate do
     |> Map.put(:gate_embedded, gate_embedded?)
   end
 
-  defp do_assess(tenant_id, opts, embedding) do
+  defp do_assess(tenant_id, opts, result) do
     dup = config(:knowledge_proposal_duplicate_threshold, @default_duplicate_threshold)
     overlap = config(:knowledge_proposal_overlap_threshold, @default_overlap_threshold)
+    {embedding, truncated?} = split_truncation(result)
 
     # Route through the GUARDED embedding path (review #4): tenant-scoped circuit
     # breaker + timeout, so a provider outage fast-fails here (this runs SYNCHRONOUSLY
@@ -100,7 +101,12 @@ defmodule Loopctl.Knowledge.ProposalGate do
 
           neighbors when is_list(neighbors) ->
             score = neighbors |> List.first() |> neighbor_score()
-            %{verdict: classify(score, dup, overlap), score: score, neighbors: neighbors}
+
+            %{
+              verdict: score |> classify(dup, overlap) |> cap_truncated(truncated?),
+              score: score,
+              neighbors: neighbors
+            }
         end
 
       {:error, :no_api_key} ->
@@ -134,6 +140,20 @@ defmodule Loopctl.Knowledge.ProposalGate do
   defp neighbor_score(nil), do: nil
   defp neighbor_score(%{similarity_score: s}), do: s
 
+  # The ladder (#617) can only embed an over-long proposal as a PREFIX, and it says so.
+  # That vector is scored against corpus vectors built from whole texts, so a shared
+  # opening (generated API docs, changelogs, a common frontmatter header) scores as a
+  # near-identity of a document it may differ from entirely after the cut. `:duplicate`
+  # makes `Knowledge.gate_proposal/4` return `created: false` — the proposal is DROPPED
+  # and the caller handed a pre-existing article — so a prefix may not reach that band:
+  # it is capped at `:low_novelty`, which still drafts the article and surfaces the
+  # neighbours for the agent to judge. The gate's job is to flag, never to lose a write.
+  defp cap_truncated(:duplicate, true), do: :low_novelty
+  defp cap_truncated(verdict, _truncated?), do: verdict
+
+  defp split_truncation({:ok, vector, :truncated}), do: {{:ok, vector}, true}
+  defp split_truncation(result), do: {result, false}
+
   # Reuse a caller-supplied embedding when present (avoids a second embedding round-trip
   # for text already embedded upstream — e.g. a memory's stored vector on graduation);
   # otherwise embed the proposal text through the guarded path. A non-list / empty
@@ -158,14 +178,18 @@ defmodule Loopctl.Knowledge.ProposalGate do
         # embedding failure, so an input-too-long rejection did not surface as an
         # error — it silently skipped novelty checking entirely, and the over-long
         # article landed as exactly the duplicate the nightly consolidation pass then
-        # has to catch. The ladder is paid only by an input the provider rejected, on
-        # a request that was already going to make an extra round trip and fall open.
+        # has to catch. `max_rungs: 1` because this runs SYNCHRONOUSLY in the write
+        # path: the full ladder puts up to four sequential provider round trips (and
+        # four embedding admission slots that interactive search shares) inside one
+        # article create, to buy a verdict this gate deliberately caps anyway. One
+        # rung, then the existing fall-open; `ArticleEmbeddingWorker` walks the rest.
         project_id = attrs["project_id"] || attrs[:project_id]
 
         {ShrinkLadder.embed_one(
            build_text(attrs),
            &Knowledge.generate_embedding(tenant_id, &1, project_id: project_id),
-           label: "ProposalGate tenant=#{tenant_id}"
+           label: "ProposalGate tenant=#{tenant_id}",
+           max_rungs: 1
          ), true}
     end
   end

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -2661,6 +2661,14 @@ defmodule Loopctl.Memory do
   # promotion run — permanently, since the next run embeds the identical text and is
   # rejected identically. The ladder makes a long memory promotable on a prefix
   # instead of making it unpromotable forever.
+  #
+  # A PREFIX vector (`:truncated`) does the near-dup lookup no good and real harm: it is
+  # compared at 0.92 against prior rows embedded from their WHOLE slice, so two long
+  # memories that share an opening and diverge after it score as one — and the hit is not
+  # merely ignored, it SUPERSEDES the prior row (`insert_promoted/5`). The apples-to-apples
+  # premise above is what licenses that write, and truncation breaks it. So a truncated
+  # candidate is inserted FRESH (`near_dup_id` nil): a permitted duplicate, never a
+  # retirement decided on comparing different extents of text.
   defp nearest_live(scope, text) do
     embed =
       ShrinkLadder.embed_one(
@@ -2672,6 +2680,9 @@ defmodule Loopctl.Memory do
     case embed do
       {:error, _reason} ->
         {:error, :embeddings_degraded}
+
+      {:ok, embedding, :truncated} ->
+        {:ok, nil, embedding}
 
       {:ok, embedding} ->
         # The near-dup HNSW recall runs on the shared HeavyRead pool behind the

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -2206,10 +2206,25 @@ defmodule Loopctl.Memory do
     |> Keyword.merge(Keyword.take(opts, [:actor_id, :actor_label, :actor_type, :metadata]))
   end
 
+  # A PREFIX-embedded memory's vector is NOT reused: `ProposalGate` treats a supplied
+  # `:embedding` as covering the whole text (its truncation cap keys on a tag only its
+  # OWN embed produces), so a shared opening could score the graduation as a duplicate of
+  # an article it differs from after the cut — and a duplicate verdict drops the write.
+  # Let the gate embed instead; it walks its own ladder and caps its own verdict.
   defp maybe_put_embedding(propose_opts, %MemorySchema{} = memory) do
-    case fetch_memory_embedding(memory) do
-      nil -> propose_opts
-      embedding -> Keyword.put(propose_opts, :embedding, embedding)
+    with false <- ShrinkLadder.truncated_hash?(stored_embedding_hash(memory)),
+         embedding when not is_nil(embedding) <- fetch_memory_embedding(memory) do
+      Keyword.put(propose_opts, :embedding, embedding)
+    else
+      _ -> propose_opts
+    end
+  end
+
+  defp stored_embedding_hash(%MemorySchema{id: id, tenant_id: tenant_id} = memory) do
+    if Embeddings.side_table_reads_enabled?() do
+      Embeddings.memory_embedded_hash(tenant_id, id, Embeddings.active_dimension(tenant_id))
+    else
+      memory.embedding_content_hash
     end
   end
 
@@ -2626,11 +2641,17 @@ defmodule Loopctl.Memory do
         {:error, :heavy_read_overloaded} = err ->
           err
 
-        {:ok, near_dup_id, embedding} ->
-          insert_promoted(scope, candidate, hash, near_dup_id, embedding)
+        {:ok, near_dup_id, embedding, truncated?} ->
+          insert_promoted(scope, candidate, stored_hash(hash, truncated?), near_dup_id, embedding)
       end
     end
   end
+
+  # The stored hash still identifies the FULL candidate text; the mark records only that
+  # the vector beside it covers a prefix of it. `promoted_hash_exists?/3` matches either
+  # form, so exact dedupe is unaffected.
+  defp stored_hash(hash, false), do: hash
+  defp stored_hash(hash, true), do: ShrinkLadder.truncated_hash(hash)
 
   # Recall the nearest near-dup that auto-promotion is ALLOWED to supersede: a prior
   # `:promoted` memory (never a user's explicit row). Returns `{:ok, near_dup_id | nil,
@@ -2669,6 +2690,13 @@ defmodule Loopctl.Memory do
   # premise above is what licenses that write, and truncation breaks it. So a truncated
   # candidate is inserted FRESH (`near_dup_id` nil): a permitted duplicate, never a
   # retirement decided on comparing different extents of text.
+  #
+  # Refusing the LOOKUP is only half of it. The vector computed here is PERSISTED as the
+  # new row's embedding, so an unmarked prefix would enter the promoted pool and the NEXT
+  # whole-text candidate would run the same forbidden compare from the other side — this
+  # time retiring the longer memory. The fourth element carries the truncation fact to
+  # `promote_one/2`, which marks the stored hash (`ShrinkLadder.truncated_hash/1`) so
+  # `first_promoted_near_dup/1` skips the row exactly as it skips an explicit-source one.
   defp nearest_live(scope, text) do
     embed =
       ShrinkLadder.embed_one(
@@ -2682,7 +2710,7 @@ defmodule Loopctl.Memory do
         {:error, :embeddings_degraded}
 
       {:ok, embedding, :truncated} ->
-        {:ok, nil, embedding}
+        {:ok, nil, embedding, true}
 
       {:ok, embedding} ->
         # The near-dup HNSW recall runs on the shared HeavyRead pool behind the
@@ -2692,7 +2720,7 @@ defmodule Loopctl.Memory do
         # would burn an Oban attempt on the promotion WRITE path, US-37.5).
         case find_promoted_near_dup(scope, embedding) do
           {:error, :heavy_read_overloaded} = err -> err
-          near_dup_id -> {:ok, near_dup_id, embedding}
+          near_dup_id -> {:ok, near_dup_id, embedding, false}
         end
     end
   end
@@ -2728,11 +2756,17 @@ defmodule Loopctl.Memory do
 
   # The id of the nearest `:promoted` row at/above the near-dup threshold (rows are
   # distance-ordered, nearest first), or nil. An explicit-source near-dup is skipped —
-  # auto-promotion never supersedes a human-authored row (AC-29.2.4).
+  # auto-promotion never supersedes a human-authored row (AC-29.2.4) — and so is a
+  # PREFIX-embedded one: its vector covers part of its text, so a whole-text candidate
+  # scoring against it is the mismatched-extent compare `nearest_live/2` refuses on the
+  # candidate side, and here it would RETIRE the longer, more informative memory.
   defp first_promoted_near_dup(rows) do
     Enum.find_value(rows, fn row ->
       score = max(0.0, 1.0 - row.distance)
-      if score >= near_dup_threshold() and row.source == :promoted, do: row.id
+
+      if score >= near_dup_threshold() and row.source == :promoted and
+           not ShrinkLadder.truncated_hash?(row.embedding_content_hash),
+         do: row.id
     end)
   end
 
@@ -2947,12 +2981,16 @@ defmodule Loopctl.Memory do
       is_nil(new.superseded_by)
   end
 
+  # Either FORM of the hash is the same content: a prefix-embedded row carries the
+  # truncation mark, and missing it here would re-promote text already promoted.
   defp promoted_hash_exists?(repo, scope, hash) do
+    forms = [hash, ShrinkLadder.truncated_hash(hash)]
+
     MemorySchema
     |> where(
       [m],
       m.tenant_id == ^scope.tenant_id and m.subject_id == ^scope.subject_id and
-        m.source == :promoted and m.embedding_content_hash == ^hash
+        m.source == :promoted and m.embedding_content_hash in ^forms
     )
     |> repo.exists?()
   end

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -55,6 +55,7 @@ defmodule Loopctl.Memory do
 
   import Loopctl.Egress, only: [is_egress_refusal: 1]
   alias Loopctl.Embeddings
+  alias Loopctl.Embeddings.ShrinkLadder
   alias Loopctl.HeavyRead
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.IdempotencyTag
@@ -2653,12 +2654,22 @@ defmodule Loopctl.Memory do
   # rather than a silent overwrite of human-authored knowledge. Results are
   # distance-ordered (nearest first), so the first ELIGIBLE promoted row above threshold
   # wins; missing one (pool dominated by explicit rows) is safe — insert fresh instead.
+  #
+  # The embed goes through `ShrinkLadder.embed_one/3` (#617): an over-long memory
+  # returned `{:api_error, 400, :context_length_exceeded}`, which fell into the
+  # `{:error, _reason}` branch below as `:embeddings_degraded` and ABORTED the whole
+  # promotion run — permanently, since the next run embeds the identical text and is
+  # rejected identically. The ladder makes a long memory promotable on a prefix
+  # instead of making it unpromotable forever.
   defp nearest_live(scope, text) do
-    case Knowledge.generate_embedding(
-           scope.tenant_id,
-           MemorySchema.embedding_input(text),
-           egress_opts(scope)
-         ) do
+    embed =
+      ShrinkLadder.embed_one(
+        MemorySchema.embedding_input(text),
+        &Knowledge.generate_embedding(scope.tenant_id, &1, egress_opts(scope)),
+        label: "Memory.nearest_live tenant=#{scope.tenant_id}"
+      )
+
+    case embed do
       {:error, _reason} ->
         {:error, :embeddings_degraded}
 

--- a/lib/loopctl/workers/article_embedding_worker.ex
+++ b/lib/loopctl/workers/article_embedding_worker.ex
@@ -81,6 +81,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
   import Loopctl.Egress, only: [is_egress_refusal: 1]
   alias Loopctl.Embeddings
   alias Loopctl.Embeddings.Dimensions
+  alias Loopctl.Embeddings.ShrinkLadder
   alias Loopctl.Embeddings.TextBudget
   alias Loopctl.Knowledge
   alias Loopctl.Llm
@@ -164,9 +165,9 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
     # did egress. AC-41.7.2 names exactly that scenario.
     result = embed_with_shrink(tenant_id, article, article_id, text, opts)
 
-    case result do
-      {:ok, embedding} ->
-        store(tenant_id, article_id, embedding, content_hash)
+    case normalize(result, content_hash) do
+      {:ok, embedding, hash} ->
+        store(tenant_id, article_id, embedding, hash)
 
       {:error, :no_api_key} ->
         skip_no_embedding_key(tenant_id, article_id)
@@ -235,55 +236,41 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
     end
   end
 
-  # The shrink ladder. `attempt` arrives as the initial (character-capped) text, so the
-  # first pass sends exactly what the pre-ladder code sent; each rejection re-truncates
-  # what was JUST SENT to half its bytes and re-sends.
+  # The shrink ladder, now the SHARED `ShrinkLadder.embed_one/3` rather than a private
+  # copy of it (#617 review follow-up). This worker had the only implementation, and
+  # every other embedding path grew one that had to agree with it by inspection. The
+  # behaviour is identical — halve what was actually SENT, floor once, then surface the
+  # provider's own error — but the `:truncated` signal now comes back with the vector.
   #
-  # The next budget is derived from `byte_size(attempt)`, never from a nominal rung:
-  # a rung larger than the text truncates nothing, so halving the rung alone would
-  # re-send byte-identical bytes and buy a guaranteed-identical rejection.
-  #
-  # Terminates unconditionally: `TextBudget.next_budget/1` returns `:exhausted` once
-  # the floor has been tried. On `:exhausted` the original error is returned untouched,
-  # so the caller's existing permanent-error branch discards it — a floor-sized input
-  # that is STILL rejected is a different defect (a much smaller model window, e.g. a
-  # self-hosted 512-token embedder) and must be legible as one, not absorbed by more
-  # halving.
+  # That signal is the point. `ArticleEmbeddingWorker` was the ONE remaining writer that
+  # stored a prefix vector under an unmarked hash, and the readers that refuse to judge
+  # on a prefix (`Consolidation.pairwise_similarity_by_group/2`, `Memory`'s near-dup
+  # scan) filter on that mark — so for the tenant's own articles, which is most of the
+  # corpus, the filter matched nothing and the guard could never fire.
   defp embed_with_shrink(tenant_id, article, article_id, attempt, opts) do
-    case embed_with_custody(tenant_id, article, article_id, attempt, opts) do
-      {:error, {:api_error, _status, :context_length_exceeded}} = error ->
-        sent = byte_size(attempt)
-
-        case TextBudget.next_budget(sent) do
-          :exhausted ->
-            Logger.warning(
-              "ArticleEmbeddingWorker: tenant=#{tenant_id} article=#{article_id} rejected as " <>
-                "too long at #{sent} bytes, at or below the #{TextBudget.floor_bytes()}-byte " <>
-                "floor — not a length problem (a smaller model window?); discarding."
-            )
-
-            error
-
-          smaller ->
-            Logger.warning(
-              "ArticleEmbeddingWorker: tenant=#{tenant_id} article=#{article_id} exceeded the " <>
-                "provider token limit at #{sent} bytes; retrying at #{smaller}. The embedding " <>
-                "will cover a prefix of the article, not all of it."
-            )
-
-            embed_with_shrink(
-              tenant_id,
-              article,
-              article_id,
-              TextBudget.truncate(attempt, smaller),
-              opts
-            )
-        end
-
-      result ->
-        result
-    end
+    ShrinkLadder.embed_one(
+      attempt,
+      &embed_with_custody(tenant_id, article, article_id, &1, opts),
+      label: "ArticleEmbeddingWorker tenant=#{tenant_id} article=#{article_id}"
+    )
   end
+
+  # Collapse the ladder's two success shapes into ONE `{:ok, embedding, hash}` so the
+  # caller's `case` keeps a single success branch (it is at credo's complexity ceiling).
+  #
+  # A TRUNCATED vector covers a PREFIX, so its hash is MARKED. The hash still identifies
+  # the FULL text — that is what keeps the idempotency guard from re-walking the ladder
+  # and re-billing on every enqueue (`already_embedded?/3` compares `whole_hash/1`) —
+  # while a reader can still tell a prefix vector from a whole-text one with no schema
+  # migration. This worker writes most of the corpus, so until it marked, the readers
+  # that filter prefixes out (`Consolidation`'s corroboration gate, `Memory`'s near-dup
+  # supersede) were filtering on something nothing ever set.
+  defp normalize({:ok, embedding}, content_hash), do: {:ok, embedding, content_hash}
+
+  defp normalize({:ok, embedding, :truncated}, content_hash),
+    do: {:ok, embedding, ShrinkLadder.truncated_hash(content_hash)}
+
+  defp normalize(other, _content_hash), do: other
 
   defp embed_with_custody(tenant_id, article, article_id, text, opts) do
     recorded = record_custody_posture(tenant_id, article, article_id)
@@ -358,16 +345,26 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
   # unbounded cost loop. Behind the cutover flag the presence+hash check therefore
   # consults the side table at the tenant's active dimension, where the hash HAS been
   # recorded all along.
+  #
+  # Both branches compare through `ShrinkLadder.whole_hash/1` (#617 review follow-up): a
+  # truncation-marked hash still identifies the FULL text, so an article whose vector
+  # covers a prefix is "already embedded" for the content it has. Comparing the raw
+  # stored value instead would miss on every marked row and re-walk the whole ladder —
+  # several billed provider calls — on every single enqueue, which is precisely the
+  # unbounded cost loop this guard was added to close.
   defp already_embedded?(tenant_id, article, content_hash) do
     # Gated on the WRITE dimension (`use_side_table_hash?/1`), NOT the read flag
     # (review): a non-1536 tenant NEVER has a legacy hash, so keying this on the read
     # flag re-billed the provider on every enqueue until cutover.
     if Embeddings.use_side_table_hash?(tenant_id) do
-      Embeddings.article_embedded_hash(
-        tenant_id,
-        article.id,
-        Embeddings.active_dimension(tenant_id)
-      ) == content_hash
+      stored =
+        Embeddings.article_embedded_hash(
+          tenant_id,
+          article.id,
+          Embeddings.active_dimension(tenant_id)
+        )
+
+      is_binary(stored) and ShrinkLadder.whole_hash(stored) == content_hash
     else
       legacy_already_embedded?(article, content_hash)
     end
@@ -378,7 +375,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
          content_hash
        )
        when not is_nil(embedding) and is_binary(hash),
-       do: hash == content_hash
+       do: ShrinkLadder.whole_hash(hash) == content_hash
 
   defp legacy_already_embedded?(_article, _content_hash), do: false
 

--- a/lib/loopctl/workers/batch_article_embedding_worker.ex
+++ b/lib/loopctl/workers/batch_article_embedding_worker.ex
@@ -69,6 +69,7 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorker do
   alias Loopctl.Egress.Scope
   alias Loopctl.Embeddings
   alias Loopctl.Embeddings.Dimensions
+  alias Loopctl.Embeddings.ShrinkLadder
   alias Loopctl.Embeddings.TextBudget
   alias Loopctl.Knowledge
   alias Loopctl.Llm
@@ -177,7 +178,14 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorker do
 
   defp generate_and_store_project_group(tenant_id, project_id, to_embed) do
     to_embed
-    |> chunk_by_char_budget(Knowledge.embedding_batch_max_chars())
+    # The SHARED greedy byte-splitter (#617 review follow-up). This worker's private
+    # `chunk_by_char_budget/2` was the original; `ShrinkLadder.chunk_by_bytes/3` is that
+    # function with the empty-input case fixed (it returned `[[]]`, a phantom sub-batch
+    # that made one no-op provider call), and the re-embed and system-corpus workers
+    # already call it. Two copies of a greedy chunker is one copy too many.
+    |> ShrinkLadder.chunk_by_bytes(Knowledge.embedding_batch_max_chars(), fn {_a, text, _h} ->
+      text
+    end)
     |> embed_sub_batches(tenant_id, project_id)
   end
 
@@ -189,29 +197,6 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorker do
       :dissolve -> {:dissolve, sub_batch ++ Enum.concat(rest)}
       other -> other
     end
-  end
-
-  # Greedy split of `to_embed` tuples into sub-batches whose cumulative text
-  # `byte_size` stays at/under `max_chars`. A single input larger than the budget
-  # (already cut by `TextBudget.initial/1`) still forms its own sub-batch rather than
-  # wedging into an empty one.
-  defp chunk_by_char_budget(to_embed, max_chars) do
-    chunk_fun = fn {_article, text, _hash} = item, {acc, size} ->
-      len = byte_size(text)
-
-      cond do
-        acc == [] -> {:cont, {[item], len}}
-        size + len > max_chars -> {:cont, Enum.reverse(acc), {[item], len}}
-        true -> {:cont, {[item | acc], size + len}}
-      end
-    end
-
-    after_fun = fn
-      {[], _size} -> {:cont, [], {[], 0}}
-      {acc, _size} -> {:cont, Enum.reverse(acc), {[], 0}}
-    end
-
-    Enum.chunk_while(to_embed, {[], 0}, chunk_fun, after_fun)
   end
 
   defp embed_and_store_sub_batch(tenant_id, project_id, to_embed) do
@@ -461,8 +446,14 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorker do
     end
   end
 
+  # Compared through `ShrinkLadder.whole_hash/1` (#617 review follow-up), like every other
+  # idempotency guard on this surface: a truncation-marked hash still identifies the FULL
+  # text, so a row whose vector covers a prefix is already embedded for the content it
+  # has. Comparing the raw stored value would miss on every marked row and re-bill the
+  # provider for the whole batch on each enqueue — and worse, the re-embed would then
+  # store an UNMARKED hash and erase the mark the readers filter on.
   defp already_embedded?(article, content_hash, hashes) when is_map(hashes),
-    do: Map.get(hashes, article.id) == content_hash
+    do: whole_hash_matches?(Map.get(hashes, article.id), content_hash)
 
   defp already_embedded?(article, content_hash, _hashes),
     do: legacy_already_embedded?(article, content_hash)
@@ -472,9 +463,14 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorker do
          content_hash
        )
        when is_binary(hash),
-       do: hash == content_hash
+       do: whole_hash_matches?(hash, content_hash)
 
   defp legacy_already_embedded?(_article, _content_hash), do: false
+
+  defp whole_hash_matches?(stored, content_hash) when is_binary(stored),
+    do: ShrinkLadder.whole_hash(stored) == content_hash
+
+  defp whole_hash_matches?(_stored, _content_hash), do: false
 
   defp content_hash(text) do
     :sha256 |> :crypto.hash(text) |> Base.encode16(case: :lower)

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -119,6 +119,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   alias Loopctl.Knowledge.Consolidation
   alias Loopctl.Knowledge.LinkPruning
   alias Loopctl.Oban.FairShare
+  alias Loopctl.SystemConfig
   alias Loopctl.Tenants.Tenant
   alias Loopctl.Workers.ArticleLinkingWorker
   alias Loopctl.Workers.BatchArticleEmbeddingWorker
@@ -591,20 +592,78 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # them as opts and the worker passed none, so the nightly was pinned to the module defaults
   # whatever an operator configured. That is why draining the standing backlog required
   # calling the context directly, which is not a thing a self-maintaining pass should need.
-  defp applies_cap do
-    Application.get_env(
-      :loopctl,
+  #
+  # Resolved through `SystemConfig` FIRST (#617). These three caps are the only lever that
+  # slows or stops the nightly drain, and until now the only way to move one was a deploy —
+  # an operator watching an auto-unpublish go wrong had no way to halt it in the minutes
+  # that matter. `SystemConfig` is DB-backed, survives restart, propagates to the fleet, and
+  # is testable by seeding a row.
+  #
+  # Explicitly NOT `Application.put_env/3` as the live lever: that is per-NODE, does not
+  # survive a restart, and fails open and silently — and mutating VM-global state makes the
+  # code untestable in an `async: true` suite. `Application.get_env/3` REMAINS the layer
+  # beneath, so a compile-time config (including `config/test.exs`) is still honoured when
+  # no DB row exists. Resolution order: DB row -> app config -> module default.
+  # Public (`@doc false`) so the resolution ORDER can be asserted directly. It is the
+  # operator's only mid-incident lever, and a lever nothing tests is a lever nobody can
+  # trust to be there when it is needed.
+  @doc false
+  @spec applies_cap() :: integer()
+  def applies_cap do
+    tunable(
+      "knowledge_consolidation_max_applies",
       :knowledge_consolidation_max_applies,
       Consolidation.default_max_applies()
     )
   end
 
-  defp unpublishes_cap do
-    Application.get_env(
-      :loopctl,
+  @doc false
+  @spec unpublishes_cap() :: integer()
+  def unpublishes_cap do
+    tunable(
+      "knowledge_consolidation_max_unpublishes",
       :knowledge_consolidation_max_unpublishes,
       Consolidation.default_max_unpublishes()
     )
+  end
+
+  @doc false
+  @spec per_class_cap() :: integer()
+  def per_class_cap do
+    tunable(
+      "knowledge_consolidation_max_per_class",
+      :knowledge_consolidation_max_per_class,
+      Consolidation.default_max_per_class()
+    )
+  end
+
+  # `get_int/2`'s own contract is that a missing row, a non-integer row, or ANY error
+  # returns the default — so the app-config value is what a fresh install and an unprimed
+  # cache both see, exactly as before this indirection existed.
+  defp tunable(db_key, app_key, default) do
+    SystemConfig.get_int(db_key, coerce_int(Application.get_env(:loopctl, app_key), default))
+  end
+
+  # The app-config layer is type-checked rather than trusted: `SystemConfig.get_int/2`
+  # requires an INTEGER default and would raise a FunctionClauseError on a `nil` or a
+  # `"25"` from a hand-edited config. Inside the nightly's rescue that surfaces as a
+  # generic `apply_failed`, which reads as an outage rather than as the config typo it is.
+  #
+  # Takes the VALUE, not the key, so it is testable without mutating VM-global application
+  # state — `Application.put_env/3` in a test is banned here for exactly the reason this
+  # whole change routes the live lever through the DB instead.
+  @doc false
+  @spec coerce_int(term(), integer()) :: integer()
+  def coerce_int(value, _default) when is_integer(value), do: value
+  def coerce_int(nil, default), do: default
+
+  def coerce_int(other, default) do
+    Logger.warning(
+      "KnowledgeLintWorker: ignoring non-integer consolidation cap #{inspect(other)}; " <>
+        "using #{default}."
+    )
+
+    default
   end
 
   defp apply_failed(tenant_id, tag) do
@@ -644,14 +703,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # the audit event instead, as a low-cardinality TAG (never the raw error, which carries
   # backend host / database / role).
   defp consolidate(tenant_id) do
-    max_per_class =
-      Application.get_env(
-        :loopctl,
-        :knowledge_consolidation_max_per_class,
-        Consolidation.default_max_per_class()
-      )
-
-    {:ok, consolidation} = Consolidation.run(tenant_id, max_per_class: max_per_class)
+    {:ok, consolidation} = Consolidation.run(tenant_id, max_per_class: per_class_cap())
     {:ok, consolidation}
   rescue
     error -> consolidation_failed(tenant_id, ExitTag.tag(error))

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -214,6 +214,9 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     })
 
     Logger.info(
+      # The #616 content gate is the single most likely reason a night applied nothing, and
+      # without this counter that night is byte-identical to a clean corpus in both this
+      # line and the audit event.
       "KnowledgeLintWorker: tenant=#{tenant_id} issues=#{report.summary.total_issues} " <>
         "orphans_relinked=#{action.relinked} orphans_embedding_enqueued=#{action.embedding_enqueued} " <>
         "conflicts_promoted=#{promoted} conflicts_judged_redundant=#{judged} " <>
@@ -222,6 +225,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         "duplicates_unpublished=#{applied.applied} duplicate_groups_skipped=#{applied.skipped} " <>
         "duplicate_apply_gate=#{applied.gate} " <>
         "duplicates_unpublish_failed=#{applied.failed} " <>
+        "duplicate_groups_uncorroborated=#{applied.uncorroborated} " <>
         consolidation_log(consolidation)
     )
 
@@ -683,7 +687,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # `:scan_failed` path guard the `:apply_failed` one, which needs a repo-level failure to
   # provoke.
   defp empty_tally(gate, error \\ nil),
-    do: %{applied: 0, skipped: 0, failed: 0, gate: gate, error: error}
+    do: %{applied: 0, skipped: 0, failed: 0, uncorroborated: 0, gate: gate, error: error}
 
   # Writes the consolidation report + its proposal rows and nothing else. The APPLY is a
   # separate step (`apply_consolidation/2`, above) on purpose: this one must run first so
@@ -749,6 +753,11 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
       "duplicates_unpublished" => applied.applied,
       "duplicate_groups_skipped" => applied.skipped,
       "duplicates_unpublish_failed" => applied.failed,
+      # Groups the #616 corroboration gate WITHHELD (title collision, bodies do not agree,
+      # or the members carry no vectors yet). Without it, a tenant whose every confirmed
+      # group is withheld records applied=0 skipped=0 failed=0 gate=open — exactly what a
+      # clean corpus records — and only per-group warnings say otherwise.
+      "duplicate_groups_uncorroborated" => applied.uncorroborated,
       # WHY nothing was applied, when nothing was. `:open` with zeroes is a clean corpus;
       # `:report_gap` / `:insufficient_history` mean the agreement gate refused to run,
       # `:drain_disabled` means an operator set a cap to 0, and `:apply_failed` means it ran

--- a/lib/loopctl/workers/memory_embedding_worker.ex
+++ b/lib/loopctl/workers/memory_embedding_worker.ex
@@ -148,11 +148,12 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
     # of the FULL text, so a truncated embed still satisfies the idempotency guard
     # instead of re-billing every enqueue.
     result =
-      ShrinkLadder.embed_one(
-        text,
+      text
+      |> ShrinkLadder.embed_one(
         &embed_with_custody(tenant_id, memory_id, &1, project_id),
         label: "MemoryEmbeddingWorker tenant=#{tenant_id} memory=#{memory_id}"
       )
+      |> store_prefix_too()
 
     case result do
       {:ok, embedding} ->
@@ -228,6 +229,13 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
 
   defp custody_outcome({:ok, _}), do: :succeeded
   defp custody_outcome(_other), do: :failed
+
+  # A PREFIX vector (`:truncated`) is stored like any other: recall over part of an
+  # over-long memory is the whole point of the ladder here, and nothing on this path
+  # compares the vector against a whole-text one — unlike the promotion near-dup read,
+  # which refuses a prefix outright (`Memory.nearest_live/2`).
+  defp store_prefix_too({:ok, embedding, :truncated}), do: {:ok, embedding}
+  defp store_prefix_too(result), do: result
 
   defp store(tenant_id, memory_id, embedding, content_hash) do
     # Pre-write dimension check (review): an off-dimension model otherwise surfaced as a

--- a/lib/loopctl/workers/memory_embedding_worker.ex
+++ b/lib/loopctl/workers/memory_embedding_worker.ex
@@ -63,6 +63,7 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
   import Loopctl.Egress, only: [is_egress_refusal: 1]
   alias Loopctl.Embeddings
   alias Loopctl.Embeddings.Dimensions
+  alias Loopctl.Embeddings.ShrinkLadder
   alias Loopctl.Knowledge
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
@@ -137,7 +138,21 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
     # Recorded BEFORE the call so a provider failure that happens AFTER the body
     # left the process still leaves a recorded operation naming the endpoint, and
     # never a contiguous sequence that omits it.
-    result = embed_with_custody(tenant_id, memory_id, text, project_id)
+    # Through `ShrinkLadder.embed_one/3` (#617). Without it an input-too-long
+    # rejection fell to the generic branch below, where `permanent_provider_error?/1`
+    # is `true` for any 4xx, and the memory DISCARDED — permanently absent from
+    # semantic recall with no repair path, the same shape as the 80-article article
+    # outage #615 fixed. Each rung re-enters `embed_with_custody/4` so every provider
+    # call it makes is its own recorded posture entry, exactly as
+    # `ArticleEmbeddingWorker`'s ladder does; `content_hash` deliberately stays that
+    # of the FULL text, so a truncated embed still satisfies the idempotency guard
+    # instead of re-billing every enqueue.
+    result =
+      ShrinkLadder.embed_one(
+        text,
+        &embed_with_custody(tenant_id, memory_id, &1, project_id),
+        label: "MemoryEmbeddingWorker tenant=#{tenant_id} memory=#{memory_id}"
+      )
 
     case result do
       {:ok, embedding} ->

--- a/lib/loopctl/workers/memory_embedding_worker.ex
+++ b/lib/loopctl/workers/memory_embedding_worker.ex
@@ -147,17 +147,18 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
     # `ArticleEmbeddingWorker`'s ladder does; `content_hash` deliberately stays that
     # of the FULL text, so a truncated embed still satisfies the idempotency guard
     # instead of re-billing every enqueue.
-    result =
+    {result, stored_hash} =
       text
       |> ShrinkLadder.embed_one(
         &embed_with_custody(tenant_id, memory_id, &1, project_id),
         label: "MemoryEmbeddingWorker tenant=#{tenant_id} memory=#{memory_id}"
       )
+      |> then(&{&1, content_hash})
       |> store_prefix_too()
 
     case result do
       {:ok, embedding} ->
-        store(tenant_id, memory_id, embedding, content_hash)
+        store(tenant_id, memory_id, embedding, stored_hash)
 
       {:error, :no_api_key} ->
         skip_no_embedding_key(tenant_id, memory_id)
@@ -230,12 +231,17 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
   defp custody_outcome({:ok, _}), do: :succeeded
   defp custody_outcome(_other), do: :failed
 
-  # A PREFIX vector (`:truncated`) is stored like any other: recall over part of an
-  # over-long memory is the whole point of the ladder here, and nothing on this path
-  # compares the vector against a whole-text one — unlike the promotion near-dup read,
-  # which refuses a prefix outright (`Memory.nearest_live/2`).
-  defp store_prefix_too({:ok, embedding, :truncated}), do: {:ok, embedding}
-  defp store_prefix_too(result), do: result
+  # A PREFIX vector (`:truncated`) IS stored — recall over part of an over-long memory is
+  # the whole point of the ladder — but stored MARKED. `Memory.first_promoted_near_dup/1`
+  # scans every promoted row's vector, so an unmarked prefix here would be compared at the
+  # near-dup threshold against candidates embedded from their WHOLE slice and could
+  # SUPERSEDE the longer memory: the same mismatched-extent compare `nearest_live/2`
+  # refuses on the candidate side, arriving from the other direction. The mark rides the
+  # content hash (`ShrinkLadder.truncated_hash/1`), which still identifies the full text.
+  defp store_prefix_too({{:ok, embedding, :truncated}, hash}),
+    do: {{:ok, embedding}, ShrinkLadder.truncated_hash(hash)}
+
+  defp store_prefix_too({result, hash}), do: {result, hash}
 
   defp store(tenant_id, memory_id, embedding, content_hash) do
     # Pre-write dimension check (review): an off-dimension model otherwise surfaced as a
@@ -284,11 +290,15 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
     # WRITE-dimension gated (`use_side_table_hash?/1`), not read-flag gated (review):
     # a non-1536 tenant has no legacy hash, so the read-flag gate re-billed the provider
     # on every enqueue until cutover.
+    # `whole_hash/1`: a truncation-marked hash still identifies the FULL text, so a
+    # prefix-embedded memory is already embedded and must not re-bill on every enqueue.
     if Embeddings.use_side_table_hash?(tenant_id) do
-      Embeddings.memory_embedded_hash(
-        tenant_id,
-        memory.id,
-        Embeddings.active_dimension(tenant_id)
+      ShrinkLadder.whole_hash(
+        Embeddings.memory_embedded_hash(
+          tenant_id,
+          memory.id,
+          Embeddings.active_dimension(tenant_id)
+        )
       ) == content_hash
     else
       legacy_already_embedded?(memory, content_hash)
@@ -300,7 +310,7 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
          content_hash
        )
        when not is_nil(embedding) and is_binary(hash),
-       do: hash == content_hash
+       do: ShrinkLadder.whole_hash(hash) == content_hash
 
   defp legacy_already_embedded?(_memory, _content_hash), do: false
 

--- a/lib/loopctl/workers/reembed_worker.ex
+++ b/lib/loopctl/workers/reembed_worker.ex
@@ -221,7 +221,29 @@ defmodule Loopctl.Workers.ReembedWorker do
   # BatchArticleEmbeddingWorker answer) is wrong here: that worker writes the ACTIVE
   # dimension with the configured model, not this run's PENDING dimension and pinned
   # model. Bisect-then-ladder keeps both pins and truncates only the offender.
+  #
+  # Sub-split by the CUMULATIVE byte budget first (`Knowledge.embedding_batch_max_chars/0`),
+  # exactly as `BatchArticleEmbeddingWorker` does and for the same reason: the count cap
+  # does not bound aggregate tokens, so 100 x ~32K chars is ~800k tokens against a ~300k
+  # per-request ceiling. That rejection names no member, so the ladder would bisect EVERY
+  # batch EVERY night — paying the whole tree as routine rather than as the one-time
+  # recovery it is for. Each sub-batch is embedded AND STORED before the next, so a
+  # failure later in the run keeps what has already been paid for (the next attempt's
+  # pending set no longer names those rows).
   defp embed_and_store(tenant_id, target_dim, model, entries, opts, store_fun) do
+    entries
+    |> ShrinkLadder.chunk_by_bytes(Knowledge.embedding_batch_max_chars(), fn {_s, text} ->
+      text
+    end)
+    |> Enum.reduce_while(:ok, fn chunk, :ok ->
+      case embed_sub_batch(tenant_id, target_dim, model, chunk, opts, store_fun) do
+        :ok -> {:cont, :ok}
+        other -> {:halt, other}
+      end
+    end)
+  end
+
+  defp embed_sub_batch(tenant_id, target_dim, model, entries, opts, store_fun) do
     texts = Enum.map(entries, fn {_subject, text} -> text end)
     embed_opts = [embedding_model: reembed_model(model)] ++ opts
 

--- a/lib/loopctl/workers/reembed_worker.ex
+++ b/lib/loopctl/workers/reembed_worker.ex
@@ -85,13 +85,13 @@ defmodule Loopctl.Workers.ReembedWorker do
   alias Loopctl.Egress
   alias Loopctl.Embeddings
   alias Loopctl.Embeddings.Dimensions
+  alias Loopctl.Embeddings.ShrinkLadder
+  alias Loopctl.Embeddings.TextBudget
   alias Loopctl.Knowledge
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
   alias Loopctl.Provider.Admission
   alias Loopctl.Provider.RetryAfter
-
-  @max_text_length 32_000
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"tenant_id" => tenant_id, "target_dim" => target_dim} = args})
@@ -213,19 +213,31 @@ defmodule Loopctl.Workers.ReembedWorker do
   # while this runs. This worker's whole job is to produce vectors at the PENDING
   # model's dimension, so it — and only it — uses the tenant's currently configured
   # model.
+  # The array call goes through `ShrinkLadder.embed_batch/3` (#617): an input-too-long
+  # rejection used to fall through `handle_error/2` to `permanent_provider_error?/1`,
+  # which is `true` for any 4xx — so ONE over-long article DISCARDED the job, the
+  # re-embed never reached `complete_reembed/3`, and the tenant's recall stayed pinned
+  # at the old dimension permanently. Dissolving to `ArticleEmbeddingWorker` (the
+  # BatchArticleEmbeddingWorker answer) is wrong here: that worker writes the ACTIVE
+  # dimension with the configured model, not this run's PENDING dimension and pinned
+  # model. Bisect-then-ladder keeps both pins and truncates only the offender.
   defp embed_and_store(tenant_id, target_dim, model, entries, opts, store_fun) do
     texts = Enum.map(entries, fn {_subject, text} -> text end)
+    embed_opts = [embedding_model: reembed_model(model)] ++ opts
 
-    case Knowledge.generate_embeddings(
-           tenant_id,
-           texts,
-           [embedding_model: reembed_model(model)] ++ opts
-         ) do
-      {:ok, vectors} when length(vectors) == length(entries) ->
+    result =
+      ShrinkLadder.embed_batch(
+        texts,
+        &Knowledge.generate_embeddings(tenant_id, &1, embed_opts),
+        label: "ReembedWorker tenant=#{tenant_id}"
+      )
+
+    case result do
+      {:ok, vectors} ->
         store_checked(tenant_id, target_dim, entries, vectors, store_fun)
 
-      {:ok, _mismatch} ->
-        {:error, :embedding_batch_length_mismatch}
+      {:error, :embedding_batch_length_mismatch} = mismatch ->
+        mismatch
 
       {:error, reason} ->
         handle_error(tenant_id, reason)
@@ -369,11 +381,15 @@ defmodule Loopctl.Workers.ReembedWorker do
     end
   end
 
+  # `TextBudget.initial/1` is the same 32,000-CHARACTER cut this worker has always
+  # applied, now named once (#617) so the first attempt cannot drift away from the
+  # rung the ladder starts below. It stays CHARACTERS on purpose: a byte cap here
+  # would silently shorten multi-byte text the provider was already accepting.
   defp article_text(article) do
-    String.slice("#{article.title}\n\n#{article.body}", 0, @max_text_length)
+    TextBudget.initial("#{article.title}\n\n#{article.body}")
   end
 
-  defp memory_text(memory), do: String.slice(memory.text || "", 0, @max_text_length)
+  defp memory_text(memory), do: TextBudget.initial(memory.text || "")
 
   defp content_hash(text), do: :sha256 |> :crypto.hash(text) |> Base.encode16(case: :lower)
 end

--- a/lib/loopctl/workers/reembed_worker.ex
+++ b/lib/loopctl/workers/reembed_worker.ex
@@ -87,6 +87,7 @@ defmodule Loopctl.Workers.ReembedWorker do
   alias Loopctl.Embeddings.Dimensions
   alias Loopctl.Embeddings.ShrinkLadder
   alias Loopctl.Embeddings.TextBudget
+  alias Loopctl.ExitTag
   alias Loopctl.Knowledge
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
@@ -266,12 +267,77 @@ defmodule Loopctl.Workers.ReembedWorker do
       {:ok, vectors, truncated} ->
         store_checked(tenant_id, target_dim, entries, vectors, truncated, store_fun)
 
-      {:error, :embedding_batch_length_mismatch} = mismatch ->
-        mismatch
+      # PARTIAL: the bisect embedded some members before another half failed (#617 review
+      # follow-up). Those vectors are already billed, and this worker self-continues off
+      # `pending_reembed_*`, so storing them is what makes the retry's pending set smaller
+      # — otherwise a deterministic failure re-pays for the same members every attempt and
+      # the re-embed never advances. The error is still propagated afterwards.
+      {:error, reason, partial} ->
+        store_partial(tenant_id, target_dim, entries, partial, store_fun)
+        propagate(tenant_id, reason)
 
       {:error, reason} ->
-        handle_error(tenant_id, reason)
+        propagate(tenant_id, reason)
     end
+  end
+
+  defp propagate(_tenant_id, :embedding_batch_length_mismatch),
+    do: {:error, :embedding_batch_length_mismatch}
+
+  defp propagate(tenant_id, reason), do: handle_error(tenant_id, reason)
+
+  # Best-effort: a store failure here must not mask the provider error that caused the
+  # partial in the first place, which is the one the Oban outcome is derived from.
+  defp store_partial(_tenant_id, _target_dim, _entries, [], _store_fun), do: :ok
+
+  defp store_partial(tenant_id, target_dim, entries, partial, store_fun) do
+    by_index = Map.new(Enum.with_index(entries), fn {entry, i} -> {i, entry} end)
+
+    salvaged =
+      Enum.flat_map(partial, fn {index, vector, truncated?} ->
+        case Map.fetch(by_index, index) do
+          {:ok, entry} -> [{entry, vector, truncated?}]
+          :error -> []
+        end
+      end)
+
+    # `store_checked/6` takes truncated indexes relative to the list it is GIVEN, and the
+    # salvaged list is a compaction of the original — so the indexes are recomputed here
+    # rather than carried over. Reusing the original-array indexes would mark the wrong
+    # rows, which is worse than not marking them: a whole-text vector labelled a prefix is
+    # silently dropped from the corroboration gate that decides auto-unpublishes.
+    salvaged_entries = Enum.map(salvaged, fn {entry, _vector, _truncated?} -> entry end)
+    salvaged_vectors = Enum.map(salvaged, fn {_entry, vector, _truncated?} -> vector end)
+
+    salvaged_truncated =
+      salvaged
+      |> Enum.with_index()
+      |> Enum.filter(fn {{_entry, _vector, truncated?}, _i} -> truncated? end)
+      |> Enum.map(fn {_triple, i} -> i end)
+
+    Logger.info(
+      "ReembedWorker: tenant=#{tenant_id} storing #{length(salvaged)} already-embedded " <>
+        "member(s) from a partially-failed batch, so the retry does not re-bill them."
+    )
+
+    store_checked(
+      tenant_id,
+      target_dim,
+      salvaged_entries,
+      salvaged_vectors,
+      salvaged_truncated,
+      store_fun
+    )
+
+    :ok
+  rescue
+    e ->
+      Logger.warning(
+        "ReembedWorker: tenant=#{tenant_id} could not store the salvaged partial batch " <>
+          "(#{ExitTag.tag(e)}); those members will be re-embedded on the retry."
+      )
+
+      :ok
   end
 
   # WHICH model this re-embed generates with. The model captured at ENQUEUE (finding

--- a/lib/loopctl/workers/reembed_worker.ex
+++ b/lib/loopctl/workers/reembed_worker.ex
@@ -256,7 +256,15 @@ defmodule Loopctl.Workers.ReembedWorker do
 
     case result do
       {:ok, vectors} ->
-        store_checked(tenant_id, target_dim, entries, vectors, store_fun)
+        store_checked(tenant_id, target_dim, entries, vectors, [], store_fun)
+
+      # The ladder could only embed these members as a PREFIX. They are stored (recall
+      # over part of an over-long text is the point of the ladder) but MARKED, so the
+      # readers that COMPARE vectors — the consolidation corroboration gate, the memory
+      # near-dup supersede — can tell a prefix from a whole text instead of judging one
+      # against the other.
+      {:ok, vectors, truncated} ->
+        store_checked(tenant_id, target_dim, entries, vectors, truncated, store_fun)
 
       {:error, :embedding_batch_length_mismatch} = mismatch ->
         mismatch
@@ -274,12 +282,16 @@ defmodule Loopctl.Workers.ReembedWorker do
   defp reembed_model(nil), do: :configured
   defp reembed_model(model) when is_binary(model), do: model
 
-  defp store_checked(tenant_id, target_dim, entries, vectors, store_fun) do
+  defp store_checked(tenant_id, target_dim, entries, vectors, truncated, store_fun) do
     case Dimensions.check_batch_length(vectors, target_dim) do
       :ok ->
+        marked = MapSet.new(truncated)
+
         triples =
-          Enum.zip_with(entries, vectors, fn {subject, text}, vector ->
-            {subject, vector, content_hash(text)}
+          entries
+          |> Enum.zip(vectors)
+          |> Enum.with_index(fn {{subject, text}, vector}, index ->
+            {subject, vector, hash_for(text, MapSet.member?(marked, index))}
           end)
 
         # The side table ONLY (`legacy_write: false`, review). The target dimension
@@ -414,4 +426,7 @@ defmodule Loopctl.Workers.ReembedWorker do
   defp memory_text(memory), do: TextBudget.initial(memory.text || "")
 
   defp content_hash(text), do: :sha256 |> :crypto.hash(text) |> Base.encode16(case: :lower)
+
+  defp hash_for(text, false), do: content_hash(text)
+  defp hash_for(text, true), do: text |> content_hash() |> ShrinkLadder.truncated_hash()
 end

--- a/lib/loopctl/workers/system_corpus_embedding_worker.ex
+++ b/lib/loopctl/workers/system_corpus_embedding_worker.ex
@@ -125,14 +125,36 @@ defmodule Loopctl.Workers.SystemCorpusEmbeddingWorker do
     embed_entries(tenant_id, dim, entries)
   end
 
-  defp embed_entries(tenant_id, dim, []), do: continue(tenant_id, dim)
-
   # Through `ShrinkLadder.embed_batch/3` (#617). An input-too-long rejection used to
   # reach `handle_error/2`, where `permanent_provider_error?/1` is `true` for any 4xx —
   # so one over-long canonical DISCARDED the job and left that canonical keyword-only
   # for this tenant while `system_corpus_meta/2` kept reporting "semantic". The ladder
   # bisects to isolate the offender and truncates only it.
+  #
+  # Sub-split by the CUMULATIVE byte budget FIRST (`Knowledge.embedding_batch_max_chars/0`),
+  # exactly as `BatchArticleEmbeddingWorker` does: the count cap does not bound aggregate
+  # tokens, and an AGGREGATE rejection names no member — so without this the ladder would
+  # bisect every batch on every run, paying the whole tree as routine rather than as the
+  # one-time recovery it exists to be. Each sub-batch is stored before the next, so an
+  # error later in the batch keeps what was already paid for (`split_unchanged/3` skips it).
   defp embed_entries(tenant_id, dim, entries) do
+    entries
+    |> ShrinkLadder.chunk_by_bytes(Knowledge.embedding_batch_max_chars(), fn {_a, text} ->
+      text
+    end)
+    |> Enum.reduce_while(:ok, fn chunk, :ok ->
+      case embed_sub_batch(tenant_id, dim, chunk) do
+        :ok -> {:cont, :ok}
+        other -> {:halt, other}
+      end
+    end)
+    |> case do
+      :ok -> continue(tenant_id, dim)
+      other -> other
+    end
+  end
+
+  defp embed_sub_batch(tenant_id, dim, entries) do
     texts = Enum.map(entries, fn {_a, text} -> text end)
 
     result =
@@ -182,24 +204,22 @@ defmodule Loopctl.Workers.SystemCorpusEmbeddingWorker do
     end
   end
 
+  # Returns `:ok` WITHOUT continuing: `embed_entries/3` drives the sub-batches and calls
+  # `continue/2` once, after the last one — continuing here would enqueue the next page
+  # per sub-batch.
   defp do_store_all(tenant_id, dim, pairs) do
-    result =
-      Enum.reduce_while(pairs, :ok, fn {{article, text}, vector}, :ok ->
-        case Embeddings.materialize_system_article_embedding(
-               tenant_id,
-               article,
-               vector,
-               content_hash(text),
-               dim
-             ) do
-          {:ok, _row} -> {:cont, :ok}
-          {:error, reason} -> {:halt, {:error, reason}}
-        end
-      end)
-
-    with :ok <- result do
-      continue(tenant_id, dim)
-    end
+    Enum.reduce_while(pairs, :ok, fn {{article, text}, vector}, :ok ->
+      case Embeddings.materialize_system_article_embedding(
+             tenant_id,
+             article,
+             vector,
+             content_hash(text),
+             dim
+           ) do
+        {:ok, _row} -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
   end
 
   defp discard_mismatch(expected, actual) do

--- a/lib/loopctl/workers/system_corpus_embedding_worker.ex
+++ b/lib/loopctl/workers/system_corpus_embedding_worker.ex
@@ -69,6 +69,7 @@ defmodule Loopctl.Workers.SystemCorpusEmbeddingWorker do
   alias Loopctl.Embeddings.Dimensions
   alias Loopctl.Embeddings.ShrinkLadder
   alias Loopctl.Embeddings.TextBudget
+  alias Loopctl.ExitTag
   alias Loopctl.Knowledge
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
@@ -173,12 +174,55 @@ defmodule Loopctl.Workers.SystemCorpusEmbeddingWorker do
       {:ok, vectors, truncated} ->
         store_all(tenant_id, dim, zip_marked(entries, vectors, truncated))
 
-      {:error, :embedding_batch_length_mismatch} = mismatch ->
-        mismatch
+      # PARTIAL: the bisect embedded some members before another half failed (#617 review
+      # follow-up). Those vectors are already billed, and `split_unchanged/3` skips a
+      # stored member on the retry — so storing them is what stops a deterministic failure
+      # re-paying for the same canonicals on every attempt. The error still propagates.
+      {:error, reason, partial} ->
+        store_partial(tenant_id, dim, entries, partial)
+        propagate(tenant_id, reason)
 
       {:error, reason} ->
-        handle_error(tenant_id, reason)
+        propagate(tenant_id, reason)
     end
+  end
+
+  defp propagate(_tenant_id, :embedding_batch_length_mismatch),
+    do: {:error, :embedding_batch_length_mismatch}
+
+  defp propagate(tenant_id, reason), do: handle_error(tenant_id, reason)
+
+  # Best-effort: a store failure here must not mask the provider error the Oban outcome is
+  # derived from.
+  defp store_partial(_tenant_id, _dim, _entries, []), do: :ok
+
+  defp store_partial(tenant_id, dim, entries, partial) do
+    by_index = Map.new(Enum.with_index(entries), fn {entry, i} -> {i, entry} end)
+
+    triples =
+      Enum.flat_map(partial, fn {index, vector, truncated?} ->
+        case Map.fetch(by_index, index) do
+          {:ok, {article, text}} -> [{article, vector, hash_for(text, truncated?)}]
+          :error -> []
+        end
+      end)
+
+    Logger.info(
+      "SystemCorpusEmbeddingWorker: tenant=#{tenant_id} storing #{length(triples)} " <>
+        "already-embedded canonical(s) from a partially-failed batch, so the retry does " <>
+        "not re-bill them."
+    )
+
+    store_all(tenant_id, dim, triples)
+    :ok
+  rescue
+    e ->
+      Logger.warning(
+        "SystemCorpusEmbeddingWorker: tenant=#{tenant_id} could not store the salvaged " <>
+          "partial batch (#{ExitTag.tag(e)}); those members re-embed on the retry."
+      )
+
+      :ok
   end
 
   # ONE batched hash read for the whole batch (AC-41.1.11: no per-item query).

--- a/lib/loopctl/workers/system_corpus_embedding_worker.ex
+++ b/lib/loopctl/workers/system_corpus_embedding_worker.ex
@@ -67,13 +67,13 @@ defmodule Loopctl.Workers.SystemCorpusEmbeddingWorker do
   alias Loopctl.Egress
   alias Loopctl.Embeddings
   alias Loopctl.Embeddings.Dimensions
+  alias Loopctl.Embeddings.ShrinkLadder
+  alias Loopctl.Embeddings.TextBudget
   alias Loopctl.Knowledge
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
   alias Loopctl.Provider.Admission
   alias Loopctl.Provider.RetryAfter
-
-  @max_text_length 32_000
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"tenant_id" => tenant_id} = args}) when is_binary(tenant_id) do
@@ -127,15 +127,27 @@ defmodule Loopctl.Workers.SystemCorpusEmbeddingWorker do
 
   defp embed_entries(tenant_id, dim, []), do: continue(tenant_id, dim)
 
+  # Through `ShrinkLadder.embed_batch/3` (#617). An input-too-long rejection used to
+  # reach `handle_error/2`, where `permanent_provider_error?/1` is `true` for any 4xx —
+  # so one over-long canonical DISCARDED the job and left that canonical keyword-only
+  # for this tenant while `system_corpus_meta/2` kept reporting "semantic". The ladder
+  # bisects to isolate the offender and truncates only it.
   defp embed_entries(tenant_id, dim, entries) do
     texts = Enum.map(entries, fn {_a, text} -> text end)
 
-    case Knowledge.generate_embeddings(tenant_id, texts) do
-      {:ok, vectors} when length(vectors) == length(entries) ->
+    result =
+      ShrinkLadder.embed_batch(
+        texts,
+        &Knowledge.generate_embeddings(tenant_id, &1),
+        label: "SystemCorpusEmbeddingWorker tenant=#{tenant_id}"
+      )
+
+    case result do
+      {:ok, vectors} ->
         store_all(tenant_id, dim, Enum.zip(entries, vectors))
 
-      {:ok, _mismatch} ->
-        {:error, :embedding_batch_length_mismatch}
+      {:error, :embedding_batch_length_mismatch} = mismatch ->
+        mismatch
 
       {:error, reason} ->
         handle_error(tenant_id, reason)
@@ -254,8 +266,11 @@ defmodule Loopctl.Workers.SystemCorpusEmbeddingWorker do
 
   defp batch_size, do: Knowledge.embedding_batch_max()
 
+  # The same 32,000-CHARACTER first attempt as before, named once (#617) so it cannot
+  # drift from the rung `ShrinkLadder` starts below. The hash in `split_unchanged/3`
+  # is computed over exactly this text, so the cut must not change silently.
   defp embedding_text(article) do
-    String.slice("#{article.title}\n\n#{article.body}", 0, @max_text_length)
+    TextBudget.initial("#{article.title}\n\n#{article.body}")
   end
 
   defp content_hash(text), do: :sha256 |> :crypto.hash(text) |> Base.encode16(case: :lower)

--- a/lib/loopctl/workers/system_corpus_embedding_worker.ex
+++ b/lib/loopctl/workers/system_corpus_embedding_worker.ex
@@ -166,7 +166,12 @@ defmodule Loopctl.Workers.SystemCorpusEmbeddingWorker do
 
     case result do
       {:ok, vectors} ->
-        store_all(tenant_id, dim, Enum.zip(entries, vectors))
+        store_all(tenant_id, dim, zip_marked(entries, vectors, []))
+
+      # A member the ladder could only embed as a PREFIX is stored MARKED, so a reader
+      # that COMPARES vectors can tell it from a whole-text one (see `ShrinkLadder`).
+      {:ok, vectors, truncated} ->
+        store_all(tenant_id, dim, zip_marked(entries, vectors, truncated))
 
       {:error, :embedding_batch_length_mismatch} = mismatch ->
         mismatch
@@ -187,7 +192,9 @@ defmodule Loopctl.Workers.SystemCorpusEmbeddingWorker do
 
     Enum.split_with(entries, fn {article, text} ->
       case Map.get(hashes, article.id) do
-        stored when is_binary(stored) -> stored == content_hash(text)
+        # `whole_hash/1`: a truncation-marked hash still identifies the FULL text, so an
+        # article whose vector is a prefix is UNCHANGED and must not be re-billed.
+        stored when is_binary(stored) -> ShrinkLadder.whole_hash(stored) == content_hash(text)
         _ -> false
       end
     end)
@@ -197,23 +204,33 @@ defmodule Loopctl.Workers.SystemCorpusEmbeddingWorker do
   # failure means zero writes and the batch retries as a unit. The batch's vector
   # LENGTH is checked once, before the first write, so a model that does not emit
   # `dim` fails legibly instead of burning five attempts of provider spend.
-  defp store_all(tenant_id, dim, pairs) do
-    case Dimensions.check_batch_length(Enum.map(pairs, fn {_entry, v} -> v end), dim) do
-      :ok -> do_store_all(tenant_id, dim, pairs)
+  defp store_all(tenant_id, dim, triples) do
+    case Dimensions.check_batch_length(Enum.map(triples, fn {_a, v, _h} -> v end), dim) do
+      :ok -> do_store_all(tenant_id, dim, triples)
       {:error, {:dimension_mismatch, expected, actual}} -> discard_mismatch(expected, actual)
     end
+  end
+
+  defp zip_marked(entries, vectors, truncated) do
+    marked = MapSet.new(truncated)
+
+    entries
+    |> Enum.zip(vectors)
+    |> Enum.with_index(fn {{article, text}, vector}, index ->
+      {article, vector, hash_for(text, MapSet.member?(marked, index))}
+    end)
   end
 
   # Returns `:ok` WITHOUT continuing: `embed_entries/3` drives the sub-batches and calls
   # `continue/2` once, after the last one — continuing here would enqueue the next page
   # per sub-batch.
-  defp do_store_all(tenant_id, dim, pairs) do
-    Enum.reduce_while(pairs, :ok, fn {{article, text}, vector}, :ok ->
+  defp do_store_all(tenant_id, dim, triples) do
+    Enum.reduce_while(triples, :ok, fn {article, vector, hash}, :ok ->
       case Embeddings.materialize_system_article_embedding(
              tenant_id,
              article,
              vector,
-             content_hash(text),
+             hash,
              dim
            ) do
         {:ok, _row} -> {:cont, :ok}
@@ -294,4 +311,7 @@ defmodule Loopctl.Workers.SystemCorpusEmbeddingWorker do
   end
 
   defp content_hash(text), do: :sha256 |> :crypto.hash(text) |> Base.encode16(case: :lower)
+
+  defp hash_for(text, false), do: content_hash(text)
+  defp hash_for(text, true), do: text |> content_hash() |> ShrinkLadder.truncated_hash()
 end

--- a/test/loopctl/embeddings/shrink_ladder_test.exs
+++ b/test/loopctl/embeddings/shrink_ladder_test.exs
@@ -58,7 +58,7 @@ defmodule Loopctl.Embeddings.ShrinkLadderTest do
       text = String.duplicate("a", 60_000)
       {fun, calls} = provider(10_000)
 
-      assert {:ok, _} = ShrinkLadder.embed_one(text, fun)
+      assert {:ok, _, :truncated} = ShrinkLadder.embed_one(text, fun)
 
       sent = calls.()
       assert length(sent) > 1, "the ladder never retried"
@@ -103,8 +103,28 @@ defmodule Loopctl.Embeddings.ShrinkLadderTest do
         if byte_size(text) <= 9_000, do: {:ok, vector(text)}, else: @too_long
       end
 
-      assert {:ok, _} = ShrinkLadder.embed_one(String.duplicate("щ", 20_000), fun)
+      assert {:ok, _, :truncated} = ShrinkLadder.embed_one(String.duplicate("щ", 20_000), fun)
       assert Enum.all?(Agent.get(seen, & &1), &String.valid?/1)
+    end
+
+    test "a shrunk vector is TAGGED :truncated and an untouched one is not" do
+      # The tag is what stops `ProposalGate` calling a prefix a duplicate (dropping the
+      # create) and `Memory` superseding a prior memory on one. An untagged prefix is a
+      # prefix the caller compares against whole-text vectors without knowing.
+      {fits, _} = provider(100_000)
+      {shrinks, _} = provider(9_000)
+
+      assert {:ok, _} = ShrinkLadder.embed_one(String.duplicate("a", 20_000), fits)
+      assert {:ok, _, :truncated} = ShrinkLadder.embed_one(String.duplicate("a", 20_000), shrinks)
+    end
+
+    test ":max_rungs bounds the ladder for a SYNCHRONOUS caller" do
+      # Every rung is a provider round trip and an embedding admission slot, paid inside an
+      # article-create request. `ProposalGate` spends one and accepts its own fail-open.
+      {fun, calls} = provider(1_000)
+
+      assert ShrinkLadder.embed_one(String.duplicate("a", 40_000), fun, max_rungs: 1) == @too_long
+      assert length(calls.()) == 2, "the rung budget was not honoured"
     end
   end
 
@@ -176,6 +196,37 @@ defmodule Loopctl.Embeddings.ShrinkLadderTest do
 
       assert {:ok, vectors} = ShrinkLadder.embed_batch(texts, fun)
       assert length(vectors) == 8
+    end
+
+    test ":max_calls bounds what one already-failing batch may spend" do
+      # With k over-long members the bisect is O(n), not the ~2*log2(n) a single offender
+      # costs — hundreds of sequential provider calls inside one Oban job. Past the budget
+      # it surfaces the provider error, exactly as an exhausted rung does.
+      texts = for _ <- 1..16, do: String.duplicate("x", 40_000)
+      {fun, calls} = batch_provider(9_000)
+
+      assert ShrinkLadder.embed_batch(texts, fun, max_calls: 5) == @too_long
+      assert length(calls.()) <= 5
+    end
+  end
+
+  describe "chunk_by_bytes/3" do
+    test "splits by CUMULATIVE bytes, so no array call is rejected on aggregate size" do
+      # An aggregate rejection names no member, so every half is rejected too and the whole
+      # batch pays the bisect tree on EVERY run. Callers pre-split instead.
+      items = for i <- 1..6, do: {i, String.duplicate("a", 400)}
+
+      chunks = ShrinkLadder.chunk_by_bytes(items, 1_000, fn {_i, text} -> text end)
+
+      assert Enum.map(chunks, &length/1) == [2, 2, 2]
+      assert Enum.concat(chunks) == items
+    end
+
+    test "an item bigger than the budget forms its own chunk rather than wedging" do
+      items = [{1, "aa"}, {2, String.duplicate("b", 5_000)}, {3, "cc"}]
+
+      assert [[{1, _}], [{2, _}], [{3, _}]] =
+               ShrinkLadder.chunk_by_bytes(items, 10, fn {_i, text} -> text end)
     end
   end
 end

--- a/test/loopctl/embeddings/shrink_ladder_test.exs
+++ b/test/loopctl/embeddings/shrink_ladder_test.exs
@@ -135,7 +135,7 @@ defmodule Loopctl.Embeddings.ShrinkLadderTest do
       texts = ["a", String.duplicate("b", 50_000), "c", "d"]
       {fun, _calls} = batch_provider(20_000)
 
-      assert {:ok, vectors} = ShrinkLadder.embed_batch(texts, fun)
+      assert {:ok, vectors, [1]} = ShrinkLadder.embed_batch(texts, fun)
       assert length(vectors) == 4
       assert Enum.at(vectors, 0) == vector("a")
       assert Enum.at(vectors, 2) == vector("c")
@@ -149,11 +149,22 @@ defmodule Loopctl.Embeddings.ShrinkLadderTest do
       long = String.duplicate("L", 50_000)
       {fun, _calls} = batch_provider(20_000)
 
-      assert {:ok, vectors} = ShrinkLadder.embed_batch([short, long, short], fun)
+      # The truncated INDEX is reported, not merely the vectors: a storing caller must mark
+      # that row or the corpus fills with prefix vectors indistinguishable from whole-text
+      # ones, and the next comparison judges a whole text against one of them.
+      assert {:ok, vectors, [1]} = ShrinkLadder.embed_batch([short, long, short], fun)
 
       assert Enum.at(vectors, 0) == vector(short)
       assert Enum.at(vectors, 2) == vector(short)
       assert Enum.at(vectors, 1) != vector(long), "the over-long member was not truncated"
+    end
+
+    test "an untruncated batch reports no truncation at all" do
+      # The two-tuple is the caller's licence to store the vectors unmarked, so it must
+      # never be returned for a batch the ladder actually shrank.
+      {fun, _calls} = batch_provider(20_000)
+
+      assert {:ok, [_, _]} = ShrinkLadder.embed_batch(["a", "b"], fun)
     end
 
     test "an empty batch makes no provider call" do
@@ -194,8 +205,21 @@ defmodule Loopctl.Embeddings.ShrinkLadderTest do
       texts = for _ <- 1..8, do: String.duplicate("x", 40_000)
       {fun, _calls} = batch_provider(9_000)
 
-      assert {:ok, vectors} = ShrinkLadder.embed_batch(texts, fun)
+      assert {:ok, vectors, truncated} = ShrinkLadder.embed_batch(texts, fun)
       assert length(vectors) == 8
+      assert truncated == Enum.to_list(0..7), "a truncated member went unreported"
+    end
+
+    test "the default call budget never gives up on work the bisect could have finished" do
+      # The bisect's own worst case is ~2n-1 calls. A fixed 64 abandoned a 40-member batch
+      # of over-long texts mid-bisect and surfaced the 4xx, which the callers classify as
+      # PERMANENT — the job discards and the rows stay un-embedded, the outage the ladder
+      # exists to end. The default therefore scales with the batch.
+      texts = for _ <- 1..40, do: String.duplicate("x", 40_000)
+      {fun, _calls} = batch_provider(9_000)
+
+      assert {:ok, vectors, _truncated} = ShrinkLadder.embed_batch(texts, fun)
+      assert length(vectors) == 40
     end
 
     test ":max_calls bounds what one already-failing batch may spend" do

--- a/test/loopctl/embeddings/shrink_ladder_test.exs
+++ b/test/loopctl/embeddings/shrink_ladder_test.exs
@@ -182,9 +182,72 @@ defmodule Loopctl.Embeddings.ShrinkLadderTest do
     end
 
     test "a batch whose offender cannot fit even at the floor surfaces the provider error" do
+      # ...and hands back the member that DID embed, so the caller's retry is not billed
+      # for it again. `"a"` fits; the 40KB member cannot fit even at the floor.
       {fun, _calls} = batch_provider(1)
 
-      assert ShrinkLadder.embed_batch(["a", String.duplicate("b", 40_000)], fun) == @too_long
+      assert {:error, {:api_error, 400, :context_length_exceeded}, [{0, _vector, false}]} =
+               ShrinkLadder.embed_batch(["a", String.duplicate("b", 40_000)], fun)
+    end
+
+    test "an already-paid-for half survives its sibling's failure" do
+      # The defect: the bisect embedded one half, the other failed, and the successful
+      # half was DISCARDED — so the caller's retry re-sent and re-paid for the whole
+      # array. Against a deterministic failure that repeats on every attempt while never
+      # making progress.
+      {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+      # First call (whole array) is rejected as too long, forcing a bisect. The left half
+      # then succeeds; the right half hits a breaker.
+      fun = fn texts ->
+        n = Agent.get_and_update(calls, &{&1 + 1, &1 + 1})
+
+        cond do
+          n == 1 -> @too_long
+          Enum.any?(texts, &String.starts_with?(&1, "r")) -> {:error, :circuit_open}
+          true -> {:ok, Enum.map(texts, &vector/1)}
+        end
+      end
+
+      assert {:error, :circuit_open, partial} =
+               ShrinkLadder.embed_batch(["l1", "l2", "r1", "r2"], fun)
+
+      # Indexes are ORIGINAL-array offsets, so the caller can zip them against its entries.
+      assert Enum.map(partial, fn {index, _v, _t} -> index end) == [0, 1]
+      assert Enum.all?(partial, fn {_i, _v, truncated?} -> truncated? == false end)
+    end
+
+    test "nothing salvaged still returns the plain two-element error" do
+      # The three-element shape must mean "there is something to store". A caller that
+      # matches `{:error, reason}` for its ordinary error handling keeps working when the
+      # whole batch failed, which is the common case.
+      fun = fn _texts -> {:error, :no_api_key} end
+
+      assert ShrinkLadder.embed_batch(["a", "b"], fun) == {:error, :no_api_key}
+    end
+
+    test "a salvaged member that had to be TRUNCATED is reported as truncated" do
+      # The mark has to survive the partial path too, or the caller stores a prefix vector
+      # under an unmarked hash — exactly the invariant the rest of this change enforces.
+      {:ok, calls} = Agent.start_link(fn -> 0 end)
+      long = String.duplicate("l", 40_000)
+
+      fun = fn texts ->
+        n = Agent.get_and_update(calls, &{&1 + 1, &1 + 1})
+
+        cond do
+          n == 1 -> @too_long
+          Enum.any?(texts, &String.starts_with?(&1, "r")) -> {:error, :circuit_open}
+          Enum.any?(texts, &(byte_size(&1) > 10_000)) -> @too_long
+          true -> {:ok, Enum.map(texts, &vector/1)}
+        end
+      end
+
+      assert {:error, :circuit_open, partial} =
+               ShrinkLadder.embed_batch([long, "l2", "r1", "r2"], fun)
+
+      assert {0, _vector, true} = Enum.find(partial, fn {i, _v, _t} -> i == 0 end)
+      assert {1, _vector, false} = Enum.find(partial, fn {i, _v, _t} -> i == 1 end)
     end
 
     test "a non-length batch error is passed through without bisecting" do

--- a/test/loopctl/embeddings/shrink_ladder_test.exs
+++ b/test/loopctl/embeddings/shrink_ladder_test.exs
@@ -1,0 +1,181 @@
+defmodule Loopctl.Embeddings.ShrinkLadderTest do
+  @moduledoc """
+  The ladder's contract at the call sites #615 did not reach (#617).
+
+  Every assertion here pins a property whose absence is a PERMANENT un-embedded row:
+  before this module, an input-too-long rejection on the re-embed, system-corpus,
+  memory and novelty-gate paths fell through to `Llm.permanent_provider_error?/1`,
+  which is `true` for any 4xx — so the job DISCARDED and nothing ever retried it.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Embeddings.ShrinkLadder
+  alias Loopctl.Embeddings.TextBudget
+
+  @too_long {:error, {:api_error, 400, :context_length_exceeded}}
+
+  # A provider that accepts anything at or under `limit` bytes and rejects the rest,
+  # recording every call it was asked to make.
+  defp provider(limit) do
+    {:ok, calls} = Agent.start_link(fn -> [] end)
+
+    fun = fn text ->
+      Agent.update(calls, &[byte_size(text) | &1])
+      if byte_size(text) <= limit, do: {:ok, vector(text)}, else: @too_long
+    end
+
+    {fun, fn -> calls |> Agent.get(& &1) |> Enum.reverse() end}
+  end
+
+  defp batch_provider(limit) do
+    {:ok, calls} = Agent.start_link(fn -> [] end)
+
+    fun = fn texts ->
+      Agent.update(calls, &[Enum.map(texts, fn t -> byte_size(t) end) | &1])
+
+      if Enum.all?(texts, &(byte_size(&1) <= limit)),
+        do: {:ok, Enum.map(texts, &vector/1)},
+        else: @too_long
+    end
+
+    {fun, fn -> calls |> Agent.get(& &1) |> Enum.reverse() end}
+  end
+
+  # A vector that identifies WHICH text produced it, so the batch tests can prove
+  # alignment rather than merely counting.
+  defp vector(text), do: [byte_size(text) * 1.0]
+
+  describe "embed_one/3" do
+    test "passes a successful first attempt straight through, with no extra calls" do
+      {fun, calls} = provider(100_000)
+
+      assert {:ok, _} = ShrinkLadder.embed_one("short text", fun)
+      assert length(calls.()) == 1
+    end
+
+    test "shrinks until the provider accepts, and every attempt is strictly smaller" do
+      text = String.duplicate("a", 60_000)
+      {fun, calls} = provider(10_000)
+
+      assert {:ok, _} = ShrinkLadder.embed_one(text, fun)
+
+      sent = calls.()
+      assert length(sent) > 1, "the ladder never retried"
+      assert sent == Enum.sort(sent, :desc) and Enum.uniq(sent) == sent
+      assert List.last(sent) <= 10_000
+    end
+
+    test "an exhausted ladder returns the ORIGINAL provider error, not a synthesized one" do
+      # A provider that rejects even the floor is a DIFFERENT defect (a much smaller model
+      # window), and must stay legible as one instead of being absorbed by more halving.
+      {fun, calls} = provider(1)
+
+      assert ShrinkLadder.embed_one(String.duplicate("a", 40_000), fun) == @too_long
+
+      assert List.last(calls.()) == TextBudget.floor_bytes(),
+             "the floor must be TRIED exactly once before giving up"
+    end
+
+    test "a non-length error is passed through untouched and never retried" do
+      # The whole point: the caller's snooze/cancel/discard handling must still see its own
+      # error. Swallowing :circuit_open into a shrink loop would hot-retry a tripped breaker.
+      for reason <- [:circuit_open, :no_api_key, :rate_limited_local, {:api_error, 500}] do
+        {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+        fun = fn _text ->
+          Agent.update(calls, &(&1 + 1))
+          {:error, reason}
+        end
+
+        assert ShrinkLadder.embed_one("text", fun) == {:error, reason}
+        assert Agent.get(calls, & &1) == 1, "#{inspect(reason)} was retried"
+      end
+    end
+
+    test "truncation never splits a UTF-8 codepoint" do
+      # The input class this exists for is multi-byte text; a cut mid-codepoint yields a
+      # binary that is not a valid string and would fail at the JSON encoder instead.
+      {:ok, seen} = Agent.start_link(fn -> [] end)
+
+      fun = fn text ->
+        Agent.update(seen, &[text | &1])
+        if byte_size(text) <= 9_000, do: {:ok, vector(text)}, else: @too_long
+      end
+
+      assert {:ok, _} = ShrinkLadder.embed_one(String.duplicate("щ", 20_000), fun)
+      assert Enum.all?(Agent.get(seen, & &1), &String.valid?/1)
+    end
+  end
+
+  describe "embed_batch/3" do
+    test "returns vectors in INPUT order after a bisect" do
+      # The caller zips these against its own entries, so a reordering silently writes each
+      # article its neighbour's vector — a corruption no length check would catch.
+      texts = ["a", String.duplicate("b", 50_000), "c", "d"]
+      {fun, _calls} = batch_provider(20_000)
+
+      assert {:ok, vectors} = ShrinkLadder.embed_batch(texts, fun)
+      assert length(vectors) == 4
+      assert Enum.at(vectors, 0) == vector("a")
+      assert Enum.at(vectors, 2) == vector("c")
+      assert Enum.at(vectors, 3) == vector("d")
+    end
+
+    test "truncates ONLY the offending member" do
+      # Shrinking every text to fit an unknown offender would gut articles that were never
+      # over the limit. That is why this bisects instead of blanket-shrinking.
+      short = String.duplicate("s", 100)
+      long = String.duplicate("L", 50_000)
+      {fun, _calls} = batch_provider(20_000)
+
+      assert {:ok, vectors} = ShrinkLadder.embed_batch([short, long, short], fun)
+
+      assert Enum.at(vectors, 0) == vector(short)
+      assert Enum.at(vectors, 2) == vector(short)
+      assert Enum.at(vectors, 1) != vector(long), "the over-long member was not truncated"
+    end
+
+    test "an empty batch makes no provider call" do
+      {fun, calls} = batch_provider(10)
+
+      assert ShrinkLadder.embed_batch([], fun) == {:ok, []}
+      assert calls.() == []
+    end
+
+    test "a short vector array is reported as a length mismatch, never zipped" do
+      fun = fn _texts -> {:ok, [[0.1]]} end
+
+      assert ShrinkLadder.embed_batch(["a", "b"], fun) ==
+               {:error, :embedding_batch_length_mismatch}
+    end
+
+    test "a batch whose offender cannot fit even at the floor surfaces the provider error" do
+      {fun, _calls} = batch_provider(1)
+
+      assert ShrinkLadder.embed_batch(["a", String.duplicate("b", 40_000)], fun) == @too_long
+    end
+
+    test "a non-length batch error is passed through without bisecting" do
+      {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+      fun = fn _texts ->
+        Agent.update(calls, &(&1 + 1))
+        {:error, :circuit_open}
+      end
+
+      assert ShrinkLadder.embed_batch(["a", "b", "c", "d"], fun) == {:error, :circuit_open}
+      assert Agent.get(calls, & &1) == 1, "an open breaker was fanned out into a bisect"
+    end
+
+    test "bisecting terminates on a batch where EVERY member is over-long" do
+      # The pathological case: no innocent members to isolate. It must still finish, with
+      # every member truncated to something the provider takes.
+      texts = for _ <- 1..8, do: String.duplicate("x", 40_000)
+      {fun, _calls} = batch_provider(9_000)
+
+      assert {:ok, vectors} = ShrinkLadder.embed_batch(texts, fun)
+      assert length(vectors) == 8
+    end
+  end
+end

--- a/test/loopctl/knowledge/consolidation_followups_test.exs
+++ b/test/loopctl/knowledge/consolidation_followups_test.exs
@@ -13,6 +13,7 @@ defmodule Loopctl.Knowledge.ConsolidationFollowupsTest do
   import Ecto.Query
 
   alias Loopctl.AdminRepo
+  alias Loopctl.Embeddings.ShrinkLadder
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.Consolidation
   alias Loopctl.Knowledge.ConsolidationProposal
@@ -196,6 +197,33 @@ defmodule Loopctl.Knowledge.ConsolidationFollowupsTest do
       assert status(other.id) == :published
     end
 
+    test "a group ARCHIVED down to two is skipped — a shrink is a remedy too, not just a retitle" do
+      # Retitling SPLITS a group, so the subgroup check catches it. Archiving members (or
+      # making them private) SHRINKS it without splitting, and the survivors still share
+      # one title — so the pass would auto-unpublish on a two-id fingerprint no report ever
+      # carried, on the night an operator hid the rest.
+      tenant = fixture(:tenant)
+
+      keep = published(tenant.id, %{title: "Shrunk Doc", body: String.duplicate("long ", 40)})
+      stays = published(tenant.id, %{title: "shrunk doc.", body: "stays"})
+
+      hidden =
+        for i <- 1..3 do
+          published(tenant.id, %{title: "Shrunk Doc" <> String.duplicate("!", i), body: "h"})
+        end
+
+      confirm_over_two_nights(tenant.id)
+
+      Enum.each(hidden, fn a ->
+        a |> Ecto.Changeset.change(%{status: :archived}) |> AdminRepo.update!()
+      end)
+
+      assert %{applied: 0, skipped: 1} = Consolidation.apply_confirmed_duplicates(tenant.id)
+
+      assert status(keep.id) == :published
+      assert status(stays.id) == :published
+    end
+
     test "a group that SPLIT into two collisions is skipped whole rather than half-applied" do
       # The persisted proposal describes ONE collision; the corpus now holds two. Applying
       # the larger half would unpublish on grounds the proposal never asserted.
@@ -307,6 +335,39 @@ defmodule Loopctl.Knowledge.ConsolidationFollowupsTest do
       assert status(a.id) == :published
       assert status(b.id) == :published
     end
+  end
+
+  describe "the corroboration gate refuses PREFIX vectors (#617 round 2)" do
+    test "a member whose vector covers only a prefix is missing evidence, not evidence" do
+      # The shrink ladder embeds an over-long body as its OPENING only. Two unrelated
+      # captures that share a boilerplate opening (CHANGELOG/API-doc headers — the exact
+      # population this gate was added for) then score near 1.0 against each other, and the
+      # content check that exists to stop unrelated same-titled articles being
+      # auto-unpublished would be satisfied by two truncations. A marked vector therefore
+      # drops out of scoring and the whole group is withheld.
+      tenant = fixture(:tenant)
+
+      keep = published(tenant.id, %{title: "Prefix Doc", body: String.duplicate("long ", 40)})
+      other = published(tenant.id, %{title: "prefix doc!", body: "short"})
+
+      confirm_over_two_nights(tenant.id)
+
+      mark_prefix_embedded!(tenant.id, other.id)
+
+      assert %{applied: 0, uncorroborated: 1} =
+               Consolidation.apply_confirmed_duplicates(tenant.id)
+
+      assert status(keep.id) == :published
+      assert status(other.id) == :published
+    end
+  end
+
+  # `corroborate_all!/1` stores whole-text hashes; this re-marks ONE of them the way the
+  # ladder's storing callers do when they could only embed a prefix.
+  defp mark_prefix_embedded!(tenant_id, id) do
+    Article
+    |> where([a], a.tenant_id == ^tenant_id and a.id == ^id)
+    |> AdminRepo.update_all(set: [embedding_content_hash: ShrinkLadder.truncated_hash("abc")])
   end
 
   describe "generic_titles — count and page are separate queries (#617 item 6)" do

--- a/test/loopctl/knowledge/consolidation_followups_test.exs
+++ b/test/loopctl/knowledge/consolidation_followups_test.exs
@@ -152,6 +152,25 @@ defmodule Loopctl.Knowledge.ConsolidationFollowupsTest do
       assert dup.fingerprint == dup2.fingerprint
       assert length(dup.evidence) == length(dup.article_ids)
     end
+
+    test "member truncation is REPORTED, not just logged" do
+      # `truncated` is the operator-facing answer to "did this class see the whole
+      # picture". Derived from group counts alone it read `false` while the proposal
+      # silently omitted 10 members and its evidence array came up short.
+      tenant = fixture(:tenant)
+
+      for i <- 1..60 do
+        published(tenant.id, %{title: "Cut Report Doc" <> String.duplicate("!", i), body: "b"})
+      end
+
+      assert {:ok, %{summary: %{truncated: %{"duplicate_capture" => true}}}} =
+               Consolidation.analyze(tenant.id)
+
+      # One group, well under the per-class cap: nothing GROUP-level was truncated, so the
+      # flag can only be coming from the member cap.
+      assert {:ok, %{summary: %{by_class: %{"duplicate_capture" => 1}}}} =
+               Consolidation.analyze(tenant.id)
+    end
   end
 
   describe "the apply-time re-check of the GROUPING signal (#617 / handoff gap)" do
@@ -195,6 +214,29 @@ defmodule Loopctl.Knowledge.ConsolidationFollowupsTest do
       assert %{applied: 0, skipped: 1} = Consolidation.apply_confirmed_duplicates(tenant.id)
 
       for a <- [a1, a2, a3, a4], do: assert(status(a.id) == :published)
+    end
+
+    test "a group PARTLY retitled is skipped whole, not applied to the remnant" do
+      # The two-run gate confirmed the FIVE-id fingerprint. Retitling three of them is a
+      # human saying "these are not one capture"; auto-unpublishing the two left over
+      # completes a partial remedy the same night it was made, on a set nothing confirmed.
+      tenant = fixture(:tenant)
+
+      keep = published(tenant.id, %{title: "Partial Doc", body: String.duplicate("long ", 40)})
+      stays = published(tenant.id, %{title: "partial doc.", body: "stays"})
+
+      moved =
+        for i <- 1..3 do
+          published(tenant.id, %{title: "Partial Doc" <> String.duplicate("!", i), body: "m"})
+        end
+
+      confirm_over_two_nights(tenant.id)
+
+      Enum.each(Enum.with_index(moved), fn {a, i} -> retitle!(a, "Unrelated Title #{i}") end)
+
+      assert %{applied: 0, skipped: 1} = Consolidation.apply_confirmed_duplicates(tenant.id)
+
+      for a <- [keep, stays | moved], do: assert(status(a.id) == :published)
     end
 
     test "an intact title-drift group still applies — the re-check is not a blanket block" do

--- a/test/loopctl/knowledge/consolidation_followups_test.exs
+++ b/test/loopctl/knowledge/consolidation_followups_test.exs
@@ -1,0 +1,306 @@
+defmodule Loopctl.Knowledge.ConsolidationFollowupsTest do
+  @moduledoc """
+  The #615/#616 review follow-ups on the consolidation pass (issue #617).
+
+  Each describe block pins ONE of them, written against the failure it prevents
+  rather than against the shape of the code.
+  """
+
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.Consolidation
+  alias Loopctl.Knowledge.ConsolidationProposal
+
+  # Published articles are written draft-then-update so the inline embedding -> linking
+  # cascade never fires: every signal exercised here is lexical, never vector.
+  defp published(tenant_id, attrs) do
+    base = %{category: :pattern, tags: [], body: "Body #{System.unique_integer([:positive])}."}
+
+    fixture(:article, Map.merge(base, Map.put(attrs, :tenant_id, tenant_id)))
+    |> Ecto.Changeset.change(%{status: :published})
+    |> AdminRepo.update!()
+  end
+
+  defp status(id), do: AdminRepo.get!(Article, id).status
+
+  defp retitle!(article, title) do
+    article |> Ecto.Changeset.change(%{title: title}) |> AdminRepo.update!()
+  end
+
+  # Genuine duplicates get identical vectors (cosine 1.0) so the #616 corroboration gate
+  # is not what these tests end up measuring.
+  defp corroborate_all!(tenant_id) do
+    vector = List.duplicate(0.1, 1536)
+
+    Article
+    |> where([a], a.tenant_id == ^tenant_id)
+    |> AdminRepo.all()
+    |> Enum.each(fn a ->
+      {:ok, _} = Loopctl.Knowledge.update_embedding(tenant_id, a.id, vector, nil)
+    end)
+  end
+
+  defp confirm_over_two_nights(tenant_id) do
+    corroborate_all!(tenant_id)
+    {:ok, _} = Consolidation.run(tenant_id, day: Date.add(Date.utc_today(), -1))
+    {:ok, _} = Consolidation.run(tenant_id)
+  end
+
+  defp proposal_count(tenant_id) do
+    ConsolidationProposal
+    |> where([p], p.tenant_id == ^tenant_id)
+    |> AdminRepo.aggregate(:count)
+  end
+
+  describe "prune_proposals — the tenant predicate on a BYPASSRLS delete_all (#617 item 1)" do
+    test "withdrawing one tenant's stale proposals never touches another tenant's rows" do
+      # This is an AdminRepo `delete_all`, so RLS is bypassed and the WHERE clause is the
+      # entire tenant boundary. `report_id` implies the tenant today; the predicate is
+      # explicit so that implication is not the only thing standing between a re-run and
+      # another tenant's data.
+      a = fixture(:tenant)
+      b = fixture(:tenant)
+
+      published(a.id, %{title: "Shared Doc", body: "one"})
+      published(a.id, %{title: "shared doc!", body: "two"})
+      published(b.id, %{title: "Neighbour Doc", body: "one"})
+      published(b.id, %{title: "neighbour doc!", body: "two"})
+
+      {:ok, _} = Consolidation.run(a.id)
+      {:ok, _} = Consolidation.run(b.id)
+
+      assert proposal_count(a.id) > 0
+      before_b = proposal_count(b.id)
+      assert before_b > 0
+
+      # Dissolve tenant A's only group, then re-run: A's proposal is withdrawn, B's stands.
+      Article
+      |> where([x], x.tenant_id == ^a.id)
+      |> AdminRepo.all()
+      |> Enum.with_index()
+      |> Enum.each(fn {article, i} -> retitle!(article, "Distinct A Title #{i}") end)
+
+      {:ok, _} = Consolidation.run(a.id)
+
+      assert proposal_count(a.id) == 0
+      assert proposal_count(b.id) == before_b
+    end
+  end
+
+  describe ":max_per_class clamping (#617 item 4)" do
+    test "a non-integer cap falls back to the DEFAULT, not to the hard ceiling" do
+      # A number sorts BELOW every atom and binary in Erlang term order, so the old
+      # `max(1) |> min(500)` resolved a config typo to 500 — the largest report available —
+      # rather than to the intended 100.
+      tenant = fixture(:tenant)
+      for i <- 1..3, do: published(tenant.id, %{title: "Untitled #{i}", body: "b"})
+
+      {:ok, typo} = Consolidation.analyze(tenant.id, max_per_class: "2")
+      {:ok, default} = Consolidation.analyze(tenant.id)
+
+      assert typo.summary.max_per_class == Consolidation.default_max_per_class()
+      assert typo.summary.max_per_class == default.summary.max_per_class
+      refute typo.summary.max_per_class == Consolidation.hard_max_per_class()
+    end
+
+    test "an integer cap is still honoured and still clamped to the ceiling" do
+      tenant = fixture(:tenant)
+      for i <- 1..3, do: published(tenant.id, %{title: "Untitled #{i}", body: "b"})
+
+      assert {:ok, %{summary: %{max_per_class: 2}}} =
+               Consolidation.analyze(tenant.id, max_per_class: 2)
+
+      assert {:ok, %{summary: %{max_per_class: cap}}} =
+               Consolidation.analyze(tenant.id, max_per_class: 10_000)
+
+      assert cap == Consolidation.hard_max_per_class()
+    end
+  end
+
+  describe "duplicate-group member cap (#617 item 5)" do
+    test "a group larger than the member cap is truncated, and truncated IDENTICALLY twice" do
+      # Determinism is what makes truncating safe: `fingerprint/2` hashes the sorted id set
+      # and the two-run gate confirms only a repeated fingerprint, so a group that truncated
+      # differently on two nights could never be confirmed — it would sit in the report
+      # forever while appearing actionable.
+      tenant = fixture(:tenant)
+
+      # Verbatim-distinct (the exact active-title unique index forbids duplicates) but
+      # normalizing to ONE key — which is exactly the collision class this pass exists for:
+      # the punctuation is stripped and the result trimmed.
+      for i <- 1..60 do
+        published(tenant.id, %{
+          title: "Bulk Collide Doc" <> String.duplicate("!", i),
+          body: "member #{i}"
+        })
+      end
+
+      {:ok, first} = Consolidation.analyze(tenant.id)
+      {:ok, second} = Consolidation.analyze(tenant.id)
+
+      [dup] = Enum.filter(first.proposals, &(&1.proposal_class == :duplicate_capture))
+      [dup2] = Enum.filter(second.proposals, &(&1.proposal_class == :duplicate_capture))
+
+      assert length(dup.article_ids) == 50
+      assert dup.article_ids == dup2.article_ids
+      assert dup.fingerprint == dup2.fingerprint
+      assert length(dup.evidence) == length(dup.article_ids)
+    end
+  end
+
+  describe "the apply-time re-check of the GROUPING signal (#617 / handoff gap)" do
+    test "a title-drift group whose members were RETITLED is skipped, not applied" do
+      # The liveness re-check proves the members are still published; it does NOT prove they
+      # still collide. Retitling is the one remedy a human has for a false grouping — it is
+      # what was done to 23 articles on 2026-08-06 to stop three unrelated `Changelog`
+      # documents being auto-unpublished — and every one of those articles stayed live.
+      tenant = fixture(:tenant)
+
+      keep = published(tenant.id, %{title: "Changelog", body: String.duplicate("long ", 40)})
+      other = published(tenant.id, %{title: "changelog!", body: "short"})
+
+      confirm_over_two_nights(tenant.id)
+
+      # The human fix lands AFTER the proposal was confirmed but BEFORE the apply.
+      retitle!(other, "Changelog for the oauth2 library")
+
+      assert %{applied: 0, skipped: 1, failed: 0} =
+               Consolidation.apply_confirmed_duplicates(tenant.id)
+
+      assert status(keep.id) == :published
+      assert status(other.id) == :published
+    end
+
+    test "a group that SPLIT into two collisions is skipped whole rather than half-applied" do
+      # The persisted proposal describes ONE collision; the corpus now holds two. Applying
+      # the larger half would unpublish on grounds the proposal never asserted.
+      tenant = fixture(:tenant)
+
+      a1 = published(tenant.id, %{title: "Split Doc", body: String.duplicate("aaa ", 40)})
+      a2 = published(tenant.id, %{title: "split doc!", body: "a2"})
+      a3 = published(tenant.id, %{title: "SPLIT DOC.", body: "a3"})
+      a4 = published(tenant.id, %{title: "Split  Doc", body: "a4"})
+
+      confirm_over_two_nights(tenant.id)
+
+      retitle!(a3, "Renamed Pair Doc")
+      retitle!(a4, "renamed pair doc!")
+
+      assert %{applied: 0, skipped: 1} = Consolidation.apply_confirmed_duplicates(tenant.id)
+
+      for a <- [a1, a2, a3, a4], do: assert(status(a.id) == :published)
+    end
+
+    test "an intact title-drift group still applies — the re-check is not a blanket block" do
+      # The guard has to be discriminating, or it silently turns the whole auto-apply class
+      # off while the run keeps reporting `gate: :open`.
+      tenant = fixture(:tenant)
+
+      winner = published(tenant.id, %{title: "Intact Doc", body: String.duplicate("long ", 40)})
+      loser = published(tenant.id, %{title: "intact doc!", body: "short"})
+
+      confirm_over_two_nights(tenant.id)
+
+      assert %{applied: 1, skipped: 0, failed: 0} =
+               Consolidation.apply_confirmed_duplicates(tenant.id)
+
+      assert status(winner.id) == :published
+      assert status(loser.id) == :draft
+    end
+
+    test "an IDEMPOTENCY-drift group is judged on its key, never on its titles" do
+      # These members collide on a writer-supplied key and have no reason to share a title.
+      # Re-checking titles here would reject every group in the class — a guard that reads
+      # as working while disabling the signal it guards.
+      tenant = fixture(:tenant)
+      key = "session:AB12-#{System.unique_integer([:positive])}"
+
+      winner =
+        published(tenant.id, %{
+          title: "Idempotency Winner",
+          body: String.duplicate("long ", 40),
+          idempotency_key: key
+        })
+
+      loser =
+        published(tenant.id, %{
+          title: "A Completely Different Title",
+          body: "short",
+          idempotency_key: String.replace(key, ":", "-")
+        })
+
+      confirm_over_two_nights(tenant.id)
+
+      assert %{applied: 1, skipped: 0, failed: 0} =
+               Consolidation.apply_confirmed_duplicates(tenant.id)
+
+      assert status(winner.id) == :published
+      assert status(loser.id) == :draft
+    end
+
+    test "a group retitled onto PLACEHOLDER titles does not re-collide as a duplicate" do
+      # `title_drift_groups/1` excludes placeholder titles on purpose — "Draft" collides with
+      # "Draft" for reasons that have nothing to do with being the same capture, and
+      # `:generic_title` is the class that owns them. The apply-time re-check must exclude
+      # them too, or a retitle-to-placeholder would auto-unpublish on a signal the scan
+      # deliberately refuses to raise.
+      tenant = fixture(:tenant)
+
+      a = published(tenant.id, %{title: "Placeholder Doc", body: String.duplicate("long ", 40)})
+      b = published(tenant.id, %{title: "placeholder doc!", body: "short"})
+
+      confirm_over_two_nights(tenant.id)
+
+      retitle!(a, "Draft")
+      retitle!(b, "draft")
+
+      assert %{applied: 0, skipped: 1} = Consolidation.apply_confirmed_duplicates(tenant.id)
+
+      assert status(a.id) == :published
+      assert status(b.id) == :published
+    end
+  end
+
+  describe "generic_titles — count and page are separate queries (#617 item 6)" do
+    test "the reported total counts the whole matching set while only the cap is fetched" do
+      # The `truncated` flag is derived from `total > length(items)`, so replacing the
+      # load-everything-then-take with count+limit must not quietly change what `total` means.
+      tenant = fixture(:tenant)
+      for i <- 1..5, do: published(tenant.id, %{title: "Untitled #{i}", body: "b"})
+
+      {:ok, capped} = Consolidation.analyze(tenant.id, max_per_class: 2)
+
+      assert capped.summary.by_class["generic_title"] == 5
+      assert Enum.count(capped.proposals, &(&1.proposal_class == :generic_title)) == 2
+      assert capped.summary.truncated["generic_title"] == true
+
+      {:ok, whole} = Consolidation.analyze(tenant.id, max_per_class: 50)
+
+      assert whole.summary.by_class["generic_title"] == 5
+      assert Enum.count(whole.proposals, &(&1.proposal_class == :generic_title)) == 5
+      assert whole.summary.truncated["generic_title"] == false
+    end
+
+    test "the capped page is the OLDEST matches, deterministically" do
+      tenant = fixture(:tenant)
+      for i <- 1..4, do: published(tenant.id, %{title: "Untitled #{i}", body: "b"})
+
+      {:ok, first} = Consolidation.analyze(tenant.id, max_per_class: 2)
+      {:ok, second} = Consolidation.analyze(tenant.id, max_per_class: 2)
+
+      ids = fn r ->
+        r.proposals
+        |> Enum.filter(&(&1.proposal_class == :generic_title))
+        |> Enum.map(& &1.article_ids)
+      end
+
+      assert ids.(first) == ids.(second)
+    end
+  end
+end

--- a/test/loopctl/knowledge/proposal_gate_truncation_test.exs
+++ b/test/loopctl/knowledge/proposal_gate_truncation_test.exs
@@ -1,0 +1,83 @@
+defmodule Loopctl.Knowledge.ProposalGateTruncationTest do
+  @moduledoc """
+  What the gate may conclude from a PREFIX vector (#617 round 2).
+
+  The shrink ladder can only embed an over-long proposal as its opening. Scored against
+  corpus vectors built from whole texts, a shared opening reads as a near-identity of a
+  document the proposal may differ from entirely after the cut.
+  """
+
+  use Loopctl.DataCase, async: true
+
+  import Mox
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.ProposalGate
+
+  @dims 1536
+  @too_long {:error, {:api_error, 400, :context_length_exceeded}}
+
+  defp e(prefix), do: prefix ++ List.duplicate(0.0, @dims - length(prefix))
+
+  # Rejects anything above `limit` bytes, exactly as the provider does, so the gate walks
+  # the real ladder rather than being handed a `:truncated` tag by the test.
+  defp provider(limit, vector) do
+    stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
+      if byte_size(text) > limit, do: @too_long, else: {:ok, vector}
+    end)
+  end
+
+  setup do
+    tenant = fixture(:tenant)
+    existing = fixture(:article, %{tenant_id: tenant.id, title: "Changelog", status: :published})
+    {:ok, _} = Knowledge.update_embedding(tenant.id, existing.id, e([1.0]))
+    %{tenant: tenant, existing: existing}
+  end
+
+  test "a proposal judged on a prefix is NEVER assessed below :novel", %{tenant: tenant} do
+    # An identical vector would be `:duplicate`. `:duplicate` makes `gate_proposal/4`
+    # return `created: false`, and `:low_novelty` drops the write outright for the
+    # unattended callers running `on_low_novelty: :skip` — so neither band is a safe cap
+    # and the verdict has to clear both. The neighbours still ride the assessment.
+    provider(20_000, e([1.0]))
+
+    assessment =
+      ProposalGate.assess(tenant.id, %{
+        "title" => "Changelog",
+        "body" => String.duplicate("x", 50_000)
+      })
+
+    assert assessment.verdict == :novel
+    assert assessment.score >= 0.97
+    assert [_ | _] = assessment.neighbors
+  end
+
+  test "a proposal that fits is judged normally", %{tenant: tenant} do
+    # The cap must key on an ACTUAL truncation: if it fired on length alone the gate would
+    # stop deduplicating every long-but-acceptable article.
+    provider(200_000, e([1.0]))
+
+    assessment = ProposalGate.assess(tenant.id, %{"title" => "Changelog", "body" => "short"})
+
+    assert assessment.verdict == :duplicate
+  end
+
+  test "the synchronous ladder reaches the byte floor for multi-byte text", %{tenant: tenant} do
+    # `build_text/1` caps at 32,000 CHARACTERS, so a dense-script proposal arrives at up to
+    # 128,000 bytes. One rung lands at 32,000 bytes — still over an 8192-token window — and
+    # the gate fell open having performed NO novelty check at all, for exactly the articles
+    # most likely to be re-captured. Three rungs reach the 8,000-byte floor from anywhere.
+    provider(8_000, e([1.0]))
+
+    assessment =
+      ProposalGate.assess(tenant.id, %{
+        "title" => "Changelog",
+        "body" => String.duplicate("д", 30_000)
+      })
+
+    refute assessment.verdict == :unknown, "the gate skipped novelty checking entirely"
+    assert assessment.score >= 0.97
+  end
+end

--- a/test/loopctl/memory/promotion_prefix_supersede_test.exs
+++ b/test/loopctl/memory/promotion_prefix_supersede_test.exs
@@ -1,0 +1,78 @@
+defmodule Loopctl.Memory.PromotionPrefixSupersedeTest do
+  @moduledoc """
+  A PREFIX-embedded promoted memory may not be SUPERSEDED on cosine alone (#617 round 2).
+
+  `nearest_live/2` refuses to LOOK UP a near-dup on a truncated candidate vector, because
+  the 0.92 compare is licensed only by both sides covering the same extent of text. The
+  same compare runs from the other side when the STORED row is the prefix — and there it
+  retires the longer, more informative memory.
+  """
+
+  use Loopctl.DataCase, async: true
+
+  import Ecto.Query
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Embeddings.ShrinkLadder
+  alias Loopctl.Memory
+  alias Loopctl.Memory.Memory, as: MemorySchema
+
+  defp candidate(text),
+    do: %{text: text, when_to_apply: "", tags: [], confidence: 0.9, cross_links: []}
+
+  defp promoted(scope) do
+    from(m in MemorySchema,
+      where:
+        m.tenant_id == ^scope.tenant_id and m.subject_id == ^scope.subject_id and
+          m.source == :promoted,
+      order_by: [asc: m.inserted_at]
+    )
+    |> AdminRepo.all()
+  end
+
+  defp mark_prefix_embedded!(memory) do
+    memory
+    |> Ecto.Changeset.change(%{
+      embedding_content_hash: ShrinkLadder.truncated_hash(memory.embedding_content_hash)
+    })
+    |> AdminRepo.update!()
+  end
+
+  setup do
+    scope = %{fixture(:memory_scope, subject_id: "A") | session_id: "s1"}
+    # The default embedding stub is deterministic per tenant, so any two promoted rows
+    # score 1.0 against each other — the near-dup path fires unless something blocks it.
+    {:ok, _} = Memory.persist_promotion(scope, [candidate("the first durable fact")])
+    [first] = promoted(scope)
+    %{scope: scope, first: first}
+  end
+
+  test "a WHOLE-text promoted row is superseded, as designed", %{scope: scope, first: first} do
+    assert {:ok, %{superseded: 1}} =
+             Memory.persist_promotion(scope, [candidate("a second durable fact")])
+
+    refute is_nil(AdminRepo.get!(MemorySchema, first.id).superseded_by)
+  end
+
+  test "a PREFIX-embedded promoted row is left alone", %{scope: scope, first: first} do
+    mark_prefix_embedded!(first)
+
+    assert {:ok, %{promoted: 1, superseded: 0}} =
+             Memory.persist_promotion(scope, [candidate("a second durable fact")])
+
+    assert is_nil(AdminRepo.get!(MemorySchema, first.id).superseded_by)
+  end
+
+  test "the mark does not break exact dedupe of the same text", %{scope: scope, first: first} do
+    # The hash still identifies the FULL text; only the vector beside it is partial. If the
+    # mark were treated as a different hash, the identical candidate would be re-promoted.
+    mark_prefix_embedded!(first)
+
+    assert {:ok, %{deduped: 1, promoted: 0}} =
+             Memory.persist_promotion(scope, [candidate("the first durable fact")])
+
+    assert length(promoted(scope)) == 1
+  end
+end

--- a/test/loopctl/workers/article_embedding_worker_test.exs
+++ b/test/loopctl/workers/article_embedding_worker_test.exs
@@ -7,6 +7,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
   alias Loopctl.Custody
   alias Loopctl.Egress
   alias Loopctl.Egress.PinCache
+  alias Loopctl.Embeddings.ShrinkLadder
   alias Loopctl.Embeddings.TextBudget
   alias Loopctl.Knowledge
   alias Loopctl.Test.AllowlistSource
@@ -582,6 +583,72 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
       # The article is embedded — not left in the reconciler's hourly retry loop.
       {:ok, stored} = Knowledge.get_article_with_embedding(tenant.id, article.id)
       refute is_nil(stored.embedding)
+
+      # ...and the stored hash is MARKED, because that vector covers a PREFIX (#617
+      # review follow-up). This worker was the last writer storing an unmarked prefix,
+      # and it writes most of the corpus — so the readers that refuse to compare against
+      # a prefix (the consolidation corroboration gate, the memory near-dup supersede)
+      # filtered on a mark that nothing ever set, and could never fire.
+      assert ShrinkLadder.truncated_hash?(stored.embedding_content_hash)
+
+      # The mark must still identify the FULL text, or the idempotency guard misses and
+      # every later enqueue re-walks the whole ladder at the provider's expense.
+      assert ShrinkLadder.whole_hash(stored.embedding_content_hash) ==
+               :sha256
+               |> :crypto.hash(TextBudget.initial("#{stored.title}\n\n#{stored.body}"))
+               |> Base.encode16(case: :lower)
+    end
+
+    test "an UNtruncated embedding is not marked" do
+      # The mark has to discriminate. Marking every row would exclude the whole corpus
+      # from the corroboration gate — the same dead guard, arrived at from the other side.
+      %{tenant: tenant} = setup_tenant()
+
+      article =
+        create_draft_then_publish(tenant.id, %{title: "Short Enough", body: "a short body"})
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, List.duplicate(0.5, 1536)}
+      end)
+
+      assert :ok =
+               ArticleEmbeddingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => article.id, "tenant_id" => tenant.id}
+               })
+
+      {:ok, stored} = Knowledge.get_article_with_embedding(tenant.id, article.id)
+      refute ShrinkLadder.truncated_hash?(stored.embedding_content_hash)
+    end
+
+    test "a marked row is still recognised as already embedded, and is not re-billed" do
+      # The whole reason the hash keeps identifying the full text. If the idempotency
+      # guard compared the raw stored value it would miss on every marked row, and each
+      # enqueue would re-walk the ladder — several billed calls — forever.
+      %{tenant: tenant} = setup_tenant()
+
+      article =
+        create_draft_then_publish(tenant.id, %{
+          title: "Marked Then Re-enqueued",
+          body: String.duplicate("привет ", 6_000)
+        })
+
+      Loopctl.MockEmbeddingClient
+      |> expect(:generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 400, :context_length_exceeded}}
+      end)
+      |> expect(:generate_embedding, fn _tenant_id, _text ->
+        {:ok, List.duplicate(0.5, 1536)}
+      end)
+
+      job = %Oban.Job{args: %{"article_id" => article.id, "tenant_id" => tenant.id}}
+      assert :ok = ArticleEmbeddingWorker.perform(job)
+
+      {:ok, stored} = Knowledge.get_article_with_embedding(tenant.id, article.id)
+      assert ShrinkLadder.truncated_hash?(stored.embedding_content_hash)
+
+      # A second run makes ZERO provider calls: `expect` above is exhausted, so any
+      # further call fails the test rather than silently re-billing.
+      assert :ok = ArticleEmbeddingWorker.perform(job)
     end
 
     test "gives up with a discard once the floor itself is rejected" do

--- a/test/loopctl/workers/knowledge_lint_worker_caps_test.exs
+++ b/test/loopctl/workers/knowledge_lint_worker_caps_test.exs
@@ -1,0 +1,103 @@
+defmodule Loopctl.Workers.KnowledgeLintWorkerCapsTest do
+  @moduledoc """
+  The nightly's three consolidation caps are the ONLY lever that slows or stops the
+  auto-unpublish drain, and until #617 the only way to move one was a deploy — an
+  operator watching an apply go wrong had no way to halt it in the minutes that
+  matter.
+
+  `async: false` DELIBERATELY, for the same reason
+  `Loopctl.ReleaseCustodyProfileTest` is: `SystemConfig.put/2` writes
+  `:persistent_term`, which is VM-GLOBAL. Seeding a cap row from an `async: true`
+  module would bleed that cap into every other test running concurrently. This is
+  the documented exception to the repo's `async: true` rule, not a lapse from it —
+  and it is why the production code reads the lever from the DB rather than from
+  `Application.put_env/3`, which would have the same global-mutation problem in
+  production as it does here.
+  """
+
+  use Loopctl.DataCase, async: false
+
+  setup :verify_on_exit!
+
+  alias Loopctl.SystemConfig
+  alias Loopctl.Workers.KnowledgeLintWorker
+
+  @keys ~w(
+    knowledge_consolidation_max_applies
+    knowledge_consolidation_max_unpublishes
+    knowledge_consolidation_max_per_class
+  )
+
+  setup do
+    on_exit(fn ->
+      # The DB row dies with the sandbox transaction; the persistent_term does NOT.
+      # Erasing it is what keeps this module from leaking a cap into the rest of the run.
+      Enum.each(@keys, &:persistent_term.erase({SystemConfig, &1}))
+    end)
+
+    :ok
+  end
+
+  describe "cap resolution order: DB row -> app config -> module default" do
+    test "with no DB row, the app config value is what the nightly uses" do
+      # config/test.exs sets max_applies: 2 / max_unpublishes: 1. The SystemConfig
+      # indirection must not change what a deployment without a row already saw.
+      assert KnowledgeLintWorker.applies_cap() ==
+               Application.get_env(:loopctl, :knowledge_consolidation_max_applies)
+
+      assert KnowledgeLintWorker.unpublishes_cap() ==
+               Application.get_env(:loopctl, :knowledge_consolidation_max_unpublishes)
+    end
+
+    test "the app config layer beats the module default when it is set" do
+      # config/config.exs sets all three. The module default is the LAST resort, reached
+      # only when neither a DB row nor an app config exists — see the coerce_int/2 block
+      # below, which pins that leg without mutating VM-global state to remove the config.
+      configured = Application.get_env(:loopctl, :knowledge_consolidation_max_per_class)
+
+      assert is_integer(configured),
+             "config/config.exs is expected to set :knowledge_consolidation_max_per_class"
+
+      assert KnowledgeLintWorker.per_class_cap() == configured
+    end
+
+    test "a DB row OVERRIDES the app config, live, with no redeploy" do
+      {:ok, _} = SystemConfig.put("knowledge_consolidation_max_applies", 7)
+      {:ok, _} = SystemConfig.put("knowledge_consolidation_max_unpublishes", 9)
+      {:ok, _} = SystemConfig.put("knowledge_consolidation_max_per_class", 11)
+
+      assert KnowledgeLintWorker.applies_cap() == 7
+      assert KnowledgeLintWorker.unpublishes_cap() == 9
+      assert KnowledgeLintWorker.per_class_cap() == 11
+    end
+
+    test "0 is reachable through the lever — the operator HALT must survive the indirection" do
+      # `apply_confirmed_duplicates/2` honours 0 as an explicit pause (`gate:
+      # :drain_disabled`) rather than rounding it up. If the lever could not express 0,
+      # the halt an operator reaches for mid-incident would not exist.
+      {:ok, _} = SystemConfig.put("knowledge_consolidation_max_unpublishes", 0)
+
+      assert KnowledgeLintWorker.unpublishes_cap() == 0
+    end
+  end
+
+  describe "coerce_int/2 — the app-config layer is type-checked, not trusted" do
+    test "a non-integer resolves to the default rather than raising" do
+      # `SystemConfig.get_int/2` requires an INTEGER default and would raise a
+      # FunctionClauseError on a `nil` or a `"25"`. Inside the nightly's rescue that
+      # surfaces as a generic `apply_failed`, which reads as an outage rather than as the
+      # config typo it is.
+      for bad <- ["25", :all, 25.0, %{}, nil] do
+        assert KnowledgeLintWorker.coerce_int(bad, 25) == 25
+      end
+    end
+
+    test "an integer passes through untouched, including 0 and negatives" do
+      # Clamping belongs to `Consolidation` (which distinguishes 0-as-pause from a typo);
+      # this layer only guarantees the fallback chain cannot fault.
+      for good <- [0, 1, -1, 500] do
+        assert KnowledgeLintWorker.coerce_int(good, 25) == good
+      end
+    end
+  end
+end

--- a/test/loopctl/workers/knowledge_lint_worker_caps_test.exs
+++ b/test/loopctl/workers/knowledge_lint_worker_caps_test.exs
@@ -95,9 +95,9 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerCapsTest do
       winner = publish!(tenant.id, "Lever Doc", String.duplicate("long ", 40))
       loser = publish!(tenant.id, "lever doc!", "short")
 
-      # Orthogonal vectors: cosine 0, so the default 0.80 threshold withholds the group.
+      # Cosine 0.6 — below the default 0.80, so the group is withheld until the lever moves.
       embed!(tenant.id, winner, [1.0 | List.duplicate(0.0, 1535)])
-      embed!(tenant.id, loser, [0.0, 1.0 | List.duplicate(0.0, 1534)])
+      embed!(tenant.id, loser, [0.6, 0.8 | List.duplicate(0.0, 1534)])
 
       {:ok, _} = Consolidation.run(tenant.id, day: Date.add(Date.utc_today(), -1))
       {:ok, _} = Consolidation.run(tenant.id)
@@ -105,12 +105,34 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerCapsTest do
       assert %{applied: 0, uncorroborated: 1} =
                Consolidation.apply_confirmed_duplicates(tenant.id)
 
-      {:ok, _} = SystemConfig.put("knowledge_consolidation_min_duplicate_similarity_pct", 0)
+      {:ok, _} = SystemConfig.put("knowledge_consolidation_min_duplicate_similarity_pct", 50)
 
       assert %{applied: 1, uncorroborated: 0} =
                Consolidation.apply_confirmed_duplicates(tenant.id)
 
       assert AdminRepo.get!(Article, loser).status == :draft
+    end
+
+    test "0 does NOT mean 'off' here — it is refused, not honoured as a pause" do
+      # The sibling drain caps read 0 as an explicit pause, so 0 is the value an operator
+      # reaches for to "turn the corroboration gate off". On THIS knob it does the
+      # opposite: `min_sim >= 0.0` holds for every pair, so every title collision would
+      # auto-unpublish with no content evidence at all. It falls back to the app layer.
+      tenant = fixture(:tenant)
+      winner = publish!(tenant.id, "Off Switch", String.duplicate("long ", 40))
+      loser = publish!(tenant.id, "off switch!", "short")
+
+      embed!(tenant.id, winner, [1.0 | List.duplicate(0.0, 1535)])
+      embed!(tenant.id, loser, [0.0, 1.0 | List.duplicate(0.0, 1534)])
+
+      {:ok, _} = Consolidation.run(tenant.id, day: Date.add(Date.utc_today(), -1))
+      {:ok, _} = Consolidation.run(tenant.id)
+      {:ok, _} = SystemConfig.put("knowledge_consolidation_min_duplicate_similarity_pct", 0)
+
+      assert %{applied: 0, uncorroborated: 1} =
+               Consolidation.apply_confirmed_duplicates(tenant.id)
+
+      assert AdminRepo.get!(Article, loser).status == :published
     end
   end
 

--- a/test/loopctl/workers/knowledge_lint_worker_caps_test.exs
+++ b/test/loopctl/workers/knowledge_lint_worker_caps_test.exs
@@ -19,6 +19,10 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerCapsTest do
 
   setup :verify_on_exit!
 
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.Consolidation
   alias Loopctl.SystemConfig
   alias Loopctl.Workers.KnowledgeLintWorker
 
@@ -26,6 +30,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerCapsTest do
     knowledge_consolidation_max_applies
     knowledge_consolidation_max_unpublishes
     knowledge_consolidation_max_per_class
+    knowledge_consolidation_min_duplicate_similarity_pct
   )
 
   setup do
@@ -80,6 +85,44 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerCapsTest do
       assert KnowledgeLintWorker.unpublishes_cap() == 0
     end
   end
+
+  describe "the duplicate-similarity threshold is the same kind of lever" do
+    test "a DB row moves the content gate live, with no redeploy" do
+      # This threshold decides whether the only self-writing class applies anything at all.
+      # Until #617 it was `Application.get_env/3` only, so an operator watching an
+      # auto-unpublish behave wrong could move it only by deploying.
+      tenant = fixture(:tenant)
+      winner = publish!(tenant.id, "Lever Doc", String.duplicate("long ", 40))
+      loser = publish!(tenant.id, "lever doc!", "short")
+
+      # Orthogonal vectors: cosine 0, so the default 0.80 threshold withholds the group.
+      embed!(tenant.id, winner, [1.0 | List.duplicate(0.0, 1535)])
+      embed!(tenant.id, loser, [0.0, 1.0 | List.duplicate(0.0, 1534)])
+
+      {:ok, _} = Consolidation.run(tenant.id, day: Date.add(Date.utc_today(), -1))
+      {:ok, _} = Consolidation.run(tenant.id)
+
+      assert %{applied: 0, uncorroborated: 1} =
+               Consolidation.apply_confirmed_duplicates(tenant.id)
+
+      {:ok, _} = SystemConfig.put("knowledge_consolidation_min_duplicate_similarity_pct", 0)
+
+      assert %{applied: 1, uncorroborated: 0} =
+               Consolidation.apply_confirmed_duplicates(tenant.id)
+
+      assert AdminRepo.get!(Article, loser).status == :draft
+    end
+  end
+
+  defp publish!(tenant_id, title, body) do
+    fixture(:article, %{tenant_id: tenant_id, title: title, body: body, category: :pattern})
+    |> Ecto.Changeset.change(%{status: :published})
+    |> AdminRepo.update!()
+    |> Map.fetch!(:id)
+  end
+
+  defp embed!(tenant_id, id, vector),
+    do: {:ok, _} = Knowledge.update_embedding(tenant_id, id, vector, nil)
 
   describe "coerce_int/2 — the app-config layer is type-checked, not trusted" do
     test "a non-integer resolves to the default rather than raising" do


### PR DESCRIPTION
Closes #617.

The follow-up worklist the #615 and #616 enhanced reviews routed out of scope. Nothing here is a new idea: each item is a place where a fix landed on one call site and the same defect stayed live on the others.

## The embedding ladder reaches the other four call sites

#615 gave the byte budget and shrink ladder to the two article-embedding workers. Everywhere else an input-too-long rejection still resolved through 'permanent_provider_error?', which is true for any 4xx - so the job DISCARDED and the row stayed un-embedded with no repair path. That is the shape of the outage #615 fixed, one call site over:

| Path | What the discard cost |
|---|---|
| 'ReembedWorker' | discards MID-RUN, so one over-long article leaves the tenant's re-embed unable to reach 'complete_reembed' and its recall pinned at the old dimension |
| 'SystemCorpusEmbeddingWorker' | the canonical stays keyword-only for that tenant while 'system_corpus_meta/2' keeps reporting semantic |
| 'MemoryEmbeddingWorker' / 'Memory.nearest_live' | the memory is permanently absent from semantic recall; the near-dup guard on promotion silently degrades |
| 'Knowledge.ProposalGate' | the gate falls OPEN, so the article skips novelty checking and lands as exactly the duplicate the nightly then has to catch |

'Loopctl.Embeddings.ShrinkLadder' carries both shapes. A single text halves what was actually SENT. An array BISECTS - the provider rejects the whole array and never says which member - until the rejection isolates to one text, which then walks the ladder. Only the offender is truncated; its innocent neighbours are re-sent whole.

Dissolving to per-article jobs (what 'BatchArticleEmbeddingWorker' does) is the better answer where a per-item worker exists at the same dimension and model. It does not here: 'ReembedWorker' embeds at a PENDING dimension with a pinned model, and re-enqueueing through 'ArticleEmbeddingWorker' would write the ACTIVE one.

## The nightly re-checks the premise it applies on

'apply_duplicate_group' re-checked that a confirmed group's members were still published - never that they still collide. Retitling is the one remedy a human has for a false grouping, and it leaves every member live, so the 23 articles retitled by hand on 2026-08-06 would have passed that check. Nothing bad happened only because a fresh derivation drops such a group before it reaches apply, i.e. by a step OUTSIDE the function that decides.

The signal that FORMED the group (normalized title, or normalized idempotency key) is now re-evaluated where it is used. A group that dissolved or SPLIT is skipped whole and re-derived rather than applied to the larger half. Placeholder titles are excluded here exactly as the deriving scan excludes them, so a retitle onto "Draft" cannot auto-unpublish on a signal the scan deliberately refuses to raise.

## The rest of #617

- **'prune_proposals' names its 'tenant_id'.** It is a BYPASSRLS 'delete_all', so the WHERE clause is the entire tenant boundary. 'report_id' does imply the tenant today, so this is defence in depth rather than a live cross-tenant delete - stated plainly because the review flagged it as the only cross-tenant-shaped entry and it is worth knowing which it is.
- **'analyze/2' type-checks ':max_per_class' before clamping.** A number sorts below every atom and binary in Erlang term order, so the old 'max(1) |> min(500)' resolved a config typo to the ceiling - the largest report available - instead of the default. Same fix 'clamp_cap/3' already carried for the apply caps.
- **A duplicate group carries at most 50 members** onto one proposal. Truncation is deterministic - 'array_agg' now orders by 'inserted_at' AND 'id' - because 'fingerprint/2' hashes the sorted id set and the two-run gate confirms only a repeated fingerprint; a group that truncated differently on two nights could never be confirmed.
- **'generic_titles/2' counts and pages in two queries** instead of loading every match through the heavy-read gate to discard most of it.
- **The three drain caps resolve through 'SystemConfig' first.** The only lever that can halt a bad apply now works without a deploy. Deliberately NOT 'Application.put_env': per-node, does not survive restart, fails open, and mutating VM-global state makes the code untestable. Resolution order is DB row, then app config, then module default - so nothing an existing deployment set changes meaning.

## Verification

- 'mix precommit' green: format, compile warnings-as-errors, credo --strict clean, dialyzer clean, 6988 tests 0 failures.
- **Every new guard was mutation-verified.** Neutering the ladder fails 6 of 12 'ShrinkLadder' tests; removing the re-grouping check, the member cap and the per-class clamp fails 5 named consolidation tests. The pass-through tests keep passing under mutation, which is what shows the guards discriminate rather than merely fire.
- Verified against prod before starting: #615 and #616 are deployed (run 31135222768, Deploy and Post-deploy Smoke both green) and the 80-article embedding outage is cleared - 'unembedded_articles' returns 0 and the active-dimension gap is 0.

## Not in this PR

The ingestion root cause - titles minted from bare filenames, which is what generates this whole collision class - is a separate change to the ingestion path and gets its own branch. It is the last open item on #617.

---

## Enhanced review (run `wf_60d57c08-362`, 42 agents)

26 findings confirmed, all 26 addressed on this branch. Two fix rounds landed as `c2d1641` and `d756803`; the review's own out-of-scope list and its one flagged invalid deferral landed as `729a3bb`.

The dominant theme — raised independently by four reviewers — was one I had half-built: the truncated-vector invariant was enforced on the COMPARING side before the STORING side. Rounds 1 and 2 added the marker and taught the readers to refuse a prefix; `729a3bb` gave it a writer. Until that last commit `ArticleEmbeddingWorker`, which writes most of the corpus, stored prefix vectors under unmarked hashes, so the consolidation corroboration gate and the memory near-dup supersede were both excluding a set that was always empty.

Also fixed from the review:

- `embed_one/3` returns `{:ok, vector, :truncated}`; `ProposalGate` will not call a prefix a duplicate, and `Memory` will not supersede a prior memory on one.
- Both batch callers pre-split by byte budget and store each sub-batch before the next, so the ladder is reserved for a genuinely over-long member and paid-for work survives a later failure.
- `embed_batch/3` carries a shared call budget across the whole bisect, and no longer discards an already-billed half when its sibling fails.
- `still_colliding` requires the surviving colliding subgroup to be the WHOLE live set, so a partially retitled group is skipped rather than applied to the remnant.
- `generic_titles/2` gets total and page from one scan via `count(*) OVER ()`, rather than two independently-timed-out passes.
- `score_groups/2` restricts and dedups its id list, off the Postgrex 65,535-bind-parameter cliff.
- The duplicate-similarity threshold joins the three caps as a live SystemConfig lever — 0 is refused there rather than honoured as a pause, because `min_sim >= 0.0` holds for every pair.
- `uncorroborated` appears in the nightly summary and audit event, so a blocked night is distinguishable from a quiet one.

Reviewer false-positive rate 1/27 (3.7%). Publish gate: `inSync: true` — local, origin and PR head all at the same SHA with the fix commits as ancestors, verified by hand as well.

**Deliberate deviation from the workflow's default:** it routes out-of-scope findings to a follow-up branch. These went in here instead, because the reader and writer halves of one invariant shipping in separate PRs would leave a dead guard on master in between.
