### PR TITLE
Close the gate that 0 could open, and stop withholding on gaps that cannot close

### DIFF
--- a/lib/loopctl/knowledge/consolidation.ex
+++ b/lib/loopctl/knowledge/consolidation.ex
@@ -113,6 +113,7 @@ defmodule Loopctl.Knowledge.Consolidation do
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ConsolidationProposal
   alias Loopctl.Knowledge.ConsolidationReport
+  alias Loopctl.Llm
   alias Loopctl.SystemConfig
   alias Loopctl.Workers.BatchArticleEmbeddingWorker
 
@@ -516,14 +517,29 @@ defmodule Loopctl.Knowledge.Consolidation do
   # undeduplicated list carrying both classes approaches Postgres's 65,535 bind-parameter
   # limit, where a Postgrex encode failure is rescued into `:unavailable` and withholds
   # EVERY title-drift group for that tenant, deterministically, every night.
-  defp score_groups(tenant_id, proposals) do
-    ids =
-      proposals
-      |> Enum.filter(&title_drift?/1)
-      |> Enum.flat_map(& &1.article_ids)
-      |> Enum.uniq()
+  # CHUNKED over the proposals, because neither the bind count nor the self-join width may
+  # scale with the apply cap. `title_pairs/2` binds the id list TWICE, so at `max_applies:
+  # 500` groups x 50 members that is ~50,000 bind parameters against Postgres's 65,535
+  # ceiling — and the whole thing runs inside a 10s statement timeout whose failure rescues
+  # to `:unavailable`, withholding EVERY title group for the night. Raising the cap to
+  # drain a backlog faster is exactly what would trip it, so the failure would arrive
+  # precisely when the pass was asked to do more work.
+  #
+  # Chunking by GROUP rather than by id keeps each query's pairs whole: a group split
+  # across two queries would have its members scored against different pools, and
+  # `min_sim` is a per-group minimum. The merged map is keyed by member id, and a member
+  # shared between groups resolves to the same entry either way.
+  @score_groups_per_query 25
 
-    pairwise_similarity_by_group(tenant_id, ids)
+  defp score_groups(tenant_id, proposals) do
+    proposals
+    |> Enum.filter(&title_drift?/1)
+    |> Enum.chunk_every(@score_groups_per_query)
+    |> Enum.reduce(%{}, fn chunk, acc ->
+      ids = chunk |> Enum.flat_map(& &1.article_ids) |> Enum.uniq()
+
+      Map.merge(acc, pairwise_similarity_by_group(tenant_id, ids))
+    end)
   rescue
     e -> log_scoring_failed(tenant_id, ExitTag.tag(e))
   catch
@@ -862,6 +878,78 @@ defmodule Loopctl.Knowledge.Consolidation do
   defp backfill_missing_embeddings(_tenant_id, []), do: :ok
 
   defp backfill_missing_embeddings(tenant_id, ids) do
