### PR TITLE
Put a ceiling on the lineage a dispatch may mint (GHSA-4rxr, #624)

### DIFF
--- a/.claude/skills/chain-of-custody/SKILL.md
+++ b/.claude/skills/chain-of-custody/SKILL.md
@@ -75,31 +75,37 @@ compare dispatch lineage and all three fail closed on a story with no custody pr
 caller's lineage is always resolved SERVER-SIDE from the authenticating key
 (`Dispatches.lineage_for_api_key/2`, `dispatches.ex:526-536`) — never read from the request body.
 
-- **verify** — `validate_not_self_verify/3` `progress.ex:1914-1952`. `nil` orchestrator identity is
-  untrusted (`progress.ex:1917`); a custody-orphaned story fails closed with
+- **verify** — `validate_not_self_verify/3` `progress.ex:2006-2064`. `nil` orchestrator identity is
+  untrusted (`progress.ex:2006`); a custody-orphaned story fails closed with
   `:missing_assigned_agent` ("nil is never permissive"); then the CALLER's lineage vs the
-  implementer's (`lineage_status/2`, `progress.ex:2549-2575`) — the same tri-state gate report and
-  review-complete use, arriving as `:verifier_lineage` and resolved server-side, which is the only
-  clause that binds the principal actually calling. THEN the RECORDED verifier
-  (`verify_recorded_separation/2`, `progress.ex:1956`) when BOTH `implementer_dispatch_id` and
-  `verifier_dispatch_id` are set, decided by `verify_lineage_separated/4` (`progress.ex:1982-2002`).
+  implementer's (`lineage_status/2`, `progress.ex:2661-2687`) — the same tri-state gate report and
+  review-complete use but at `:root` separation, arriving as `:verifier_lineage` and resolved
+  server-side, which is the only clause that binds the principal actually calling. It is REQUIRED
+  on every path that reaches `verified`/`rejected` (`verify`, `verify-all`, `reject`, bulk
+  verify/reject via `ensure_verify_allowed/3`) — the argument has no default, so a path cannot omit
+  it and silently degrade to agent-id inequality, which is what verify-all, reject and bulk did. An
+  EMPTY caller lineage on a story that HAS an `implementer_dispatch_id` is blocked outright
+  (`legacy_caller_on_dispatched_story?/2`): a key no dispatch minted cannot be shown separate from
+  dispatch-minted work. THEN the RECORDED verifier
+  (`verify_recorded_separation/2`, `progress.ex:2068`) when BOTH `implementer_dispatch_id` and
+  `verifier_dispatch_id` are set, decided by `verify_lineage_separated/4` (`progress.ex:2094-2114`).
   An EMPTY lineage on either side (what an unloadable dispatch yields,
-  `get_dispatch_lineage/2` `progress.ex:2004-2009`) fails **CLOSED**, and the `assigned_agent_id`
+  `get_dispatch_lineage/2` `progress.ex:2116-2121`) fails **CLOSED**, and the `assigned_agent_id`
   equality check runs IN ADDITION to the lineage comparison rather than being short-circuited by it.
   `verifier_dispatch_id` is written only by the assign-verifier flow (`assign_rotating_verifier/3`,
   `progress.ex:448-487`); that write is result-checked, and a failure flags `verifier_needed` plus a
-  `verifier_not_assigned` audit event (`flag_verifier_needed/5`, `progress.ex:492`) instead of
+  `verifier_not_assigned` audit event (`flag_verifier_needed/5`, `progress.ex:500`) instead of
   silently leaving the field nil. `request-review` is OPTIONAL, so most stories reach verify with no
   verifier dispatch — the CALLER-lineage step is what keeps that path lineage-gated.
-- **report** — `validate_not_self_report/3` `progress.ex:2464-2490`. `nil` caller blocked
-  (`progress.ex:2464`); a story with nil `assigned_agent_id` AND nil `implementer_dispatch_id` is
+- **report** — `validate_not_self_report/3` `progress.ex:2576-2602`. `nil` caller blocked
+  (`progress.ex:2576`); a story with nil `assigned_agent_id` AND nil `implementer_dispatch_id` is
   **custody-unattributed** and fails closed with `:missing_assigned_agent` + a
-  `custody_orphaned_blocked` log (`custody_unattributed?/1`, `progress.ex:2503-2506`) — it used to
+  `custody_orphaned_blocked` log (`custody_unattributed?/1`, `progress.ex:2615-2618`) — it used to
   pass vacuously; then the reporter's lineage vs the implementer's (`lineage_status/2`,
-  `progress.ex:2549-2575`) — tri-state `:ok | :conflict | :unresolvable`, where an unresolvable
+  `progress.ex:2661-2687`) — tri-state `:ok | :conflict | :unresolvable`, where an unresolvable
   implementer dispatch fails CLOSED with `unresolvable_dispatch_lineage` (LCP-1 §7.5); then plain
   `assigned_agent_id` equality.
-- **review-complete** — `validate_not_self_review/3` `progress.ex:2577-2607`. Custody-orphan backstop
+- **review-complete** — `validate_not_self_review/3` `progress.ex:2689-2719`. Custody-orphan backstop
   first (`progress.ex:2584-2586`), then a **`nil` reviewer is deliberately PERMITTED**
   (`progress.ex:2593-2594`) because nil means a human operator on a user-role key; then the
   reviewer's lineage; then plain equality. That nil permit has THREE parts, all of which must change
@@ -143,7 +149,7 @@ correct behavior; do not add a workaround.
 **Enforcement is conditional — this is the deprecation seam.** `Progress.maybe_consume_cap/6`
 (`progress.ex:352-398`) is what actually gates the custody ops: a `nil` `cap_id` is rejected with
 `:missing_capability` **only for tenants that have an audit key** (`tenant_has_audit_key?/1`,
-`progress.ex:520-525`); a pre-v2 (keyless) tenant returns `{:ok, :pre_v2_tenant}` and the operation
+`progress.ex:528-533`); a pre-v2 (keyless) tenant returns `{:ok, :pre_v2_tenant}` and the operation
 proceeds with NO capability at all. So L1 strength is per-tenant. A REJECTED cap is split by
 `cap_refusal/4`: only `:invalid_signature` / `:replay` surface as `{:cap_rejected, _}`, which
 FallbackController answers with a plain 403 — it halts NOTHING and counts toward nothing (see the
@@ -172,7 +178,15 @@ served unauthenticated on the discovery endpoint — every candidate could preco
 selection. No public value is an acceptable fallback, so the no-secret case (pre-v2 tenant,
 unreachable secret store) returns `{:error, :verifier_seed_unavailable}` and the story is flagged
 `verifier_needed` instead: selecting nobody is strictly better than selecting predictably, because
-verify enforces lineage separation either way.
+verify enforces lineage separation either way — it refuses an unlineaged caller on a
+dispatch-minted story rather than falling back to agent-id inequality. That failure also emits
+`[:loopctl, :custody, :verifier_seed_unavailable]`; a secret-store outage fires it on every
+request-review deployment-wide, so alert on the counter rather than reading logs.
+
+An empty pool has TWO causes with different remedies and they are reported separately:
+`:no_eligible_verifier` (no active dispatch at all) versus `:no_independent_root` (dispatches
+exist, but every one descends from the implementer's root — the single-root tenant). The second is
+not a shortage; its remedy is the operator minting an independently-rooted verifier tree.
 
 **Empty-lineage caveat, in BOTH directions.** When the implementer dispatch cannot be loaded,
 `assign_rotating_verifier/3` passes `[]` (`progress.ex:448-452`), and with `[]` the rejection is
@@ -187,19 +201,31 @@ long-lived env-var keys.
 `LoopctlWeb.DispatchController.create/2` (`lib/loopctl_web/controllers/dispatch_controller.ex:20-59`)
 resolves the CALLER's lineage server-side and refuses two shapes:
 
-- a **parentless** create by a caller that already has a lineage → `403 root_dispatch_forbidden`.
+- a **parentless** create by anyone but the OPERATOR → `403 root_dispatch_forbidden`.
   A root dispatch starts a NEW tree sharing no root with anything, which the L4 checks read as an
   unrelated principal; a caller able to mint one can hand itself separation from its own work.
-  Only a key no dispatch minted (lineage `[]` — the tenant's operator key, rooted in the human
-  anchor) may start a tree.
 - a parent **outside** the caller's lineage → `403 parent_outside_caller_lineage`
-  (`lineage_within_caller?/2`). Closing only the parentless case would leave the same escape one
+  (`lineage_within_caller?/3`). Closing only the parentless case would leave the same escape one
   step out, since every dispatch id in the tenant is enumerable.
 
+**"Operator" is a POSITIVE test, not an absent lineage**: `lineage_for_api_key/2` returns `[]` for
+three different principals — the tenant's human-anchored operator key (`role: :user`, minted by the
+signup ceremony), a legacy long-lived env-var key, and a key whose dispatch row no longer resolves.
+Only the first deserves the privilege, so the check is `caller_lineage == [] and
+Role.role_at_least?(role, :user)`. Inferring it from `[]` alone let every legacy `:orchestrator`
+key hand itself an independently-rooted dispatch for the whole deprecation window.
+
+Both refusals are logged (`lineage_ceiling_refused`) and emit
+`[:loopctl, :custody, :lineage_ceiling_refused]`, and each 403 body carries the caller's own
+`your_dispatch_id` — the remediation says "mint under your own dispatch", and nothing else on this
+API tells a caller which row is its own.
+
 This is the structural analogue of the role ceiling (`role_exceeds_caller?/2`) directly above it.
-It does NOT make a tenant single-rooted — the operator key can still mint several roots, which is
-what keeps `select_verifier/3` able to find a different-root candidate at all. Do not "fix" a
-`root_dispatch_forbidden` by relaxing the check; mint from the operator key, or pass a parent.
+It does mean a tenant is single-rooted unless the OPERATOR mints a second tree — and it must, since
+`select_verifier/3` needs a different-root candidate and the verify gate is root-separated. A
+single-root tenant gets `:no_independent_root` from selection (distinct from an empty pool) and
+`self_verify_blocked` at the gate. Do not "fix" either by relaxing the check; mint a second root
+from the operator key.
 
 ## Custody halt (L6) — escalation is thresholded, and the halt is SCOPED
 
@@ -271,7 +297,7 @@ gate, and an empty lineage is never a match.
 - Taking the caller's lineage from request params instead of `Dispatches.lineage_for_api_key/2` —
   a client-supplied lineage is self-attested and defeats the gate.
 - Trusting a `nil` identity as permissive where the code blocks it — `verify`
-  (`progress.ex:1917`) and `report` (`progress.ex:2464`) fail closed on nil *caller identity*. The one
+  (`progress.ex:2006`) and `report` (`progress.ex:2576`) fail closed on nil *caller identity*. The one
   documented exception is `review-complete` (`progress.ex:2593-2594`, nil = human operator, paired
   with the exact_role plug and the controller check). Do not "fix" it without reading its comment.
 

--- a/.claude/skills/chain-of-custody/SKILL.md
+++ b/.claude/skills/chain-of-custody/SKILL.md
@@ -73,35 +73,35 @@ If yes, the change is wrong.
 Enforced in `lib/loopctl/progress.ex`. The three gates are NOT one implementation, but ALL THREE now
 compare dispatch lineage and all three fail closed on a story with no custody provenance. The
 caller's lineage is always resolved SERVER-SIDE from the authenticating key
-(`Dispatches.lineage_for_api_key/2`, `dispatches.ex:518-528`) — never read from the request body.
+(`Dispatches.lineage_for_api_key/2`, `dispatches.ex:526-536`) — never read from the request body.
 
-- **verify** — `validate_not_self_verify/3` `progress.ex:1865-1897`. `nil` orchestrator identity is
-  untrusted (`progress.ex:1863`); a custody-orphaned story fails closed with
+- **verify** — `validate_not_self_verify/3` `progress.ex:1914-1952`. `nil` orchestrator identity is
+  untrusted (`progress.ex:1917`); a custody-orphaned story fails closed with
   `:missing_assigned_agent` ("nil is never permissive"); then the CALLER's lineage vs the
-  implementer's (`lineage_status/2`, `progress.ex:2478-2495`) — the same tri-state gate report and
+  implementer's (`lineage_status/2`, `progress.ex:2549-2575`) — the same tri-state gate report and
   review-complete use, arriving as `:verifier_lineage` and resolved server-side, which is the only
   clause that binds the principal actually calling. THEN the RECORDED verifier
-  (`verify_recorded_separation/2`, `progress.ex:1899`) when BOTH `implementer_dispatch_id` and
-  `verifier_dispatch_id` are set, decided by `verify_lineage_separated/4` (`progress.ex:1925-1945`).
+  (`verify_recorded_separation/2`, `progress.ex:1956`) when BOTH `implementer_dispatch_id` and
+  `verifier_dispatch_id` are set, decided by `verify_lineage_separated/4` (`progress.ex:1982-2002`).
   An EMPTY lineage on either side (what an unloadable dispatch yields,
-  `get_dispatch_lineage/2` `progress.ex:1947-1952`) fails **CLOSED**, and the `assigned_agent_id`
+  `get_dispatch_lineage/2` `progress.ex:2004-2009`) fails **CLOSED**, and the `assigned_agent_id`
   equality check runs IN ADDITION to the lineage comparison rather than being short-circuited by it.
   `verifier_dispatch_id` is written only by the assign-verifier flow (`assign_rotating_verifier/3`,
-  `progress.ex:448-486`); that write is result-checked, and a failure flags `verifier_needed` plus a
-  `verifier_not_assigned` audit event (`flag_verifier_needed/5`, `progress.ex:487`) instead of
+  `progress.ex:448-487`); that write is result-checked, and a failure flags `verifier_needed` plus a
+  `verifier_not_assigned` audit event (`flag_verifier_needed/5`, `progress.ex:492`) instead of
   silently leaving the field nil. `request-review` is OPTIONAL, so most stories reach verify with no
   verifier dispatch — the CALLER-lineage step is what keeps that path lineage-gated.
-- **report** — `validate_not_self_report/3` `progress.ex:2407-2433`. `nil` caller blocked
-  (`progress.ex:2407`); a story with nil `assigned_agent_id` AND nil `implementer_dispatch_id` is
+- **report** — `validate_not_self_report/3` `progress.ex:2464-2490`. `nil` caller blocked
+  (`progress.ex:2464`); a story with nil `assigned_agent_id` AND nil `implementer_dispatch_id` is
   **custody-unattributed** and fails closed with `:missing_assigned_agent` + a
-  `custody_orphaned_blocked` log (`custody_unattributed?/1`, `progress.ex:2446-2449`) — it used to
+  `custody_orphaned_blocked` log (`custody_unattributed?/1`, `progress.ex:2503-2506`) — it used to
   pass vacuously; then the reporter's lineage vs the implementer's (`lineage_status/2`,
-  `progress.ex:2478-2495`) — tri-state `:ok | :conflict | :unresolvable`, where an unresolvable
+  `progress.ex:2549-2575`) — tri-state `:ok | :conflict | :unresolvable`, where an unresolvable
   implementer dispatch fails CLOSED with `unresolvable_dispatch_lineage` (LCP-1 §7.5); then plain
   `assigned_agent_id` equality.
-- **review-complete** — `validate_not_self_review/3` `progress.ex:2498-2528`. Custody-orphan backstop
-  first (`progress.ex:2441-2443`), then a **`nil` reviewer is deliberately PERMITTED**
-  (`progress.ex:2450-2451`) because nil means a human operator on a user-role key; then the
+- **review-complete** — `validate_not_self_review/3` `progress.ex:2577-2607`. Custody-orphan backstop
+  first (`progress.ex:2584-2586`), then a **`nil` reviewer is deliberately PERMITTED**
+  (`progress.ex:2593-2594`) because nil means a human operator on a user-role key; then the
   reviewer's lineage; then plain equality. That nil permit has THREE parts, all of which must change
   together: (a) the `exact_role: [:orchestrator, :user]` plug (`review_record_controller.ex:22-23`),
   which 403s an agent key before the controller runs — so the `:agent` branch of the controller cond
@@ -143,7 +143,7 @@ correct behavior; do not add a workaround.
 **Enforcement is conditional — this is the deprecation seam.** `Progress.maybe_consume_cap/6`
 (`progress.ex:352-398`) is what actually gates the custody ops: a `nil` `cap_id` is rejected with
 `:missing_capability` **only for tenants that have an audit key** (`tenant_has_audit_key?/1`,
-`progress.ex:513-518`); a pre-v2 (keyless) tenant returns `{:ok, :pre_v2_tenant}` and the operation
+`progress.ex:520-525`); a pre-v2 (keyless) tenant returns `{:ok, :pre_v2_tenant}` and the operation
 proceeds with NO capability at all. So L1 strength is per-tenant. A REJECTED cap is split by
 `cap_refusal/4`: only `:invalid_signature` / `:replay` surface as `{:cap_rejected, _}`, the shape
 FallbackController answers with a tenant-wide custody halt. `:expired` and `:wrong_lineage` are
@@ -156,12 +156,23 @@ audit-key condition either breaks pre-v2 tenants or silently widens the bypass.
 ## Dispatch lineage (L4) — structural verifier separation
 
 `lib/loopctl/dispatches.ex`: each dispatch carries a `lineage_path` (root → self).
-`lineage_shares_prefix?/2` (`dispatches.ex:593-597`) is the primitive the self-* checks use — note it
+`lineage_shares_prefix?/2` (`dispatches.ex:601-605`) is the primitive the self-* checks use — note it
 compares lineage **ROOTS** (element 0) only, not arbitrary prefixes, and an empty list on either side
-is never a match. `select_verifier/3` (`dispatches.ex:664-701`) picks a verifier whose lineage does
-NOT share the implementer's root — rejected in SQL (`reject_same_root/2`, `dispatches.ex:709-715`)
-and again in Elixir — from a pool capped at `@verifier_pool_limit`, seeded deterministically by
-`sha256(tenant audit pubkey || story_id)` so the orchestrator cannot predict the pick.
+is never a match. `select_verifier/3` (`dispatches.ex:674-704`) picks a verifier whose lineage does
+NOT share the implementer's root — rejected in SQL (`reject_same_root/2`, `dispatches.ex:751-757`)
+and again in Elixir — from a pool capped at `@verifier_pool_limit`.
+
+**The selection index must come from a SECRET the candidates do not hold.** The pool is
+enumerable by any agent key (`GET /api/v1/dispatches`) and the story id is known, so the seed
+is the only thing standing between "deterministic" and "predictable". `verifier_seed/2`
+(`dispatches.ex:725-745`) keys an HMAC with the tenant's audit signing **private** key
+(`TenantKeys`, secret store + ETS), domain-separated and bound to `(tenant, story)`. It used
+to hash the **public** key, which is served unauthenticated on the discovery endpoint — every
+candidate could precompute its own selection. No public value is an acceptable fallback, so
+the no-secret case (pre-v2 tenant, unreachable secret store) returns
+`{:error, :verifier_seed_unavailable}` and the story is flagged `verifier_needed` instead:
+selecting nobody is strictly better than selecting predictably, because verify enforces
+lineage separation either way.
 
 **Empty-lineage caveat, in BOTH directions.** When the implementer dispatch cannot be loaded,
 `assign_rotating_verifier/3` passes `[]` (`progress.ex:448-452`), and with `[]` the rejection is
@@ -171,6 +182,24 @@ do not "simplify" either half.
 
 Ephemeral per-dispatch keys (minted via `POST /api/v1/dispatches`, MCP `dispatch` tool) replace
 long-lived env-var keys.
+
+**The lineage CEILING on minting — you may only dispatch inside your own subtree.**
+`LoopctlWeb.DispatchController.create/2` (`lib/loopctl_web/controllers/dispatch_controller.ex:20-59`)
+resolves the CALLER's lineage server-side and refuses two shapes:
+
+- a **parentless** create by a caller that already has a lineage → `403 root_dispatch_forbidden`.
+  A root dispatch starts a NEW tree sharing no root with anything, which the L4 checks read as an
+  unrelated principal; a caller able to mint one can hand itself separation from its own work.
+  Only a key no dispatch minted (lineage `[]` — the tenant's operator key, rooted in the human
+  anchor) may start a tree.
+- a parent **outside** the caller's lineage → `403 parent_outside_caller_lineage`
+  (`lineage_within_caller?/2`). Closing only the parentless case would leave the same escape one
+  step out, since every dispatch id in the tenant is enumerable.
+
+This is the structural analogue of the role ceiling (`role_exceeds_caller?/2`) directly above it.
+It does NOT make a tenant single-rooted — the operator key can still mint several roots, which is
+what keeps `select_verifier/3` able to find a different-root candidate at all. Do not "fix" a
+`root_dispatch_forbidden` by relaxing the check; mint from the operator key, or pass a parent.
 
 ## The two lineage comparisons — report and verify demand DIFFERENT distance
 
@@ -208,8 +237,8 @@ gate, and an empty lineage is never a match.
 - Taking the caller's lineage from request params instead of `Dispatches.lineage_for_api_key/2` —
   a client-supplied lineage is self-attested and defeats the gate.
 - Trusting a `nil` identity as permissive where the code blocks it — `verify`
-  (`progress.ex:1818`) and `report` (`progress.ex:2407`) fail closed on nil *caller identity*. The one
-  documented exception is `review-complete` (`progress.ex:2450-2451`, nil = human operator, paired
+  (`progress.ex:1917`) and `report` (`progress.ex:2464`) fail closed on nil *caller identity*. The one
+  documented exception is `review-complete` (`progress.ex:2593-2594`, nil = human operator, paired
   with the exact_role plug and the controller check). Do not "fix" it without reading its comment.
 
 ## Related

--- a/.claude/skills/chain-of-custody/SKILL.md
+++ b/.claude/skills/chain-of-custody/SKILL.md
@@ -75,40 +75,46 @@ compare dispatch lineage and all three fail closed on a story with no custody pr
 caller's lineage is always resolved SERVER-SIDE from the authenticating key
 (`Dispatches.lineage_for_api_key/2`, `dispatches.ex:526-536`) — never read from the request body.
 
-- **verify** — `validate_not_self_verify/3` `progress.ex:2006-2064`. `nil` orchestrator identity is
-  untrusted (`progress.ex:2006`); a custody-orphaned story fails closed with
+- **verify** — `validate_not_self_verify/4`. `nil` orchestrator identity is untrusted; a custody-orphaned story fails closed with
   `:missing_assigned_agent` ("nil is never permissive"); then the CALLER's lineage vs the
-  implementer's (`lineage_status/2`, `progress.ex:2661-2687`) — the same tri-state gate report and
-  review-complete use but at `:root` separation, arriving as `:verifier_lineage` and resolved
-  server-side, which is the only clause that binds the principal actually calling. It is REQUIRED
-  on every path that reaches `verified`/`rejected` (`verify`, `verify-all`, `reject`, bulk
-  verify/reject via `ensure_verify_allowed/3`) — the argument has no default, so a path cannot omit
-  it and silently degrade to agent-id inequality, which is what verify-all, reject and bulk did. An
-  EMPTY caller lineage on a story that HAS an `implementer_dispatch_id` is blocked outright
-  (`legacy_caller_on_dispatched_story?/2`): a key no dispatch minted cannot be shown separate from
-  dispatch-minted work. THEN the RECORDED verifier
-  (`verify_recorded_separation/2`, `progress.ex:2068`) when BOTH `implementer_dispatch_id` and
-  `verifier_dispatch_id` are set, decided by `verify_lineage_separated/4` (`progress.ex:2094-2114`).
+  implementer's (`lineage_status/2`) — the SAME gate report and review-complete use, at the SAME
+  `lineage_same_chain?/2` distance (ancestor/descendant blocked, SIBLING allowed), arriving as
+  `:verifier_lineage` and resolved server-side, which is the only clause that binds the principal
+  actually calling. It is passed on every path that reaches `verified`/`rejected` (`verify`,
+  `verify-all`, `reject`, bulk verify/reject via `ensure_verify_allowed/4`); the private guard takes
+  it with no default, and the public opts boundary still defaults it to `[]` — which no longer
+  DEGRADES, because on dispatch-minted work `[]` is `:unlineaged`. An EMPTY caller lineage on a
+  story that HAS an `implementer_dispatch_id` is refused with `:caller_lineage_required` — a key no
+  dispatch minted cannot be shown separate from dispatch-minted work. Its own code, not
+  `self_verify_blocked`: the latter is an L6 byzantine signal that escalates to a tenant-wide halt,
+  and an unmigrated legacy key would have armed it on every call. REJECT is exempt from that one
+  refusal (`unlineaged_caller/3`) — sending work back is the remediation path, and refusing it
+  strands the story at reported_done. THEN the RECORDED verifier
+  (`verify_recorded_separation/2`) when BOTH `implementer_dispatch_id` and
+  `verifier_dispatch_id` are set, decided by `verify_lineage_separated/4`.
   An EMPTY lineage on either side (what an unloadable dispatch yields,
-  `get_dispatch_lineage/2` `progress.ex:2116-2121`) fails **CLOSED**, and the `assigned_agent_id`
+  `get_dispatch_lineage/2`) fails **CLOSED**, and the `assigned_agent_id`
   equality check runs IN ADDITION to the lineage comparison rather than being short-circuited by it.
   `verifier_dispatch_id` is written only by the assign-verifier flow (`assign_rotating_verifier/3`,
   `progress.ex:448-487`); that write is result-checked, and a failure flags `verifier_needed` plus a
   `verifier_not_assigned` audit event (`flag_verifier_needed/5`, `progress.ex:500`) instead of
   silently leaving the field nil. `request-review` is OPTIONAL, so most stories reach verify with no
   verifier dispatch — the CALLER-lineage step is what keeps that path lineage-gated.
-- **report** — `validate_not_self_report/3` `progress.ex:2576-2602`. `nil` caller blocked
-  (`progress.ex:2576`); a story with nil `assigned_agent_id` AND nil `implementer_dispatch_id` is
+- **report** — `validate_not_self_report/3`. `nil` caller blocked
+  ; a story with nil `assigned_agent_id` AND nil `implementer_dispatch_id` is
   **custody-unattributed** and fails closed with `:missing_assigned_agent` + a
-  `custody_orphaned_blocked` log (`custody_unattributed?/1`, `progress.ex:2615-2618`) — it used to
-  pass vacuously; then the reporter's lineage vs the implementer's (`lineage_status/2`,
-  `progress.ex:2661-2687`) — tri-state `:ok | :conflict | :unresolvable`, where an unresolvable
-  implementer dispatch fails CLOSED with `unresolvable_dispatch_lineage` (LCP-1 §7.5); then plain
-  `assigned_agent_id` equality.
-- **review-complete** — `validate_not_self_review/3` `progress.ex:2689-2719`. Custody-orphan backstop
-  first (`progress.ex:2584-2586`), then a **`nil` reviewer is deliberately PERMITTED**
-  (`progress.ex:2593-2594`) because nil means a human operator on a user-role key; then the
-  reviewer's lineage; then plain equality. That nil permit has THREE parts, all of which must change
+  `custody_orphaned_blocked` log (`custody_unattributed?/1`) — it used to
+  pass vacuously; then the reporter's lineage vs the implementer's (`lineage_status/2`) —
+  `:ok | :conflict | :unresolvable | :unlineaged`, where an unresolvable implementer dispatch fails
+  CLOSED with `unresolvable_dispatch_lineage` (LCP-1 §7.5) and is ranked BEFORE `:unlineaged` so an
+  empty caller lineage cannot mask a broken dispatch reference; then plain `assigned_agent_id`
+  equality.
+- **review-complete** — `validate_not_self_review/3`. Custody-orphan backstop first, then a **`nil`
+  reviewer WITH AN EMPTY LINEAGE is deliberately PERMITTED** because that pair means a human
+  operator on a user-role key — the empty-lineage half is load-bearing, since a DISPATCH-minted
+  user-role key also has no `agent_id` and permitting on nil alone let an ANCESTOR of the
+  implementer review its own subtree; then the reviewer's lineage; then plain equality. That nil
+  permit has THREE parts, all of which must change
   together: (a) the `exact_role: [:orchestrator, :user]` plug (`review_record_controller.ex:22-23`),
   which 403s an agent key before the controller runs — so the `:agent` branch of the controller cond
   is unreachable today; (b) `LoopctlWeb.ReviewRecordController.create/2`
@@ -163,9 +169,12 @@ audit-key condition either breaks pre-v2 tenants or silently widens the bypass.
 
 `lib/loopctl/dispatches.ex`: each dispatch carries a `lineage_path` (root → self).
 Two primitives serve the self-* checks and they demand DIFFERENT distance — see "The two lineage
-comparisons" below before touching either. `lineage_shares_prefix?/2` is the stricter one (verify +
-verifier selection): it compares lineage **ROOTS** (element 0) only, not arbitrary prefixes, and an
-empty list on either side is never a match. `select_verifier/3` picks a verifier whose lineage does
+comparisons" below before touching either. `lineage_shares_prefix?/2` is the stricter one, and it
+applies where separation is guaranteed BY CONSTRUCTION (verifier SELECTION, and the RECORDED
+verifier) rather than demanded of an arbitrary caller: it compares lineage **ROOTS** (element 0)
+only, not arbitrary prefixes, and an empty list on either side is never a match. Every CALLER
+comparison — report, review-complete and verify alike — uses `lineage_same_chain?/2`.
+`select_verifier/3` picks a verifier whose lineage does
 NOT share the implementer's root — rejected in SQL (`reject_same_root/2`) and again in Elixir — from
 a pool capped at `@verifier_pool_limit`.
 
@@ -178,8 +187,9 @@ served unauthenticated on the discovery endpoint — every candidate could preco
 selection. No public value is an acceptable fallback, so the no-secret case (pre-v2 tenant,
 unreachable secret store) returns `{:error, :verifier_seed_unavailable}` and the story is flagged
 `verifier_needed` instead: selecting nobody is strictly better than selecting predictably, because
-verify enforces lineage separation either way — it refuses an unlineaged caller on a
-dispatch-minted story rather than falling back to agent-id inequality. That failure also emits
+verify enforces lineage separation either way — it compares the CALLER's lineage on every path and
+refuses an unlineaged caller on a dispatch-minted story rather than falling back to agent-id
+inequality. That failure also emits
 `[:loopctl, :custody, :verifier_seed_unavailable]`; a secret-store outage fires it on every
 request-review deployment-wide, so alert on the counter rather than reading logs.
 
@@ -206,7 +216,11 @@ resolves the CALLER's lineage server-side and refuses two shapes:
   unrelated principal; a caller able to mint one can hand itself separation from its own work.
 - a parent **outside** the caller's lineage → `403 parent_outside_caller_lineage`
   (`lineage_within_caller?/3`). Closing only the parentless case would leave the same escape one
-  step out, since every dispatch id in the tenant is enumerable.
+  step out, since every dispatch id in the tenant is enumerable. A caller with NO lineage of its
+  own is exempt from this half: it has no subtree to step outside of, and refusing it here closed
+  the only mint a legacy `:orchestrator` key had left — leaving it unable to obtain a lineage by
+  ANY request, and therefore unable to verify anything, against the documented deprecation window.
+  Naming a parent gives it a lineage, which SUBJECTS it to the custody gates.
 
 **"Operator" is a POSITIVE test, not an absent lineage**: `lineage_for_api_key/2` returns `[]` for
 three different principals — the tenant's human-anchored operator key (`role: :user`, minted by the