+    # An article whose stored vector is a PREFIX is unscored on purpose — `score_pairs/2`
+    # excludes truncation-marked rows so a prefix is never compared against a whole text.
+    # It is NOT backfillable, and enqueueing it was a no-op loop I created in #617:
+    # `BatchArticleEmbeddingWorker` compares through `ShrinkLadder.whole_hash/1`, so a
+    # marked row reads as ALREADY EMBEDDED and the job returns without doing anything.
+    # The gap therefore never closed, the group withheld on every subsequent night, and
+    # the pass re-enqueued the same dead jobs forever — a producer with no consumer, the
+    # exact shape #605 named and this pass keeps re-finding.
+    #
+    # Re-embedding would not help either: the text is over the provider's limit, which is
+    # why it is a prefix. So the correct handling is to stop pretending it is a gap.
+    # A tenant with no BYO embedding key can NEVER satisfy this gate: every backfill job
+    # it enqueues is discarded `{:no_embedding_key, _}` on pickup, so the title-drift class
+    # withholds on every run forever while looking transient in the log ("backfill
+    # enqueued") — a drain converging to a floor, and nightly Oban churn to go with it.
+    # Say so once, plainly, and enqueue nothing.
+    if Llm.has_embedding_key?(tenant_id) do
+      backfill_embeddable(tenant_id, ids)
+    else
+      Logger.info(
+        "Consolidation: tenant=#{tenant_id} has no embedding key (mandatory BYO), so the " <>
+          "#{length(ids)} unscored member(s) can never be embedded and title-drift groups " <>
+          "stay withheld permanently. Not enqueued — this is a configuration state, not a " <>
+          "transient gap. Idempotency-drift groups are unaffected (they need no vectors)."
+      )
+
+      :ok
+    end
+  end
+
+  defp backfill_embeddable(tenant_id, ids) do
+    {prefix, missing} = split_prefix_embedded(tenant_id, ids)
+
+    if prefix != [] do
+      Logger.info(
+        "Consolidation: tenant=#{tenant_id} #{length(prefix)} withheld member(s) carry a " <>
+          "PREFIX embedding (input over the provider limit), which cannot corroborate a " <>
+          "title collision and cannot be backfilled. Not enqueued; the group stays withheld " <>
+          "until the article is shortened or split."
+      )
+    end
+
+    enqueue_backfill(tenant_id, missing)
+  end
+
+  # Which of `ids` already carry a truncation-MARKED hash, read the same way every
+  # idempotency guard on this surface reads it: the side table at the active dimension
+  # when the tenant writes there, the legacy column otherwise.
+  defp split_prefix_embedded(tenant_id, ids) do
+    hashes =
+      if Embeddings.use_side_table_hash?(tenant_id) do
+        Embeddings.article_embedded_hashes(tenant_id, ids, Embeddings.active_dimension(tenant_id))
+      else
+        legacy_hashes(tenant_id, ids)
+      end
+
+    Enum.split_with(ids, &ShrinkLadder.truncated_hash?(Map.get(hashes, &1)))
+  end
+
+  defp legacy_hashes(tenant_id, ids) do
+    from(a in Article,
+      where: a.tenant_id == ^tenant_id,
+      where: a.id in ^ids,
+      select: {a.id, a.embedding_content_hash}
+    )
+    |> AdminRepo.all()
+    |> Map.new()
+  end
+
+  defp enqueue_backfill(_tenant_id, []), do: :ok
+
+  defp enqueue_backfill(tenant_id, ids) do
     ids
     |> Enum.chunk_every(Knowledge.embedding_batch_max())
     |> Enum.each(fn chunk ->
@@ -1490,14 +1578,38 @@ defmodule Loopctl.Knowledge.Consolidation do
     end
   end
 
-  defp validate_similarity(value)
-       when (is_float(value) or is_integer(value)) and value >= 0 and value <= 1,
-       do: value * 1.0
+  # The bounds are EXCLUSIVE at both ends, matching the DB percent path's 1..99.
+  #
+  # `0` was accepted here, and it is the one in-range value that is catastrophic: the gate
+  # is `min_sim >= threshold`, so a threshold of 0.0 is satisfied by EVERY pair — including
+  # a pair with a cosine of 0. The only content check on the only self-applying class is
+  # then fully OFF, silently, while every run still reports `gate: :open` and unpublishes.
+  # This module's own comment above already explained why clamping a NEGATIVE to 0.0 would
+  # be a disaster; it just never noticed that an explicit 0 walked straight through the
+  # in-range clause to the same place. `0` is also the exact value an operator reaches for
+  # meaning "turn this off" — on the sibling drain caps it IS a pause, so the wrong guess
+  # here is the likely one.
+  #
+  # `1.0` is excluded for the mirror-image reason: identical vectors score exactly 1.0, so
+  # an operator hard-disabling the class mid-incident with 1.0 would still auto-unpublish
+  # byte-identical captures. Neither end of this range is the safe one, which is why an
+  # out-of-band value falls back to the default rather than being clamped toward a bound.
+  # Public (`@doc false`) so the bound can be asserted as a pure function. The alternative
+  # is mutating `:loopctl`'s application env from a test, which is banned here — it is
+  # VM-global, so an `async: true` sibling would see another module's threshold. A guard on
+  # the auto-unpublish path that nothing can test is a guard nobody can trust.
+  @doc false
+  @spec validate_similarity(term()) :: float()
+  def validate_similarity(value)
+      when (is_float(value) or is_integer(value)) and value > 0 and value < 1,
+      do: value * 1.0
 
-  defp validate_similarity(value) do
+  def validate_similarity(value) do
     Logger.warning(
       "Consolidation: ignoring duplicate similarity threshold #{inspect(value)} — not a " <>
-        "number in 0.0..1.0; using #{@default_min_duplicate_similarity}."
+        "number strictly between 0.0 and 1.0 (0 would turn the corroboration gate OFF " <>
+        "rather than disable the class, and 1.0 still admits byte-identical pairs); " <>
+        "using #{@default_min_duplicate_similarity}."
     )
 
     @default_min_duplicate_similarity

--- a/lib/loopctl/knowledge/okf.ex
+++ b/lib/loopctl/knowledge/okf.ex
@@ -765,20 +765,63 @@ defmodule Loopctl.Knowledge.OKF do
     end
   end
 
+  # Titles that hundreds of unrelated documents all produce. A bundle carrying a bare
+  # `CHANGELOG.md` with no frontmatter title used to import as the article "Changelog", and
+  # three such documents then collided into a false duplicate group on the hosted corpus —
+  # the class #617 traced back to title minting. The REST ingestion path was fixed by
+  # showing its extractor the source; this importer derives titles itself, so it qualifies
+  # them itself. Matched on the NORMALIZED derived title, so "change-log" and "CHANGELOG"
+  # are both caught.
+  #
+  # Deliberately NOT `Consolidation.generic_title_pattern/0`: that one matches PLACEHOLDER
+  # titles ("Untitled", "Draft") and is owned by a different proposal class. These are
+  # perfectly good document names that are merely not unique.
+  @generic_concept_titles ~w(
+    changelog readme license contributing installation configuration
+    overview index introduction usage reference api getting started
+    quickstart quick start faq notes todo roadmap security upgrading
+  )
+
   defp concept_title(fm, path) do
     case Map.get(fm, "title") do
       title when is_binary(title) and title != "" ->
         title
 
       _ ->
-        # Derive from the concept id (filename minus .md), de-slugified.
-        path
-        |> Path.basename(".md")
-        |> String.replace(["-", "_"], " ")
-        |> String.split()
-        |> Enum.map_join(" ", &String.capitalize/1)
+        path |> derived_title() |> qualify_generic(path)
     end
     |> String.slice(0, 500)
+  end
+
+  # Derive from the concept id (filename minus .md), de-slugified.
+  defp derived_title(path) do
+    path
+    |> Path.basename(".md")
+    |> String.replace(["-", "_"], " ")
+    |> String.split()
+    |> Enum.map_join(" ", &String.capitalize/1)
+  end
+
+  # Qualify with the nearest enclosing directory, which in an OKF bundle names the concept
+  # group the file belongs to. No directory (a file at the bundle root) means there is
+  # nothing honest to qualify WITH, so the bare title stands rather than being padded with
+  # an invented source — the same rule the extraction prompt follows.
+  defp qualify_generic(title, path) do
+    if String.downcase(title) in @generic_concept_titles do
+      case qualifier(path) do
+        nil -> title
+        source -> "#{title} — #{source}"
+      end
+    else
+      title
+    end
+  end
+
+  defp qualifier(path) do
+    case path |> Path.dirname() |> Path.basename() do
+      dir when dir in [".", "/", "", "concepts"] -> nil
+      dir -> dir |> String.replace(["-", "_"], " ") |> String.trim()
+    end
   end
 
   defp category_for(fm, type) do

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -123,7 +123,16 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
         "publish them on extraction instead. Role: orchestrator+.\n\n" <>
         "**At rest:** inline `content` is encrypted (AES-256-GCM) in the job record " <>
         "and is never persisted in the clear. `url`, `source_type`, and `metadata` " <>
-        "are NOT encrypted — do not put sensitive values in `metadata`.",
+        "are NOT encrypted — do not put sensitive values in `metadata`.\n\n" <>
+        "**In transit to your LLM provider:** the extraction prompt names the source, " <>
+        "so titles can be self-qualifying (a bare \"Changelog\" from three different " <>
+        "documents is indistinguishable once it is in the corpus). What is sent is " <>
+        "`metadata.source_ref` if you supply it, otherwise the `url` reduced to " <>
+        "scheme+host+path — userinfo and the query string are stripped, so credentials " <>
+        "and query-string signatures are not transmitted, but the host and PATH are. A " <>
+        "share link carrying its token in a path segment still sends it. Omit " <>
+        "`source_ref` rather than passing a placeholder: a model will qualify a title " <>
+        "WITH it.",
     request_body:
       {"Ingestion request", "application/json",
        %OpenApiSpex.Schema{
@@ -158,7 +167,22 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
            },
            metadata: %OpenApiSpex.Schema{
              type: :object,
-             description: "Optional metadata map"
+             description:
+               "Optional metadata map. `source_ref` is the one key with behaviour: it " <>
+                 "names the SPECIFIC source (a URL, repo, or document name) and drives " <>
+                 "article-title qualification, overriding the name derived from `url` " <>
+                 "(which matters when a URL's identity lives in its stripped query " <>
+                 "string). It is the only way to name the source of an inline `content` " <>
+                 "ingest. Its value is included in the extraction prompt POSTed to your " <>
+                 "configured LLM provider, reduced the same way `url` is. Omit it rather " <>
+                 "than passing a placeholder. Nothing in `metadata` is encrypted at rest.",
+             properties: %{
+               source_ref: %OpenApiSpex.Schema{
+                 type: :string,
+                 description: "The specific source that titles are qualified with.",
+                 example: "https://github.com/scrogson/oauth2"
+               }
+             }
            }
          },
          required: ["source_type"]
@@ -289,9 +313,12 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
                "Array of ingestion items (max 50). Each item has the same shape as " <>
                  "POST /knowledge/ingest: url or content, source_type (required), " <>
                  "project_id (optional), publish (optional, default false → draft), " <>
-                 "metadata (optional). Per-item `content` obeys the same " <>
+                 "metadata (optional; `metadata.source_ref` names the specific source " <>
+                 "and drives title qualification, overriding the `url`-derived name). " <>
+                 "Per-item `content` obeys the same " <>
                  "#{@max_inline_content_bytes}-byte cap and is encrypted at rest; " <>
-                 "`metadata` is not encrypted.",
+                 "`metadata` is not encrypted, and `source_ref` (or the reduced `url`) " <>
+                 "is sent to your LLM provider in the extraction prompt.",
              maxItems: 50
            }
          },

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.72.0 — 2026-08-07 (name the source, so titles can stand alone)
+
+### Added
+
+- **`knowledge_ingest` accepts a `metadata` object, and forwards it.** It previously did
+  not, which made `metadata.source_ref` unreachable from MCP entirely — the server honours
+  it, but no agent using these tools could set it.
+
+  `source_ref` names the SPECIFIC source (a URL, repo, or document name) and is what lets an
+  extracted article title qualify itself. Without it the extractor sees only a coarse
+  `source_type` like `web_article` and a CHANGELOG file can only become an article titled
+  "Changelog" — indistinguishable from every other document's changelog once it is in the
+  corpus. Three unrelated documents did exactly that on the hosted corpus and were then
+  proposed for automatic unpublishing as "the same capture".
+
+  It overrides the name derived from `url` (which matters when a URL's identity lives in its
+  stripped query string) and is the ONLY way to name the source of an inline `content`
+  ingest. **Omit it rather than passing a placeholder** — a model will dutifully qualify a
+  title WITH the word "unknown".
+
+### Changed
+
+- **`knowledge_ingest_batch`'s per-item `metadata` documents `source_ref`.** The parameter
+  was already accepted and forwarded; its description said only "Optional metadata map", so
+  the behaviour was undiscoverable.
+
+### Note on what is sent to your LLM provider
+
+`source_ref` — or, absent it, the ingest `url` reduced to scheme+host+path — is included in
+the extraction prompt POSTed to the tenant's configured provider. Userinfo and the query
+string are stripped, so credentials and query-string signatures are not transmitted; the
+host and PATH are, so a share link carrying its token in a path segment still sends it.
+
 ## 2.71.0 — 2026-08-05 (consolidation: two classes retired, and the pass now writes)
 
 ### Changed

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -1942,12 +1942,16 @@ async function knowledgeConsolidation({ day, class: klass, limit, offset } = {})
   return toContent(result);
 }
 
-async function knowledgeIngest({ url, content, source_type, project_id, publish }) {
+async function knowledgeIngest({ url, content, source_type, project_id, publish, metadata }) {
   const body = { source_type };
   if (url) body.url = url;
   if (content) body.content = content;
   if (project_id) body.project_id = project_id;
   if (publish) body.publish = true;
+  // Forwarded so `metadata.source_ref` is reachable at all: the server honours it as the
+  // source that article titles are qualified with, and declaring it in the schema above
+  // without forwarding it here would advertise a parameter that silently does nothing.
+  if (metadata && typeof metadata === "object") body.metadata = metadata;
   const result = await apiCall("POST", "/api/v1/knowledge/ingest", body, process.env.LOOPCTL_ORCH_KEY);
   // A keyless tenant gets a 422 (code no_api_key) carrying a remediation — surface it
   // prominently so a first-time agent knows to call set_llm_config before ingesting.
@@ -5667,6 +5671,25 @@ const TOOLS = [
           description:
             "Optional: publish extracted articles immediately instead of staging them as drafts (default false).",
         },
+        metadata: {
+          type: "object",
+          description:
+            "Optional metadata map. `source_ref` is the one key with behaviour: it names the " +
+            "SPECIFIC source (a URL, repo, or document name) and is what lets extracted article " +
+            "titles qualify themselves — without it a CHANGELOG file can only become an article " +
+            "titled \"Changelog\", which is indistinguishable from every other document's " +
+            "changelog once it is in the corpus. It overrides the name derived from `url`, and " +
+            "is the ONLY way to name the source of an inline `content` ingest. Its value is " +
+            "included in the extraction prompt POSTed to the tenant's LLM provider (reduced the " +
+            "same way a url is: userinfo and query string stripped, host and path kept). Omit it " +
+            "rather than passing a placeholder — a model will qualify a title WITH it.",
+          properties: {
+            source_ref: {
+              type: "string",
+              description: "The specific source that article titles are qualified with.",
+            },
+          },
+        },
       },
       required: ["source_type"],
     },