@@ -216,16 +230,20 @@ Role.role_at_least?(role, :user)`. Inferring it from `[]` alone let every legacy
 key hand itself an independently-rooted dispatch for the whole deprecation window.
 
 Both refusals are logged (`lineage_ceiling_refused`) and emit
-`[:loopctl, :custody, :lineage_ceiling_refused]`, and each 403 body carries the caller's own
-`your_dispatch_id` — the remediation says "mint under your own dispatch", and nothing else on this
-API tells a caller which row is its own.
+`[:loopctl, :custody, :lineage_ceiling_refused]`. A 403 body carries the caller's own
+`your_dispatch_id` when it HAS one — the remediation says "mint under your own dispatch", and
+nothing else on this API tells a caller which row is its own. For a caller with no lineage the key
+is OMITTED (never a bare null) and the message names a remedy that caller can actually perform:
+pass any active dispatch as `parent_dispatch_id`, or have the operator key mint the root. **A
+refusal that names an action the refused caller cannot take is a dead end, not a remediation** —
+that is the recurring defect on this surface; check every new 403 message against it.
 
 This is the structural analogue of the role ceiling (`role_exceeds_caller?/2`) directly above it.
-It does mean a tenant is single-rooted unless the OPERATOR mints a second tree — and it must, since
-`select_verifier/3` needs a different-root candidate and the verify gate is root-separated. A
-single-root tenant gets `:no_independent_root` from selection (distinct from an empty pool) and
-`self_verify_blocked` at the gate. Do not "fix" either by relaxing the check; mint a second root
-from the operator key.
+It does mean a tenant is single-rooted unless the OPERATOR mints a second tree. That is a
+selection-quality concern, NOT a liveness one: `select_verifier/3` still wants a different-root
+candidate and reports `:no_independent_root` (distinct from an empty pool) when it has none, but
+the verify GATE is chain-separated, so a sibling verifier under the same root certifies fine. Do
+not "fix" selection by relaxing the ceiling; mint a second root from the operator key.
 
 ## Custody halt (L6) — escalation is thresholded, and the halt is SCOPED
 
@@ -261,25 +279,27 @@ clears it, so both its trigger and its blast radius are deliberately bounded.
 - Root-of-trust rotation and the superadmin break-glass stay reachable during a halt — they are
   the remediation paths. A standalone superadmin key has a nil `tenant_id`, so the halt check
   never applies to it.
-## The two lineage comparisons — report and verify demand DIFFERENT distance
+## The two lineage comparisons — CALLERS and SELECTION demand DIFFERENT distance
 
 There are two, and using the wrong one either breaks the product or weakens the gate:
 
 - `Dispatches.lineage_same_chain?/2` — ancestry: identical, or one an ancestor of the other.
-  A SIBLING passes. Used by **report** and **review-complete** (`lineage_status/3` defaults to
-  `:chain`).
+  A SIBLING passes. Used by every CALLER comparison — **report**, **review-complete** AND
+  **verify** (`lineage_status/2`).
 - `Dispatches.lineage_shares_prefix?/2` — shared ROOT (element 0 only). A sibling is BLOCKED.
-  Used by **verify** (`lineage_status(story, caller, :root)`) and by `select_verifier/3`'s
-  `reject_same_root/2`.
+  Used where separation is guaranteed by CONSTRUCTION rather than demanded of whoever calls:
+  `select_verifier/3`'s `reject_same_root/2`, and `verify_lineage_separated/4` on the RECORDED
+  verifier that selection produced.
 
 Why they differ: the documented dispatch tree puts the implementer and the reviewer side by
 side under one orchestrator, and roots the whole tenant at one operator dispatch. Under a
 root test *every* pair of dispatches in a tenant matches, so the reviewer counts as the
-implementer and nothing can ever be reported — and `select_verifier` rejects its entire pool.
-This was invisible until #621 began recording `implementer_dispatch_id` on the HTTP path,
-which is what made the comparison run at all. Verify stays on the root test deliberately: it
-is the final certification, and the selector already refuses to nominate a same-root verifier,
-so accepting one at the gate would contradict the selection rule.
+implementer and nothing can ever be reported — and applying it to verify's CALLER left a
+single-root tenant with no principal able to certify anything at all, which is why verify's
+caller comparison is `:chain` too. This was invisible until #621 began recording
+`implementer_dispatch_id` on the HTTP path, which is what made the comparison run at all.
+The selector keeps the root test: it CHOOSES the candidate, so it can insist on the stronger
+property without stranding anyone.
 
 Neither relaxes self-approval — `assigned_agent_id` equality is evaluated IN ADDITION at every
 gate, and an empty lineage is never a match.
@@ -296,10 +316,13 @@ gate, and an empty lineage is never a match.
   compare lineage, so this is blocked; do not "route around" it by minting a key outside the lineage.
 - Taking the caller's lineage from request params instead of `Dispatches.lineage_for_api_key/2` —
   a client-supplied lineage is self-attested and defeats the gate.
-- Trusting a `nil` identity as permissive where the code blocks it — `verify`
-  (`progress.ex:2006`) and `report` (`progress.ex:2576`) fail closed on nil *caller identity*. The one
-  documented exception is `review-complete` (`progress.ex:2593-2594`, nil = human operator, paired
-  with the exact_role plug and the controller check). Do not "fix" it without reading its comment.
+- Trusting a `nil` identity as permissive where the code blocks it — `verify` and `report` fail
+  closed on nil *caller identity*. The one documented exception is `review-complete` (nil agent
+  AND empty lineage = human operator, paired with the exact_role plug and the controller check).
+  Do not "fix" it without reading its comment, and do not drop the lineage half.
+- Answering an ordinary configuration refusal with an L6 code. `self_*_blocked` records a custody
+  violation and escalates to a tenant-wide halt; "your key has no dispatch lineage" is a setup
+  state that fires on every call, so it is `caller_lineage_required` (plain 409).
 
 ## Related
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,11 +67,16 @@ All notable changes to loopctl are documented here.
   itself minted by a dispatch sends no `parent_dispatch_id` (only a key no dispatch minted —
   the tenant's operator key, rooted in the human anchor — may start a lineage tree), and
   `parent_outside_caller_lineage` when the named parent is not the caller's own dispatch or a
-  descendant of it. **What changed for clients:** a sub-agent that used to mint a fresh root
-  must now pass its own dispatch id as `parent_dispatch_id`; anything minting on behalf of the
-  whole tenant must use the tenant's operator key. Existing lineages are unaffected, and a
-  tenant can still hold several roots — which is what keeps an independently-rooted verifier
-  available for selection.
+  descendant of it. "Operator key" is decided POSITIVELY — `role: :user` AND not minted by a
+  dispatch — because an absent lineage also describes a legacy long-lived key. **What changed
+  for clients:** a sub-agent that used to mint a fresh root must now pass its own dispatch id as
+  `parent_dispatch_id` (the 403 body returns it as `remediation.your_dispatch_id`); a legacy
+  `LOOPCTL_ORCH_KEY` can no longer mint a root at all — use the tenant's `user`-role operator
+  key. **Operators must mint at least two roots**: verification is root-separated, so a tenant
+  whose dispatches all descend from one root has no principal that can verify — selection
+  reports `no_independent_root` and the verify gate answers `self_verify_blocked`. Both refusals
+  are logged as `lineage_ceiling_refused` and emit
+  `[:loopctl, :custody, :lineage_ceiling_refused]`.
 
 - **Verifier selection is seeded from a server-side secret.** The rotating verifier's index was
   derived from the tenant's audit signing PUBLIC key, which `/.well-known/loopctl` serves
@@ -81,20 +86,37 @@ All notable changes to loopctl are documented here.
   a tenant whose audit signing key is not provisioned (or an unreachable secret store) now has
   no seed and none is invented — selection fails closed, the story is flagged `verifier_needed`,
   and a `verifier_not_assigned` entry with reason `verifier_seed_unavailable` is written to the
-  audit chain plus an `audit_chain_append_failed`-style error log. Verification itself is
-  unaffected: the verify gate enforces lineage separation independently. Provision the tenant's
-  audit key to restore automatic selection.
+  audit chain plus an `audit_chain_append_failed`-style error log and a
+  `[:loopctl, :custody, :verifier_seed_unavailable]` telemetry counter — alert on it, since a
+  secret-store outage fires it on every request-review deployment-wide. Verification itself is
+  unaffected: the verify gate enforces lineage separation independently, and now refuses an
+  unlineaged caller outright on a dispatch-minted story rather than falling back to agent-id
+  inequality. Provision the tenant's audit key to restore automatic selection.
 
 - **Backfill can no longer be used to certify work that ran inside loopctl.** `POST
   /stories/:id/backfill` (and the bulk `mark-complete`) refused stories carrying dispatch
   markers, but `force-unclaim` clears `assigned_agent_id`, and a story claimed with a key that
   no dispatch minted never records an implementer dispatch — so a worked story could be
   returned to a state indistinguishable from pre-loopctl work and then marked verified with no
-  report, review record or independent verifier. Both paths now also consult the append-only
-  audit log and refuse a story that ever recorded a lifecycle transition, with a new 422
-  (`story_entered_lifecycle`). Imported and never-dispatched work — the case backfill exists
-  for — is unaffected. Backfill is additionally mounted on the LCP-1 signed-claim gate, so
-  under the `signed` custody profile an enrolled caller must sign it exactly as for `verify`.
+  report, review record or independent verifier. Unclaim and force-unclaim now stamp a durable
+  `metadata.lifecycle_entered_at` on the story, and both paths refuse a story carrying it — or
+  a lifecycle entry in the audit log — with a new 422 (`story_entered_lifecycle`). The row stamp
+  is the durable half deliberately: `audit_log` is partitioned and pruned at
+  `AUDIT_RETENTION_DAYS` (default 90), so an audit-only guard would have reopened this path on a
+  timer. Imported and never-dispatched work — the case backfill exists for — is unaffected.
+  Backfill is additionally mounted on the LCP-1 signed-claim gate, so under the `signed` custody
+  profile an enrolled caller must sign it exactly as for `verify`, and the verified claim is
+  recorded in the hash-chained audit log (§9.4) as it is for `verify`.
+
+- **The caller's dispatch lineage is now compared on every custody path, not just single-story
+  verify.** `POST /epics/:id/verify-all`, `POST /stories/:id/reject` and the bulk verify/reject
+  endpoints reached the same terminal states while comparing only story fields, so an
+  orchestrator dispatched inside the implementer's own lineage cleared them where
+  `POST /stories/:id/verify` returned `409 self_verify_blocked`. All four now resolve the
+  caller's lineage server-side from the authenticating key. **What changed for clients:** calls
+  that were previously accepted from inside the implementer's lineage now return
+  `409 self_verify_blocked` (bulk: a per-story error entry) — use an independently-rooted
+  verifier dispatch.
 
 ## [Unreleased] — 2026-07-24 — Self-hosting: fresh-install fixes, multilingual search, at-rest ingestion encryption
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,43 @@ All notable changes to loopctl are documented here.
   CaseClauseError — making a correct refusal indistinguishable from a crash in logs and alerts.
   A non-UUID `capability` value likewise 500'd (`Ecto.Query.CastError`) instead of 403ing.
 
+- **A dispatch may now only be minted inside the caller's own lineage.** `POST
+  /api/v1/dispatches` accepted a parentless request from any orchestrator-or-above key, and
+  accepted any active dispatch in the tenant as `parent_dispatch_id`. Both let a caller place
+  itself in a lineage unrelated to its own, which is the separation the L4 custody gates read
+  as "an independent principal". Two new 403s: `root_dispatch_forbidden` when a key that was
+  itself minted by a dispatch sends no `parent_dispatch_id` (only a key no dispatch minted —
+  the tenant's operator key, rooted in the human anchor — may start a lineage tree), and
+  `parent_outside_caller_lineage` when the named parent is not the caller's own dispatch or a
+  descendant of it. **What changed for clients:** a sub-agent that used to mint a fresh root
+  must now pass its own dispatch id as `parent_dispatch_id`; anything minting on behalf of the
+  whole tenant must use the tenant's operator key. Existing lineages are unaffected, and a
+  tenant can still hold several roots — which is what keeps an independently-rooted verifier
+  available for selection.
+
+- **Verifier selection is seeded from a server-side secret.** The rotating verifier's index was
+  derived from the tenant's audit signing PUBLIC key, which `/.well-known/loopctl` serves
+  unauthenticated, while the candidate pool is listable by any agent key — so the choice was
+  reproducible by the parties it chooses between. It is now an HMAC keyed by the tenant's audit
+  signing PRIVATE key, domain-separated and bound to the tenant and story. **Operator impact:**
+  a tenant whose audit signing key is not provisioned (or an unreachable secret store) now has
+  no seed and none is invented — selection fails closed, the story is flagged `verifier_needed`,
+  and a `verifier_not_assigned` entry with reason `verifier_seed_unavailable` is written to the
+  audit chain plus an `audit_chain_append_failed`-style error log. Verification itself is
+  unaffected: the verify gate enforces lineage separation independently. Provision the tenant's
+  audit key to restore automatic selection.
+
+- **Backfill can no longer be used to certify work that ran inside loopctl.** `POST
+  /stories/:id/backfill` (and the bulk `mark-complete`) refused stories carrying dispatch
+  markers, but `force-unclaim` clears `assigned_agent_id`, and a story claimed with a key that
+  no dispatch minted never records an implementer dispatch — so a worked story could be
+  returned to a state indistinguishable from pre-loopctl work and then marked verified with no
+  report, review record or independent verifier. Both paths now also consult the append-only
+  audit log and refuse a story that ever recorded a lifecycle transition, with a new 422
+  (`story_entered_lifecycle`). Imported and never-dispatched work — the case backfill exists
+  for — is unaffected. Backfill is additionally mounted on the LCP-1 signed-claim gate, so
+  under the `signed` custody profile an enrolled caller must sign it exactly as for `verify`.
+
 ## [Unreleased] — 2026-07-24 — Self-hosting: fresh-install fixes, multilingual search, at-rest ingestion encryption
 
 Operator-facing changes for deployments outside the hosted instance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,10 +71,12 @@ All notable changes to loopctl are documented here.
   dispatch — because an absent lineage also describes a legacy long-lived key. **What changed
   for clients:** a sub-agent that used to mint a fresh root must now pass its own dispatch id as
   `parent_dispatch_id` (the 403 body returns it as `remediation.your_dispatch_id`); a legacy
-  `LOOPCTL_ORCH_KEY` can no longer mint a root at all — use the tenant's `user`-role operator
-  key. **Operators must mint at least two roots**: verification is root-separated, so a tenant
-  whose dispatches all descend from one root has no principal that can verify — selection
-  reports `no_independent_root` and the verify gate answers `self_verify_blocked`. Both refusals
+  `LOOPCTL_ORCH_KEY` can no longer mint a ROOT — use the tenant's `user`-role operator key —
+  but it may still mint BENEATH any active dispatch, which is how it obtains a lineage during
+  the deprecation window. Minting a second, independently-rooted tree remains worthwhile
+  (`select_verifier/3` prefers a different-root candidate and reports `no_independent_root`
+  without one), but it is not required for liveness: the verify gate compares the caller at
+  chain distance, so a sibling verifier under the same root certifies fine. Both refusals
   are logged as `lineage_ceiling_refused` and emit
   `[:loopctl, :custody, :lineage_ceiling_refused]`.
 
@@ -98,12 +100,14 @@ All notable changes to loopctl are documented here.
   markers, but `force-unclaim` clears `assigned_agent_id`, and a story claimed with a key that
   no dispatch minted never records an implementer dispatch — so a worked story could be
   returned to a state indistinguishable from pre-loopctl work and then marked verified with no
-  report, review record or independent verifier. Unclaim and force-unclaim now stamp a durable
-  `metadata.lifecycle_entered_at` on the story, and both paths refuse a story carrying it — or
-  a lifecycle entry in the audit log — with a new 422 (`story_entered_lifecycle`). The row stamp
-  is the durable half deliberately: `audit_log` is partitioned and pruned at
-  `AUDIT_RETENTION_DAYS` (default 90), so an audit-only guard would have reopened this path on a
-  timer. Imported and never-dispatched work — the case backfill exists for — is unaffected.
+  report, review record or independent verifier. Unclaim, force-unclaim and the reject
+  auto-reset now stamp `metadata.lifecycle_entered_at` on the story, and both paths refuse a
+  story carrying it — or a lifecycle entry in the audit log — with a new 422
+  (`story_entered_lifecycle`). The row stamp is the longer-lived half deliberately: `audit_log`
+  is partitioned and pruned at `AUDIT_RETENTION_DAYS` (default 90), so an audit-only guard would
+  have reopened this path on a timer. The stamp is not tamper-proof — `PATCH /stories/:id`
+  replaces `metadata` wholesale, so an orchestrator key can still erase it; both sources are
+  consulted. Imported and never-dispatched work — the case backfill exists for — is unaffected.
   Backfill is additionally mounted on the LCP-1 signed-claim gate, so under the `signed` custody
   profile an enrolled caller must sign it exactly as for `verify`, and the verified claim is
   recorded in the hash-chained audit log (§9.4) as it is for `verify`.
@@ -114,9 +118,14 @@ All notable changes to loopctl are documented here.
   orchestrator dispatched inside the implementer's own lineage cleared them where
   `POST /stories/:id/verify` returned `409 self_verify_blocked`. All four now resolve the
   caller's lineage server-side from the authenticating key. **What changed for clients:** calls
-  that were previously accepted from inside the implementer's lineage now return
-  `409 self_verify_blocked` (bulk: a per-story error entry) — use an independently-rooted
-  verifier dispatch.
+  that were previously accepted from ON the implementer's lineage chain (an ancestor or a
+  sub-agent; siblings are fine) now return `409 self_verify_blocked` (bulk: a per-story error
+  entry) — use a sibling or independently-rooted verifier dispatch. A key that no dispatch
+  minted (a legacy env-var key) gets `409 caller_lineage_required` on report, review-complete
+  and verify of DISPATCH-MINTED work, because its separation cannot be shown; mint an ephemeral
+  key with `POST /api/v1/dispatches`. That is a plain refusal and records no custody violation,
+  so it never arms a tenant halt. Stories that predate dispatches are unaffected, and `reject`
+  is deliberately exempt so bad work can always be sent back.
 
 ## [Unreleased] — 2026-07-24 — Self-hosting: fresh-install fixes, multilingual search, at-rest ingestion encryption
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,25 +142,32 @@ All three gates are lineage-aware. They do NOT share one implementation, but eac
 CALLER's dispatch lineage (resolved server-side from the authenticating key, never client-supplied)
 against the implementer's, and each fails CLOSED on a story with no custody provenance.
 
-**verify** — `validate_not_self_verify/3` (`lib/loopctl/progress.ex:1914-1952`, US-26.2.2),
+**verify** — `validate_not_self_verify/3` (`lib/loopctl/progress.ex:2006-2064`, US-26.2.2),
 in order:
-1. **nil caller identity is blocked** — untrusted, never permissive (US-26.1.3, `progress.ex:1917`).
+1. **nil caller identity is blocked** — untrusted, never permissive (US-26.1.3, `progress.ex:2006`).
 2. **Custody-orphaned story is blocked** with `missing_assigned_agent` — a reported-done
    story with no assigned agent and no lineage would otherwise pass VACUOUSLY, since a
    non-nil verifier never equals a nil implementer.
-3. **CALLER lineage vs the implementer's** (`lineage_status/2`, `progress.ex:2549-2575`) — the
-   SAME tri-state comparison report and review-complete run, and the only clause that binds
-   the principal actually making the call: a shared lineage root is `self_verify_blocked`, a
-   declared-but-unresolvable implementer dispatch is `unresolvable_dispatch_lineage` (fails
-   CLOSED). The caller's lineage arrives as `:verifier_lineage`, resolved server-side from
-   the authenticating key. Without it verify compared only STORY fields, so any orchestrator
-   key with a different `agent_id` — including one inside the implementer's own chain — could
-   verify the implementer's work.
-4. **RECORDED verifier vs implementer** (`verify_recorded_separation/2`, `progress.ex:1956`)
+3. **CALLER lineage vs the implementer's** (`lineage_status/2`, `progress.ex:2661-2687`) — the
+   same tri-state comparison report and review-complete run, but at `:root` separation, and
+   the only clause that binds the principal actually making the call: a shared lineage root is
+   `self_verify_blocked`, a declared-but-unresolvable implementer dispatch is
+   `unresolvable_dispatch_lineage` (fails CLOSED). An EMPTY caller lineage on a story that HAS
+   an `implementer_dispatch_id` is also blocked (`legacy_caller_on_dispatched_story?/2`): a key
+   no dispatch minted cannot be shown separate from dispatch-minted work, and permitting it
+   left two legacy env-var keys in one process able to report, review AND verify. The caller's
+   lineage arrives as `:verifier_lineage`, resolved server-side from the authenticating key —
+   on EVERY path that reaches a terminal custody state: `verify`, `verify-all`, `reject`, and
+   bulk verify/reject (`ensure_verify_allowed/3`, which takes it as a REQUIRED argument
+   precisely so a path cannot omit it and silently degrade to agent-id inequality).
+   Operationally this means a tenant needs the OPERATOR key to mint a SECOND,
+   independently-rooted tree for its verifier — a single-root tenant has no principal that can
+   verify, and `Dispatches.select_verifier/3` answers `:no_independent_root` there.
+4. **RECORDED verifier vs implementer** (`verify_recorded_separation/2`, `progress.ex:2068`)
    when BOTH `implementer_dispatch_id` and `verifier_dispatch_id` are set, decided by
-   `verify_lineage_separated/4` (`progress.ex:1982-2002`): an EMPTY lineage on either side —
+   `verify_lineage_separated/4` (`progress.ex:2094-2114`): an EMPTY lineage on either side —
    which is what an unloadable/deleted dispatch row yields (`get_dispatch_lineage/2`,
-   `progress.ex:2004-2009`) — fails CLOSED, a shared lineage root
+   `progress.ex:2116-2121`) — fails CLOSED, a shared lineage root
    (`Dispatches.lineage_shares_prefix?/2`, `lib/loopctl/dispatches.ex:601-605`) blocks, and the
    `assigned_agent_id` equality check is evaluated IN ADDITION to the lineage comparison, never
    short-circuited by it.
@@ -170,23 +177,23 @@ in order:
 `verifier_dispatch_id` is written only by the assign-verifier flow
 (`assign_rotating_verifier/3`, `progress.ex:448-487`); that write is checked, and a failure
 flags `verifier_needed` plus a `verifier_not_assigned` audit event
-(`flag_verifier_needed/5`, `progress.ex:492`) rather than silently leaving the field nil.
+(`flag_verifier_needed/5`, `progress.ex:500`) rather than silently leaving the field nil.
 Because `request-review` is OPTIONAL, a story often reaches verify with no verifier dispatch
 at all — step 3 is what keeps that path lineage-gated instead of a bare agent-id inequality.
 
-**report** — `validate_not_self_report/3` (`progress.ex:2464-2490`) — nil identity is blocked
-(`progress.ex:2464`); a **custody-unattributed** story (nil `assigned_agent_id` AND nil
+**report** — `validate_not_self_report/3` (`progress.ex:2576-2602`) — nil identity is blocked
+(`progress.ex:2576`); a **custody-unattributed** story (nil `assigned_agent_id` AND nil
 `implementer_dispatch_id`) fails CLOSED with `missing_assigned_agent` and a
-`custody_orphaned_blocked` log (`custody_unattributed?/1`, `progress.ex:2503-2506`) instead of
+`custody_orphaned_blocked` log (`custody_unattributed?/1`, `progress.ex:2615-2618`) instead of
 passing vacuously; then the reporter's dispatch lineage is compared against the implementer's
-(`lineage_status/2`, `progress.ex:2549-2575`) — a tri-state `:ok | :conflict | :unresolvable`
+(`lineage_status/2`, `progress.ex:2661-2687`) — a tri-state `:ok | :conflict | :unresolvable`
 where a DECLARED-but-unresolvable implementer dispatch fails CLOSED with
 `unresolvable_dispatch_lineage` (LCP-1 §7.5), a shared lineage root yields `self_report_blocked`,
 and `:ok` falls through to plain `assigned_agent_id == agent_id`. The DB CHECK
 `stories_reported_done_requires_agent` does NOT cover this — it is satisfied whenever
 `implementer_dispatch_id IS NULL` — so the code guard is the enforcement.
 
-**review-complete** — `validate_not_self_review/3` (`progress.ex:2577-2607`) — custody-orphan
+**review-complete** — `validate_not_self_review/3` (`progress.ex:2689-2719`) — custody-orphan
 backstop first (`progress.ex:2584-2586`), then a **nil reviewer is deliberately PERMITTED**
 (`progress.ex:2593-2594`): nil means a human operator on a user-role key. That permit has
 THREE parts which must change together:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,32 +142,31 @@ All three gates are lineage-aware. They do NOT share one implementation, but eac
 CALLER's dispatch lineage (resolved server-side from the authenticating key, never client-supplied)
 against the implementer's, and each fails CLOSED on a story with no custody provenance.
 
-**verify** — `validate_not_self_verify/3` (`lib/loopctl/progress.ex:2006-2064`, US-26.2.2),
+**verify** — `validate_not_self_verify/4` (`lib/loopctl/progress.ex`, US-26.2.2),
 in order:
-1. **nil caller identity is blocked** — untrusted, never permissive (US-26.1.3, `progress.ex:2006`).
+1. **nil caller identity is blocked** — untrusted, never permissive (US-26.1.3).
 2. **Custody-orphaned story is blocked** with `missing_assigned_agent` — a reported-done
    story with no assigned agent and no lineage would otherwise pass VACUOUSLY, since a
    non-nil verifier never equals a nil implementer.
-3. **CALLER lineage vs the implementer's** (`lineage_status/2`, `progress.ex:2661-2687`) — the
-   same tri-state comparison report and review-complete run, but at `:root` separation, and
-   the only clause that binds the principal actually making the call: a shared lineage root is
-   `self_verify_blocked`, a declared-but-unresolvable implementer dispatch is
-   `unresolvable_dispatch_lineage` (fails CLOSED). An EMPTY caller lineage on a story that HAS
-   an `implementer_dispatch_id` is also blocked (`legacy_caller_on_dispatched_story?/2`): a key
-   no dispatch minted cannot be shown separate from dispatch-minted work, and permitting it
-   left two legacy env-var keys in one process able to report, review AND verify. The caller's
-   lineage arrives as `:verifier_lineage`, resolved server-side from the authenticating key —
-   on EVERY path that reaches a terminal custody state: `verify`, `verify-all`, `reject`, and
-   bulk verify/reject (`ensure_verify_allowed/3`, which takes it as a REQUIRED argument
-   precisely so a path cannot omit it and silently degrade to agent-id inequality).
-   Operationally this means a tenant needs the OPERATOR key to mint a SECOND,
-   independently-rooted tree for its verifier — a single-root tenant has no principal that can
-   verify, and `Dispatches.select_verifier/3` answers `:no_independent_root` there.
-4. **RECORDED verifier vs implementer** (`verify_recorded_separation/2`, `progress.ex:2068`)
+3. **CALLER lineage vs the implementer's** (`lineage_status/2`) — the SAME comparison report and
+   review-complete run, at the SAME `lineage_same_chain?/2` distance, and the only clause that
+   binds the principal actually making the call: an ancestor or descendant of the implementer is
+   `self_verify_blocked` (a SIBLING is separation — demanding a separate ROOT of the caller made
+   verify unreachable in the documented single-root tenant), a declared-but-unresolvable
+   implementer dispatch is `unresolvable_dispatch_lineage` (fails CLOSED), and an EMPTY caller
+   lineage on a story that HAS an `implementer_dispatch_id` is `caller_lineage_required` — a key
+   no dispatch minted cannot be shown separate from dispatch-minted work, and permitting it left
+   two legacy env-var keys in one process able to report, review AND verify. That refusal has
+   its OWN code deliberately: `self_verify_blocked` is an L6 byzantine signal that escalates to
+   a tenant-wide halt, and an unmigrated legacy key is a configuration state, not byzantium.
+   REJECT is exempt from the empty-lineage refusal only — sending work back is remediation, and
+   refusing it strands the story. The caller's lineage arrives as `:verifier_lineage`, resolved
+   server-side, on EVERY path that reaches a terminal custody state: `verify`, `verify-all`,
+   `reject`, and bulk verify/reject (`ensure_verify_allowed/4`).
+4. **RECORDED verifier vs implementer** (`verify_recorded_separation/2`)
    when BOTH `implementer_dispatch_id` and `verifier_dispatch_id` are set, decided by
-   `verify_lineage_separated/4` (`progress.ex:2094-2114`): an EMPTY lineage on either side —
-   which is what an unloadable/deleted dispatch row yields (`get_dispatch_lineage/2`,
-   `progress.ex:2116-2121`) — fails CLOSED, a shared lineage root
+   `verify_lineage_separated/4`: an EMPTY lineage on either side —
+   which is what an unloadable/deleted dispatch row yields (`get_dispatch_lineage/2`) — fails CLOSED, a shared lineage root
    (`Dispatches.lineage_shares_prefix?/2`, `lib/loopctl/dispatches.ex:601-605`) blocks, and the
    `assigned_agent_id` equality check is evaluated IN ADDITION to the lineage comparison, never
    short-circuited by it.
@@ -181,21 +180,25 @@ flags `verifier_needed` plus a `verifier_not_assigned` audit event
 Because `request-review` is OPTIONAL, a story often reaches verify with no verifier dispatch
 at all — step 3 is what keeps that path lineage-gated instead of a bare agent-id inequality.
 
-**report** — `validate_not_self_report/3` (`progress.ex:2576-2602`) — nil identity is blocked
-(`progress.ex:2576`); a **custody-unattributed** story (nil `assigned_agent_id` AND nil
+**report** — `validate_not_self_report/3` — nil identity is blocked
+; a **custody-unattributed** story (nil `assigned_agent_id` AND nil
 `implementer_dispatch_id`) fails CLOSED with `missing_assigned_agent` and a
-`custody_orphaned_blocked` log (`custody_unattributed?/1`, `progress.ex:2615-2618`) instead of
+`custody_orphaned_blocked` log (`custody_unattributed?/1`) instead of
 passing vacuously; then the reporter's dispatch lineage is compared against the implementer's
-(`lineage_status/2`, `progress.ex:2661-2687`) — a tri-state `:ok | :conflict | :unresolvable`
-where a DECLARED-but-unresolvable implementer dispatch fails CLOSED with
-`unresolvable_dispatch_lineage` (LCP-1 §7.5), a shared lineage root yields `self_report_blocked`,
-and `:ok` falls through to plain `assigned_agent_id == agent_id`. The DB CHECK
+(`lineage_status/2`) — `:ok | :conflict | :unresolvable | :unlineaged`, where a
+DECLARED-but-unresolvable implementer dispatch fails CLOSED with
+`unresolvable_dispatch_lineage` (LCP-1 §7.5), a caller on the implementer's root-to-leaf CHAIN
+(ancestor or descendant; siblings pass) yields `self_report_blocked`, an EMPTY caller lineage on
+dispatch-minted work yields `caller_lineage_required`, and `:ok` falls through to plain
+`assigned_agent_id == agent_id`. The DB CHECK
 `stories_reported_done_requires_agent` does NOT cover this — it is satisfied whenever
 `implementer_dispatch_id IS NULL` — so the code guard is the enforcement.
 
-**review-complete** — `validate_not_self_review/3` (`progress.ex:2689-2719`) — custody-orphan
-backstop first (`progress.ex:2584-2586`), then a **nil reviewer is deliberately PERMITTED**
-(`progress.ex:2593-2594`): nil means a human operator on a user-role key. That permit has
+**review-complete** — `validate_not_self_review/3` — custody-orphan backstop first, then a
+**nil reviewer WITH AN EMPTY LINEAGE is deliberately PERMITTED**: that pair means a human
+operator on a user-role key. The empty-lineage half is load-bearing — a DISPATCH-minted
+user-role key also carries no `agent_id`, and permitting on nil alone let an ANCESTOR of the
+implementer rubber-stamp its own subtree without the lineage ever being read. That permit has
 THREE parts which must change together:
 1. the `exact_role: [:orchestrator, :user]` plug
    (`lib/loopctl_web/controllers/review_record_controller.ex:22-23`), which 403s an `:agent` key
@@ -208,10 +211,10 @@ THREE parts which must change together:
 3. the `Progress` permit itself.
 Then the reviewer's dispatch lineage comparison, then plain `assigned_agent_id` equality.
 
-The reporter/reviewer lineage both come from `Dispatches.lineage_for_api_key/2`
-(`lib/loopctl/dispatches.ex:526-536`) — the dispatch that minted the calling key. A key not
-minted by a dispatch yields `[]`, which is inert (the agent-id checks still apply); it never
-short-circuits a gate.
+The reporter/reviewer lineage both come from `Dispatches.lineage_for_api_key/2` — the dispatch
+that minted the calling key. A key not minted by a dispatch yields `[]`. On a PRE-DISPATCH story
+that is inert (the agent-id checks are the whole gate, by design); on DISPATCH-MINTED work it is
+refused with `caller_lineage_required` rather than silently short-circuiting the comparison.
 
 **The MCP server must NEVER hold both implementer and reviewer keys in the same process.** The 409 errors are the system working correctly — do not add workarounds.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,13 +142,13 @@ All three gates are lineage-aware. They do NOT share one implementation, but eac
 CALLER's dispatch lineage (resolved server-side from the authenticating key, never client-supplied)
 against the implementer's, and each fails CLOSED on a story with no custody provenance.
 
-**verify** — `validate_not_self_verify/3` (`lib/loopctl/progress.ex:1865-1897`, US-26.2.2),
+**verify** — `validate_not_self_verify/3` (`lib/loopctl/progress.ex:1914-1952`, US-26.2.2),
 in order:
-1. **nil caller identity is blocked** — untrusted, never permissive (US-26.1.3, `progress.ex:1863`).
+1. **nil caller identity is blocked** — untrusted, never permissive (US-26.1.3, `progress.ex:1917`).
 2. **Custody-orphaned story is blocked** with `missing_assigned_agent` — a reported-done
    story with no assigned agent and no lineage would otherwise pass VACUOUSLY, since a
    non-nil verifier never equals a nil implementer.
-3. **CALLER lineage vs the implementer's** (`lineage_status/2`, `progress.ex:2478-2495`) — the
+3. **CALLER lineage vs the implementer's** (`lineage_status/2`, `progress.ex:2549-2575`) — the
    SAME tri-state comparison report and review-complete run, and the only clause that binds
    the principal actually making the call: a shared lineage root is `self_verify_blocked`, a
    declared-but-unresolvable implementer dispatch is `unresolvable_dispatch_lineage` (fails
@@ -156,39 +156,39 @@ in order:
    the authenticating key. Without it verify compared only STORY fields, so any orchestrator
    key with a different `agent_id` — including one inside the implementer's own chain — could
    verify the implementer's work.
-4. **RECORDED verifier vs implementer** (`verify_recorded_separation/2`, `progress.ex:1899`)
+4. **RECORDED verifier vs implementer** (`verify_recorded_separation/2`, `progress.ex:1956`)
    when BOTH `implementer_dispatch_id` and `verifier_dispatch_id` are set, decided by
-   `verify_lineage_separated/4` (`progress.ex:1925-1945`): an EMPTY lineage on either side —
+   `verify_lineage_separated/4` (`progress.ex:1982-2002`): an EMPTY lineage on either side —
    which is what an unloadable/deleted dispatch row yields (`get_dispatch_lineage/2`,
-   `progress.ex:1947-1952`) — fails CLOSED, a shared lineage root
-   (`Dispatches.lineage_shares_prefix?/2`, `lib/loopctl/dispatches.ex:593-597`) blocks, and the
+   `progress.ex:2004-2009`) — fails CLOSED, a shared lineage root
+   (`Dispatches.lineage_shares_prefix?/2`, `lib/loopctl/dispatches.ex:601-605`) blocks, and the
    `assigned_agent_id` equality check is evaluated IN ADDITION to the lineage comparison, never
    short-circuited by it.
 5. **`assigned_agent_id` equality** as the fallback for pre-dispatch stories and for every
    story that lacks a verifier dispatch.
 
 `verifier_dispatch_id` is written only by the assign-verifier flow
-(`assign_rotating_verifier/3`, `progress.ex:448-486`); that write is checked, and a failure
+(`assign_rotating_verifier/3`, `progress.ex:448-487`); that write is checked, and a failure
 flags `verifier_needed` plus a `verifier_not_assigned` audit event
-(`flag_verifier_needed/5`, `progress.ex:487`) rather than silently leaving the field nil.
+(`flag_verifier_needed/5`, `progress.ex:492`) rather than silently leaving the field nil.
 Because `request-review` is OPTIONAL, a story often reaches verify with no verifier dispatch
 at all — step 3 is what keeps that path lineage-gated instead of a bare agent-id inequality.
 
-**report** — `validate_not_self_report/3` (`progress.ex:2407-2433`) — nil identity is blocked
-(`progress.ex:2407`); a **custody-unattributed** story (nil `assigned_agent_id` AND nil
+**report** — `validate_not_self_report/3` (`progress.ex:2464-2490`) — nil identity is blocked
+(`progress.ex:2464`); a **custody-unattributed** story (nil `assigned_agent_id` AND nil
 `implementer_dispatch_id`) fails CLOSED with `missing_assigned_agent` and a
-`custody_orphaned_blocked` log (`custody_unattributed?/1`, `progress.ex:2446-2449`) instead of
+`custody_orphaned_blocked` log (`custody_unattributed?/1`, `progress.ex:2503-2506`) instead of
 passing vacuously; then the reporter's dispatch lineage is compared against the implementer's
-(`lineage_status/2`, `progress.ex:2478-2495`) — a tri-state `:ok | :conflict | :unresolvable`
+(`lineage_status/2`, `progress.ex:2549-2575`) — a tri-state `:ok | :conflict | :unresolvable`
 where a DECLARED-but-unresolvable implementer dispatch fails CLOSED with
 `unresolvable_dispatch_lineage` (LCP-1 §7.5), a shared lineage root yields `self_report_blocked`,
 and `:ok` falls through to plain `assigned_agent_id == agent_id`. The DB CHECK
 `stories_reported_done_requires_agent` does NOT cover this — it is satisfied whenever
 `implementer_dispatch_id IS NULL` — so the code guard is the enforcement.
 
-**review-complete** — `validate_not_self_review/3` (`progress.ex:2498-2528`) — custody-orphan
-backstop first (`progress.ex:2441-2443`), then a **nil reviewer is deliberately PERMITTED**
-(`progress.ex:2450-2451`): nil means a human operator on a user-role key. That permit has
+**review-complete** — `validate_not_self_review/3` (`progress.ex:2577-2607`) — custody-orphan
+backstop first (`progress.ex:2584-2586`), then a **nil reviewer is deliberately PERMITTED**
+(`progress.ex:2593-2594`): nil means a human operator on a user-role key. That permit has
 THREE parts which must change together:
 1. the `exact_role: [:orchestrator, :user]` plug
    (`lib/loopctl_web/controllers/review_record_controller.ex:22-23`), which 403s an `:agent` key
@@ -202,7 +202,7 @@ THREE parts which must change together:
 Then the reviewer's dispatch lineage comparison, then plain `assigned_agent_id` equality.
 
 The reporter/reviewer lineage both come from `Dispatches.lineage_for_api_key/2`
-(`lib/loopctl/dispatches.ex:518-528`) — the dispatch that minted the calling key. A key not
+(`lib/loopctl/dispatches.ex:526-536`) — the dispatch that minted the calling key. A key not
 minted by a dispatch yields `[]`, which is inert (the agent-id checks still apply); it never
 short-circuits a gate.
 

--- a/lib/loopctl/audit_chain.ex
+++ b/lib/loopctl/audit_chain.ex
@@ -94,6 +94,39 @@ defmodule Loopctl.AuditChain do
   end
 
   @doc """
+  Passes an `append/2` result through unchanged, logging loudly when it failed.
+
+  For an append INSIDE an `Ecto.Multi`, a failure aborts the transaction and the
+  state change never happens — nothing to report. For an append that runs AFTER its
+  state change has already committed, discarding the result is different in kind:
+  the transition happened and the hash-chained log silently does not record it, so
+  the chain quietly stops being a complete account of custody decisions and nothing
+  anywhere says so. Nothing at that point can roll the write back, so the honest
+  response is to make the gap loud.
+
+  Use at every post-commit append site: `AuditChain.append(t, attrs) |>
+  AuditChain.log_append_failure("action", t, entity_id)`.
+  """
+  @spec log_append_failure(
+          {:ok, Entry.t()} | {:error, term()},
+          String.t(),
+          Ecto.UUID.t(),
+          Ecto.UUID.t() | nil
+        ) :: {:ok, Entry.t()} | {:error, term()}
+  def log_append_failure({:error, reason} = result, action, tenant_id, entity_id) do
+    Logger.error(
+      "audit_chain_append_failed: action=#{action} tenant=#{tenant_id} " <>
+        "entity=#{inspect(entity_id)} error=#{inspect(reason)}. The state change already " <>
+        "committed, so the hash-chained log is missing this entry — reconcile before " <>
+        "relying on the chain for this entity."
+    )
+
+    result
+  end
+
+  def log_append_failure(result, _action, _tenant_id, _entity_id), do: result
+
+  @doc """
   Lists audit chain entries for a tenant with pagination.
 
   ## Options

--- a/lib/loopctl/bulk_operations.ex
+++ b/lib/loopctl/bulk_operations.ex
@@ -380,7 +380,13 @@ defmodule Loopctl.BulkOperations do
 
     with :ok <- validate_reason(reason),
          :ok <- validate_reject_preconditions(story),
-         :ok <- Progress.ensure_verify_allowed(story, orchestrator_agent_id, ctx.caller_lineage),
+         :ok <-
+           Progress.ensure_verify_allowed(
+             story,
+             orchestrator_agent_id,
+             ctx.caller_lineage,
+             :reject
+           ),
          {:ok, updated} <- apply_rejection(story, reason) do
       create_rejection_result(tenant_id, story, orchestrator_agent_id, params)
       audit_rejection(tenant_id, story, updated, actor_id, actor_label, orchestrator_agent_id)
@@ -866,9 +872,11 @@ defmodule Loopctl.BulkOperations do
 
   defp format_reason(:story_entered_lifecycle),
     do:
-      "story's audit log shows it was worked inside loopctl (a status change or a " <>
-        "force-unclaim), even though its dispatch markers are now clear; use the normal " <>
-        "report → review → verify flow, not mark-complete"
+      "story is recorded as having entered the dispatch lifecycle (a status change, a " <>
+        "force-unclaim or an auto-reset), even though its dispatch markers are now clear; " <>
+        "use the normal report → review → verify flow, not mark-complete. The record is " <>
+        "the story's own lifecycle stamp, the audit log, or both — the audit log is pruned " <>
+        "at AUDIT_RETENTION_DAYS, so an empty story history does not contradict this"
 
   defp format_reason(:story_in_progress),
     do:

--- a/lib/loopctl/bulk_operations.ex
+++ b/lib/loopctl/bulk_operations.ex
@@ -836,6 +836,12 @@ defmodule Loopctl.BulkOperations do
       "story has dispatch lineage (an assigned agent or dispatch id); use the normal " <>
         "report → review → verify flow, not mark-complete"
 
+  defp format_reason(:story_entered_lifecycle),
+    do:
+      "story's audit log shows it was worked inside loopctl (a status change or a " <>
+        "force-unclaim), even though its dispatch markers are now clear; use the normal " <>
+        "report → review → verify flow, not mark-complete"
+
   defp format_reason(:story_in_progress),
     do:
       "story is mid-lifecycle (being worked) with no dispatch lineage yet; it is not " <>

--- a/lib/loopctl/bulk_operations.ex
+++ b/lib/loopctl/bulk_operations.ex
@@ -21,6 +21,7 @@ defmodule Loopctl.BulkOperations do
   alias Loopctl.AdminRepo
   alias Loopctl.Artifacts.VerificationResult
   alias Loopctl.Audit
+  alias Loopctl.Dispatches
   alias Loopctl.Progress
   alias Loopctl.Webhooks.EventGenerator
   alias Loopctl.Webhooks.WebhookEvent
@@ -108,7 +109,8 @@ defmodule Loopctl.BulkOperations do
         tenant_id: tenant_id,
         orch_id: orchestrator_agent_id,
         actor_id: actor_id,
-        actor_label: actor_label
+        actor_label: actor_label,
+        caller_lineage: caller_lineage(tenant_id, opts)
       }
 
       AdminRepo.transaction(fn ->
@@ -159,7 +161,8 @@ defmodule Loopctl.BulkOperations do
         tenant_id: tenant_id,
         orch_id: orchestrator_agent_id,
         actor_id: actor_id,
-        actor_label: actor_label
+        actor_label: actor_label,
+        caller_lineage: caller_lineage(tenant_id, opts)
       }
 
       AdminRepo.transaction(fn ->
@@ -219,6 +222,10 @@ defmodule Loopctl.BulkOperations do
 
       AdminRepo.transaction(fn ->
         locked_stories = lock_stories_by_ids(tenant_id, sorted_ids)
+        # ONE audit query for the batch, taken before the per-story loop: the guard
+        # used to run it per story while holding FOR UPDATE locks on all of them.
+        lifecycle_ids = Progress.stories_with_lifecycle_history(tenant_id, sorted_ids)
+        ctx = Map.put(ctx, :lifecycle_ids, lifecycle_ids)
         process_mark_completes(sorted_ids, locked_stories, story_params, ctx)
       end)
     end
@@ -237,27 +244,20 @@ defmodule Loopctl.BulkOperations do
           %{story_id: story_id, status: "error", reason: "Story not found"}
 
         story ->
-          process_mark_complete(
-            story,
-            params,
-            ctx.tenant_id,
-            ctx.orch_id,
-            ctx.actor_id,
-            ctx.actor_label
-          )
+          process_mark_complete(story, params, ctx)
       end
     end)
   end
 
-  defp process_mark_complete(
-         story,
-         params,
-         tenant_id,
-         orchestrator_agent_id,
-         actor_id,
-         actor_label
-       ) do
-    with :ok <- Progress.ensure_mark_complete_allowed(story),
+  defp process_mark_complete(story, params, ctx) do
+    %{
+      tenant_id: tenant_id,
+      orch_id: orchestrator_agent_id,
+      actor_id: actor_id,
+      actor_label: actor_label
+    } = ctx
+
+    with :ok <- Progress.ensure_mark_complete_allowed(story, ctx.lifecycle_ids),
          {:ok, updated} <- apply_mark_complete(story) do
       create_mark_complete_result(tenant_id, story, orchestrator_agent_id, params)
 
@@ -296,7 +296,7 @@ defmodule Loopctl.BulkOperations do
           %{story_id: story_id, status: "error", reason: "Story not found"}
 
         story ->
-          process_verify(story, params, ctx.tenant_id, ctx.orch_id, ctx.actor_id, ctx.actor_label)
+          process_verify(story, params, ctx)
       end
     end)
   end
@@ -310,8 +310,21 @@ defmodule Loopctl.BulkOperations do
           %{story_id: story_id, status: "error", reason: "Story not found"}
 
         story ->
-          process_reject(story, params, ctx.tenant_id, ctx.orch_id, ctx.actor_id, ctx.actor_label)
+          process_reject(story, params, ctx)
       end
+    end)
+  end
+
+  # The CALLER's dispatch lineage, resolved SERVER-SIDE from the authenticating key —
+  # never client-supplied. `AuditContext.from_conn/1` puts that key's id in `:actor_id`
+  # (the superadmin's, under impersonation — still the principal that authenticated),
+  # so the bulk path can run the SAME L4 caller comparison the single-story path does.
+  # Without it `ensure_verify_allowed/3` saw an empty lineage, `lineage_status/3` read
+  # that as "no conflict", and bulk verify/reject degraded to agent-id inequality — a
+  # condition any orchestrator key satisfies trivially.
+  defp caller_lineage(tenant_id, opts) do
+    Keyword.get_lazy(opts, :verifier_lineage, fn ->
+      Dispatches.lineage_for_api_key(tenant_id, Keyword.get(opts, :actor_id))
     end)
   end
 
@@ -331,9 +344,16 @@ defmodule Loopctl.BulkOperations do
     end
   end
 
-  defp process_verify(story, params, tenant_id, orchestrator_agent_id, actor_id, actor_label) do
+  defp process_verify(story, params, ctx) do
+    %{
+      tenant_id: tenant_id,
+      orch_id: orchestrator_agent_id,
+      actor_id: actor_id,
+      actor_label: actor_label
+    } = ctx
+
     with :ok <- validate_verify_preconditions(story),
-         :ok <- Progress.ensure_verify_allowed(story, orchestrator_agent_id),
+         :ok <- Progress.ensure_verify_allowed(story, orchestrator_agent_id, ctx.caller_lineage),
          :ok <- Progress.ensure_review_conducted(tenant_id, story.id, story),
          {:ok, updated} <- apply_verification(story) do
       create_verification_result(tenant_id, story, orchestrator_agent_id, params)
@@ -346,13 +366,21 @@ defmodule Loopctl.BulkOperations do
     end
   end
 
-  defp process_reject(story, params, tenant_id, orchestrator_agent_id, actor_id, actor_label) do
+  defp process_reject(story, params, ctx) do
     require Logger
+
+    %{
+      tenant_id: tenant_id,
+      orch_id: orchestrator_agent_id,
+      actor_id: actor_id,
+      actor_label: actor_label
+    } = ctx
+
     reason = params["reason"] || params[:reason]
 
     with :ok <- validate_reason(reason),
          :ok <- validate_reject_preconditions(story),
-         :ok <- Progress.ensure_verify_allowed(story, orchestrator_agent_id),
+         :ok <- Progress.ensure_verify_allowed(story, orchestrator_agent_id, ctx.caller_lineage),
          {:ok, updated} <- apply_rejection(story, reason) do
       create_rejection_result(tenant_id, story, orchestrator_agent_id, params)
       audit_rejection(tenant_id, story, updated, actor_id, actor_label, orchestrator_agent_id)

--- a/lib/loopctl/custody/signed_profile_policy.ex
+++ b/lib/loopctl/custody/signed_profile_policy.ex
@@ -79,27 +79,57 @@ defmodule Loopctl.Custody.SignedProfilePolicy do
   @claim_max_age_seconds 300
   @claim_max_future_skew_seconds 60
 
-  @doc "The active deployment custody profile (`:bearer` | `:signed`)."
+  # Sentinel default for the config read: `SystemConfig.get_int/2` cannot report a
+  # miss, and 0 is ALSO the legitimate `bearer` value — so reading with a default of
+  # 0 makes "an operator deliberately chose bearer" and "the key is not set at all"
+  # the same observation. A value outside the valid domain separates them.
+  @profile_unset -1
+
+  @doc """
+  The active deployment custody profile (`:bearer` | `:signed`).
+
+  Emits `[:loopctl, :custody, :profile_resolved]` on EVERY resolution, with the
+  resolved `profile`, the `source` (`:unset` | `:configured` | `:invalid`) and the
+  `raw` config value. Only the `:invalid` branch used to make any noise, so the
+  most likely real-world drift — a deployment intended to run `signed` whose config
+  row never landed, silently serving `bearer` — produced no signal whatsoever and
+  looked exactly like a healthy bearer deployment. Alert on
+  `source: :unset`/`profile: :bearer` where `signed` is expected.
+  """
   @spec profile() :: :bearer | :signed
   def profile do
-    case config_get_int(@profile_key, 0) do
-      0 ->
-        :bearer
+    raw = config_get_int(@profile_key, @profile_unset)
 
-      1 ->
-        :signed
+    {profile, source} =
+      case raw do
+        @profile_unset ->
+          {:bearer, :unset}
 
-      other ->
-        # Fail SAFE to bearer, but never SILENTLY: an unrecognized value most likely
-        # means an operator who intended `signed` misconfigured the key, and would
-        # otherwise have signed-claim enforcement waived with no signal. Surface it.
-        Logger.warning(
-          "custody_signed_profile_enforcement=#{inspect(other)} is not a recognized value " <>
-            "(0=bearer, 1=signed); defaulting to bearer — signed-claim enforcement is OFF."
-        )
+        0 ->
+          {:bearer, :configured}
 
-        :bearer
-    end
+        1 ->
+          {:signed, :configured}
+
+        other ->
+          # Fail SAFE to bearer, but never SILENTLY: an unrecognized value most likely
+          # means an operator who intended `signed` misconfigured the key, and would
+          # otherwise have signed-claim enforcement waived with no signal. Surface it.
+          Logger.warning(
+            "custody_signed_profile_enforcement=#{inspect(other)} is not a recognized value " <>
+              "(0=bearer, 1=signed); defaulting to bearer — signed-claim enforcement is OFF."
+          )
+
+          {:bearer, :invalid}
+      end
+
+    :telemetry.execute(
+      [:loopctl, :custody, :profile_resolved],
+      %{count: 1},
+      %{profile: profile, source: source, raw: raw}
+    )
+
+    profile
   end
 
   @doc "The profile as the wire string advertised in `/.well-known/loopctl` (§2.1)."
@@ -190,6 +220,13 @@ defmodule Loopctl.Custody.SignedProfilePolicy do
   epic unsigned, defeating the §9.3 attribution guarantee on the highest-volume
   path. A bearer/legacy caller is unaffected, mirroring `verify_request/7`'s
   enrolled-only gradual-rollout waiver.
+
+  "Enrolled" is decided the SAME way as on the single-story path: an enrolled
+  dispatch, OR a bearer dispatch belonging to an agent that has an enrolled key
+  elsewhere (`Dispatches.agent_has_enrolled_key?/2`). Without that second clause the
+  bulk gate is strictly WEAKER than the single-story gate it mirrors — an agent that
+  had migrated to signing could take its BEARER dispatch to verify-all and clear a
+  whole epic unsigned, which is the exact bypass this function exists to close.
   """
   @spec verify_bulk_request(:bearer | :signed, Ecto.UUID.t(), Ecto.UUID.t() | nil) ::
           :ok | {:error, :bulk_signature_unsupported}
@@ -199,6 +236,17 @@ defmodule Loopctl.Custody.SignedProfilePolicy do
     case Dispatches.dispatch_for_api_key(tenant_id, api_key_id) do
       {:ok, %{agent_pubkey: pubkey}} when is_binary(pubkey) ->
         {:error, :bulk_signature_unsupported}
+
+      {:ok, %{agent_id: agent_id}} when is_binary(agent_id) ->
+        # A bearer dispatch for an agent that HAS opted into signing. The single-story
+        # path answers `:agent_enrollment_required` ("use your enrolled dispatch"), but
+        # here that remedy leads nowhere — the enrolled dispatch is refused too — so
+        # name the terminal remedy directly: verify each story individually.
+        if Dispatches.agent_has_enrolled_key?(tenant_id, agent_id) do
+          {:error, :bulk_signature_unsupported}
+        else
+          :ok
+        end
 
       _not_enrolled ->
         :ok

--- a/lib/loopctl/custody/signed_profile_policy.ex
+++ b/lib/loopctl/custody/signed_profile_policy.ex
@@ -227,9 +227,18 @@ defmodule Loopctl.Custody.SignedProfilePolicy do
   bulk gate is strictly WEAKER than the single-story gate it mirrors — an agent that
   had migrated to signing could take its BEARER dispatch to verify-all and clear a
   whole epic unsigned, which is the exact bypass this function exists to close.
+
+  The two cases answer with DIFFERENT codes because their remedies differ, and each
+  message must be true of the caller it is sent to. An ENROLLED dispatch gets
+  `:bulk_signature_unsupported` ("verify each story individually") — its next call
+  succeeds. A BEARER dispatch gets `:agent_enrollment_required` ("use your enrolled
+  dispatch") exactly as on the single-story path; answering it
+  `:bulk_signature_unsupported` told it "your dispatch is enrolled with an agent key"
+  (false) and sent it to a single-story path that then 403s the same bearer key —
+  a dead end wrapped in a misdescription of its own credential.
   """
   @spec verify_bulk_request(:bearer | :signed, Ecto.UUID.t(), Ecto.UUID.t() | nil) ::
-          :ok | {:error, :bulk_signature_unsupported}
+          :ok | {:error, :bulk_signature_unsupported | :agent_enrollment_required}
   def verify_bulk_request(:bearer, _tenant_id, _api_key_id), do: :ok
 
   def verify_bulk_request(:signed, tenant_id, api_key_id) do
@@ -238,12 +247,8 @@ defmodule Loopctl.Custody.SignedProfilePolicy do
         {:error, :bulk_signature_unsupported}
 
       {:ok, %{agent_id: agent_id}} when is_binary(agent_id) ->
-        # A bearer dispatch for an agent that HAS opted into signing. The single-story
-        # path answers `:agent_enrollment_required` ("use your enrolled dispatch"), but
-        # here that remedy leads nowhere — the enrolled dispatch is refused too — so
-        # name the terminal remedy directly: verify each story individually.
         if Dispatches.agent_has_enrolled_key?(tenant_id, agent_id) do
-          {:error, :bulk_signature_unsupported}
+          {:error, :agent_enrollment_required}
         else
           :ok
         end

--- a/lib/loopctl/custody/signed_profile_policy.ex
+++ b/lib/loopctl/custody/signed_profile_policy.ex
@@ -236,6 +236,13 @@ defmodule Loopctl.Custody.SignedProfilePolicy do
   `:bulk_signature_unsupported` told it "your dispatch is enrolled with an agent key"
   (false) and sent it to a single-story path that then 403s the same bearer key —
   a dead end wrapped in a misdescription of its own credential.
+
+  Both remedies are TERMINAL on this endpoint only when read together, so the shared
+  `:agent_enrollment_required` message (`LoopctlWeb.Plugs.RequireSignedClaim.message_for/1`)
+  names both hops for the bulk caller: switch to the enrolled dispatch AND, because bulk
+  refuses that too, verify each story individually on the single-story signed path.
+  Naming only the enrolled dispatch here sent the caller to a credential this same
+  function refuses on its next call.
   """
   @spec verify_bulk_request(:bearer | :signed, Ecto.UUID.t(), Ecto.UUID.t() | nil) ::
           :ok | {:error, :bulk_signature_unsupported | :agent_enrollment_required}

--- a/lib/loopctl/dispatches.ex
+++ b/lib/loopctl/dispatches.ex
@@ -10,6 +10,8 @@ defmodule Loopctl.Dispatches do
 
   import Ecto.Query
 
+  require Logger
+
   alias Ecto.Multi
   alias Loopctl.AdminRepo
   alias Loopctl.AuditChain
@@ -17,6 +19,7 @@ defmodule Loopctl.Dispatches do
   alias Loopctl.Custody.SignedProfile
   alias Loopctl.Dispatches.Dispatch
   alias Loopctl.HeavyRead
+  alias Loopctl.TenantKeys
   alias Loopctl.Tenants
 
   @max_expires_seconds 14_400
@@ -26,6 +29,11 @@ defmodule Loopctl.Dispatches do
   # selection never degrades into an unbounded fetch as ephemeral dispatches
   # accumulate with agent fan-out.
   @verifier_pool_limit 500
+
+  # Domain-separation label for the verifier-selection PRF (see `verifier_seed/2`).
+  # Versioned so a future change to what the seed binds is a new label rather than a
+  # silent reinterpretation of the same key.
+  @verifier_seed_domain "loopctl/verifier-selection/v1|"
 
   @doc """
   Creates a new dispatch with an ephemeral API key.
@@ -647,8 +655,8 @@ defmodule Loopctl.Dispatches do
   Eligible dispatches: active, non-expired, non-revoked, in the same tenant,
   whose lineage does NOT share a prefix with the implementer's lineage.
 
-  Selection is deterministic but unpredictable to the orchestrator:
-  seeded with sha256(tenant_audit_public_key + story_id).
+  Selection is deterministic but unpredictable to the caller: the index is drawn
+  from an HMAC keyed by the tenant's audit signing PRIVATE key (`verifier_seed/2`).
 
   SCALE: the same-lineage rejection is pushed into SQL (compare lineage ROOTS,
   `lineage_path[1]`) and the candidate pool is capped at `@verifier_pool_limit`,
@@ -657,10 +665,12 @@ defmodule Loopctl.Dispatches do
   pool. The Elixir `Enum.reject` is kept as a belt-and-braces filter for the rows
   the SQL predicate cannot express (e.g. a NULL/empty lineage_path).
 
-  Returns `{:ok, dispatch}` or `{:error, :no_eligible_verifier}`.
+  Returns `{:ok, dispatch}`, `{:error, :no_eligible_verifier}`, or
+  `{:error, :verifier_seed_unavailable}` when no server-side seed secret can be
+  read (see `verifier_seed/2` — that case fails CLOSED rather than selecting).
   """
   @spec select_verifier(Ecto.UUID.t(), Ecto.UUID.t(), [Ecto.UUID.t()]) ::
-          {:ok, Dispatch.t()} | {:error, :no_eligible_verifier}
+          {:ok, Dispatch.t()} | {:error, :no_eligible_verifier | :verifier_seed_unavailable}
   def select_verifier(tenant_id, story_id, implementer_lineage) do
     now = DateTime.utc_now()
 
@@ -683,24 +693,56 @@ defmodule Loopctl.Dispatches do
         {:error, :no_eligible_verifier}
 
       pool ->
-        # Deterministic selection: hash(tenant_pub_key || story_id) → index
-        pub_key =
-          from(t in Loopctl.Tenants.Tenant,
-            where: t.id == ^tenant_id,
-            select: t.audit_signing_public_key
-          )
-          |> AdminRepo.one()
+        case verifier_seed(tenant_id, story_id) do
+          {:ok, <<index_seed::unsigned-64, _rest::binary>>} ->
+            {:ok, Enum.at(pool, rem(index_seed, length(pool)))}
 
-        seed_data = (pub_key || "") <> story_id
-        hash = :crypto.hash(:sha256, seed_data)
-        <<index_seed::unsigned-64, _rest::binary>> = hash
-        selected = Enum.at(pool, rem(index_seed, length(pool)))
-
-        {:ok, selected}
+          :error ->
+            {:error, :verifier_seed_unavailable}
+        end
     end
   end
 
   # --- Private ---
+
+  # The selection index MUST NOT be derivable by the principals it selects between.
+  # The candidate pool is enumerable by any agent key (GET /api/v1/dispatches), so
+  # everything except the seed key is already known to a caller; the seed is the
+  # only secret standing between "deterministic" and "predictable". It is therefore
+  # keyed by the tenant's audit signing PRIVATE key — held in the secret store and
+  # reachable only server-side (`TenantKeys`, ETS-cached) — never by the audit
+  # signing PUBLIC key, which is served unauthenticated on the discovery endpoint.
+  #
+  # Domain-separated and bound to (tenant, story) so a seed can serve no other
+  # purpose and cannot be carried between stories or tenants.
+  #
+  # FAILS CLOSED. A tenant with no audit key (pre-v2) or an unreachable secret store
+  # yields no seed, and there is no public value to fall back to that would not
+  # reinstate predictability — so no verifier is selected and the caller flags the
+  # story instead (see `Progress.assign_rotating_verifier/3`). Selecting with a
+  # guessable seed would be worse than selecting nobody: the verify gate still
+  # enforces lineage separation either way.
+  defp verifier_seed(tenant_id, story_id) do
+    case TenantKeys.get_private_key(tenant_id) do
+      {:ok, key} when is_binary(key) and byte_size(key) > 0 ->
+        {:ok,
+         :crypto.mac(
+           :hmac,
+           :sha256,
+           key,
+           @verifier_seed_domain <> tenant_id <> story_id
+         )}
+
+      other ->
+        Logger.error(
+          "verifier_seed_unavailable: no server-side seed secret for tenant=#{tenant_id} " <>
+            "story=#{story_id} (#{inspect(other)}). Verifier selection fails closed; the " <>
+            "story is flagged verifier_needed. Provision the tenant's audit signing key."
+        )
+
+        :error
+    end
+  end
 
   # SQL half of the same-lineage rejection: drop every candidate whose lineage
   # ROOT equals the implementer's root. With an empty implementer lineage there

--- a/lib/loopctl/dispatches.ex
+++ b/lib/loopctl/dispatches.ex
@@ -653,7 +653,7 @@ defmodule Loopctl.Dispatches do
   Selects a verifier dispatch from the eligible pool for a story.
 
   Eligible dispatches: active, non-expired, non-revoked, in the same tenant,
-  whose lineage does NOT share a prefix with the implementer's lineage.
+  whose lineage does NOT share a ROOT with the implementer's lineage.
 
   Selection is deterministic but unpredictable to the caller: the index is drawn
   from an HMAC keyed by the tenant's audit signing PRIVATE key (`verifier_seed/2`).
@@ -665,34 +665,29 @@ defmodule Loopctl.Dispatches do
   pool. The Elixir `Enum.reject` is kept as a belt-and-braces filter for the rows
   the SQL predicate cannot express (e.g. a NULL/empty lineage_path).
 
-  Returns `{:ok, dispatch}`, `{:error, :no_eligible_verifier}`, or
-  `{:error, :verifier_seed_unavailable}` when no server-side seed secret can be
-  read (see `verifier_seed/2` — that case fails CLOSED rather than selecting).
+  Returns `{:ok, dispatch}` or:
+
+    * `{:error, :no_independent_root}` — the tenant HAS active dispatches, but every
+      one of them descends from the implementer's root. Only the operator key may
+      start a tree (`LoopctlWeb.DispatchController`'s lineage ceiling), so a tenant
+      that minted ONE root has no principal that can verify: `verify_story/4`
+      root-separation 409s every dispatch-minted caller. That is L4 working, not a
+      pool miss — it is reported separately so `verifier_needed` names the actual
+      remedy (have the operator mint an independently-rooted verifier tree) instead
+      of looking like a transient shortage.
+    * `{:error, :no_eligible_verifier}` — no active candidate dispatches at all.
+    * `{:error, :verifier_seed_unavailable}` — no server-side seed secret can be read
+      (see `verifier_seed/2` — that case fails CLOSED rather than selecting).
   """
   @spec select_verifier(Ecto.UUID.t(), Ecto.UUID.t(), [Ecto.UUID.t()]) ::
-          {:ok, Dispatch.t()} | {:error, :no_eligible_verifier | :verifier_seed_unavailable}
+          {:ok, Dispatch.t()}
+          | {:error, :no_eligible_verifier | :no_independent_root | :verifier_seed_unavailable}
   def select_verifier(tenant_id, story_id, implementer_lineage) do
-    now = DateTime.utc_now()
+    case verifier_pool(tenant_id, implementer_lineage) do
+      {:error, reason} ->
+        {:error, reason}
 
-    candidates =
-      from(d in Dispatch,
-        where:
-          d.tenant_id == ^tenant_id and
-            is_nil(d.revoked_at) and
-            d.expires_at > ^now and
-            d.role in [:orchestrator, :agent],
-        order_by: [asc: d.created_at],
-        limit: @verifier_pool_limit
-      )
-      |> reject_same_root(implementer_lineage)
-      |> AdminRepo.all()
-      |> Enum.reject(fn d -> lineage_shares_prefix?(d.lineage_path, implementer_lineage) end)
-
-    case candidates do
-      [] ->
-        {:error, :no_eligible_verifier}
-
-      pool ->
+      {:ok, pool} ->
         case verifier_seed(tenant_id, story_id) do
           {:ok, <<index_seed::unsigned-64, _rest::binary>>} ->
             {:ok, Enum.at(pool, rem(index_seed, length(pool)))}
@@ -704,6 +699,45 @@ defmodule Loopctl.Dispatches do
   end
 
   # --- Private ---
+
+  # An empty pool has two causes with DIFFERENT remedies, and reporting both as
+  # `:no_eligible_verifier` hid the one an operator has to act on: "wait for a
+  # dispatch" versus "mint an independently-rooted verifier tree". Distinguish them
+  # with one extra COUNT, paid only when the pool came back empty.
+  defp verifier_pool(tenant_id, implementer_lineage) do
+    case candidate_query(tenant_id)
+         |> reject_same_root(implementer_lineage)
+         |> AdminRepo.all()
+         |> Enum.reject(&lineage_shares_prefix?(&1.lineage_path, implementer_lineage)) do
+      [] ->
+        any_candidate? =
+          candidate_query(tenant_id)
+          |> exclude(:order_by)
+          |> exclude(:limit)
+          |> AdminRepo.exists?()
+
+        if any_candidate?,
+          do: {:error, :no_independent_root},
+          else: {:error, :no_eligible_verifier}
+
+      pool ->
+        {:ok, pool}
+    end
+  end
+
+  defp candidate_query(tenant_id) do
+    now = DateTime.utc_now()
+
+    from(d in Dispatch,
+      where:
+        d.tenant_id == ^tenant_id and
+          is_nil(d.revoked_at) and
+          d.expires_at > ^now and
+          d.role in [:orchestrator, :agent],
+      order_by: [asc: d.created_at],
+      limit: @verifier_pool_limit
+    )
+  end
 
   # The selection index MUST NOT be derivable by the principals it selects between.
   # The candidate pool is enumerable by any agent key (GET /api/v1/dispatches), so
@@ -740,6 +774,15 @@ defmodule Loopctl.Dispatches do
             "story is flagged verifier_needed. Provision the tenant's audit signing key."
         )
 
+        # A secret-store outage makes this fire on EVERY request-review, deployment-wide,
+        # and the only other trace is a log line. Emit a counter so the state is alertable
+        # rather than something an operator discovers from unverifiable stories later.
+        :telemetry.execute(
+          [:loopctl, :custody, :verifier_seed_unavailable],
+          %{count: 1},
+          %{tenant_id: tenant_id, story_id: story_id}
+        )
+
         :error
     end
   end
@@ -751,8 +794,15 @@ defmodule Loopctl.Dispatches do
   defp reject_same_root(query, []), do: query
 
   defp reject_same_root(query, [root | _]) do
+    # `type(^root, Ecto.UUID)` is load-bearing: a bare `^root` inside a fragment
+    # comparison carries no type, so Postgrex received the 36-char string for a
+    # uuid[] element and raised — which meant this branch crashed for EVERY story
+    # that had an implementer dispatch (the only way to reach it with a non-empty
+    # lineage).
     from(d in query,
-      where: is_nil(fragment("?[1]", d.lineage_path)) or fragment("?[1]", d.lineage_path) != ^root
+      where:
+        is_nil(fragment("?[1]", d.lineage_path)) or
+          fragment("?[1]", d.lineage_path) != type(^root, Ecto.UUID)
     )
   end
 

--- a/lib/loopctl/dispatches.ex
+++ b/lib/loopctl/dispatches.ex
@@ -591,11 +591,13 @@ defmodule Loopctl.Dispatches do
   "same lineage" means for custody separation. An empty lineage on either side is
   never a match.
 
-  This is the STRICTER of the two comparisons and belongs to the VERIFY side —
-  `validate_not_self_verify/3` and `select_verifier/3`'s `reject_same_root/2`,
-  which deliberately declines to pick a verifier under the implementer's root.
-  For the REPORT gate, where a sibling reviewer IS acceptable separation, use
-  `lineage_same_chain?/2` instead and read the note there.
+  This is the STRICTER of the two comparisons, and it applies where separation can be
+  guaranteed BY CONSTRUCTION rather than demanded of an arbitrary caller:
+  `select_verifier/3`'s `reject_same_root/2`, which declines to pick a verifier under
+  the implementer's root, and `Progress.verify_lineage_separated/4`, which compares the
+  verifier dispatch that selection RECORDED. Every CALLER comparison — report,
+  review-complete and verify alike — uses `lineage_same_chain?/2`; read the note there
+  for why demanding a separate root of the caller locks a single-root tenant out.
   """
   @spec lineage_shares_prefix?(list(), list()) :: boolean()
   def lineage_shares_prefix?([], _), do: false
@@ -608,7 +610,7 @@ defmodule Loopctl.Dispatches do
   True when the two dispatches lie on ONE root-to-leaf chain — identical, or one
   an ancestor of the other. Siblings are NOT a match.
 
-  ## Why report needs this and verify does not
+  ## Why every CALLER comparison needs this
 
   The documented dispatch tree puts the implementer and the reviewer side by side
   under one orchestrator, and roots everything at a single operator dispatch:
@@ -633,10 +635,12 @@ defmodule Loopctl.Dispatches do
     * `[r, o, i]` vs `[r, o, v]` (two siblings) — allowed: separate dispatches,
       separate ephemeral keys, separate `agent_id`s.
 
-  VERIFY deliberately stays stricter (`lineage_shares_prefix?/2`): it is the
-  final certification, and `select_verifier/3` already refuses to nominate a
-  verifier sharing the implementer's root, so accepting one at the gate would
-  contradict the selection rule.
+  VERIFY's CALLER comparison uses this too. Demanding a separate ROOT of the
+  caller made verify unreachable in the tree drawn above — every dispatch-minted
+  key shares the one root, so a single-root tenant had no principal that could
+  certify anything. The stricter `lineage_shares_prefix?/2` still governs where
+  selection can satisfy it by construction: `select_verifier/3` will not nominate
+  a same-root verifier, and the RECORDED verifier is compared at root distance.
 
   Self-approval is not relaxed either way — the `assigned_agent_id` equality
   check runs IN ADDITION at every gate, and an empty lineage is never a match.

--- a/lib/loopctl/progress.ex
+++ b/lib/loopctl/progress.ex
@@ -481,7 +481,15 @@ defmodule Loopctl.Progress do
             flag_verifier_needed(tenant_id, story_id, story, "assign_failed", reason)
         end
 
-      {:error, reason} when reason in [:no_eligible_verifier, :verifier_seed_unavailable] ->
+      # `:no_independent_root` is reported distinctly on purpose: it is not a shortage
+      # but the single-root tenant shape, and its remedy is an operator action (mint an
+      # independently-rooted verifier tree), not waiting.
+      {:error, reason}
+      when reason in [
+             :no_eligible_verifier,
+             :no_independent_root,
+             :verifier_seed_unavailable
+           ] ->
         flag_verifier_needed(tenant_id, story_id, story, to_string(reason), nil)
     end
   end
@@ -962,7 +970,11 @@ defmodule Loopctl.Progress do
           assigned_agent_id: nil,
           assigned_at: nil,
           reported_done_at: nil,
-          reported_by_agent_id: nil
+          reported_by_agent_id: nil,
+          # Durable record that this story WAS worked — the dispatch markers being
+          # cleared right here is exactly what backfill would otherwise read as
+          # "never dispatched". See guard_no_lifecycle_history/1.
+          metadata: lifecycle_marked_metadata(story)
         })
         |> AdminRepo.update()
       end)
@@ -1275,15 +1287,20 @@ defmodule Loopctl.Progress do
   `{:error, :unresolvable_dispatch_lineage}` (passed through from
   `verify_lineage_separated/4`).
 
+  `caller_lineage` is the CALLER's dispatch lineage, resolved SERVER-SIDE from the
+  authenticating key — never client-supplied. It is REQUIRED: passing `[]` because a
+  path did not bother to resolve it silences the entire L4 caller comparison and
+  leaves only agent-id inequality, which an orchestrator key satisfies trivially.
+
   Exposed so `Loopctl.BulkOperations` enforces the SAME self-verify invariant as
   the single-story `verify_story/4` path — otherwise bulk verify is a chain-of-custody bypass.
   """
-  @spec ensure_verify_allowed(Story.t(), Ecto.UUID.t() | nil) ::
+  @spec ensure_verify_allowed(Story.t(), Ecto.UUID.t() | nil, [Ecto.UUID.t()]) ::
           :ok
           | {:error,
              :self_verify_blocked | :missing_assigned_agent | :unresolvable_dispatch_lineage}
-  def ensure_verify_allowed(story, orchestrator_agent_id) do
-    case validate_not_self_verify(story, orchestrator_agent_id) do
+  def ensure_verify_allowed(story, orchestrator_agent_id, caller_lineage) do
+    case validate_not_self_verify(story, orchestrator_agent_id, caller_lineage) do
       {:ok, _} -> :ok
       {:error, reason} -> {:error, reason}
     end
@@ -1312,8 +1329,12 @@ defmodule Loopctl.Progress do
   with `initial_agent_status: "reported_done"`), for which mark-complete is the
   correct remediation. Matches `backfill_story/4`. Prevents mark-complete from
   being used to self-verify dispatched work.
+
+  `lifecycle_ids` is the batch's precomputed lifecycle-history set (see
+  `stories_with_lifecycle_history/2`), so a 50-story batch costs one audit query
+  rather than 50 inside the locking transaction.
   """
-  @spec ensure_mark_complete_allowed(Story.t()) ::
+  @spec ensure_mark_complete_allowed(Story.t(), MapSet.t()) ::
           :ok
           | {:error,
              :already_verified
@@ -1321,8 +1342,8 @@ defmodule Loopctl.Progress do
              | :story_has_dispatch_lineage
              | :story_entered_lifecycle
              | :story_in_progress}
-  def ensure_mark_complete_allowed(story) do
-    case guard_backfillable(story) do
+  def ensure_mark_complete_allowed(story, lifecycle_ids) do
+    case guard_backfillable(story, lifecycle_ids) do
       {:ok, _} -> :ok
       {:error, reason} -> {:error, reason}
     end
@@ -1384,15 +1405,13 @@ defmodule Loopctl.Progress do
              | :story_in_progress
              | Ecto.Changeset.t()}
   def backfill_story(tenant_id, story_id, params, opts \\ []) do
-    actor_id = Keyword.get(opts, :actor_id)
-    actor_label = Keyword.get(opts, :actor_label)
     reason = params |> Map.get("reason") |> normalize_string()
 
     with :ok <- validate_backfill_reason(reason),
          {:ok, pr_number} <- cast_pr_number(Map.get(params, "pr_number")),
          {:ok, evidence_url} <-
            validate_evidence_url(params |> Map.get("evidence_url") |> normalize_string()) do
-      do_backfill(tenant_id, story_id, reason, evidence_url, pr_number, actor_id, actor_label)
+      do_backfill(tenant_id, story_id, reason, evidence_url, pr_number, opts)
     end
   end
 
@@ -1434,7 +1453,10 @@ defmodule Loopctl.Progress do
     end
   end
 
-  defp do_backfill(tenant_id, story_id, reason, evidence_url, pr_number, actor_id, actor_label) do
+  defp do_backfill(tenant_id, story_id, reason, evidence_url, pr_number, opts) do
+    actor_id = Keyword.get(opts, :actor_id)
+    actor_label = Keyword.get(opts, :actor_label)
+
     multi =
       Multi.new()
       |> Multi.run(:lock, fn _repo, _changes -> lock_story(tenant_id, story_id) end)
@@ -1465,6 +1487,12 @@ defmodule Loopctl.Progress do
           }
         }
       end)
+      # LCP-1 §9.4: backfill reaches the same `verified_status: :verified` terminal
+      # state as verify and mounts the same RequireSignedClaim gate, so it records the
+      # same durable cryptographic residue. Verifying a signature and then dropping it
+      # is half a control: the signature evaporates at request end and the record it
+      # authorized becomes indistinguishable from one an operator fabricated.
+      |> maybe_chain_signed_claim(tenant_id, story_id, opts)
       |> EventGenerator.generate_events(:webhook_events, fn %{story: updated} ->
         %{
           tenant_id: tenant_id,
@@ -1555,28 +1583,35 @@ defmodule Loopctl.Progress do
   #     force_unclaim_story does NOT clear, so relying on assigned_agent_id alone
   #     is bypassable; all three are checked.
   #   - otherwise, only :pending or :reported_done (never-dispatched) are
-  #     backfillable, AND only if the story has no lifecycle history in the audit
-  #     log (see guard_no_lifecycle_history/1); a story mid-lifecycle (:contracted
+  #     backfillable, AND only if the story has no lifecycle history (see
+  #     guard_no_lifecycle_history/2); a story mid-lifecycle (:contracted
   #     with no dispatch yet) is being worked, not pre-existing done work — an
   #     ACCURATE reason, not a false "dispatch lineage" claim.
-  defp guard_backfillable(%{verified_status: :verified}), do: {:error, :already_verified}
-  defp guard_backfillable(%{verified_status: :rejected}), do: {:error, :story_rejected}
+  #
+  # `lookup` is `:query` on the single-story path and a precomputed MapSet on the
+  # batch path.
+  defp guard_backfillable(story), do: guard_backfillable(story, :query)
 
-  defp guard_backfillable(%{assigned_agent_id: agent_id}) when not is_nil(agent_id),
+  defp guard_backfillable(%{verified_status: :verified}, _lookup),
+    do: {:error, :already_verified}
+
+  defp guard_backfillable(%{verified_status: :rejected}, _lookup), do: {:error, :story_rejected}
+
+  defp guard_backfillable(%{assigned_agent_id: agent_id}, _lookup) when not is_nil(agent_id),
     do: {:error, :story_has_dispatch_lineage}
 
-  defp guard_backfillable(%{implementer_dispatch_id: id}) when not is_nil(id),
+  defp guard_backfillable(%{implementer_dispatch_id: id}, _lookup) when not is_nil(id),
     do: {:error, :story_has_dispatch_lineage}
 
-  defp guard_backfillable(%{verifier_dispatch_id: id}) when not is_nil(id),
+  defp guard_backfillable(%{verifier_dispatch_id: id}, _lookup) when not is_nil(id),
     do: {:error, :story_has_dispatch_lineage}
 
   # No dispatch markers from here down.
-  defp guard_backfillable(%{agent_status: status} = story)
+  defp guard_backfillable(%{agent_status: status} = story, lookup)
        when status in [:pending, :reported_done],
-       do: guard_no_lifecycle_history(story)
+       do: guard_no_lifecycle_history(story, lookup)
 
-  defp guard_backfillable(_story), do: {:error, :story_in_progress}
+  defp guard_backfillable(_story, _lookup), do: {:error, :story_in_progress}
 
   # The dispatch markers above record the story's CURRENT shape, and one of them is
   # erasable: `force_unclaim_story/3` clears `assigned_agent_id`. For a story claimed
@@ -1587,35 +1622,74 @@ defmodule Loopctl.Progress do
   # review record and no independent verifier: the entire custody chain skipped by two
   # ordinary calls.
   #
-  # The audit log is append-only and immutable, so it remembers what the story row no
-  # longer does. A story that ever entered the lifecycle carries a `status_changed`
-  # (contract / claim / start / report / request-review) or `force_unclaimed` entry,
-  # and is refused here regardless of its present state.
+  # Two sources answer "did this story ever enter the lifecycle", and the DURABLE one
+  # is the story row itself. `metadata["lifecycle_entered_at"]` is stamped by the only
+  # two calls that can clear `assigned_agent_id` on a worked story — `unclaim_story/3`
+  # and `force_unclaim_story/3` — and nothing ever clears it, so it survives for as
+  # long as the story does.
+  #
+  # The `audit_log` query is the SECOND source, and it is retention-BOUNDED, not
+  # permanent: `Loopctl.Workers.AuditPartitionWorker` DROPs monthly partitions older
+  # than `:audit_retention_days` (default 90). Relying on it alone reopened the launder
+  # path on a timer — after the window the lifecycle rows are gone and a
+  # force-unclaimed story reads as never-dispatched again. It is kept because it also
+  # covers stories force-unclaimed BEFORE the marker existed, within the window.
   #
   # Never-dispatched work is untouched: `created`, `imported` and `merge_imported` are
   # not lifecycle actions, so a story imported with
   # `initial_agent_status: "reported_done"` remains backfillable — which is the case
   # backfill exists for. Indexed by `audit_log_tenant_entity_idx`.
   @lifecycle_audit_actions ["status_changed", "force_unclaimed"]
+  @lifecycle_marker "lifecycle_entered_at"
 
-  defp guard_no_lifecycle_history(%{id: id, tenant_id: tenant_id})
+  defp guard_no_lifecycle_history(%{metadata: %{@lifecycle_marker => stamp}}, _lookup)
+       when not is_nil(stamp),
+       do: {:error, :story_entered_lifecycle}
+
+  defp guard_no_lifecycle_history(%{id: id}, lookup)
+       when is_binary(id) and is_struct(lookup, MapSet) do
+    if MapSet.member?(lookup, id), do: {:error, :story_entered_lifecycle}, else: {:ok, :ok}
+  end
+
+  defp guard_no_lifecycle_history(%{id: id, tenant_id: tenant_id}, :query)
        when is_binary(id) and is_binary(tenant_id) do
-    entered? =
-      from(a in AuditLog,
-        where:
-          a.tenant_id == ^tenant_id and a.entity_type == "story" and a.entity_id == ^id and
-            a.action in ^@lifecycle_audit_actions,
-        select: 1,
-        limit: 1
-      )
-      |> AdminRepo.one()
-      |> is_integer()
-
-    if entered?, do: {:error, :story_entered_lifecycle}, else: {:ok, :ok}
+    if MapSet.member?(stories_with_lifecycle_history(tenant_id, [id]), id) do
+      {:error, :story_entered_lifecycle}
+    else
+      {:ok, :ok}
+    end
   end
 
   # A story we cannot identify cannot be shown to be never-dispatched. Fail closed.
-  defp guard_no_lifecycle_history(_story), do: {:error, :story_entered_lifecycle}
+  defp guard_no_lifecycle_history(_story, _lookup), do: {:error, :story_entered_lifecycle}
+
+  @doc """
+  The subset of `ids` whose audit log shows lifecycle history — the set
+  `backfill_story/4` and `ensure_mark_complete_allowed/2` refuse.
+
+  Hoisted out of the per-story guard so the bulk mark-complete path pays ONE query
+  per batch instead of one per story while holding `FOR UPDATE` locks on all of them
+  and one of AdminRepo's deliberately tiny (3-connection) pool.
+  """
+  @spec stories_with_lifecycle_history(Ecto.UUID.t(), [Ecto.UUID.t()]) :: MapSet.t()
+  def stories_with_lifecycle_history(tenant_id, ids) do
+    from(a in AuditLog,
+      where:
+        a.tenant_id == ^tenant_id and a.entity_type == "story" and a.entity_id in ^ids and
+          a.action in ^@lifecycle_audit_actions,
+      select: a.entity_id,
+      distinct: true
+    )
+    |> AdminRepo.all()
+    |> MapSet.new()
+  end
+
+  # Durable proof that a story entered the dispatch lifecycle, stamped where the
+  # erasure happens. `metadata` is not cleared by any unclaim path, so unlike the
+  # dispatch markers (and unlike the retention-bounded audit log) this survives.
+  defp lifecycle_marked_metadata(%{metadata: metadata}) do
+    Map.put(metadata || %{}, @lifecycle_marker, DateTime.to_iso8601(DateTime.utc_now()))
+  end
 
   defp apply_backfill_status(story, reason, evidence_url, pr_number) do
     now = DateTime.utc_now()
@@ -1666,7 +1740,8 @@ defmodule Loopctl.Progress do
   - `tenant_id` -- the tenant UUID
   - `story_id` -- the story UUID
   - `params` -- map with `reason` (required), optional `findings`, `review_type`
-  - `opts` -- keyword list with `:orchestrator_agent_id`, `:actor_id`, `:actor_label`
+  - `opts` -- keyword list with `:orchestrator_agent_id`, `:actor_id`, `:actor_label`,
+    and `:verifier_lineage` (the CALLER's dispatch lineage, resolved server-side)
 
   ## Returns
 
@@ -1690,7 +1765,14 @@ defmodule Loopctl.Progress do
         Multi.new()
         |> Multi.run(:lock, fn _repo, _changes -> lock_story(tenant_id, story_id) end)
         |> Multi.run(:self_verify_check, fn _repo, %{lock: story} ->
-          validate_not_self_verify(story, orchestrator_agent_id)
+          # Reject reaches the TERMINAL `verified_status: :rejected` and auto-resets
+          # the agent status, so it is the same custody decision verify is and takes
+          # the same caller-lineage comparison.
+          validate_not_self_verify(
+            story,
+            orchestrator_agent_id,
+            Keyword.get(opts, :verifier_lineage, [])
+          )
         end)
         |> Multi.run(:validate, fn _repo, %{lock: story} ->
           validate_rejectable(story)
@@ -1860,7 +1942,10 @@ defmodule Loopctl.Progress do
             assigned_agent_id: nil,
             assigned_at: nil,
             reported_done_at: nil,
-            reported_by_agent_id: nil
+            reported_by_agent_id: nil,
+            # See unclaim_story/3: the durable half of the anti-launder guard, stamped
+            # at the moment the erasable dispatch markers are erased.
+            metadata: lifecycle_marked_metadata(story)
           })
           |> AdminRepo.update()
         end
@@ -1911,8 +1996,12 @@ defmodule Loopctl.Progress do
 
   # --- Verification/Rejection helpers ---
 
-  defp validate_not_self_verify(story, orchestrator_agent_id, caller_lineage \\ [])
-
+  # NO default for `caller_lineage`. A defaulted [] made "this path resolved the
+  # caller's lineage and it is empty" indistinguishable from "this path forgot to
+  # resolve it", and lineage_status/3 treats [] as :ok — so every forgetful call site
+  # (verify-all, bulk verify/reject, reject) silently skipped the whole L4 caller
+  # comparison. Making the argument mandatory turns that omission into a compile error.
+  #
   # nil orchestrator identity: untrusted (US-26.1.3)
   defp validate_not_self_verify(_story, nil, _caller_lineage), do: {:error, :self_verify_blocked}
 
@@ -1931,18 +2020,29 @@ defmodule Loopctl.Progress do
       log_custody_orphaned(story, orchestrator_agent_id, "verify")
       {:error, :missing_assigned_agent}
     else
-      # CALLER separation (LCP-1 §7.5) — the same comparison report and
-      # review-complete run, and the ONLY clause here that says anything about
-      # the principal actually making this call: the verifier's lineage is
-      # resolved SERVER-SIDE from the authenticating key, so an ancestor or a
-      # sub-agent in the implementer's chain is blocked even when its agent_id
-      # differs. The story-side clauses below compare RECORDED dispatches, which
-      # are silent about the caller — and `verifier_dispatch_id` is only written
-      # by the OPTIONAL request-review, so without this the common path degraded
-      # to a single agent-id inequality.
-      # :root — verify demands the stricter separation. select_verifier/3 will not
-      # nominate a verifier under the implementer's root, so a caller sharing it
-      # must not be able to certify either.
+      verify_caller_separation(story, orchestrator_agent_id, caller_lineage)
+    end
+  end
+
+  # CALLER separation (LCP-1 §7.5) — the same comparison report and review-complete
+  # run, and the ONLY clause here that says anything about the principal actually
+  # making this call: the verifier's lineage is resolved SERVER-SIDE from the
+  # authenticating key, so an ancestor or a sub-agent in the implementer's chain is
+  # blocked even when its agent_id differs. The story-side clauses compare RECORDED
+  # dispatches, which are silent about the caller — and `verifier_dispatch_id` is only
+  # written by the OPTIONAL request-review, so without this the common path degraded
+  # to a single agent-id inequality.
+  #
+  # :root — verify demands the stricter separation. select_verifier/3 will not
+  # nominate a verifier under the implementer's root, so a caller sharing it must not
+  # be able to certify either. NOTE what this implies operationally: a tenant needs the
+  # OPERATOR key to mint a SECOND, independently-rooted tree for its verifier — a
+  # single-root tenant has no principal that can verify, and select_verifier/3 answers
+  # `:no_independent_root` there rather than pretending the pool was empty.
+  defp verify_caller_separation(story, orchestrator_agent_id, caller_lineage) do
+    if legacy_caller_on_dispatched_story?(story, caller_lineage) do
+      {:error, :self_verify_blocked}
+    else
       case lineage_status(story, caller_lineage, :root) do
         :unresolvable -> {:error, :unresolvable_dispatch_lineage}
         :conflict -> {:error, :self_verify_blocked}
@@ -1950,6 +2050,21 @@ defmodule Loopctl.Progress do
       end
     end
   end
+
+  # VERIFY-ONLY fail-closed clause. `lineage_status/3` deliberately permits an EMPTY
+  # caller lineage (a key no dispatch minted — a legacy env-var key, OQ2 deprecation
+  # window), which leaves verify with nothing but `assigned_agent_id` inequality. Two
+  # env-var keys with distinct agent_ids in ONE process therefore cleared report,
+  # review-complete AND verify — the whole L4 structural separation absent, with only
+  # a prose rule against it. Where the WORK was dispatch-minted, the certifier must be
+  # too: an unlineaged caller cannot be shown separate from it, so it is refused.
+  # Pre-dispatch stories (no implementer dispatch) are untouched — there the agent-id
+  # check is the whole gate by design.
+  defp legacy_caller_on_dispatched_story?(%Story{implementer_dispatch_id: impl}, [])
+       when not is_nil(impl),
+       do: true
+
+  defp legacy_caller_on_dispatched_story?(_story, _caller_lineage), do: false
 
   # The STORY-side half of the gate: loopctl's SELECTED verifier against the
   # implementer when request-review recorded one, else agent-id equality.

--- a/lib/loopctl/progress.ex
+++ b/lib/loopctl/progress.ex
@@ -464,20 +464,25 @@ defmodule Loopctl.Progress do
             # No verify_cap is minted: see verify_story/4 for why L1 cannot gate
             # verify. The selection itself is the gate — it writes
             # verifier_dispatch_id, which validate_not_self_verify/2 enforces.
-            Loopctl.AuditChain.append(tenant_id, %{
+            tenant_id
+            |> Loopctl.AuditChain.append(%{
               action: "verifier_selected",
               actor_lineage: [],
               entity_type: "story",
               entity_id: story_id,
               payload: %{"verifier_dispatch_id" => verifier.id}
             })
+            # Post-commit append: the verifier_dispatch_id write above has already
+            # committed, so a discarded failure would leave the chain missing an entry
+            # for a custody decision that DID happen. See AuditChain.log_append_failure/4.
+            |> Loopctl.AuditChain.log_append_failure("verifier_selected", tenant_id, story_id)
 
           {:error, reason} ->
             flag_verifier_needed(tenant_id, story_id, story, "assign_failed", reason)
         end
 
-      {:error, :no_eligible_verifier} ->
-        flag_verifier_needed(tenant_id, story_id, story, "no_eligible_verifier", nil)
+      {:error, reason} when reason in [:no_eligible_verifier, :verifier_seed_unavailable] ->
+        flag_verifier_needed(tenant_id, story_id, story, to_string(reason), nil)
     end
   end
 
@@ -499,13 +504,15 @@ defmodule Loopctl.Progress do
       )
     end
 
-    Loopctl.AuditChain.append(tenant_id, %{
+    tenant_id
+    |> Loopctl.AuditChain.append(%{
       action: "verifier_not_assigned",
       actor_lineage: [],
       entity_type: "story",
       entity_id: story_id,
       payload: %{"reason" => reason}
     })
+    |> Loopctl.AuditChain.log_append_failure("verifier_not_assigned", tenant_id, story_id)
 
     result
   end
@@ -1299,10 +1306,10 @@ defmodule Loopctl.Progress do
   @doc """
   Structural custody guard for the bulk mark-complete (backfill) path.
 
-  Returns `:ok` only when `story` never entered the dispatch lifecycle (no
-  dispatch markers) — including a never-dispatched story already at
-  `agent_status: :reported_done` (e.g. imported with
-  `initial_agent_status: "reported_done"`), for which mark-complete is the
+  Returns `:ok` only when `story` never entered the dispatch lifecycle — no
+  dispatch markers AND no lifecycle history in the audit log — including a
+  never-dispatched story already at `agent_status: :reported_done` (e.g. imported
+  with `initial_agent_status: "reported_done"`), for which mark-complete is the
   correct remediation. Matches `backfill_story/4`. Prevents mark-complete from
   being used to self-verify dispatched work.
   """
@@ -1312,6 +1319,7 @@ defmodule Loopctl.Progress do
              :already_verified
              | :story_rejected
              | :story_has_dispatch_lineage
+             | :story_entered_lifecycle
              | :story_in_progress}
   def ensure_mark_complete_allowed(story) do
     case guard_backfillable(story) do
@@ -1353,6 +1361,9 @@ defmodule Loopctl.Progress do
     * `{:error, :story_has_dispatch_lineage}` — story has a dispatch marker
       (`assigned_agent_id`, `implementer_dispatch_id`, or `verifier_dispatch_id`);
       use the normal report/review/verify flow
+    * `{:error, :story_entered_lifecycle}` — the audit log shows the story was
+      worked inside loopctl (a `status_changed` or `force_unclaimed` entry), even
+      though its dispatch markers are now clear; use report/review/verify
     * `{:error, :story_in_progress}` — story is mid-lifecycle (e.g. `:contracted`)
       with no dispatch lineage yet; it is being worked, not pre-existing done work
     * `{:error, %Ecto.Changeset{}}` — persistence error surfaced from Multi step
@@ -1369,6 +1380,7 @@ defmodule Loopctl.Progress do
              | :already_verified
              | :story_rejected
              | :story_has_dispatch_lineage
+             | :story_entered_lifecycle
              | :story_in_progress
              | Ecto.Changeset.t()}
   def backfill_story(tenant_id, story_id, params, opts \\ []) do
@@ -1543,9 +1555,10 @@ defmodule Loopctl.Progress do
   #     force_unclaim_story does NOT clear, so relying on assigned_agent_id alone
   #     is bypassable; all three are checked.
   #   - otherwise, only :pending or :reported_done (never-dispatched) are
-  #     backfillable; a story mid-lifecycle (:contracted with no dispatch yet) is
-  #     being worked, not pre-existing done work — an ACCURATE reason, not a false
-  #     "dispatch lineage" claim.
+  #     backfillable, AND only if the story has no lifecycle history in the audit
+  #     log (see guard_no_lifecycle_history/1); a story mid-lifecycle (:contracted
+  #     with no dispatch yet) is being worked, not pre-existing done work — an
+  #     ACCURATE reason, not a false "dispatch lineage" claim.
   defp guard_backfillable(%{verified_status: :verified}), do: {:error, :already_verified}
   defp guard_backfillable(%{verified_status: :rejected}), do: {:error, :story_rejected}
 
@@ -1559,9 +1572,50 @@ defmodule Loopctl.Progress do
     do: {:error, :story_has_dispatch_lineage}
 
   # No dispatch markers from here down.
-  defp guard_backfillable(%{agent_status: :pending}), do: {:ok, :ok}
-  defp guard_backfillable(%{agent_status: :reported_done}), do: {:ok, :ok}
+  defp guard_backfillable(%{agent_status: status} = story)
+       when status in [:pending, :reported_done],
+       do: guard_no_lifecycle_history(story)
+
   defp guard_backfillable(_story), do: {:error, :story_in_progress}
+
+  # The dispatch markers above record the story's CURRENT shape, and one of them is
+  # erasable: `force_unclaim_story/3` clears `assigned_agent_id`. For a story claimed
+  # with a key that no dispatch minted, `implementer_dispatch_id` is never written
+  # either, so after a force-unclaim a genuinely worked story presents with all three
+  # markers NULL and `agent_status: :pending` — indistinguishable, by state alone,
+  # from work that predates loopctl. Backfill would then certify it with no report, no
+  # review record and no independent verifier: the entire custody chain skipped by two
+  # ordinary calls.
+  #
+  # The audit log is append-only and immutable, so it remembers what the story row no
+  # longer does. A story that ever entered the lifecycle carries a `status_changed`
+  # (contract / claim / start / report / request-review) or `force_unclaimed` entry,
+  # and is refused here regardless of its present state.
+  #
+  # Never-dispatched work is untouched: `created`, `imported` and `merge_imported` are
+  # not lifecycle actions, so a story imported with
+  # `initial_agent_status: "reported_done"` remains backfillable — which is the case
+  # backfill exists for. Indexed by `audit_log_tenant_entity_idx`.
+  @lifecycle_audit_actions ["status_changed", "force_unclaimed"]
+
+  defp guard_no_lifecycle_history(%{id: id, tenant_id: tenant_id})
+       when is_binary(id) and is_binary(tenant_id) do
+    entered? =
+      from(a in AuditLog,
+        where:
+          a.tenant_id == ^tenant_id and a.entity_type == "story" and a.entity_id == ^id and
+            a.action in ^@lifecycle_audit_actions,
+        select: 1,
+        limit: 1
+      )
+      |> AdminRepo.one()
+      |> is_integer()
+
+    if entered?, do: {:error, :story_entered_lifecycle}, else: {:ok, :ok}
+  end
+
+  # A story we cannot identify cannot be shown to be never-dispatched. Fail closed.
+  defp guard_no_lifecycle_history(_story), do: {:error, :story_entered_lifecycle}
 
   defp apply_backfill_status(story, reason, evidence_url, pr_number) do
     now = DateTime.utc_now()

--- a/lib/loopctl/progress.ex
+++ b/lib/loopctl/progress.ex
@@ -720,8 +720,10 @@ defmodule Loopctl.Progress do
   - `{:error, :not_found}` if story not found in tenant
   - `{:error, :invalid_transition}` if not in implementing state
   - `{:error, :self_report_blocked}` if calling agent is the same as the assigned agent,
-    or shares a dispatch lineage root with the implementer (pass the caller's
+    or lies on the implementer's dispatch lineage chain (pass the caller's
     server-resolved lineage as `:reporter_lineage`)
+  - `{:error, :caller_lineage_required}` if a key no dispatch minted reports
+    dispatch-minted work — its separation cannot be shown (fails closed)
   - `{:error, :missing_assigned_agent}` if the story has neither an assigned agent
     nor an implementer dispatch (custody-unattributed — fails closed)
   - `{:error, :unresolvable_dispatch_lineage}` if the story's declared implementer
@@ -1044,8 +1046,11 @@ defmodule Loopctl.Progress do
   - `{:ok, %ReviewRecord{}}` on success
   - `{:error, :not_found}` if story not found in tenant
   - `{:error, :story_not_reported_done}` if story is not in reported_done status
-  - `{:error, :self_review_blocked}` if the reviewer is the assigned agent or shares
-    the implementer's dispatch lineage root
+  - `{:error, :self_review_blocked}` if the reviewer is the assigned agent or lies on
+    the implementer's dispatch lineage chain
+  - `{:error, :caller_lineage_required}` if a key no dispatch minted reviews
+    dispatch-minted work (the nil-reviewer human-operator permit requires BOTH a nil
+    `:reviewer_agent_id` and an empty `:reviewer_lineage`)
   - `{:error, :missing_assigned_agent}` on a custody-orphaned story (fails closed)
   - `{:error, :unresolvable_dispatch_lineage}` if the story's declared implementer
     dispatch cannot be resolved (lineage-integrity failure, fails closed — LCP-1 §7.5)
@@ -1193,8 +1198,10 @@ defmodule Loopctl.Progress do
   - `{:ok, %Story{}}` on success
   - `{:error, :not_found}` if story not found in tenant
   - `{:error, :invalid_transition}` if story is not reported_done
-  - `{:error, :self_verify_blocked}` if the verifier is the assigned agent or shares
-    the implementer's dispatch lineage root
+  - `{:error, :self_verify_blocked}` if the verifier is the assigned agent or lies on
+    the implementer's dispatch lineage chain
+  - `{:error, :caller_lineage_required}` if a key no dispatch minted tries to certify
+    dispatch-minted work (fails closed; an ordinary refusal, not a byzantine signal)
   - `{:error, :missing_assigned_agent}` on a custody-orphaned story (fails closed)
   - `{:error, :unresolvable_dispatch_lineage}` if a dispatch the story references
     (implementer or verifier) cannot be resolved (lineage-integrity failure, fails
@@ -1234,7 +1241,8 @@ defmodule Loopctl.Progress do
         validate_not_self_verify(
           story,
           orchestrator_agent_id,
-          Keyword.get(opts, :verifier_lineage, [])
+          Keyword.get(opts, :verifier_lineage, []),
+          :verify
         )
       end)
       |> Multi.run(:validate, fn _repo, %{lock: story} ->
@@ -1289,18 +1297,25 @@ defmodule Loopctl.Progress do
 
   `caller_lineage` is the CALLER's dispatch lineage, resolved SERVER-SIDE from the
   authenticating key — never client-supplied. It is REQUIRED: passing `[]` because a
-  path did not bother to resolve it silences the entire L4 caller comparison and
-  leaves only agent-id inequality, which an orchestrator key satisfies trivially.
+  path did not bother to resolve it used to silence the entire L4 caller comparison and
+  leave only agent-id inequality, which an orchestrator key satisfies trivially. On
+  dispatch-minted work `[]` now returns `{:error, :caller_lineage_required}` instead.
+
+  `gate` is `:verify` (default) or `:reject`; reject exempts the unlineaged caller so
+  bad work can always be sent back (see `unlineaged_caller/3`).
 
   Exposed so `Loopctl.BulkOperations` enforces the SAME self-verify invariant as
   the single-story `verify_story/4` path — otherwise bulk verify is a chain-of-custody bypass.
   """
-  @spec ensure_verify_allowed(Story.t(), Ecto.UUID.t() | nil, [Ecto.UUID.t()]) ::
+  @spec ensure_verify_allowed(Story.t(), Ecto.UUID.t() | nil, [Ecto.UUID.t()], :verify | :reject) ::
           :ok
           | {:error,
-             :self_verify_blocked | :missing_assigned_agent | :unresolvable_dispatch_lineage}
-  def ensure_verify_allowed(story, orchestrator_agent_id, caller_lineage) do
-    case validate_not_self_verify(story, orchestrator_agent_id, caller_lineage) do
+             :self_verify_blocked
+             | :missing_assigned_agent
+             | :unresolvable_dispatch_lineage
+             | :caller_lineage_required}
+  def ensure_verify_allowed(story, orchestrator_agent_id, caller_lineage, gate \\ :verify) do
+    case validate_not_self_verify(story, orchestrator_agent_id, caller_lineage, gate) do
       {:ok, _} -> :ok
       {:error, reason} -> {:error, reason}
     end
@@ -1382,9 +1397,9 @@ defmodule Loopctl.Progress do
     * `{:error, :story_has_dispatch_lineage}` — story has a dispatch marker
       (`assigned_agent_id`, `implementer_dispatch_id`, or `verifier_dispatch_id`);
       use the normal report/review/verify flow
-    * `{:error, :story_entered_lifecycle}` — the audit log shows the story was
-      worked inside loopctl (a `status_changed` or `force_unclaimed` entry), even
-      though its dispatch markers are now clear; use report/review/verify
+    * `{:error, :story_entered_lifecycle}` — the story's own lifecycle stamp or the
+      audit log records that it was worked inside loopctl, even though its dispatch
+      markers are now clear; use report/review/verify
     * `{:error, :story_in_progress}` — story is mid-lifecycle (e.g. `:contracted`)
       with no dispatch lineage yet; it is being worked, not pre-existing done work
     * `{:error, %Ecto.Changeset{}}` — persistence error surfaced from Multi step
@@ -1622,11 +1637,17 @@ defmodule Loopctl.Progress do
   # review record and no independent verifier: the entire custody chain skipped by two
   # ordinary calls.
   #
-  # Two sources answer "did this story ever enter the lifecycle", and the DURABLE one
-  # is the story row itself. `metadata["lifecycle_entered_at"]` is stamped by the only
-  # two calls that can clear `assigned_agent_id` on a worked story — `unclaim_story/3`
-  # and `force_unclaim_story/3` — and nothing ever clears it, so it survives for as
-  # long as the story does.
+  # Two sources answer "did this story ever enter the lifecycle", and the longer-lived
+  # one is the story row itself. `metadata["lifecycle_entered_at"]` is stamped by every
+  # call that can clear `assigned_agent_id` on a worked story — `unclaim_story/3`,
+  # `force_unclaim_story/3` and `perform_auto_reset/4` — and no lifecycle path clears
+  # it, so unlike the audit log it is not on a retention timer.
+  #
+  # It is NOT tamper-proof: `:metadata` is castable by `Story.update_changeset/2` and
+  # `PATCH /api/v1/stories/:id` REPLACES the whole map, so an orchestrator-role key can
+  # still erase the marker. Closing that needs a non-castable column (or a merging
+  # update); until then the audit-log query below is the second, independent source and
+  # BOTH are consulted.
   #
   # The `audit_log` query is the SECOND source, and it is retention-BOUNDED, not
   # permanent: `Loopctl.Workers.AuditPartitionWorker` DROPs monthly partitions older
@@ -1639,7 +1660,7 @@ defmodule Loopctl.Progress do
   # not lifecycle actions, so a story imported with
   # `initial_agent_status: "reported_done"` remains backfillable — which is the case
   # backfill exists for. Indexed by `audit_log_tenant_entity_idx`.
-  @lifecycle_audit_actions ["status_changed", "force_unclaimed"]
+  @lifecycle_audit_actions ["status_changed", "force_unclaimed", "auto_reset"]
   @lifecycle_marker "lifecycle_entered_at"
 
   defp guard_no_lifecycle_history(%{metadata: %{@lifecycle_marker => stamp}}, _lookup)
@@ -1684,9 +1705,9 @@ defmodule Loopctl.Progress do
     |> MapSet.new()
   end
 
-  # Durable proof that a story entered the dispatch lifecycle, stamped where the
-  # erasure happens. `metadata` is not cleared by any unclaim path, so unlike the
-  # dispatch markers (and unlike the retention-bounded audit log) this survives.
+  # Proof that a story entered the dispatch lifecycle, stamped where the erasure
+  # happens. `metadata` is not cleared by any unclaim/reset path, so unlike the dispatch
+  # markers (and unlike the retention-bounded audit log) this survives them.
   defp lifecycle_marked_metadata(%{metadata: metadata}) do
     Map.put(metadata || %{}, @lifecycle_marker, DateTime.to_iso8601(DateTime.utc_now()))
   end
@@ -1766,12 +1787,14 @@ defmodule Loopctl.Progress do
         |> Multi.run(:lock, fn _repo, _changes -> lock_story(tenant_id, story_id) end)
         |> Multi.run(:self_verify_check, fn _repo, %{lock: story} ->
           # Reject reaches the TERMINAL `verified_status: :rejected` and auto-resets
-          # the agent status, so it is the same custody decision verify is and takes
-          # the same caller-lineage comparison.
+          # the agent status, so it takes the same caller-lineage comparison verify
+          # does — minus the unlineaged refusal, which would strand bad work with no
+          # way back (see unlineaged_caller/3).
           validate_not_self_verify(
             story,
             orchestrator_agent_id,
-            Keyword.get(opts, :verifier_lineage, [])
+            Keyword.get(opts, :verifier_lineage, []),
+            :reject
           )
         end)
         |> Multi.run(:validate, fn _repo, %{lock: story} ->
@@ -1996,16 +2019,20 @@ defmodule Loopctl.Progress do
 
   # --- Verification/Rejection helpers ---
 
-  # NO default for `caller_lineage`. A defaulted [] made "this path resolved the
+  # NO default for `caller_lineage` HERE. A defaulted [] made "this path resolved the
   # caller's lineage and it is empty" indistinguishable from "this path forgot to
-  # resolve it", and lineage_status/3 treats [] as :ok — so every forgetful call site
-  # (verify-all, bulk verify/reject, reject) silently skipped the whole L4 caller
-  # comparison. Making the argument mandatory turns that omission into a compile error.
+  # resolve it", and lineage_status/2 used to treat [] as :ok — so every forgetful call
+  # site (verify-all, bulk verify/reject, reject) silently skipped the whole L4 caller
+  # comparison. The public `verify_story/4` / `reject_story/4` opts boundary still
+  # DEFAULTS `:verifier_lineage` to [] (every current call site passes it), so the
+  # guarantee is not "omission is a compile error" — it is that [] no longer DEGRADES:
+  # on dispatch-minted work it is now `:unlineaged`, which verify refuses.
   #
   # nil orchestrator identity: untrusted (US-26.1.3)
-  defp validate_not_self_verify(_story, nil, _caller_lineage), do: {:error, :self_verify_blocked}
+  defp validate_not_self_verify(_story, nil, _caller_lineage, _gate),
+    do: {:error, :self_verify_blocked}
 
-  defp validate_not_self_verify(story, orchestrator_agent_id, caller_lineage) do
+  defp validate_not_self_verify(story, orchestrator_agent_id, caller_lineage, gate) do
     # INVARIANT 1 (fail closed / §2.2 "nil is never permissive"): a story that
     # is reported_done but not yet verified, with NO assigned agent and NO
     # dispatch lineage, has no implementer to compare the verifier against — the
@@ -2020,7 +2047,7 @@ defmodule Loopctl.Progress do
       log_custody_orphaned(story, orchestrator_agent_id, "verify")
       {:error, :missing_assigned_agent}
     else
-      verify_caller_separation(story, orchestrator_agent_id, caller_lineage)
+      verify_caller_separation(story, orchestrator_agent_id, caller_lineage, gate)
     end
   end
 
@@ -2033,38 +2060,40 @@ defmodule Loopctl.Progress do
   # written by the OPTIONAL request-review, so without this the common path degraded
   # to a single agent-id inequality.
   #
-  # :root — verify demands the stricter separation. select_verifier/3 will not
-  # nominate a verifier under the implementer's root, so a caller sharing it must not
-  # be able to certify either. NOTE what this implies operationally: a tenant needs the
-  # OPERATOR key to mint a SECOND, independently-rooted tree for its verifier — a
-  # single-root tenant has no principal that can verify, and select_verifier/3 answers
-  # `:no_independent_root` there rather than pretending the pool was empty.
-  defp verify_caller_separation(story, orchestrator_agent_id, caller_lineage) do
-    if legacy_caller_on_dispatched_story?(story, caller_lineage) do
-      {:error, :self_verify_blocked}
-    else
-      case lineage_status(story, caller_lineage, :root) do
-        :unresolvable -> {:error, :unresolvable_dispatch_lineage}
-        :conflict -> {:error, :self_verify_blocked}
-        :ok -> verify_recorded_separation(story, orchestrator_agent_id)
-      end
+  # The CALLER comparison is `lineage_same_chain?/2`, the SAME distance report and
+  # review-complete demand — an ancestor or a descendant of the implementer is blocked,
+  # a SIBLING is not. Demanding a separate ROOT here made verify unreachable in the
+  # documented single-root tenant (operator root -> orchestrator -> implementer): every
+  # dispatch-minted key shares the one root, so no principal could certify anything,
+  # while report and review-complete were relaxed to `:chain` for that exact reason.
+  # The stricter ROOT separation is still enforced where it can be satisfied by
+  # construction — `select_verifier/3` will not NOMINATE a same-root verifier, and
+  # `verify_recorded_separation/2` compares the RECORDED verifier at root distance.
+  defp verify_caller_separation(story, orchestrator_agent_id, caller_lineage, gate) do
+    case lineage_status(story, caller_lineage) do
+      :unresolvable -> {:error, :unresolvable_dispatch_lineage}
+      :conflict -> {:error, :self_verify_blocked}
+      :unlineaged -> unlineaged_caller(story, orchestrator_agent_id, gate)
+      :ok -> verify_recorded_separation(story, orchestrator_agent_id)
     end
   end
 
-  # VERIFY-ONLY fail-closed clause. `lineage_status/3` deliberately permits an EMPTY
-  # caller lineage (a key no dispatch minted — a legacy env-var key, OQ2 deprecation
-  # window), which leaves verify with nothing but `assigned_agent_id` inequality. Two
-  # env-var keys with distinct agent_ids in ONE process therefore cleared report,
-  # review-complete AND verify — the whole L4 structural separation absent, with only
-  # a prose rule against it. Where the WORK was dispatch-minted, the certifier must be
-  # too: an unlineaged caller cannot be shown separate from it, so it is refused.
-  # Pre-dispatch stories (no implementer dispatch) are untouched — there the agent-id
-  # check is the whole gate by design.
-  defp legacy_caller_on_dispatched_story?(%Story{implementer_dispatch_id: impl}, [])
-       when not is_nil(impl),
-       do: true
+  # An EMPTY caller lineage is a key no dispatch minted (a legacy env-var key, OQ2
+  # deprecation window). On dispatch-minted work it cannot be SHOWN separate from the
+  # implementer, leaving verify nothing but `assigned_agent_id` inequality — which two
+  # env-var keys with distinct agent_ids in one process satisfy trivially. So verify
+  # refuses it, under its OWN code: `:caller_lineage_required` is an ordinary
+  # configuration refusal (409, no violation recorded), NOT `self_verify_blocked`,
+  # which is an L6 byzantine signal that escalates to a tenant-wide custody halt.
+  #
+  # REJECT is exempt. Sending work back is the remediation path, not a certification —
+  # refusing it strands a bad story at reported_done with no way out — and the recorded
+  # and agent-id comparisons below still apply.
+  defp unlineaged_caller(story, orchestrator_agent_id, :reject),
+    do: verify_recorded_separation(story, orchestrator_agent_id)
 
-  defp legacy_caller_on_dispatched_story?(_story, _caller_lineage), do: false
+  defp unlineaged_caller(_story, _orchestrator_agent_id, :verify),
+    do: {:error, :caller_lineage_required}
 
   # The STORY-side half of the gate: loopctl's SELECTED verifier against the
   # implementer when request-review recorded one, else agent-id equality.
@@ -2413,7 +2442,11 @@ defmodule Loopctl.Progress do
         agent_status: :pending,
         assigned_agent_id: nil,
         assigned_at: nil,
-        reported_done_at: nil
+        reported_done_at: nil,
+        # The THIRD site that clears assigned_agent_id on a worked story. Only
+        # `:story_rejected` in guard_backfillable/2 masks it today; stamp the durable
+        # marker here too so the backfill guard never depends on that coincidence.
+        metadata: lifecycle_marked_metadata(story)
       })
 
     with {:ok, reset_story} <- AdminRepo.update(changeset),
@@ -2598,6 +2631,7 @@ defmodule Loopctl.Progress do
       # closed under its own error code (see lineage_status/2).
       case lineage_status(story, reporter_lineage) do
         :unresolvable -> {:error, :unresolvable_dispatch_lineage}
+        :unlineaged -> {:error, :caller_lineage_required}
         :conflict -> {:error, :self_report_blocked}
         :ok -> validate_report_not_same_agent(story, agent_id)
       end
@@ -2633,40 +2667,33 @@ defmodule Loopctl.Progress do
   #                       leaning on `lineage_shares_prefix?([], _) = false` would
   #                       read an unloadable dispatch as INDEPENDENT lineage, the
   #                       exact inverse of its meaning.
+  #   * `:unlineaged`   — the CALLER's credential was not minted by a dispatch (legacy
+  #                       env-var key; OQ2 deprecation window) while the WORK was. Its
+  #                       separation cannot be SHOWN, so each gate decides: report,
+  #                       review-complete and verify refuse it with
+  #                       `:caller_lineage_required`; reject (the remediation path)
+  #                       falls through to the agent-id check. Ranked AFTER
+  #                       `:unresolvable` deliberately — an empty caller lineage used to
+  #                       match first and mask a broken implementer dispatch as an
+  #                       ordinary permit.
   #   * `:ok`           — no lineage conflict; the agent-id equality check decides.
   #
-  # Two absences yield `:ok` deliberately — they are NOT integrity failures:
+  # One absence yields `:ok` deliberately and is NOT an integrity failure:
+  # `implementer_dispatch_id` is nil — no delegation ever recorded (pre-dispatch
+  # story) — and there the agent-id equality check is the whole gate by design.
   #
-  #   1. `implementer_dispatch_id` is nil — no delegation ever recorded (pre-dispatch
-  #      story); the agent-id equality check is the whole gate.
-  #   2. `caller_lineage` is [] — the caller used a credential not minted by a
-  #      dispatch (legacy env-var key; OQ2 deprecation window). NOTE the intentional
-  #      asymmetry with verify: verify_lineage_separated/4 fails closed when EITHER
-  #      side's lineage is empty, but this clause matches an empty CALLER lineage
-  #      BEFORE the `:unresolvable` check runs, so a legacy-key reporter/reviewer on
-  #      a story with an unresolvable implementer dispatch is caught only by the
-  #      agent-id check, not by fail-closed. The permit is scoped to legacy keys and
-  #      the agent-id check still applies; the gates align for dispatch-minted keys.
-  # `separation` selects HOW MUCH lineage distance this gate demands:
+  # The distance demanded is `lineage_same_chain?/2` at EVERY gate: the caller must not
+  # be on the implementer's root-to-leaf chain, but a SIBLING dispatch passes. The
+  # documented tree puts implementer and reviewer/verifier side by side under one
+  # orchestrator, so demanding a separate ROOT means no principal in a normal tenant can
+  # ever act (#621). Root separation is still enforced where selection can guarantee it
+  # — `select_verifier/3` and `verify_lineage_separated/4` on the RECORDED verifier.
   #
-  #   :chain — the caller must not be on the implementer's root-to-leaf chain.
-  #            A SIBLING dispatch passes. Used by report and review-complete,
-  #            where the documented tree puts the reviewer beside the implementer
-  #            under one orchestrator; demanding a separate root there means no
-  #            reviewer in a normal tenant can ever act (#621).
-  #   :root  — the caller must not share the implementer's root at all. Stricter,
-  #            and used by verify, the final certification: select_verifier/3
-  #            already refuses to nominate a same-root verifier, so accepting one
-  #            at the gate would contradict the selection rule.
-  #
-  # Both fail closed on an unresolvable implementer dispatch, and both are
-  # evaluated IN ADDITION to the agent-id equality check, never instead of it.
-  defp lineage_status(story, caller_lineage, separation \\ :chain)
+  # Every state is evaluated IN ADDITION to the agent-id equality check, never instead
+  # of it.
+  defp lineage_status(%Story{implementer_dispatch_id: nil}, _caller_lineage), do: :ok
 
-  defp lineage_status(%Story{implementer_dispatch_id: nil}, _caller_lineage, _separation), do: :ok
-  defp lineage_status(_story, [], _separation), do: :ok
-
-  defp lineage_status(story, caller_lineage, separation) do
+  defp lineage_status(story, caller_lineage) do
     case get_dispatch_lineage(story.tenant_id, story.implementer_dispatch_id) do
       [] ->
         # Declared-but-unresolvable implementer dispatch — fail closed.
@@ -2678,14 +2705,11 @@ defmodule Loopctl.Progress do
 
         :unresolvable
 
-      impl ->
-        overlap? =
-          case separation do
-            :root -> Dispatches.lineage_shares_prefix?(impl, caller_lineage)
-            :chain -> Dispatches.lineage_same_chain?(impl, caller_lineage)
-          end
+      _impl when caller_lineage == [] ->
+        :unlineaged
 
-        if overlap?, do: :conflict, else: :ok
+      impl ->
+        if Dispatches.lineage_same_chain?(impl, caller_lineage), do: :conflict, else: :ok
     end
   end
 
@@ -2700,12 +2724,15 @@ defmodule Loopctl.Progress do
         log_custody_orphaned(story, reviewer_agent_id, "review")
         {:error, :missing_assigned_agent}
 
-      # nil reviewer_agent_id: this is a human operator (user-role key with no
-      # agent). Humans are structurally different from the assigned implementing
-      # agent, so nil cannot equal any agent_id — pass through. The controller
-      # enforces that agent/orchestrator-role keys must provide a real
-      # reviewer_agent_id.
-      is_nil(reviewer_agent_id) ->
+      # nil reviewer_agent_id AND no lineage: this is a human operator (user-role key
+      # that no dispatch minted). Humans are structurally different from the assigned
+      # implementing agent, so nil cannot equal any agent_id — pass through. The
+      # controller enforces that agent/orchestrator-role keys must provide a real
+      # reviewer_agent_id. The `reviewer_lineage == []` half is load-bearing: a
+      # DISPATCH-minted user-role key also carries no agent_id, and permitting it on nil
+      # alone let an ANCESTOR of the implementer rubber-stamp its own subtree — the
+      # lineage this function is handed was never read on that path.
+      is_nil(reviewer_agent_id) and reviewer_lineage == [] ->
         :ok
 
       # US-26.2.2 AC-2: lineage comparison (primary), from the caller's dispatch
@@ -2715,6 +2742,7 @@ defmodule Loopctl.Progress do
       true ->
         case lineage_status(story, reviewer_lineage) do
           :unresolvable -> {:error, :unresolvable_dispatch_lineage}
+          :unlineaged -> {:error, :caller_lineage_required}
           :conflict -> {:error, :self_review_blocked}
           :ok -> validate_review_not_same_agent(story, reviewer_agent_id)
         end

--- a/lib/loopctl_web/controllers/dispatch_controller.ex
+++ b/lib/loopctl_web/controllers/dispatch_controller.ex
@@ -18,25 +18,43 @@ defmodule LoopctlWeb.DispatchController do
 
   @doc "POST /api/v1/dispatches"
   def create(conn, params) do
-    tenant_id = conn.assigns.current_api_key.tenant_id
+    api_key = conn.assigns.current_api_key
+    tenant_id = api_key.tenant_id
     parent_id = params["parent_dispatch_id"]
 
-    # Role ceiling: a dispatch may not be minted at a HIGHER privilege than the
-    # caller's own key. Without this an orchestrator (or any holder of an attestation
-    # over an agent key) could mint a `:user`-role dispatch bearing that key, escaping
-    # the role hierarchy — the attestation authorizes the KEY, it must not silently
-    # elevate the key's PRIVILEGE. A higher requested role is 403'd here.
-    if role_exceeds_caller?(conn, params["role"]) do
-      reject_role_ceiling(conn, params["role"])
-    else
-      # G6: Non-root dispatches must provide their parent's dispatch ID.
-      # The parent must be active (not revoked, not expired). Root dispatches
-      # (parent_id is nil) are only created at tenant signup.
-      if parent_id do
-        validate_parent_and_create(conn, tenant_id, parent_id, params)
-      else
+    # The CALLER's own lineage, resolved SERVER-SIDE from the authenticating key —
+    # never taken from the request body. `[]` means the key was not minted by a
+    # dispatch: the tenant's human/operator-held key, which is the trust root the
+    # whole tree hangs from and is therefore the only principal allowed to START a
+    # tree. See lineage_within_caller?/2.
+    caller_lineage = Dispatches.lineage_for_api_key(tenant_id, api_key.id)
+
+    cond do
+      # Role ceiling: a dispatch may not be minted at a HIGHER privilege than the
+      # caller's own key. Without this an orchestrator (or any holder of an attestation
+      # over an agent key) could mint a `:user`-role dispatch bearing that key, escaping
+      # the role hierarchy — the attestation authorizes the KEY, it must not silently
+      # elevate the key's PRIVILEGE. A higher requested role is 403'd here.
+      role_exceeds_caller?(conn, params["role"]) ->
+        reject_role_ceiling(conn, params["role"])
+
+      # G6: Non-root dispatches must provide their parent's dispatch ID. The parent
+      # must be active (not revoked, not expired) AND inside the caller's own subtree.
+      parent_id ->
+        validate_parent_and_create(conn, tenant_id, parent_id, caller_lineage, params)
+
+      # LINEAGE CEILING (root half). A parentless dispatch starts a NEW, independent
+      # lineage tree — one that shares no root with any existing dispatch, and which
+      # the L4 separation checks therefore treat as an unrelated principal. A caller
+      # that already HAS a lineage must not be able to hand itself one: the structural
+      # separation the custody gates rest on is only meaningful if a principal cannot
+      # step outside its own tree on demand. Only a key with no lineage of its own —
+      # the operator key rooted in the tenant's human anchor — may start a tree.
+      caller_lineage != [] ->
+        reject_root_mint(conn)
+
+      true ->
         do_create_dispatch(conn, tenant_id, params)
-      end
     end
   end
 
@@ -76,23 +94,28 @@ defmodule LoopctlWeb.DispatchController do
     })
   end
 
-  defp validate_parent_and_create(conn, tenant_id, parent_id, params) do
+  defp validate_parent_and_create(conn, tenant_id, parent_id, caller_lineage, params) do
     case Dispatches.get_dispatch(tenant_id, parent_id) do
       {:ok, parent} ->
         now = DateTime.utc_now()
 
-        if parent.revoked_at || DateTime.compare(parent.expires_at, now) != :gt do
-          conn
-          |> put_status(:forbidden)
-          |> json(%{
-            error: %{
-              code: "parent_dispatch_expired",
-              status: 403,
-              message: "Parent dispatch is expired or revoked"
-            }
-          })
-        else
-          do_create_dispatch(conn, tenant_id, params)
+        cond do
+          parent.revoked_at || DateTime.compare(parent.expires_at, now) != :gt ->
+            conn
+            |> put_status(:forbidden)
+            |> json(%{
+              error: %{
+                code: "parent_dispatch_expired",
+                status: 403,
+                message: "Parent dispatch is expired or revoked"
+              }
+            })
+
+          not lineage_within_caller?(parent.lineage_path, caller_lineage) ->
+            reject_lineage_escape(conn)
+
+          true ->
+            do_create_dispatch(conn, tenant_id, params)
         end
 
       {:error, :not_found} ->
@@ -100,6 +123,57 @@ defmodule LoopctlWeb.DispatchController do
         |> put_status(:not_found)
         |> json(%{error: %{message: "Parent dispatch not found", status: 404}})
     end
+  end
+
+  # LINEAGE CEILING (parent half). Rejecting only the parentless case would leave the
+  # same escape open one step further out: any dispatch in the tenant is enumerable
+  # via GET /api/v1/dispatches, so a caller could name a parent under a DIFFERENT root
+  # and mint itself into that unrelated tree. A minted dispatch must therefore descend
+  # from the caller's own dispatch — `parent.lineage_path` must have the caller's
+  # lineage as a prefix.
+  #
+  # A caller with NO lineage (the operator key) may parent anywhere in its tenant: it
+  # is not inside any tree, so it cannot escape one.
+  defp lineage_within_caller?(_parent_lineage, []), do: true
+
+  defp lineage_within_caller?(parent_lineage, caller_lineage)
+       when is_list(parent_lineage),
+       do: List.starts_with?(parent_lineage, caller_lineage)
+
+  defp lineage_within_caller?(_parent_lineage, _caller_lineage), do: false
+
+  defp reject_root_mint(conn) do
+    conn
+    |> put_status(:forbidden)
+    |> json(%{
+      error: %{
+        status: 403,
+        code: "root_dispatch_forbidden",
+        message:
+          "A parentless dispatch starts a NEW independent lineage tree, which only the " <>
+            "tenant's own operator key (a key not itself minted by a dispatch) may do. " <>
+            "Your key was minted by a dispatch, so pass `parent_dispatch_id` and mint " <>
+            "this dispatch inside your own lineage.",
+        remediation: %{learn_more: "https://loopctl.com/wiki/dispatch-lineage"}
+      }
+    })
+  end
+
+  defp reject_lineage_escape(conn) do
+    conn
+    |> put_status(:forbidden)
+    |> json(%{
+      error: %{
+        status: 403,
+        code: "parent_outside_caller_lineage",
+        message:
+          "The requested parent dispatch is not in your lineage. A dispatch may only be " <>
+            "minted beneath the caller's own dispatch, so that the lineage separation the " <>
+            "custody gates rest on cannot be sidestepped. Use your own dispatch id (or one " <>
+            "of its descendants) as `parent_dispatch_id`.",
+        remediation: %{learn_more: "https://loopctl.com/wiki/dispatch-lineage"}
+      }
+    })
   end
 
   defp do_create_dispatch(conn, tenant_id, params) do

--- a/lib/loopctl_web/controllers/dispatch_controller.ex
+++ b/lib/loopctl_web/controllers/dispatch_controller.ex
@@ -5,6 +5,8 @@ defmodule LoopctlWeb.DispatchController do
 
   use LoopctlWeb, :controller
 
+  require Logger
+
   alias Loopctl.Auth.Role
   alias Loopctl.Dispatches
 
@@ -23,11 +25,19 @@ defmodule LoopctlWeb.DispatchController do
     parent_id = params["parent_dispatch_id"]
 
     # The CALLER's own lineage, resolved SERVER-SIDE from the authenticating key —
-    # never taken from the request body. `[]` means the key was not minted by a
-    # dispatch: the tenant's human/operator-held key, which is the trust root the
-    # whole tree hangs from and is therefore the only principal allowed to START a
-    # tree. See lineage_within_caller?/2.
+    # never taken from the request body. See lineage_within_caller?/3.
     caller_lineage = Dispatches.lineage_for_api_key(tenant_id, api_key.id)
+
+    # The operator privilege — starting a NEW tree, and parenting anywhere in the
+    # tenant — is decided POSITIVELY, not inferred from an absent lineage.
+    # `lineage_for_api_key/2` returns [] for THREE different principals: the tenant's
+    # human-anchored operator key, a legacy long-lived env-var key, and a key whose
+    # dispatch row no longer resolves. Only the first deserves the privilege, and only
+    # it is minted at `role: :user` (Tenants signup ceremony). Treating [] alone as
+    # "operator" left every legacy `:orchestrator` key able to hand ITSELF an
+    # independently-rooted dispatch for the whole deprecation window — the exact escape
+    # the ceiling exists to close.
+    operator? = caller_lineage == [] and Role.role_at_least?(api_key.role, :user)
 
     cond do
       # Role ceiling: a dispatch may not be minted at a HIGHER privilege than the
@@ -41,17 +51,16 @@ defmodule LoopctlWeb.DispatchController do
       # G6: Non-root dispatches must provide their parent's dispatch ID. The parent
       # must be active (not revoked, not expired) AND inside the caller's own subtree.
       parent_id ->
-        validate_parent_and_create(conn, tenant_id, parent_id, caller_lineage, params)
+        validate_parent_and_create(conn, tenant_id, parent_id, caller_lineage, operator?, params)
 
       # LINEAGE CEILING (root half). A parentless dispatch starts a NEW, independent
       # lineage tree — one that shares no root with any existing dispatch, and which
       # the L4 separation checks therefore treat as an unrelated principal. A caller
-      # that already HAS a lineage must not be able to hand itself one: the structural
+      # that is not the operator must not be able to hand itself one: the structural
       # separation the custody gates rest on is only meaningful if a principal cannot
-      # step outside its own tree on demand. Only a key with no lineage of its own —
-      # the operator key rooted in the tenant's human anchor — may start a tree.
-      caller_lineage != [] ->
-        reject_root_mint(conn)
+      # step outside its own tree on demand.
+      not operator? ->
+        reject_root_mint(conn, api_key, caller_lineage)
 
       true ->
         do_create_dispatch(conn, tenant_id, params)
@@ -94,7 +103,7 @@ defmodule LoopctlWeb.DispatchController do
     })
   end
 
-  defp validate_parent_and_create(conn, tenant_id, parent_id, caller_lineage, params) do
+  defp validate_parent_and_create(conn, tenant_id, parent_id, caller_lineage, operator?, params) do
     case Dispatches.get_dispatch(tenant_id, parent_id) do
       {:ok, parent} ->
         now = DateTime.utc_now()
@@ -111,8 +120,8 @@ defmodule LoopctlWeb.DispatchController do
               }
             })
 
-          not lineage_within_caller?(parent.lineage_path, caller_lineage) ->
-            reject_lineage_escape(conn)
+          not lineage_within_caller?(parent.lineage_path, caller_lineage, operator?) ->
+            reject_lineage_escape(conn, conn.assigns.current_api_key, caller_lineage, parent_id)
 
           true ->
             do_create_dispatch(conn, tenant_id, params)
@@ -132,17 +141,20 @@ defmodule LoopctlWeb.DispatchController do
   # from the caller's own dispatch — `parent.lineage_path` must have the caller's
   # lineage as a prefix.
   #
-  # A caller with NO lineage (the operator key) may parent anywhere in its tenant: it
-  # is not inside any tree, so it cannot escape one.
-  defp lineage_within_caller?(_parent_lineage, []), do: true
+  # The OPERATOR key may parent anywhere in its tenant: it is not inside any tree, so
+  # it cannot escape one. Every other caller — including a []-lineage legacy key, which
+  # is NOT the operator — must name a parent inside its own subtree.
+  defp lineage_within_caller?(_parent_lineage, _caller_lineage, true), do: true
 
-  defp lineage_within_caller?(parent_lineage, caller_lineage)
+  defp lineage_within_caller?(parent_lineage, [_ | _] = caller_lineage, false)
        when is_list(parent_lineage),
        do: List.starts_with?(parent_lineage, caller_lineage)
 
-  defp lineage_within_caller?(_parent_lineage, _caller_lineage), do: false
+  defp lineage_within_caller?(_parent_lineage, _caller_lineage, false), do: false
 
-  defp reject_root_mint(conn) do
+  defp reject_root_mint(conn, api_key, caller_lineage) do
+    log_ceiling_refusal("root_dispatch_forbidden", api_key, caller_lineage, nil)
+
     conn
     |> put_status(:forbidden)
     |> json(%{
@@ -151,15 +163,23 @@ defmodule LoopctlWeb.DispatchController do
         code: "root_dispatch_forbidden",
         message:
           "A parentless dispatch starts a NEW independent lineage tree, which only the " <>
-            "tenant's own operator key (a key not itself minted by a dispatch) may do. " <>
-            "Your key was minted by a dispatch, so pass `parent_dispatch_id` and mint " <>
-            "this dispatch inside your own lineage.",
-        remediation: %{learn_more: "https://loopctl.com/wiki/dispatch-lineage"}
+            "tenant's own operator key (a `user`-role key that no dispatch minted) may do. " <>
+            "Pass `parent_dispatch_id` and mint this dispatch inside your own lineage.",
+        # The remediation is only actionable if the caller can NAME its own dispatch, and
+        # nothing else on this API tells it which row is its own. It is already resolved
+        # server-side as the last element of the caller's lineage, so hand it back.
+        remediation: %{
+          your_dispatch_id: List.last(caller_lineage),
+          your_lineage_path: caller_lineage,
+          learn_more: "https://loopctl.com/wiki/dispatch-lineage"
+        }
       }
     })
   end
 
-  defp reject_lineage_escape(conn) do
+  defp reject_lineage_escape(conn, api_key, caller_lineage, parent_id) do
+    log_ceiling_refusal("parent_outside_caller_lineage", api_key, caller_lineage, parent_id)
+
     conn
     |> put_status(:forbidden)
     |> json(%{
@@ -171,9 +191,31 @@ defmodule LoopctlWeb.DispatchController do
             "minted beneath the caller's own dispatch, so that the lineage separation the " <>
             "custody gates rest on cannot be sidestepped. Use your own dispatch id (or one " <>
             "of its descendants) as `parent_dispatch_id`.",
-        remediation: %{learn_more: "https://loopctl.com/wiki/dispatch-lineage"}
+        remediation: %{
+          your_dispatch_id: List.last(caller_lineage),
+          your_lineage_path: caller_lineage,
+          learn_more: "https://loopctl.com/wiki/dispatch-lineage"
+        }
       }
     })
+  end
+
+  # A principal trying to place itself in a lineage it does not belong to is the
+  # highest-signal event on this endpoint. Without this the refusals were invisible:
+  # a 403 body to the attacker and nothing at all to the operator.
+  defp log_ceiling_refusal(code, api_key, caller_lineage, parent_id) do
+    Logger.warning(
+      "lineage_ceiling_refused: code=#{code} tenant_id=#{api_key.tenant_id} " <>
+        "api_key_id=#{api_key.id} role=#{api_key.role} " <>
+        "caller_lineage_root=#{inspect(List.first(caller_lineage))} " <>
+        "requested_parent_dispatch_id=#{inspect(parent_id)}"
+    )
+
+    :telemetry.execute(
+      [:loopctl, :custody, :lineage_ceiling_refused],
+      %{count: 1},
+      %{code: code, tenant_id: api_key.tenant_id, api_key_id: api_key.id}
+    )
   end
 
   defp do_create_dispatch(conn, tenant_id, params) do

--- a/lib/loopctl_web/controllers/dispatch_controller.ex
+++ b/lib/loopctl_web/controllers/dispatch_controller.ex
@@ -142,9 +142,15 @@ defmodule LoopctlWeb.DispatchController do
   # lineage as a prefix.
   #
   # The OPERATOR key may parent anywhere in its tenant: it is not inside any tree, so
-  # it cannot escape one. Every other caller — including a []-lineage legacy key, which
-  # is NOT the operator — must name a parent inside its own subtree.
+  # it cannot escape one. The same reasoning covers a []-lineage NON-operator (a legacy
+  # env-var key): it has no subtree to step outside of, and the ceiling exists to stop a
+  # principal escaping ITS OWN tree. Refusing it here closed the only remaining mint it
+  # had — root minting is already operator-only — leaving a legacy `:orchestrator` key
+  # unable to obtain a lineage by any request at all, against the documented deprecation
+  # window. Naming a parent gives it a lineage, which SUBJECTS it to the custody gates.
+  # A caller that IS inside a tree must stay inside it.
   defp lineage_within_caller?(_parent_lineage, _caller_lineage, true), do: true
+  defp lineage_within_caller?(_parent_lineage, [], false), do: true
 
   defp lineage_within_caller?(parent_lineage, [_ | _] = caller_lineage, false)
        when is_list(parent_lineage),
@@ -164,17 +170,37 @@ defmodule LoopctlWeb.DispatchController do
         message:
           "A parentless dispatch starts a NEW independent lineage tree, which only the " <>
             "tenant's own operator key (a `user`-role key that no dispatch minted) may do. " <>
-            "Pass `parent_dispatch_id` and mint this dispatch inside your own lineage.",
-        # The remediation is only actionable if the caller can NAME its own dispatch, and
-        # nothing else on this API tells it which row is its own. It is already resolved
-        # server-side as the last element of the caller's lineage, so hand it back.
-        remediation: %{
-          your_dispatch_id: List.last(caller_lineage),
-          your_lineage_path: caller_lineage,
-          learn_more: "https://loopctl.com/wiki/dispatch-lineage"
-        }
+            root_mint_remedy(caller_lineage),
+        remediation: root_mint_remediation(caller_lineage)
       }
     })
+  end
+
+  # The remedy must be one the REFUSED caller can actually perform. "Mint inside your
+  # own lineage" is meaningless to a caller that has none — and `your_dispatch_id`
+  # would be a bare null there, which is how the previous wording read to every legacy
+  # key. Name a parent it can obtain instead.
+  defp root_mint_remedy([]),
+    do:
+      "Your key was not minted by a dispatch, so you have no lineage of your own: pass " <>
+        "`parent_dispatch_id` naming any active dispatch in your tenant (GET " <>
+        "/api/v1/dispatches), or have the tenant's `user`-role operator key mint the root."
+
+  defp root_mint_remedy(_caller_lineage),
+    do: "Pass `parent_dispatch_id` and mint this dispatch inside your own lineage."
+
+  # The remediation is only actionable if the caller can NAME its own dispatch, and
+  # nothing else on this API tells it which row is its own. It is already resolved
+  # server-side as the last element of the caller's lineage, so hand it back — and OMIT
+  # the key entirely when there is no such row, rather than emitting null.
+  defp root_mint_remediation([]), do: %{learn_more: "https://loopctl.com/wiki/dispatch-lineage"}
+
+  defp root_mint_remediation(caller_lineage) do
+    %{
+      your_dispatch_id: List.last(caller_lineage),
+      your_lineage_path: caller_lineage,
+      learn_more: "https://loopctl.com/wiki/dispatch-lineage"
+    }
   end
 
   defp reject_lineage_escape(conn, api_key, caller_lineage, parent_id) do

--- a/lib/loopctl_web/controllers/story_verification_controller.ex
+++ b/lib/loopctl_web/controllers/story_verification_controller.ex
@@ -275,7 +275,16 @@ defmodule LoopctlWeb.StoryVerificationController do
   def backfill(conn, %{"id" => story_id} = params) do
     api_key = conn.assigns.current_api_key
     tenant_id = api_key.tenant_id
-    opts = AuditContext.from_conn(conn)
+
+    opts =
+      Keyword.merge(AuditContext.from_conn(conn),
+        # LCP-1 §9.4: backfill mounts RequireSignedClaim (gate "verify") and reaches
+        # the same `verified` terminal state, so the verified claim must be recorded
+        # in the hash-chained audit entry — verifying it and dropping it leaves no
+        # durable residue and is half a control.
+        custody_claim: conn.assigns[:custody_signed_claim],
+        verifier_lineage: Dispatches.lineage_for_api_key(tenant_id, api_key.id)
+      )
 
     case Progress.backfill_story(tenant_id, story_id, params, opts) do
       {:ok, story} ->
@@ -337,8 +346,9 @@ defmodule LoopctlWeb.StoryVerificationController do
 
   defp backfill_error_message(:story_in_progress) do
     "Story is mid-lifecycle (e.g. contracted) with no dispatch lineage yet — it is " <>
-      "being worked, not pre-existing done work. Let the report → review → verify " <>
-      "flow run, or force_unclaim it back to pending first if it was abandoned."
+      "being worked, not pre-existing done work. Let the report_story → review_complete " <>
+      "→ verify_story flow run. force_unclaim does NOT make it backfillable: it records " <>
+      "a lifecycle entry, after which backfill refuses with `story_entered_lifecycle`."
   end
 
   @doc """
@@ -352,7 +362,14 @@ defmodule LoopctlWeb.StoryVerificationController do
 
     with :ok <- validate_orchestrator_agent_linked(api_key) do
       tenant_id = api_key.tenant_id
-      opts = Keyword.merge(AuditContext.from_conn(conn), orchestrator_agent_id: api_key.agent_id)
+
+      opts =
+        Keyword.merge(AuditContext.from_conn(conn),
+          orchestrator_agent_id: api_key.agent_id,
+          # Reject is a custody decision (terminal `:rejected` + auto-reset), so it
+          # takes the same server-resolved caller lineage verify does.
+          verifier_lineage: Dispatches.lineage_for_api_key(tenant_id, api_key.id)
+        )
 
       case Progress.reject_story(tenant_id, story_id, params, opts) do
         {:ok, story} ->
@@ -462,7 +479,15 @@ defmodule LoopctlWeb.StoryVerificationController do
 
     with :ok <- validate_orchestrator_agent_linked(api_key) do
       tenant_id = api_key.tenant_id
-      opts = Keyword.merge(AuditContext.from_conn(conn), orchestrator_agent_id: api_key.agent_id)
+
+      opts =
+        Keyword.merge(AuditContext.from_conn(conn),
+          orchestrator_agent_id: api_key.agent_id,
+          # verify-all forwards these opts to verify_story/4 per story, so omitting
+          # the caller's lineage skipped the whole L4 comparison on the WIDER-blast-
+          # radius path while the single-story route enforced it.
+          verifier_lineage: Dispatches.lineage_for_api_key(tenant_id, api_key.id)
+        )
 
       {:ok, result} = Progress.verify_all_in_epic(tenant_id, epic_id, params, opts)
       json(conn, result)

--- a/lib/loopctl_web/controllers/story_verification_controller.ex
+++ b/lib/loopctl_web/controllers/story_verification_controller.ex
@@ -338,8 +338,10 @@ defmodule LoopctlWeb.StoryVerificationController do
   end
 
   defp backfill_error_message(:story_entered_lifecycle) do
-    "Story's audit log shows it was worked inside loopctl (a status change or a force-unclaim), " <>
-      "even though its dispatch markers are now clear. Backfill is only for work completed " <>
+    "Story is recorded as having entered the dispatch lifecycle (a status change, a force-unclaim " <>
+      "or an auto-reset) — by its own lifecycle stamp, the audit log, or both; the audit log is " <>
+      "pruned at AUDIT_RETENTION_DAYS, so an empty GET /stories/:id/history does not contradict " <>
+      "this. Its dispatch markers are now clear. Backfill is only for work completed " <>
       "OUTSIDE the loopctl dispatch lifecycle, so it cannot certify this story. " <>
       "Use the normal report_story -> review_complete -> verify_story flow instead."
   end

--- a/lib/loopctl_web/controllers/story_verification_controller.ex
+++ b/lib/loopctl_web/controllers/story_verification_controller.ex
@@ -38,7 +38,13 @@ defmodule LoopctlWeb.StoryVerificationController do
 
   # LCP-1 §9.3: under the `signed` custody profile, an enrolled verifier's claim
   # must carry a valid signature. No-op under the default `bearer` profile.
-  plug LoopctlWeb.Plugs.RequireSignedClaim, [gate: "verify"] when action in [:verify]
+  #
+  # `backfill` is mounted here too: it reaches the SAME `verified_status: :verified`
+  # terminal state as `verify`, on a single named work item, so leaving it off left an
+  # unsigned route to the outcome the signed profile exists to attribute. It shares
+  # the `verify` gate name deliberately — same transition, same claim binding.
+  plug LoopctlWeb.Plugs.RequireSignedClaim,
+       [gate: "verify"] when action in [:verify, :backfill]
 
   # The aggregate verify-all path reaches the SAME `verified` transition but cannot
   # carry a per-item signature; under `signed` it refuses an enrolled caller rather
@@ -86,6 +92,11 @@ defmodule LoopctlWeb.StoryVerificationController do
       "Marks a story as verified for work completed outside loopctl (e.g. before onboarding). " <>
         "Only permitted for stories that never entered loopctl's dispatch lifecycle — " <>
         "stories with `assigned_agent_id` set, or already `:verified`/`:rejected`, are refused. " <>
+        "A story whose audit log shows it was worked inside loopctl (a `status_changed` or " <>
+        "`force_unclaimed` entry) is refused even when its dispatch markers are now clear, so " <>
+        "clearing them cannot turn backfill into a shortcut past report/review/verify. " <>
+        "Under the LCP-1 `signed` custody profile an enrolled caller must present a valid " <>
+        "`claim` signature (gate `verify`), as for POST /stories/:id/verify. " <>
         "Requires a non-empty `reason`; `evidence_url` and `pr_number` are optional but strongly recommended. " <>
         "Emits a `story.backfilled` webhook event on success.",
     parameters: [id: [in: :path, type: :string, description: "Story UUID"]],
@@ -102,11 +113,14 @@ defmodule LoopctlWeb.StoryVerificationController do
        }},
     responses: %{
       200 => {"Story backfilled", "application/json", Schemas.StoryStatusResponse},
+      401 =>
+        {"Claim signature required/invalid (LCP-1 signed profile)", "application/json",
+         Schemas.ErrorResponse},
       403 =>
         {"Insufficient role (orchestrator+ required)", "application/json", Schemas.ErrorResponse},
       404 => {"Story not found", "application/json", Schemas.ErrorResponse},
       422 =>
-        {"Validation error: missing reason, already verified, already rejected, or has dispatch lineage",
+        {"Validation error: missing reason, already verified, already rejected, has dispatch lineage, or already entered the lifecycle",
          "application/json", Schemas.ErrorResponse},
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
     }
@@ -312,6 +326,13 @@ defmodule LoopctlWeb.StoryVerificationController do
       "or verifier_dispatch_id is set). " <>
       "Backfill is only for work completed OUTSIDE the loopctl dispatch lifecycle. " <>
       "Use the normal report_story → review_complete → verify_story flow instead."
+  end
+
+  defp backfill_error_message(:story_entered_lifecycle) do
+    "Story's audit log shows it was worked inside loopctl (a status change or a force-unclaim), " <>
+      "even though its dispatch markers are now clear. Backfill is only for work completed " <>
+      "OUTSIDE the loopctl dispatch lifecycle, so it cannot certify this story. " <>
+      "Use the normal report_story -> review_complete -> verify_story flow instead."
   end
 
   defp backfill_error_message(:story_in_progress) do

--- a/lib/loopctl_web/fallback_controller.ex
+++ b/lib/loopctl_web/fallback_controller.ex
@@ -21,6 +21,7 @@ defmodule LoopctlWeb.FallbackController do
   - `{:error, :self_review_blocked}` -> 409 (implementer tries to review their own work)
   - `{:error, :missing_assigned_agent}` -> 409 (reported_done story has no assigned agent/dispatch lineage; custody chain broken)
   - `{:error, :unresolvable_dispatch_lineage}` -> 409 (a dispatch the story references — implementer, or verifier on verify — could not be resolved; custody gate failed closed on an integrity error, tenant NOT halted)
+  - `{:error, :caller_lineage_required}` -> 409 (a key no dispatch minted tried to report/review/verify dispatch-minted work; a configuration refusal, tenant NOT halted)
   - `{:error, :rate_limited}` -> 429 with retry_after_seconds from header
   - `{:error, :ingestion_backlog_exceeded, retry_after}` -> 429 with `Retry-After` header and
     a machine-readable `code: "ingestion_backlog_exceeded"` (US-36.3 ingest backpressure —
@@ -242,6 +243,27 @@ defmodule LoopctlWeb.FallbackController do
             "This is a lineage-integrity failure; re-establish the dispatch provenance " <>
             "before reporting, reviewing, or verifying.",
         remediation: %{learn_more: "https://loopctl.com/wiki/chain-of-custody"}
+      }
+    })
+  end
+
+  def call(conn, {:error, :caller_lineage_required}) do
+    # The caller's key was not minted by a dispatch, so its separation from
+    # dispatch-minted work cannot be SHOWN. That is a credential/configuration
+    # condition, not a byzantine self-claim: it must NOT record a custody violation
+    # (which escalates to a tenant-wide halt), because it fires on every call an
+    # unmigrated legacy key makes.
+    conn
+    |> put_status(:conflict)
+    |> json(%{
+      error: %{
+        status: 409,
+        code: "caller_lineage_required",
+        message:
+          "This story's work was dispatch-minted, so the custody gate compares dispatch " <>
+            "lineages — and your key was not minted by a dispatch, so it has none. Call " <>
+            "again with an ephemeral key from POST /api/v1/dispatches.",
+        remediation: %{learn_more: "https://loopctl.com/wiki/dispatch-lineage"}
       }
     })
   end

--- a/lib/loopctl_web/plugs/require_signed_claim.ex
+++ b/lib/loopctl_web/plugs/require_signed_claim.ex
@@ -165,7 +165,10 @@ defmodule LoopctlWeb.Plugs.RequireSignedClaim do
     do:
       "This agent has an enrolled signing key (LCP-1 §9), but you are calling on a " <>
         "BEARER dispatch that carries none. Use the agent's ENROLLED dispatch (which can " <>
-        "sign the claim); an unsigned bearer dispatch may not act in an enrolled agent's name."
+        "sign the claim); an unsigned bearer dispatch may not act in an enrolled agent's " <>
+        "name. On a BULK/aggregate custody action the enrolled dispatch is refused too " <>
+        "(`bulk_signature_unsupported` — no per-item signature is possible), so there the " <>
+        "terminal remedy is to verify each story individually on the single-story signed path."
 
   defp message_for(:self_signed_claim),
     do:

--- a/test/loopctl/custody/custody_observability_test.exs
+++ b/test/loopctl/custody/custody_observability_test.exs
@@ -1,0 +1,151 @@
+defmodule Loopctl.Custody.CustodyObservabilityTest do
+  @moduledoc """
+  Three places where a custody control was in force but invisible:
+
+  * a post-commit audit-chain append whose failure was discarded, leaving the
+    hash-chained log quietly incomplete;
+  * the signed-profile resolution, which announced a misconfigured value but said
+    nothing at all when the config was simply absent — the likeliest way a
+    deployment meant to run `signed` ends up serving `bearer`;
+  * the bulk custody gate, which recognised fewer "enrolled" callers than the
+    single-story gate it mirrors.
+  """
+  use Loopctl.DataCase, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Loopctl.AuditChain
+  alias Loopctl.Custody.SignedProfilePolicy
+  alias Loopctl.Test.CustodyEnrollment
+  alias Loopctl.Test.CustodyProfileStub
+
+  setup :verify_on_exit!
+
+  describe "AuditChain.log_append_failure/4" do
+    test "a failed post-commit append is logged loudly and passed through" do
+      log =
+        capture_log(fn ->
+          assert {:error, :boom} =
+                   AuditChain.log_append_failure(
+                     {:error, :boom},
+                     "verifier_selected",
+                     Ecto.UUID.generate(),
+                     Ecto.UUID.generate()
+                   )
+        end)
+
+      assert log =~ "audit_chain_append_failed"
+      assert log =~ "verifier_selected"
+    end
+
+    test "a successful append logs nothing and is passed through unchanged" do
+      log =
+        capture_log(fn ->
+          assert {:ok, :entry} =
+                   AuditChain.log_append_failure(
+                     {:ok, :entry},
+                     "verifier_selected",
+                     Ecto.UUID.generate(),
+                     nil
+                   )
+        end)
+
+      refute log =~ "audit_chain_append_failed"
+    end
+  end
+
+  describe "both post-commit appends in Progress route through the guard" do
+    # These two appends run AFTER their state change has committed, so nothing can
+    # roll them back — the only available response to a failure is to say so. A
+    # source scan keeps a future edit from quietly reverting to a discarded result.
+    test "verifier_selected and verifier_not_assigned pipe into log_append_failure" do
+      source = File.read!("lib/loopctl/progress.ex")
+
+      for action <- ["verifier_selected", "verifier_not_assigned"] do
+        assert source =~ ~s|log_append_failure("#{action}"|,
+               "#{action}'s audit-chain append must pipe into AuditChain.log_append_failure/4"
+      end
+    end
+  end
+
+  describe "signed profile resolution telemetry" do
+    setup do
+      handler = "custody-profile-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      :telemetry.attach(
+        handler,
+        [:loopctl, :custody, :profile_resolved],
+        fn _event, measurements, metadata, _cfg ->
+          send(test_pid, {:profile_resolved, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+      :ok
+    end
+
+    test "an UNSET config emits telemetry naming the source, not just a silent bearer" do
+      assert SignedProfilePolicy.profile() == :bearer
+
+      assert_received {:profile_resolved, %{count: 1}, %{profile: :bearer, source: :unset}}
+    end
+
+    test "an explicitly configured signed profile is distinguishable from a default" do
+      CustodyProfileStub.set_profile(:signed)
+      on_exit(fn -> CustodyProfileStub.set_profile(:bearer) end)
+
+      assert SignedProfilePolicy.profile() == :signed
+
+      assert_received {:profile_resolved, %{count: 1}, %{profile: :signed, source: :configured}}
+    end
+  end
+
+  describe "verify_bulk_request/3 enrolled-caller parity" do
+    setup do
+      tenant = fixture(:tenant)
+      agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
+      %{tenant: tenant, agent: agent}
+    end
+
+    test "an enrolled dispatch is refused", %{tenant: tenant, agent: agent} do
+      %{dispatch: dispatch} = CustodyEnrollment.enroll_root(tenant.id, %{agent_id: agent.id})
+
+      assert {:error, :bulk_signature_unsupported} =
+               SignedProfilePolicy.verify_bulk_request(:signed, tenant.id, dispatch.api_key_id)
+    end
+
+    test "a BEARER dispatch of an agent that has enrolled elsewhere is refused too",
+         %{tenant: tenant, agent: agent} do
+      # Same agent_id, two dispatches: one enrolled (signs), one bearer. The single-story
+      # gate already refuses the bearer one; the bulk gate must not be the softer door.
+      CustodyEnrollment.enroll_root(tenant.id, %{agent_id: agent.id, role: :orchestrator})
+      bearer = bearer_dispatch(tenant.id, agent.id)
+
+      assert {:error, :bulk_signature_unsupported} =
+               SignedProfilePolicy.verify_bulk_request(:signed, tenant.id, bearer.api_key_id)
+    end
+
+    test "a bearer dispatch of an agent with no enrolled key is still waived",
+         %{tenant: tenant, agent: agent} do
+      bearer = bearer_dispatch(tenant.id, agent.id)
+
+      assert :ok = SignedProfilePolicy.verify_bulk_request(:signed, tenant.id, bearer.api_key_id)
+    end
+
+    test "the bearer profile waives everything", %{tenant: tenant, agent: agent} do
+      %{dispatch: dispatch} = CustodyEnrollment.enroll_root(tenant.id, %{agent_id: agent.id})
+
+      assert :ok =
+               SignedProfilePolicy.verify_bulk_request(:bearer, tenant.id, dispatch.api_key_id)
+    end
+  end
+
+  defp bearer_dispatch(tenant_id, agent_id) do
+    {:ok, %{dispatch: dispatch}} =
+      Loopctl.Dispatches.create_dispatch(tenant_id, %{role: :agent, agent_id: agent_id})
+
+    dispatch
+  end
+end

--- a/test/loopctl/custody/custody_observability_test.exs
+++ b/test/loopctl/custody/custody_observability_test.exs
@@ -120,10 +120,16 @@ defmodule Loopctl.Custody.CustodyObservabilityTest do
          %{tenant: tenant, agent: agent} do
       # Same agent_id, two dispatches: one enrolled (signs), one bearer. The single-story
       # gate already refuses the bearer one; the bulk gate must not be the softer door.
+      #
+      # It answers with the SINGLE-STORY code, not the bulk one: the bulk message says
+      # "your dispatch is enrolled" (false here) and sends the caller to a single-story
+      # path that 403s the same bearer key — a dead end that also misdescribes the
+      # caller's own credential. `:agent_enrollment_required` is true of this caller and
+      # its remedy (use the enrolled dispatch) actually leads somewhere.
       CustodyEnrollment.enroll_root(tenant.id, %{agent_id: agent.id, role: :orchestrator})
       bearer = bearer_dispatch(tenant.id, agent.id)
 
-      assert {:error, :bulk_signature_unsupported} =
+      assert {:error, :agent_enrollment_required} =
                SignedProfilePolicy.verify_bulk_request(:signed, tenant.id, bearer.api_key_id)
     end
 

--- a/test/loopctl/dispatches/verifier_seed_test.exs
+++ b/test/loopctl/dispatches/verifier_seed_test.exs
@@ -1,0 +1,99 @@
+defmodule Loopctl.Dispatches.VerifierSeedTest do
+  @moduledoc """
+  `select_verifier/3` is deterministic on purpose — the orchestrator must not be able
+  to re-roll until it likes the answer. Determinism is only safe while the SEED is
+  secret: the candidate pool is enumerable by any agent key and the story id is known,
+  so everything else in the computation is already public.
+
+  The seed is keyed by the tenant's audit signing PRIVATE key (secret store,
+  server-side only), never by the public key that the discovery endpoint serves
+  unauthenticated. With no secret available there is nothing to fall back on that
+  would not restore predictability, so selection fails closed.
+  """
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.Dispatches
+
+  setup :verify_on_exit!
+
+  # Fixed, valid UUIDs so the test's inputs — and therefore its outcome — are identical
+  # on every run: this comparison must never be able to flake.
+  defp story_ids do
+    for i <- 1..20, do: "00000000-0000-4000-8000-#{String.pad_leading("#{i}", 12, "0")}"
+  end
+
+  # TenantKeys caches per tenant for 5 minutes, so a test that swaps the key must
+  # invalidate — otherwise it would silently measure the first key twice.
+  defp stub_tenant_key(tenant_id, key) do
+    Mox.stub(Loopctl.MockSecrets, :get, fn _name -> {:ok, Base.encode64(key)} end)
+    Loopctl.TenantKeys.invalidate(tenant_id)
+  end
+
+  defp tenant_with_pubkey do
+    {pub, _priv} = :crypto.generate_key(:eddsa, :ed25519)
+    fixture(:tenant, %{audit_signing_public_key: pub})
+  end
+
+  defp root_dispatch(tenant_id) do
+    agent = fixture(:agent, %{tenant_id: tenant_id, agent_type: :implementer})
+
+    {:ok, %{dispatch: dispatch}} =
+      Dispatches.create_dispatch(tenant_id, %{role: :agent, agent_id: agent.id})
+
+    dispatch
+  end
+
+  describe "select_verifier/3 seeding" do
+    test "fails closed when no server-side seed secret is available" do
+      # The DataCase default stubs MockSecrets.get to {:error, :not_found}, i.e. a
+      # tenant whose audit key is not provisioned.
+      tenant = tenant_with_pubkey()
+      _pool = [root_dispatch(tenant.id), root_dispatch(tenant.id)]
+
+      assert {:error, :verifier_seed_unavailable} =
+               Dispatches.select_verifier(tenant.id, Enum.at(story_ids(), 0), [])
+    end
+
+    test "selects from the eligible pool when the tenant key is available" do
+      tenant = tenant_with_pubkey()
+      pool = [root_dispatch(tenant.id), root_dispatch(tenant.id)]
+      stub_tenant_key(tenant.id, :crypto.strong_rand_bytes(32))
+
+      assert {:ok, picked} = Dispatches.select_verifier(tenant.id, Enum.at(story_ids(), 0), [])
+      assert picked.id in Enum.map(pool, & &1.id)
+    end
+
+    test "is deterministic for the same tenant key and story" do
+      tenant = tenant_with_pubkey()
+      _pool = [root_dispatch(tenant.id), root_dispatch(tenant.id)]
+      stub_tenant_key(tenant.id, :crypto.strong_rand_bytes(32))
+      story_id = Enum.at(story_ids(), 0)
+
+      assert {:ok, first} = Dispatches.select_verifier(tenant.id, story_id, [])
+      assert {:ok, second} = Dispatches.select_verifier(tenant.id, story_id, [])
+      assert first.id == second.id
+    end
+
+    test "the pick depends on the PRIVATE key, not on the public one" do
+      # Same tenant (so the same public key, the same pool, the same story ids) under
+      # two different private keys. If the seed were derived from anything public, every
+      # pick would be identical across the two runs.
+      tenant = tenant_with_pubkey()
+      _pool = [root_dispatch(tenant.id), root_dispatch(tenant.id)]
+
+      picks_a = picks_with_key(tenant.id, <<1::256>>)
+      picks_b = picks_with_key(tenant.id, <<2::256>>)
+
+      assert picks_a != picks_b
+    end
+  end
+
+  defp picks_with_key(tenant_id, key) do
+    stub_tenant_key(tenant_id, key)
+
+    Enum.map(story_ids(), fn story_id ->
+      {:ok, picked} = Dispatches.select_verifier(tenant_id, story_id, [])
+      picked.id
+    end)
+  end
+end

--- a/test/loopctl/dispatches/verifier_seed_test.exs
+++ b/test/loopctl/dispatches/verifier_seed_test.exs
@@ -88,6 +88,28 @@ defmodule Loopctl.Dispatches.VerifierSeedTest do
     end
   end
 
+  describe "select_verifier/3 empty-pool causes" do
+    test "no active dispatch at all is :no_eligible_verifier" do
+      tenant = tenant_with_pubkey()
+
+      assert {:error, :no_eligible_verifier} =
+               Dispatches.select_verifier(tenant.id, Enum.at(story_ids(), 0), [])
+    end
+
+    test "a single-root tenant is :no_independent_root, not a pool miss" do
+      # Only the OPERATOR key may start a tree, so a tenant whose orchestrator runs on
+      # its own dispatch has exactly one root and no principal that can verify: the
+      # verify gate is root-separated. That is a standing operator action (mint an
+      # independently-rooted verifier tree), not a transient shortage, so it must not
+      # be reported as one.
+      tenant = tenant_with_pubkey()
+      impl = root_dispatch(tenant.id)
+
+      assert {:error, :no_independent_root} =
+               Dispatches.select_verifier(tenant.id, Enum.at(story_ids(), 0), impl.lineage_path)
+    end
+  end
+
   defp picks_with_key(tenant_id, key) do
     stub_tenant_key(tenant_id, key)
 

--- a/test/loopctl/progress/backfill_lifecycle_history_test.exs
+++ b/test/loopctl/progress/backfill_lifecycle_history_test.exs
@@ -7,8 +7,10 @@ defmodule Loopctl.Progress.BackfillLifecycleHistoryTest do
 
   The dispatch markers alone cannot carry that claim, because one of them is erasable:
   `force_unclaim_story/3` clears `assigned_agent_id`, and a story claimed with a key no
-  dispatch minted never gets an `implementer_dispatch_id` either. The append-only audit
-  log remembers what the story row no longer does.
+  dispatch minted never gets an `implementer_dispatch_id` either. Two sources remember
+  what the story row no longer does: a DURABLE `metadata["lifecycle_entered_at"]` stamp
+  written where the erasure happens, and — only inside the audit retention window — the
+  `audit_log` lifecycle entries.
   """
   use Loopctl.DataCase, async: true
 
@@ -61,6 +63,40 @@ defmodule Loopctl.Progress.BackfillLifecycleHistoryTest do
       assert {:error, :story_entered_lifecycle} = backfill(unclaimed)
     end
 
+    test "force-unclaim stamps a DURABLE marker on the story row itself" do
+      agent = fixture(:agent, %{agent_type: :implementer})
+      story = fixture(:story, %{tenant_id: agent.tenant_id, agent_status: :contracted})
+
+      {:ok, _} = Progress.claim_story(story.tenant_id, story.id, agent_id: agent.id)
+      {:ok, unclaimed} = Progress.force_unclaim_story(story.tenant_id, story.id)
+
+      assert unclaimed.metadata["lifecycle_entered_at"]
+    end
+
+    test "agent self-unclaim stamps it too" do
+      agent = fixture(:agent, %{agent_type: :implementer})
+      story = fixture(:story, %{tenant_id: agent.tenant_id, agent_status: :contracted})
+
+      {:ok, _} = Progress.claim_story(story.tenant_id, story.id, agent_id: agent.id)
+      {:ok, unclaimed} = Progress.unclaim_story(story.tenant_id, story.id, agent_id: agent.id)
+
+      assert unclaimed.metadata["lifecycle_entered_at"]
+      assert {:error, :story_entered_lifecycle} = backfill(unclaimed)
+    end
+
+    test "the marker alone refuses, with no audit history at all" do
+      # `audit_log` is RANGE-partitioned and AuditPartitionWorker DROPs partitions past
+      # `:audit_retention_days` (default 90), so the audit arm of the guard EXPIRES: a
+      # story force-unclaimed long enough ago reads as never-dispatched again. This is
+      # that story — the marker set, not one audit row — and it must still be refused.
+      story =
+        fixture(:story, %{agent_status: :pending})
+        |> Ecto.Changeset.change(metadata: %{"lifecycle_entered_at" => "2020-01-01T00:00:00Z"})
+        |> Loopctl.AdminRepo.update!()
+
+      assert {:error, :story_entered_lifecycle} = backfill(story)
+    end
+
     test "still allows never-dispatched imported work at reported_done" do
       story = imported_reported_done_story()
       # Creation/import actions are not lifecycle actions — this is the case backfill
@@ -97,21 +133,36 @@ defmodule Loopctl.Progress.BackfillLifecycleHistoryTest do
     end
   end
 
-  describe "ensure_mark_complete_allowed/1 parity" do
+  describe "ensure_mark_complete_allowed/2 parity" do
     test "the bulk path refuses the same laundered story" do
       story = fixture(:story, %{agent_status: :pending})
       lifecycle_entry(story, "status_changed")
 
       assert {:error, :story_entered_lifecycle} =
-               Progress.ensure_mark_complete_allowed(reload(story))
+               Progress.ensure_mark_complete_allowed(reload(story), lifecycle_set(story))
     end
 
     test "the bulk path still allows never-dispatched work" do
       story = imported_reported_done_story()
 
-      assert :ok = Progress.ensure_mark_complete_allowed(reload(story))
+      assert :ok = Progress.ensure_mark_complete_allowed(reload(story), lifecycle_set(story))
+    end
+
+    test "the batch set is one query for the whole batch, not one per story" do
+      worked = fixture(:story, %{agent_status: :pending})
+      lifecycle_entry(worked, "force_unclaimed")
+      untouched = fixture(:story, %{tenant_id: worked.tenant_id, agent_status: :pending})
+
+      set =
+        Progress.stories_with_lifecycle_history(worked.tenant_id, [worked.id, untouched.id])
+
+      assert MapSet.member?(set, worked.id)
+      refute MapSet.member?(set, untouched.id)
     end
   end
+
+  defp lifecycle_set(story),
+    do: Progress.stories_with_lifecycle_history(story.tenant_id, [story.id])
 
   # Work imported with `initial_agent_status: "reported_done"` and no agent: the shape
   # backfill/mark-complete exists to remediate. The story fixture auto-assigns an agent

--- a/test/loopctl/progress/backfill_lifecycle_history_test.exs
+++ b/test/loopctl/progress/backfill_lifecycle_history_test.exs
@@ -1,0 +1,127 @@
+defmodule Loopctl.Progress.BackfillLifecycleHistoryTest do
+  @moduledoc """
+  Backfill (and its bulk sibling, mark-complete) certifies a story as verified with no
+  report, no review record and no independent verifier. The only thing keeping that
+  from being a shortcut past the whole custody chain is "this story never entered the
+  dispatch lifecycle".
+
+  The dispatch markers alone cannot carry that claim, because one of them is erasable:
+  `force_unclaim_story/3` clears `assigned_agent_id`, and a story claimed with a key no
+  dispatch minted never gets an `implementer_dispatch_id` either. The append-only audit
+  log remembers what the story row no longer does.
+  """
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.Progress
+
+  setup :verify_on_exit!
+
+  defp backfill(story) do
+    Progress.backfill_story(story.tenant_id, story.id, %{"reason" => "pre-loopctl work"})
+  end
+
+  defp lifecycle_entry(story, action) do
+    fixture(:audit_log, %{
+      tenant_id: story.tenant_id,
+      entity_type: "story",
+      entity_id: story.id,
+      action: action
+    })
+  end
+
+  describe "backfill_story/4 with lifecycle history" do
+    test "refuses a story with a status_changed entry even when every marker is clear" do
+      story = fixture(:story, %{agent_status: :pending})
+      lifecycle_entry(story, "status_changed")
+
+      assert {:error, :story_entered_lifecycle} = backfill(story)
+    end
+
+    test "refuses a story that was force-unclaimed back to pending" do
+      story = fixture(:story, %{agent_status: :pending})
+      lifecycle_entry(story, "force_unclaimed")
+
+      assert {:error, :story_entered_lifecycle} = backfill(story)
+    end
+
+    test "the claim -> force-unclaim -> backfill route is closed end to end" do
+      agent = fixture(:agent, %{agent_type: :implementer})
+      story = fixture(:story, %{tenant_id: agent.tenant_id, agent_status: :contracted})
+
+      {:ok, _} = Progress.claim_story(story.tenant_id, story.id, agent_id: agent.id)
+      {:ok, unclaimed} = Progress.force_unclaim_story(story.tenant_id, story.id)
+
+      # Every dispatch marker is clear again — state alone can no longer tell this
+      # apart from work that predates loopctl.
+      assert unclaimed.agent_status == :pending
+      assert is_nil(unclaimed.assigned_agent_id)
+      assert is_nil(unclaimed.implementer_dispatch_id)
+      assert is_nil(unclaimed.verifier_dispatch_id)
+
+      assert {:error, :story_entered_lifecycle} = backfill(unclaimed)
+    end
+
+    test "still allows never-dispatched imported work at reported_done" do
+      story = imported_reported_done_story()
+      # Creation/import actions are not lifecycle actions — this is the case backfill
+      # exists for and it must keep working.
+      lifecycle_entry(story, "created")
+      lifecycle_entry(story, "imported")
+
+      assert {:ok, backfilled} = backfill(story)
+      assert backfilled.verified_status == :verified
+    end
+
+    test "still allows a plain pending story with no history at all" do
+      story = fixture(:story, %{agent_status: :pending})
+
+      assert {:ok, backfilled} = backfill(story)
+      assert backfilled.verified_status == :verified
+    end
+
+    test "tenant isolation: another tenant's lifecycle entry does not block this story" do
+      story = fixture(:story, %{agent_status: :pending})
+      other_tenant = fixture(:tenant)
+
+      # Same entity_id, different tenant. A guard that forgot to scope by tenant would
+      # refuse this backfill.
+      fixture(:audit_log, %{
+        tenant_id: other_tenant.id,
+        entity_type: "story",
+        entity_id: story.id,
+        action: "status_changed"
+      })
+
+      assert {:ok, backfilled} = backfill(story)
+      assert backfilled.verified_status == :verified
+    end
+  end
+
+  describe "ensure_mark_complete_allowed/1 parity" do
+    test "the bulk path refuses the same laundered story" do
+      story = fixture(:story, %{agent_status: :pending})
+      lifecycle_entry(story, "status_changed")
+
+      assert {:error, :story_entered_lifecycle} =
+               Progress.ensure_mark_complete_allowed(reload(story))
+    end
+
+    test "the bulk path still allows never-dispatched work" do
+      story = imported_reported_done_story()
+
+      assert :ok = Progress.ensure_mark_complete_allowed(reload(story))
+    end
+  end
+
+  # Work imported with `initial_agent_status: "reported_done"` and no agent: the shape
+  # backfill/mark-complete exists to remediate. The story fixture auto-assigns an agent
+  # for :reported_done, which is the ever-dispatched shape, so build it directly (the
+  # DB CHECK is satisfied because `implementer_dispatch_id` is NULL).
+  defp imported_reported_done_story do
+    fixture(:story, %{agent_status: :pending})
+    |> Ecto.Changeset.change(agent_status: :reported_done)
+    |> Loopctl.AdminRepo.update!()
+  end
+
+  defp reload(story), do: Loopctl.AdminRepo.get!(Loopctl.WorkBreakdown.Story, story.id)
+end

--- a/test/loopctl/progress/custody_invariants_test.exs
+++ b/test/loopctl/progress/custody_invariants_test.exs
@@ -5,7 +5,7 @@ defmodule Loopctl.Progress.CustodyInvariantsTest do
   * INVARIANT 1 — `reported_done` ⇒ `assigned_agent_id NOT NULL` (or backfilled).
     Enforced structurally by the DB CHECK `stories_reported_done_requires_agent`
     and backstopped by the fail-closed `validate_not_self_verify/2` guard
-    (surfaced via `ensure_verify_allowed/2`).
+    (surfaced via `ensure_verify_allowed/3`).
 
   * INVARIANT 2 — a review record is bound to the report generation it reviewed
     via `reviewed_report_at`. A review of a superseded report no longer qualifies
@@ -155,7 +155,7 @@ defmodule Loopctl.Progress.CustodyInvariantsTest do
   end
 
   describe "INVARIANT 1: self-verify guard fails closed (backstop)" do
-    test "ensure_verify_allowed/2 rejects a custody-orphaned story with :missing_assigned_agent" do
+    test "ensure_verify_allowed/3 rejects a custody-orphaned story with :missing_assigned_agent" do
       orphan = %Story{
         tenant_id: Ecto.UUID.generate(),
         agent_status: :reported_done,
@@ -167,10 +167,10 @@ defmodule Loopctl.Progress.CustodyInvariantsTest do
 
       # A non-nil verifier would otherwise "!= nil implementer" and pass VACUOUSLY.
       assert {:error, :missing_assigned_agent} =
-               Progress.ensure_verify_allowed(orphan, Ecto.UUID.generate())
+               Progress.ensure_verify_allowed(orphan, Ecto.UUID.generate(), [])
     end
 
-    test "ensure_verify_allowed/2 still separates verifier from a real assigned agent" do
+    test "ensure_verify_allowed/3 still separates verifier from a real assigned agent" do
       implementer = Ecto.UUID.generate()
 
       story = %Story{
@@ -182,8 +182,10 @@ defmodule Loopctl.Progress.CustodyInvariantsTest do
         verifier_dispatch_id: nil
       }
 
-      assert :ok = Progress.ensure_verify_allowed(story, Ecto.UUID.generate())
-      assert {:error, :self_verify_blocked} = Progress.ensure_verify_allowed(story, implementer)
+      assert :ok = Progress.ensure_verify_allowed(story, Ecto.UUID.generate(), [])
+
+      assert {:error, :self_verify_blocked} =
+               Progress.ensure_verify_allowed(story, implementer, [])
     end
 
     test "verify_story/4 fails closed on a persisted custody-orphaned story" do

--- a/test/loopctl/progress/verify_caller_lineage_test.exs
+++ b/test/loopctl/progress/verify_caller_lineage_test.exs
@@ -54,12 +54,63 @@ defmodule Loopctl.Progress.VerifyCallerLineageTest do
       # Two legacy env-var keys with distinct agent_ids in one process cleared report,
       # review AND verify: `[]` short-circuits the lineage comparison and the agent-id
       # inequality is trivially true. Where the WORK was dispatch-minted, the certifier
-      # must be too.
+      # must be too — under its OWN code, because `self_verify_blocked` is an L6
+      # byzantine signal that escalates to a tenant-wide custody halt and this fires on
+      # every call an unmigrated legacy key makes.
       ctx = dispatched_story()
       other_agent = fixture(:agent, %{tenant_id: ctx.tenant.id, agent_type: :orchestrator})
 
-      assert {:error, :self_verify_blocked} =
+      assert {:error, :caller_lineage_required} =
                Progress.ensure_verify_allowed(ctx.story, other_agent.id, [])
+    end
+
+    test "reject is exempt: bad work can always be sent back" do
+      # Refusing the unlineaged caller here strands the story at reported_done with no
+      # remediation path. Rejecting is not certifying.
+      ctx = dispatched_story()
+      other_agent = fixture(:agent, %{tenant_id: ctx.tenant.id, agent_type: :orchestrator})
+
+      assert :ok = Progress.ensure_verify_allowed(ctx.story, other_agent.id, [], :reject)
+    end
+
+    test "a sibling verifier clears the gate in a single-root tenant" do
+      # The documented tree is single-rooted (operator root -> orchestrator ->
+      # implementer/verifier), so demanding a separate ROOT of the CALLER left no
+      # principal able to verify anything. A sibling IS separation.
+      tenant = fixture(:tenant)
+      agent = fn -> fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator}).id end
+
+      {:ok, %{dispatch: root}} =
+        Dispatches.create_dispatch(tenant.id, %{role: :orchestrator, agent_id: agent.()})
+
+      {:ok, %{dispatch: impl}} =
+        Dispatches.create_dispatch(tenant.id, %{
+          role: :agent,
+          agent_id: fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer}).id,
+          parent_dispatch_id: root.id
+        })
+
+      {:ok, %{dispatch: verifier}} =
+        Dispatches.create_dispatch(tenant.id, %{
+          role: :orchestrator,
+          agent_id: agent.(),
+          parent_dispatch_id: root.id
+        })
+
+      story =
+        fixture(:story, %{tenant_id: tenant.id, agent_status: :reported_done})
+        |> Ecto.Changeset.change(%{
+          assigned_agent_id: impl.agent_id,
+          implementer_dispatch_id: impl.id
+        })
+        |> Loopctl.AdminRepo.update!()
+
+      assert hd(verifier.lineage_path) == hd(impl.lineage_path)
+      assert :ok = Progress.ensure_verify_allowed(story, verifier.agent_id, verifier.lineage_path)
+
+      # The ancestor that dispatched the implementer is still refused.
+      assert {:error, :self_verify_blocked} =
+               Progress.ensure_verify_allowed(story, root.agent_id, root.lineage_path)
     end
 
     test "a pre-dispatch story still permits an unlineaged independent caller" do
@@ -119,6 +170,45 @@ defmodule Loopctl.Progress.VerifyCallerLineageTest do
 
       assert result.status == "error"
       assert result.reason =~ "no independent review record"
+    end
+  end
+
+  describe "report and review-complete take the same caller-lineage rule" do
+    test "an unlineaged reporter cannot report dispatch-minted work" do
+      ctx = dispatched_story()
+
+      story =
+        ctx.story
+        |> Ecto.Changeset.change(%{agent_status: :implementing})
+        |> Loopctl.AdminRepo.update!()
+
+      other = fixture(:agent, %{tenant_id: ctx.tenant.id, agent_type: :implementer})
+
+      assert {:error, :caller_lineage_required} =
+               Progress.report_story(ctx.tenant.id, story.id, agent_id: other.id)
+    end
+
+    test "a dispatch-minted user-role key may not review its own subtree's work" do
+      # A user-role dispatch carries no agent_id, and the nil-reviewer permit used to
+      # match on that alone — so an ANCESTOR of the implementer reviewed its own
+      # subtree without the lineage it was handed ever being read.
+      ctx = dispatched_story()
+
+      assert {:error, :self_review_blocked} =
+               Progress.record_review(ctx.tenant.id, ctx.story.id, %{"review_type" => "enhanced"},
+                 reviewer_agent_id: nil,
+                 reviewer_lineage: ctx.impl.lineage_path
+               )
+    end
+
+    test "a genuine human operator (no agent, no lineage) still reviews" do
+      ctx = dispatched_story()
+
+      assert {:ok, _review} =
+               Progress.record_review(ctx.tenant.id, ctx.story.id, %{"review_type" => "enhanced"},
+                 reviewer_agent_id: nil,
+                 reviewer_lineage: []
+               )
     end
   end
 

--- a/test/loopctl/progress/verify_caller_lineage_test.exs
+++ b/test/loopctl/progress/verify_caller_lineage_test.exs
@@ -1,0 +1,137 @@
+defmodule Loopctl.Progress.VerifyCallerLineageTest do
+  @moduledoc """
+  The L4 caller comparison must bind the principal that actually makes the call — on
+  EVERY path that reaches a terminal custody state, not only single-story verify.
+
+  `lineage_status/3` reads an empty caller lineage as "no conflict", so a path that
+  simply forgot to resolve the caller's lineage was left with nothing but
+  `assigned_agent_id != orchestrator_agent_id` — a condition any orchestrator key
+  satisfies trivially. Bulk verify, bulk reject and single-story reject each did.
+  """
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.BulkOperations
+  alias Loopctl.Dispatches
+  alias Loopctl.Progress
+
+  setup :verify_on_exit!
+
+  defp dispatched_story do
+    tenant = fixture(:tenant)
+    impl_agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
+
+    {:ok, %{dispatch: impl}} =
+      Dispatches.create_dispatch(tenant.id, %{role: :agent, agent_id: impl_agent.id})
+
+    {:ok, %{dispatch: sub}} =
+      Dispatches.create_dispatch(tenant.id, %{
+        role: :orchestrator,
+        agent_id: fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator}).id,
+        parent_dispatch_id: impl.id
+      })
+
+    story =
+      fixture(:story, %{tenant_id: tenant.id, agent_status: :reported_done})
+      |> Ecto.Changeset.change(%{
+        assigned_agent_id: impl_agent.id,
+        implementer_dispatch_id: impl.id
+      })
+      |> Loopctl.AdminRepo.update!()
+
+    %{tenant: tenant, impl_agent: impl_agent, impl: impl, sub: sub, story: story}
+  end
+
+  describe "ensure_verify_allowed/3 (the bulk verify/reject gate)" do
+    test "a caller inside the implementer's lineage is blocked even with a different agent_id" do
+      ctx = dispatched_story()
+      other_agent = fixture(:agent, %{tenant_id: ctx.tenant.id, agent_type: :orchestrator})
+
+      assert {:error, :self_verify_blocked} =
+               Progress.ensure_verify_allowed(ctx.story, other_agent.id, ctx.sub.lineage_path)
+    end
+
+    test "an unlineaged caller cannot certify dispatch-minted work" do
+      # Two legacy env-var keys with distinct agent_ids in one process cleared report,
+      # review AND verify: `[]` short-circuits the lineage comparison and the agent-id
+      # inequality is trivially true. Where the WORK was dispatch-minted, the certifier
+      # must be too.
+      ctx = dispatched_story()
+      other_agent = fixture(:agent, %{tenant_id: ctx.tenant.id, agent_type: :orchestrator})
+
+      assert {:error, :self_verify_blocked} =
+               Progress.ensure_verify_allowed(ctx.story, other_agent.id, [])
+    end
+
+    test "a pre-dispatch story still permits an unlineaged independent caller" do
+      story = fixture(:story, %{agent_status: :reported_done})
+      other = fixture(:agent, %{tenant_id: story.tenant_id, agent_type: :orchestrator})
+
+      assert :ok = Progress.ensure_verify_allowed(story, other.id, [])
+    end
+  end
+
+  describe "bulk verify resolves the caller lineage server-side" do
+    setup do
+      ctx = dispatched_story()
+
+      # An independently-rooted orchestrator: the shape that IS allowed to certify.
+      {:ok, %{dispatch: independent}} =
+        Dispatches.create_dispatch(ctx.tenant.id, %{
+          role: :orchestrator,
+          agent_id: fixture(:agent, %{tenant_id: ctx.tenant.id, agent_type: :orchestrator}).id
+        })
+
+      {:ok, Map.put(ctx, :independent, independent)}
+    end
+
+    defp bulk_verify_as(ctx, dispatch) do
+      {_raw, api_key} = fixture(:api_key, %{tenant_id: ctx.tenant.id, role: :orchestrator})
+
+      Loopctl.AdminRepo.get!(Loopctl.Dispatches.Dispatch, dispatch.id)
+      |> Ecto.Changeset.change(api_key_id: api_key.id)
+      |> Loopctl.AdminRepo.update!()
+
+      {:ok, [result]} =
+        BulkOperations.bulk_verify(
+          ctx.tenant.id,
+          [%{"story_id" => ctx.story.id, "result" => "pass", "summary" => "lgtm"}],
+          dispatch.agent_id,
+          actor_id: api_key.id,
+          actor_label: "orchestrator:test"
+        )
+
+      result
+    end
+
+    test "an orchestrator dispatched under the implementer cannot bulk-verify its work", ctx do
+      result = bulk_verify_as(ctx, ctx.sub)
+
+      assert result.status == "error"
+      assert result.reason =~ "cannot verify your own implemented work"
+    end
+
+    test "an independently-rooted orchestrator clears the custody gate", ctx do
+      # The DISCRIMINATING half. Both callers are refused when the lineage is not
+      # threaded (an unlineaged caller cannot certify dispatch-minted work), so only
+      # this case shows the caller's real lineage reached the gate: it gets past
+      # custody and stops at the NEXT gate, the missing review record.
+      result = bulk_verify_as(ctx, ctx.independent)
+
+      assert result.status == "error"
+      assert result.reason =~ "no independent review record"
+    end
+  end
+
+  describe "reject_story/4" do
+    test "takes the same caller-lineage comparison as verify" do
+      ctx = dispatched_story()
+      other_agent = fixture(:agent, %{tenant_id: ctx.tenant.id, agent_type: :orchestrator})
+
+      assert {:error, :self_verify_blocked} =
+               Progress.reject_story(ctx.tenant.id, ctx.story.id, %{"reason" => "no"},
+                 orchestrator_agent_id: other_agent.id,
+                 verifier_lineage: ctx.sub.lineage_path
+               )
+    end
+  end
+end

--- a/test/loopctl/spec/lcp1_conformance_test.exs
+++ b/test/loopctl/spec/lcp1_conformance_test.exs
@@ -294,7 +294,7 @@ defmodule Loopctl.Spec.LCP1ConformanceTest do
   describe "LCP-1 §7.4 verify" do
     test "clause 1 — nil caller identity is REJECTED" do
       ctx = reported_story()
-      assert {:error, :self_verify_blocked} = Progress.ensure_verify_allowed(ctx.story, nil)
+      assert {:error, :self_verify_blocked} = Progress.ensure_verify_allowed(ctx.story, nil, [])
     end
 
     test "clause 2 — ORPHANED story rejects with :missing_assigned_agent" do
@@ -302,25 +302,28 @@ defmodule Loopctl.Spec.LCP1ConformanceTest do
       verifier = fixture(:agent, %{tenant_id: ctx.tenant.id, agent_type: :orchestrator})
 
       assert {:error, :missing_assigned_agent} =
-               Progress.ensure_verify_allowed(ctx.story, verifier.id)
+               Progress.ensure_verify_allowed(ctx.story, verifier.id, [])
     end
 
     test "clause 4 — verifier equal to the assigned agent is REJECTED (no dispatches)" do
       ctx = reported_story()
 
       assert {:error, :self_verify_blocked} =
-               Progress.ensure_verify_allowed(ctx.story, ctx.agent.id)
+               Progress.ensure_verify_allowed(ctx.story, ctx.agent.id, [])
     end
 
     test "clause 5 — an independent verifier is PERMITTED (no dispatches)" do
       ctx = reported_story()
       verifier = fixture(:agent, %{tenant_id: ctx.tenant.id, agent_type: :orchestrator})
-      assert :ok = Progress.ensure_verify_allowed(ctx.story, verifier.id)
+      assert :ok = Progress.ensure_verify_allowed(ctx.story, verifier.id, [])
     end
 
     test "§7.4.1 clause 1 — an unresolvable dispatch FAILS CLOSED" do
       # Both ids declared, neither resolvable. SHARES_ROOT([], []) is false, so a
-      # naive implementation would read this as separated lineage and PERMIT.
+      # naive implementation would read this as separated lineage and PERMIT. The
+      # caller carries a real (dispatch-minted) lineage: a story with a declared
+      # implementer dispatch refuses an unlineaged caller outright, which would mask
+      # the clause under test.
       ctx =
         reported_story(%{
           implementer_dispatch_id: foreign_dispatch_id(),
@@ -330,7 +333,7 @@ defmodule Loopctl.Spec.LCP1ConformanceTest do
       verifier = fixture(:agent, %{tenant_id: ctx.tenant.id, agent_type: :orchestrator})
 
       assert {:error, :unresolvable_dispatch_lineage} =
-               Progress.ensure_verify_allowed(ctx.story, verifier.id)
+               Progress.ensure_verify_allowed(ctx.story, verifier.id, [Ecto.UUID.generate()])
     end
 
     test "§7.4.1 clause 2 — shared lineage root is REJECTED" do
@@ -354,7 +357,7 @@ defmodule Loopctl.Spec.LCP1ConformanceTest do
         |> AdminRepo.update!()
 
       assert {:error, :self_verify_blocked} =
-               Progress.ensure_verify_allowed(story, verifier_agent.id)
+               Progress.ensure_verify_allowed(story, verifier_agent.id, child.lineage_path)
     end
 
     test "§7.4.1 clause 3 — separated lineage does NOT short-circuit the agent-id check" do
@@ -380,7 +383,11 @@ defmodule Loopctl.Spec.LCP1ConformanceTest do
         |> AdminRepo.update!()
 
       assert {:error, :self_verify_blocked} =
-               Progress.ensure_verify_allowed(story, ctx.agent.id)
+               Progress.ensure_verify_allowed(
+                 story,
+                 ctx.agent.id,
+                 verifier_dispatch.lineage_path
+               )
     end
 
     test "§7.4.1 clause 4 — separated lineage and a distinct verifier is PERMITTED" do
@@ -397,7 +404,12 @@ defmodule Loopctl.Spec.LCP1ConformanceTest do
         })
         |> AdminRepo.update!()
 
-      assert :ok = Progress.ensure_verify_allowed(story, verifier_agent.id)
+      assert :ok =
+               Progress.ensure_verify_allowed(
+                 story,
+                 verifier_agent.id,
+                 verifier_dispatch.lineage_path
+               )
     end
   end
 

--- a/test/loopctl_web/controllers/backfill_signed_claim_test.exs
+++ b/test/loopctl_web/controllers/backfill_signed_claim_test.exs
@@ -1,0 +1,47 @@
+defmodule LoopctlWeb.BackfillSignedClaimTest do
+  @moduledoc """
+  `POST /stories/:id/backfill` reaches the same terminal `verified_status: :verified`
+  as `POST /stories/:id/verify`, on a single named work item. Leaving it off the
+  §9.3 signed-claim plug left an unsigned route to the outcome the signed profile
+  exists to attribute.
+  """
+  use LoopctlWeb.ConnCase, async: true
+
+  alias Loopctl.Test.CustodyEnrollment
+  alias Loopctl.Test.CustodyProfileStub
+
+  setup :verify_on_exit!
+
+  setup do
+    tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+    agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+
+    %{raw_key: raw_key} =
+      CustodyEnrollment.enroll_root(tenant.id, %{agent_id: agent.id, role: :orchestrator})
+
+    story = fixture(:story, %{tenant_id: tenant.id, agent_status: :pending})
+
+    %{tenant: tenant, raw_key: raw_key, story: story}
+  end
+
+  defp backfill(conn, raw_key, story) do
+    conn
+    |> put_req_header("authorization", "Bearer #{raw_key}")
+    |> post(~p"/api/v1/stories/#{story.id}/backfill", %{"reason" => "pre-loopctl work"})
+  end
+
+  test "under the bearer default the backfill path is unchanged", ctx do
+    conn = backfill(build_conn(), ctx.raw_key, ctx.story)
+
+    assert json_response(conn, 200)["story"]["verified_status"] == "verified"
+  end
+
+  test "under the signed profile an enrolled caller must sign the backfill claim", ctx do
+    CustodyProfileStub.set_profile(:signed)
+    on_exit(fn -> CustodyProfileStub.set_profile(:bearer) end)
+
+    conn = backfill(build_conn(), ctx.raw_key, ctx.story)
+
+    assert json_response(conn, 401)["error"]["code"] == "claim_signature_required"
+  end
+end

--- a/test/loopctl_web/controllers/backfill_signed_claim_test.exs
+++ b/test/loopctl_web/controllers/backfill_signed_claim_test.exs
@@ -7,6 +7,7 @@ defmodule LoopctlWeb.BackfillSignedClaimTest do
   """
   use LoopctlWeb.ConnCase, async: true
 
+  alias Loopctl.Custody.SignedProfile
   alias Loopctl.Test.CustodyEnrollment
   alias Loopctl.Test.CustodyProfileStub
 
@@ -16,12 +17,18 @@ defmodule LoopctlWeb.BackfillSignedClaimTest do
     tenant = fixture(:tenant, %{trust_tier: :human_anchored})
     agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
 
-    %{raw_key: raw_key} =
+    %{raw_key: raw_key, agent_pub: agent_pub, agent_priv: agent_priv} =
       CustodyEnrollment.enroll_root(tenant.id, %{agent_id: agent.id, role: :orchestrator})
 
     story = fixture(:story, %{tenant_id: tenant.id, agent_status: :pending})
 
-    %{tenant: tenant, raw_key: raw_key, story: story}
+    %{
+      tenant: tenant,
+      raw_key: raw_key,
+      agent_pub: agent_pub,
+      agent_priv: agent_priv,
+      story: story
+    }
   end
 
   defp backfill(conn, raw_key, story) do
@@ -43,5 +50,53 @@ defmodule LoopctlWeb.BackfillSignedClaimTest do
     conn = backfill(build_conn(), ctx.raw_key, ctx.story)
 
     assert json_response(conn, 401)["error"]["code"] == "claim_signature_required"
+  end
+
+  test "a VALID signed claim is recorded in the hash-chained audit log (§9.4)", ctx do
+    CustodyProfileStub.set_profile(:signed)
+    on_exit(fn -> CustodyProfileStub.set_profile(:bearer) end)
+
+    claimed_at = System.system_time(:second)
+
+    claim_sig =
+      SignedProfile.sign(
+        "ed25519",
+        SignedProfile.claim_preimage(
+          "ed25519",
+          ctx.tenant.id,
+          "verify",
+          ctx.story.id,
+          %{},
+          nil,
+          claimed_at
+        ),
+        ctx.agent_priv
+      )
+
+    conn =
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{ctx.raw_key}")
+      |> post(~p"/api/v1/stories/#{ctx.story.id}/backfill", %{
+        "reason" => "pre-loopctl work",
+        "claim" => %{
+          "alg" => "ed25519",
+          "claim_sig" => Base.encode16(claim_sig, case: :lower),
+          "claimed_at" => claimed_at
+        }
+      })
+
+    assert json_response(conn, 200)["story"]["verified_status"] == "verified"
+
+    # Verifying the signature and then dropping it is half a control: the signature
+    # evaporates at request end and the resulting `verified` record becomes
+    # indistinguishable from one an operator fabricated.
+    entry =
+      Loopctl.AuditChain.list_entries(ctx.tenant.id, action: "signed_custody_claim").data
+      |> Enum.find(&(&1.entity_id == ctx.story.id))
+
+    assert entry, "expected a signed_custody_claim audit-chain entry for backfill"
+    assert entry.payload["gate"] == "verify"
+    assert entry.payload["agent_pubkey"] == Base.encode16(ctx.agent_pub, case: :lower)
+    assert entry.payload["claim_sig"] == Base.encode16(claim_sig, case: :lower)
   end
 end

--- a/test/loopctl_web/controllers/dispatch_controller_test.exs
+++ b/test/loopctl_web/controllers/dispatch_controller_test.exs
@@ -14,10 +14,12 @@ defmodule LoopctlWeb.DispatchControllerTest do
     put_req_header(conn, "authorization", "Bearer #{raw_key}")
   end
 
-  # The :create action is orchestrator-role + human-anchored.
+  # The :create action is orchestrator-role+ and human-anchored. These cases mint a
+  # ROOT dispatch (no parent), which the lineage ceiling reserves for the tenant's
+  # OPERATOR key — a `user`-role key that no dispatch minted.
   defp orchestrator_ctx do
     tenant = fixture(:tenant, %{trust_tier: :human_anchored})
-    {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+    {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
     agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
     %{tenant: tenant, raw_key: raw_key, agent: agent}
   end

--- a/test/loopctl_web/controllers/dispatch_lineage_ceiling_test.exs
+++ b/test/loopctl_web/controllers/dispatch_lineage_ceiling_test.exs
@@ -79,7 +79,14 @@ defmodule LoopctlWeb.DispatchLineageCeilingTest do
         |> auth(legacy_key)
         |> post(~p"/api/v1/dispatches", %{"role" => "orchestrator", "agent_id" => agent.id})
 
-      assert json_response(conn, 403)["error"]["code"] == "root_dispatch_forbidden"
+      error = json_response(conn, 403)["error"]
+      assert error["code"] == "root_dispatch_forbidden"
+
+      # A remedy the refused caller can perform. "Mint under your own dispatch id" is
+      # meaningless with no lineage, and the id would be a bare null.
+      refute Map.has_key?(error["remediation"], "your_dispatch_id")
+      assert error["message"] =~ "parent_dispatch_id"
+      assert error["message"] =~ "operator key"
     end
   end
 
@@ -125,6 +132,27 @@ defmodule LoopctlWeb.DispatchLineageCeilingTest do
         })
 
       assert json_response(conn, 403)["error"]["code"] == "parent_outside_caller_lineage"
+    end
+
+    test "a LEGACY orchestrator key may still mint BENEATH an existing dispatch" do
+      # The ceiling stops a principal escaping ITS OWN tree; a key with no lineage has
+      # none to escape. Refusing it here left a legacy key unable to obtain a lineage by
+      # ANY request — and, with the verify gate refusing unlineaged callers on
+      # dispatch-minted work, unable to certify anything either.
+      ctx = operator_ctx()
+      %{"dispatch" => root} = mint_root(ctx)
+      {legacy_key, _} = fixture(:api_key, %{tenant_id: ctx.tenant.id, role: :orchestrator})
+
+      conn =
+        build_conn()
+        |> auth(legacy_key)
+        |> post(~p"/api/v1/dispatches", %{
+          "role" => "agent",
+          "agent_id" => fixture(:agent, %{tenant_id: ctx.tenant.id, agent_type: :implementer}).id,
+          "parent_dispatch_id" => root["id"]
+        })
+
+      assert json_response(conn, 201)["data"]["dispatch"]["parent_dispatch_id"] == root["id"]
     end
 
     test "an operator key may still parent anywhere in its own tenant" do

--- a/test/loopctl_web/controllers/dispatch_lineage_ceiling_test.exs
+++ b/test/loopctl_web/controllers/dispatch_lineage_ceiling_test.exs
@@ -6,9 +6,13 @@ defmodule LoopctlWeb.DispatchLineageCeilingTest do
   A parentless dispatch starts a new lineage tree that shares no root with anything
   else, which is exactly the shape the L4 custody gates read as "an unrelated
   principal". A caller able to mint one on demand can hand itself separation from its
-  own work, so only a key that no dispatch minted — the tenant's operator key, rooted
-  in the human anchor — may start a tree. Naming someone else's dispatch as parent is
-  the same escape one step out, since every dispatch id is enumerable.
+  own work, so only the tenant's OPERATOR key — a `user`-role key that no dispatch
+  minted, rooted in the human anchor — may start a tree. Naming someone else's dispatch
+  as parent is the same escape one step out, since every dispatch id is enumerable.
+
+  "Operator" is a POSITIVE test, not the absence of a lineage: `lineage_for_api_key/2`
+  also returns [] for a legacy long-lived `:orchestrator` key, and treating that as the
+  operator left it able to hand itself an independently-rooted dispatch.
   """
   use LoopctlWeb.ConnCase, async: true
 
@@ -16,11 +20,12 @@ defmodule LoopctlWeb.DispatchLineageCeilingTest do
 
   defp auth(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
 
-  # `:create` is orchestrator-role + human-anchored. The api_key fixture is a plain
-  # tenant key — no dispatch minted it, so its lineage is [] (the operator shape).
+  # `:create` is orchestrator-role+ and human-anchored. The operator key is the
+  # `role: :user` key the signup ceremony mints — no dispatch minted it, so its
+  # lineage is [].
   defp operator_ctx do
     tenant = fixture(:tenant, %{trust_tier: :human_anchored})
-    {operator_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+    {operator_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
     agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
     %{tenant: tenant, operator_key: operator_key, agent: agent}
   end
@@ -46,7 +51,7 @@ defmodule LoopctlWeb.DispatchLineageCeilingTest do
 
     test "a dispatch-minted key may NOT start a second, independent tree" do
       ctx = operator_ctx()
-      %{"api_key" => %{"raw_key" => dispatched_key}} = mint_root(ctx)
+      %{"dispatch" => root, "api_key" => %{"raw_key" => dispatched_key}} = mint_root(ctx)
 
       conn =
         build_conn()
@@ -55,6 +60,24 @@ defmodule LoopctlWeb.DispatchLineageCeilingTest do
           "role" => "orchestrator",
           "agent_id" => ctx.agent.id
         })
+
+      error = json_response(conn, 403)["error"]
+      assert error["code"] == "root_dispatch_forbidden"
+
+      # The refusal tells the caller to mint under its OWN dispatch, so it has to be
+      # able to name it. Nothing else on this API identifies which row is the caller's.
+      assert error["remediation"]["your_dispatch_id"] == root["id"]
+    end
+
+    test "a LEGACY orchestrator key is not the operator and may NOT start a tree" do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {legacy_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+
+      conn =
+        build_conn()
+        |> auth(legacy_key)
+        |> post(~p"/api/v1/dispatches", %{"role" => "orchestrator", "agent_id" => agent.id})
 
       assert json_response(conn, 403)["error"]["code"] == "root_dispatch_forbidden"
     end

--- a/test/loopctl_web/controllers/dispatch_lineage_ceiling_test.exs
+++ b/test/loopctl_web/controllers/dispatch_lineage_ceiling_test.exs
@@ -1,0 +1,140 @@
+defmodule LoopctlWeb.DispatchLineageCeilingTest do
+  @moduledoc """
+  The lineage ceiling on `POST /api/v1/dispatches`: a caller may only mint inside its
+  OWN subtree.
+
+  A parentless dispatch starts a new lineage tree that shares no root with anything
+  else, which is exactly the shape the L4 custody gates read as "an unrelated
+  principal". A caller able to mint one on demand can hand itself separation from its
+  own work, so only a key that no dispatch minted — the tenant's operator key, rooted
+  in the human anchor — may start a tree. Naming someone else's dispatch as parent is
+  the same escape one step out, since every dispatch id is enumerable.
+  """
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  defp auth(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+  # `:create` is orchestrator-role + human-anchored. The api_key fixture is a plain
+  # tenant key — no dispatch minted it, so its lineage is [] (the operator shape).
+  defp operator_ctx do
+    tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+    {operator_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+    agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+    %{tenant: tenant, operator_key: operator_key, agent: agent}
+  end
+
+  defp mint_root(%{operator_key: operator_key, agent: agent}) do
+    build_conn()
+    |> auth(operator_key)
+    |> post(~p"/api/v1/dispatches", %{"role" => "orchestrator", "agent_id" => agent.id})
+    |> json_response(201)
+    |> Map.fetch!("data")
+  end
+
+  describe "root minting" do
+    test "an operator key (no lineage of its own) may start a tree" do
+      ctx = operator_ctx()
+
+      data = mint_root(ctx)
+
+      assert [root_id] = data["dispatch"]["lineage_path"]
+      assert root_id == data["dispatch"]["id"]
+      assert is_nil(data["dispatch"]["parent_dispatch_id"])
+    end
+
+    test "a dispatch-minted key may NOT start a second, independent tree" do
+      ctx = operator_ctx()
+      %{"api_key" => %{"raw_key" => dispatched_key}} = mint_root(ctx)
+
+      conn =
+        build_conn()
+        |> auth(dispatched_key)
+        |> post(~p"/api/v1/dispatches", %{
+          "role" => "orchestrator",
+          "agent_id" => ctx.agent.id
+        })
+
+      assert json_response(conn, 403)["error"]["code"] == "root_dispatch_forbidden"
+    end
+  end
+
+  describe "parent minting" do
+    test "a dispatch-minted key may mint beneath its own dispatch" do
+      ctx = operator_ctx()
+      %{"dispatch" => root, "api_key" => %{"raw_key" => dispatched_key}} = mint_root(ctx)
+
+      conn =
+        build_conn()
+        |> auth(dispatched_key)
+        |> post(~p"/api/v1/dispatches", %{
+          "role" => "agent",
+          "agent_id" => ctx.agent.id,
+          "parent_dispatch_id" => root["id"]
+        })
+
+      data = json_response(conn, 201)["data"]
+      root_id = root["id"]
+      child_id = data["dispatch"]["id"]
+
+      assert data["dispatch"]["lineage_path"] == [root_id, child_id]
+      assert data["dispatch"]["parent_dispatch_id"] == root_id
+    end
+
+    test "a dispatch-minted key may NOT parent under a different root" do
+      ctx = operator_ctx()
+      %{"api_key" => %{"raw_key" => dispatched_key}} = mint_root(ctx)
+
+      # A second, unrelated tree the operator started (a distinct agent: one agent may
+      # hold only one active key per role). Its id is readable by any agent key in the
+      # tenant, which is why naming it as parent has to be refused here.
+      second_agent = fixture(:agent, %{tenant_id: ctx.tenant.id, agent_type: :orchestrator})
+      %{"dispatch" => other_root} = mint_root(%{ctx | agent: second_agent})
+
+      conn =
+        build_conn()
+        |> auth(dispatched_key)
+        |> post(~p"/api/v1/dispatches", %{
+          "role" => "agent",
+          "agent_id" => ctx.agent.id,
+          "parent_dispatch_id" => other_root["id"]
+        })
+
+      assert json_response(conn, 403)["error"]["code"] == "parent_outside_caller_lineage"
+    end
+
+    test "an operator key may still parent anywhere in its own tenant" do
+      ctx = operator_ctx()
+      %{"dispatch" => root} = mint_root(ctx)
+
+      conn =
+        build_conn()
+        |> auth(ctx.operator_key)
+        |> post(~p"/api/v1/dispatches", %{
+          "role" => "agent",
+          "agent_id" => ctx.agent.id,
+          "parent_dispatch_id" => root["id"]
+        })
+
+      assert json_response(conn, 201)["data"]["dispatch"]["parent_dispatch_id"] == root["id"]
+    end
+
+    test "tenant isolation: another tenant's dispatch is not a usable parent" do
+      ctx = operator_ctx()
+      other = operator_ctx()
+      %{"dispatch" => foreign_root} = mint_root(other)
+
+      conn =
+        build_conn()
+        |> auth(ctx.operator_key)
+        |> post(~p"/api/v1/dispatches", %{
+          "role" => "agent",
+          "agent_id" => ctx.agent.id,
+          "parent_dispatch_id" => foreign_root["id"]
+        })
+
+      assert json_response(conn, 404)
+    end
+  end
+end

--- a/test/loopctl_web/controllers/story_lifecycle_capability_test.exs
+++ b/test/loopctl_web/controllers/story_lifecycle_capability_test.exs
@@ -467,12 +467,15 @@ defmodule LoopctlWeb.StoryLifecycleCapabilityTest do
       ctx = reviewed(conn, keyed_context())
 
       # The leg agent-id equality cannot reach, and the one the retired verify_cap
-      # used to cover: a distinct agent_id whose dispatch shares the implementer's
-      # lineage ROOT. request-review was never called, so verifier_dispatch_id is
-      # nil — uncompared caller lineage means a bare agent-id inequality passes.
-      sibling = fixture(:agent, %{tenant_id: ctx.tenant.id})
-      shared_root = [hd(ctx.implementer.lineage), Ecto.UUID.generate()]
-      raw_key = orchestrator_key_on_lineage(ctx, sibling.id, shared_root)
+      # used to cover: a distinct agent_id on the implementer's own root-to-leaf
+      # CHAIN — here a sub-agent the implementer dispatched. request-review was never
+      # called, so verifier_dispatch_id is nil — uncompared caller lineage means a
+      # bare agent-id inequality passes. (A SIBLING under the same root is separation
+      # and is allowed: demanding a separate root of the caller left a single-root
+      # tenant with no principal able to verify at all.)
+      sub_agent = fixture(:agent, %{tenant_id: ctx.tenant.id})
+      under_implementer = ctx.implementer.lineage ++ [Ecto.UUID.generate()]
+      raw_key = orchestrator_key_on_lineage(ctx, sub_agent.id, under_implementer)
 
       body =
         conn


### PR DESCRIPTION
Closes the remainder of the chain-of-custody advisory (private draft GHSA-4rxr-fmj9-g76h) and items 1–3 of #624. Findings F1 and F2 already landed via #625's review.

## F3 — a dispatch could mint itself out of its own tree

Any orchestrator key could create a **parentless** dispatch (a fresh root), and — because the dispatch list is readable by any agent key — could equally name a **parent under someone else's root**. Either way a principal already inside one tree placed itself in another, which is the manoeuvre every lineage comparison in the custody stack exists to prevent.

A minted dispatch must now descend from the caller's own, and only a caller with **no** lineage — the tenant's operator key, the human anchor the chain hangs from — may create a root. This is the structural analogue of the role ceiling already above it.

### The advisory's literal fix would have bricked the subsystem

It asked to "reject a parentless create outside signup". **There is no signup root creation.** `Dispatches.create_dispatch/2,3` has exactly one production caller — this controller — and nothing in `Loopctl.Tenants` or the signup path creates a dispatch; the old code comment claiming otherwise was aspirational. Reject parentless creates and there is no root to parent from, so **no dispatch of any kind could ever be created again**.

A tenant confined to one root also starves verification: `select_verifier/3`'s `reject_same_root/2` would refuse the entire pool, returning `:no_eligible_verifier` for every story, and the verify gate's root comparison would block every dispatch-minted orchestrator. The ceiling closes the same escape while leaving tenants multi-rooted, so selection and the verify gate are untouched.

Verified independently before accepting: `create_dispatch` has one caller, and no dispatch is created anywhere in the tenant/signup path.

**Client-visible:** a sub-agent that used to mint a fresh root must now pass its own dispatch id as parent (`403 root_dispatch_forbidden`); anything acting for the whole tenant uses the operator key. Both 403s carry remediation text.

## F4 — backfill could launder in-system work to verified

Backfill exists for work completed before loopctl. But a story could be claimed, **force-unclaimed** (which deliberately clears the assignment), then backfilled straight to `verified` with no report, no review record and no verifier.

#625 closed the dispatch-minted half — `implementer_dispatch_id` now survives force-unclaim and permanently blocks backfill. A **legacy bearer** claim left no marker at all and remained state-indistinguishable from pre-loopctl work. The guard now asks the audit log whether the story ever had a lifecycle event, which is the question backfill was always trying to ask. `RequireSignedClaim` mounts on backfill too, matching its siblings.

## F5 — verifier selection was externally computable

Seeded on the tenant's audit signing **public** key — served unauthenticated on `/.well-known/loopctl` — over a pool any agent key can list, so every candidate could compute whether it was about to be chosen. Now seeded from a server-side secret (HMAC-SHA256, domain-separated, bound to tenant+story).

**Behaviour change:** a tenant with no provisioned audit key now flags `verifier_needed` instead of auto-selecting. Its previous seed was effectively the story id alone — zero unpredictability — so nothing real is lost, and the flag plus audit entry makes the gap visible rather than fake. The public-key read was removed rather than kept as a fallback; falling back to any public value would have undone the fix.

## #624 items 1–3

- Post-commit `AuditChain.append/2` results are no longer discarded — a failed append left the chain silently missing an entry while the state change had already committed.
- Signed-profile resolution can no longer report "config row never landed" and "operator chose bearer" as the same observation (`0` was both), and emits telemetry on every resolution so a deployment drifting signed → bearer is visible.
- The bulk verify gate now refuses a bearer dispatch whose agent has enrolled elsewhere, which the single-story gate already did — a migrated agent could otherwise clear a whole epic unsigned. It returns `:bulk_signature_unsupported` rather than the single-story `:agent_enrollment_required`, because on the bulk path "use your enrolled dispatch" leads nowhere.

## Verification

- `mix precommit` green on the first full run: 7076 tests, 0 failures; credo `--strict` clean; 125 citations resolve.
- 29 new tests across 5 files, including tenant-isolation cases on the backfill history guard and the lineage ceiling.
- **All 8 new guards mutation-verified** — each mutated individually, its suite run, the failure observed, the tree restored byte-identical.
- The verifier-seed test pins 20 fixed UUIDs so the input set is identical every run: it asserts the pick depends on the **private** key while the public key and pool are held constant, and cannot flake.

## Flagged, deliberately not changed

`assign_rotating_verifier/3` passes `[]` when the implementer lineage is unresolvable, and with `[]` the `reject_same_root/2` filter is inert — selection could nominate the implementer's own dispatch. It is caught at verify (fail-closed on empty lineage) and the skill documents the split deliberately, so this is a design decision rather than a defect. Raised because F5's work sat directly next to it.