@@ -5712,7 +5735,19 @@ const TOOLS = [
               },
               metadata: {
                 type: "object",
-                description: "Optional metadata map.",
+                description:
+                  "Optional metadata map. Set `source_ref` to the SPECIFIC source (URL, repo, " +
+                  "or document name) so extracted titles qualify themselves — without it a " +
+                  "CHANGELOG becomes an article titled \"Changelog\", indistinguishable from " +
+                  "every other document's changelog in the corpus. Overrides the url-derived " +
+                  "name, and is the only way to name an inline `content` item. Sent to the " +
+                  "LLM provider in the extraction prompt. Omit rather than passing a placeholder.",
+                properties: {
+                  source_ref: {
+                    type: "string",
+                    description: "The specific source that article titles are qualified with.",
+                  },
+                },
               },
             },
             required: ["source_type"],

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.71.0",
+  "version": "2.72.0",
   "description": "MCP server for loopctl \u2014 structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/test/loopctl/knowledge/consolidation_followups_test.exs
+++ b/test/loopctl/knowledge/consolidation_followups_test.exs
@@ -406,4 +406,121 @@ defmodule Loopctl.Knowledge.ConsolidationFollowupsTest do
       assert ids.(first) == ids.(second)
     end
   end
+
+  describe "validate_similarity/1 — the threshold cannot be set to a value that disables the gate" do
+    test "0 falls back to the default instead of admitting every pair" do
+      # The gate is `min_sim >= threshold`, so 0.0 is satisfied by EVERY pair — including a
+      # cosine of 0. The only content check on the only self-applying class would be fully
+      # OFF, silently, while every run still reported `gate: :open` and unpublished. 0 is
+      # also the exact value an operator reaches for meaning "off", because on the sibling
+      # drain caps 0 IS a pause. The DB percent path already refused it; this path did not.
+      for off <- [0, 0.0] do
+        assert Consolidation.validate_similarity(off) == 0.80
+      end
+    end
+
+    test "1.0 is refused too — identical vectors score exactly 1.0" do
+      # The mirror image: an operator hard-disabling the class with 1.0 would still
+      # auto-unpublish byte-identical captures, which is the opposite of disabling it.
+      # Neither end of this range is the safe one, which is why an out-of-band value falls
+      # back to the default rather than being clamped toward a bound.
+      assert Consolidation.validate_similarity(1) == 0.80
+      assert Consolidation.validate_similarity(1.0) == 0.80
+    end
+
+    test "a legitimate in-range threshold is honoured, as a float" do
+      # The guard has to discriminate, or it silently pins the threshold at the default and
+      # an operator's tuning does nothing.
+      assert Consolidation.validate_similarity(0.68) == 0.68
+      assert Consolidation.validate_similarity(0.95) == 0.95
+    end
+
+    test "a non-number still falls back, and never sorts its way past the bound" do
+      # A number sorts BELOW every atom and binary in Erlang term order, so a comparison
+      # guard alone would let `nil` or `"0.8"` through as "greater than 0".
+      for bad <- [nil, "0.8", :off, %{}] do
+        assert Consolidation.validate_similarity(bad) == 0.80
+      end
+    end
+  end
+
+  describe "a withhold that can never clear does not churn nightly" do
+    test "a tenant with NO embedding key enqueues no backfill at all" do
+      # Mandatory BYO: every backfill job such a tenant enqueues is discarded
+      # `{:no_embedding_key, _}` on pickup. The pass used to enqueue them every night
+      # forever while logging "backfill enqueued", so a PERMANENT withhold read as a
+      # transient gap and the drain converged to a floor.
+      tenant = fixture(:tenant)
+      a = published(tenant.id, %{title: "Keyless Doc", body: String.duplicate("long ", 40)})
+      b = published(tenant.id, %{title: "keyless doc!", body: "short"})
+
+      # `a` is embedded, `b` is not — so `b` is the unscored member that would be backfilled.
+      embed!(tenant.id, a.id, List.duplicate(0.1, 1536))
+
+      confirm_over_two_nights_no_corroborate(tenant.id)
+
+      assert %{applied: 0, uncorroborated: 1} =
+               Consolidation.apply_confirmed_duplicates(tenant.id)
+
+      # Inline Oban would have embedded `b` had a job been enqueued. Nothing was.
+      refute embedded?(tenant.id, b.id)
+      assert status(a.id) == :published
+      assert status(b.id) == :published
+    end
+
+    test "a member whose vector is a PREFIX is not enqueued for backfill" do
+      # A prefix-marked row is excluded from scoring on purpose (a prefix must never be
+      # compared against a whole text), so it lands in `unscored`. But
+      # `BatchArticleEmbeddingWorker` compares through `whole_hash/1` and reads a marked
+      # row as ALREADY EMBEDDED — so the job did nothing, the gap never closed, and the
+      # pass re-enqueued the same dead job every night. Re-embedding cannot help: the text
+      # is over the provider's limit, which is WHY it is a prefix.
+      tenant = fixture(:tenant)
+
+      {:ok, _} =
+        Loopctl.Llm.upsert_settings(tenant.id, %{"embedding_api_key" => "test-openai-embed-pfx"})
+
+      a = published(tenant.id, %{title: "Prefix Doc", body: String.duplicate("long ", 40)})
+      b = published(tenant.id, %{title: "prefix doc!", body: "short"})
+
+      embed!(tenant.id, a.id, List.duplicate(0.1, 1536))
+      # `b` carries a vector under a TRUNCATION-MARKED hash.
+      {:ok, _} =
+        Loopctl.Knowledge.update_embedding(
+          tenant.id,
+          b.id,
+          List.duplicate(0.2, 1536),
+          ShrinkLadder.truncated_hash("deadbeef")
+        )
+
+      confirm_over_two_nights_no_corroborate(tenant.id)
+
+      assert %{applied: 0, uncorroborated: 1} =
+               Consolidation.apply_confirmed_duplicates(tenant.id)
+
+      # The mark SURVIVES: nothing re-embedded it and erased the prefix marker.
+      assert ShrinkLadder.truncated_hash?(stored_hash(tenant.id, b.id))
+    end
+  end
+
+  # Confirms a group over two nights WITHOUT forcing corroboration, so the tests above
+  # measure the gate rather than a helper that pre-satisfies it.
+  defp confirm_over_two_nights_no_corroborate(tenant_id) do
+    {:ok, _} = Consolidation.run(tenant_id, day: Date.add(Date.utc_today(), -1))
+    {:ok, _} = Consolidation.run(tenant_id)
+  end
+
+  defp embed!(tenant_id, id, vector),
+    do: {:ok, _} = Loopctl.Knowledge.update_embedding(tenant_id, id, vector, nil)
+
+  defp stored_hash(tenant_id, id) do
+    Loopctl.Embeddings.article_embedded_hashes(
+      tenant_id,
+      [id],
+      Loopctl.Embeddings.active_dimension(tenant_id)
+    )
+    |> Map.get(id)
+  end
+
+  defp embedded?(tenant_id, id), do: is_binary(stored_hash(tenant_id, id))
 end

--- a/test/loopctl/knowledge/consolidation_test.exs
+++ b/test/loopctl/knowledge/consolidation_test.exs
@@ -985,6 +985,16 @@ defmodule Loopctl.Knowledge.ConsolidationTest do
       # the pairs that happen to have vectors would let a 3-member group be judged on its one
       # scorable pair — which could be exactly the two that match.
       tenant = fixture(:tenant)
+      # The tenant needs a BYO embedding key for this claim to hold. Mandatory BYO means a
+      # keyless tenant's backfill jobs are discarded `{:no_embedding_key, _}` on pickup, so
+      # its withhold is PERMANENT, not self-clearing — the pass now says so and enqueues
+      # nothing. The mock embedding client ignores keys, which is what let this test assert
+      # a production property while omitting its production prerequisite.
+      {:ok, _} =
+        Loopctl.Llm.upsert_settings(tenant.id, %{
+          "embedding_api_key" => "test-openai-embed-consolidation"
+        })
+
       {a, b} = duplicate_pair(tenant.id)
 
       c = published(tenant.id, %{title: "aws codedeploy traffic control!", body: "third"})

--- a/test/loopctl/knowledge/okf_test.exs
+++ b/test/loopctl/knowledge/okf_test.exs
@@ -717,4 +717,86 @@ defmodule Loopctl.Knowledge.OKFTest do
       assert %{conformant: true, errors: []} = OKF.validate_files(files)
     end
   end
+
+  describe "#617: a filename-derived title is qualified when it is generic" do
+    # A bundle carrying a bare CHANGELOG.md with no frontmatter title used to import as the
+    # article "Changelog". Three such documents then collided into a false duplicate group
+    # on the hosted corpus, which is the class #617 traced back to title minting. The REST
+    # ingestion path was fixed by showing its extractor the source; this importer derives
+    # titles itself, so it qualifies them itself.
+    defp bundle(files) do
+      entries =
+        Enum.map(files, fn {path, content} ->
+          {String.to_charlist(path), content}
+        end)
+
+      # `:erl_tar.create/3` with `:memory` returns a bare `:ok` on this OTP and writes to
+      # disk instead of handing back a binary, so build it in a tmp file and read it back.
+      path =
+        Path.join(
+          System.tmp_dir!(),
+          "okf-#{System.unique_integer([:positive])}.tar.gz"
+        )
+
+      on_exit(fn -> File.rm(path) end)
+      :ok = :erl_tar.create(String.to_charlist(path), entries, [:compressed])
+      File.read!(path)
+    end
+
+    defp concept(body), do: "---\ntype: pattern\n---\n\n" <> body
+
+    test "a generic name is qualified with its enclosing directory" do
+      dest = fixture(:tenant)
+
+      targz =
+        bundle([
+          {"concepts/oauth2/CHANGELOG.md", concept("Release notes for the oauth2 library.")}
+        ])
+
+      assert {:ok, report} = OKF.import_zip(dest.id, targz)
+      assert report.errors == []
+
+      %{data: articles} = Knowledge.list_articles(dest.id, category: :pattern)
+      titles = Enum.map(articles, & &1.title)
+
+      refute "Changelog" in titles,
+             "a bare generic title is exactly the collision this guard exists to prevent"
+
+      assert Enum.any?(titles, &String.starts_with?(&1, "Changelog "))
+      assert Enum.any?(titles, &(&1 =~ "oauth2"))
+    end
+
+    test "an already-specific name is NOT padded" do
+      # The guard has to discriminate. Qualifying every title would make the corpus noisier
+      # rather than more distinguishable, which is the failure mode in the other direction.
+      dest = fixture(:tenant)
+
+      targz =
+        bundle([
+          {"concepts/oauth2/retry-backoff-strategy.md", concept("Use jittered backoff.")}
+        ])
+
+      assert {:ok, report} = OKF.import_zip(dest.id, targz)
+      assert report.errors == []
+
+      %{data: articles} = Knowledge.list_articles(dest.id, category: :pattern)
+      assert Enum.any?(articles, &(&1.title == "Retry Backoff Strategy"))
+    end
+
+    test "an explicit frontmatter title always wins over both" do
+      dest = fixture(:tenant)
+
+      targz =
+        bundle([
+          {"concepts/oauth2/CHANGELOG.md",
+           "---\ntype: pattern\ntitle: Hand-written Title\n---\n\nBody."}
+        ])
+
+      assert {:ok, report} = OKF.import_zip(dest.id, targz)
+      assert report.errors == []
+
+      %{data: articles} = Knowledge.list_articles(dest.id, category: :pattern)
+      assert Enum.any?(articles, &(&1.title == "Hand-written Title"))
+    end
+  end
 end


### PR DESCRIPTION
The nine out-of-scope findings from the #619 enhanced review, **fixed rather than filed** (SOUL rule 0). Two were live defects on master, and one of those I introduced hours earlier in #618.

No new review run on this branch: the findings arrived already verified, and re-reviewing a fix list is the hop the chain bound refuses.

## The gate that `0` could open

`validate_similarity/1` accepted an explicit `0` from app config. The gate is `min_sim >= threshold`, so `0.0` is satisfied by **every** pair — including a cosine of 0. The only content check on the only self-applying class would be fully OFF, silently, while every run still reported `gate: :open` and unpublished.

The module's own comment already explained why clamping a *negative* to `0.0` would be a disaster. It never noticed that an explicit `0` walked straight through the in-range clause to the same place. And `0` is exactly the value an operator reaches for meaning "off" — on the sibling drain caps `0` **is** a pause, so the wrong guess here is the likely one.

Both ends are now exclusive. `1.0` is refused for the mirror reason: identical vectors score exactly `1.0`, so an operator hard-disabling the class with `1.0` would still auto-unpublish byte-identical captures.

## Two withholds that could never clear — and re-enqueued nightly forever

**A prefix-embedded member.** `score_pairs/2` excludes truncation-marked rows on purpose (a prefix must never be compared against a whole text), so such a member lands in `unscored` and was enqueued for backfill. `BatchArticleEmbeddingWorker` compares through `whole_hash/1`, reads the marked row as *already embedded*, and returns having done nothing. The gap never closed, the group withheld on every subsequent night, and the same dead job was re-enqueued forever.

I built both halves of that in #618. It is a producer with no consumer — the exact shape this codebase keeps re-finding, arrived at while fixing the same class. Re-embedding could not help either: the text is over the provider's limit, which is *why* it is a prefix. So the correct handling is to stop pretending it is a gap.

**A tenant with no BYO embedding key** can never satisfy the gate at all — every backfill job it enqueues is discarded `{:no_embedding_key, _}` on pickup. Title-drift withheld permanently while the log cheerfully said "backfill enqueued", so a configuration state read as a transient one and the drain converged to a floor.

Both now say what they are, and enqueue nothing.

## The rest

- **`score_groups` chunks over proposals.** `title_pairs/2` binds the id list twice, so at `max_applies: 500` × 50 members that is ~50,000 binds against Postgres's 65,535 ceiling — inside a 10s statement timeout whose failure rescues to `:unavailable` and withholds *every* title group for the night. It would have tripped precisely when the cap was raised to drain a backlog faster.
- **The OKF importer qualifies generic filename-derived titles.** Same root cause #619 fixed for the REST path, arriving through a different door: this importer derives titles itself, so it qualifies them itself. A bare `CHANGELOG.md` no longer imports as the article "Changelog". An already-specific name is left unpadded.
- **`metadata.source_ref` is documented** on both ingestion `operation/2` specs — including that its value egresses to the LLM provider, which the existing at-rest note understated.
- **The `knowledge_ingest` MCP tool accepts and forwards `metadata` at all.** It did not, which made `source_ref` unreachable from MCP entirely — the server honours it, but no agent using these tools could set it. mcp-server 2.72.0.

## One test was asserting a property it had removed the prerequisite for

`consolidation_test.exs`'s "the withhold is SELF-CLEARING" test ran against a tenant with no BYO key. The mock embedding client ignores keys, so the backfill "worked" in test while being impossible in production. It now grants the key — the guard was not relaxed to suit the test.

## Verification

- `mix precommit` green: credo --strict clean, dialyzer clean, 7030 tests 0 failures.
- Every new guard mutation-verified: 4 named consolidation tests and 1 OKF test fail when the guard is removed.
- The OKF tests build a real `.tar.gz` and import it end to end, rather than unit-testing the private title function.
