### PR TITLE
Bust the key caches on bootstrap too, and test the wiring that #638 left inert

### DIFF
--- a/lib/loopctl/tenants.ex
+++ b/lib/loopctl/tenants.ex
@@ -632,8 +632,32 @@ defmodule Loopctl.Tenants do
       end)
 
     case result do
-      {:ok, %{set_public_key: tenant}} -> {:ok, tenant}
-      {:error, _step, reason, _changes} -> {:error, reason}
+      {:ok, %{set_public_key: tenant}} ->
+        # Same cluster bust as `rotate_audit_key/2`, for the mirror-image reason.
+        # A tenant with NO audit key answers `:not_found`, and that failure is
+        # CACHED (`TenantKeys.@negative_ttl_seconds`) — deliberately, because
+        # `Dispatches.verifier_seed/2` asks on every request-review, so a keyless
+        # tenant is a permanent miss storm. Bootstrap ends that state, and until
+        # each peer's own entry lapses it keeps answering `:not_found` for a
+        # tenant that now HAS a key: `verifier_seed/2` fails closed, so a story
+        # gets flagged `verifier_needed` on a tenant that was just made able to
+        # verify. Bounded by the negative TTL rather than the 300s positive one,
+        # which is why this is a smaller window than the rotation bug — not a
+        # different one.
+        #
+        # The SIGNUP paths deliberately do NOT do this: they INSERT the tenant in
+        # the same transaction, so no peer can hold a cached entry for a
+        # tenant_id that did not exist. Bootstrap is the one key-write that runs
+        # against a tenant peers have already been asking about.
+        TenantKeys.invalidate_cluster(tenant.id)
+        # The cached api_key snapshots carry `audit_signing_public_key`; bootstrap
+        # sets it from nil, so they are stale in exactly the way a rotation makes
+        # them stale (US-33.3).
+        Auth.invalidate_tenant_key_cache(tenant.id)
+        {:ok, tenant}
+
+      {:error, _step, reason, _changes} ->
+        {:error, reason}
     end
   end
 

--- a/test/loopctl/tenants/audit_key_test.exs
+++ b/test/loopctl/tenants/audit_key_test.exs
@@ -177,6 +177,59 @@ defmodule Loopctl.Tenants.AuditKeyTest do
   end
 
   describe "rotate_audit_key/2" do
+    test "broadcasts the cluster invalidation, so peers stop signing with the retired key" do
+      # #638 gave `TenantKeys` a cross-node bridge, and both halves were covered:
+      # `invalidate_cluster/1` broadcasts, and the supervised owner busts on
+      # receipt. NOTHING covered the WIRING — deleting this call site from
+      # `rotate_audit_key/2` left the full suite green, so the fix could have been
+      # refactored away silently. That is the whole failure it exists to prevent:
+      # a peer keeps signing with the RETIRED key, and `signing_keys/2` admits a
+      # historical key only for the window it was live, so the token verifies as
+      # `:invalid_signature` and is chained as `capability_forged`,
+      # `byzantine: true` — a benign rotation manufacturing forgery evidence.
+      tenant = fixture(:tenant)
+
+      tenant =
+        tenant
+        |> Ecto.Changeset.change(audit_signing_public_key: :crypto.strong_rand_bytes(32))
+        |> AdminRepo.update!()
+
+      Mox.expect(Loopctl.MockSecrets, :set, fn _name, _value -> :ok end)
+      :ok = Phoenix.PubSub.subscribe(Loopctl.PubSub, "tenant_keys:invalidate")
+
+      assert {:ok, _updated} =
+               Tenants.rotate_audit_key(tenant.id, :crypto.strong_rand_bytes(64))
+
+      tenant_id = tenant.id
+      assert_receive {:invalidate, ^tenant_id}
+    end
+
+    test "busts the api_key cache, whose snapshots carry the tenant's audit public key" do
+      # The SECOND untested wiring on this path (US-33.3). Cached api_key
+      # snapshots embed `audit_signing_public_key`, so a rotation leaves every
+      # cached key advertising the RETIRED public half — which is what the
+      # capability verifier checks a signature against. Deleting this call site
+      # also left the full suite green.
+      tenant = fixture(:tenant)
+
+      tenant =
+        tenant
+        |> Ecto.Changeset.change(audit_signing_public_key: :crypto.strong_rand_bytes(32))
+        |> AdminRepo.update!()
+
+      {_raw, api_key} =
+        fixture(:api_key, %{tenant_id: tenant.id, role: :user, name: "rotate-cache"})
+
+      Mox.expect(Loopctl.MockSecrets, :set, fn _name, _value -> :ok end)
+      :ok = Phoenix.PubSub.subscribe(Loopctl.PubSub, "auth:api_key_cache:invalidate")
+
+      assert {:ok, _updated} =
+               Tenants.rotate_audit_key(tenant.id, :crypto.strong_rand_bytes(64))
+
+      key_hash = api_key.key_hash
+      assert_receive {:invalidate, ^key_hash}
+    end
+
     test "rotates the key, archives the old one, and writes audit entry" do
       # Create tenant with an initial audit key
       tenant = fixture(:tenant, %{slug: "rotate-me"})
@@ -296,6 +349,33 @@ defmodule Loopctl.Tenants.AuditKeyTest do
 
       secret_name = Secrets.audit_key_secret_name(slug)
       assert_received {:deleted, ^secret_name}
+    end
+
+    test "busts the cached miss, so a peer stops refusing a tenant that now HAS a key" do
+      tenant = fixture(:tenant)
+      secret_name = Secrets.audit_key_secret_name(tenant.slug)
+      test_pid = self()
+
+      # A keyless tenant answers `:not_found`, and that failure is cached ON
+      # PURPOSE: `Dispatches.verifier_seed/2` asks on every request-review, so an
+      # uncached miss is a permanent storm against a 3-connection pool.
+      Mox.stub(Loopctl.MockSecrets, :get, fn ^secret_name -> {:error, :not_found} end)
+      assert {:error, :not_found} = TenantKeys.get_private_key(tenant.id)
+
+      Mox.expect(Loopctl.MockSecrets, :set, fn ^secret_name, priv ->
+        send(test_pid, {:stored, priv})
+        :ok
+      end)
+
+      assert {:ok, _tenant} = Tenants.bootstrap_audit_key(tenant.id)
+      assert_received {:stored, priv}
+
+      # The store now HAS the key. Without the bust, the cached `:not_found`
+      # keeps answering until the negative TTL lapses — and `verifier_seed/2`
+      # fails CLOSED on it, so a story is flagged `verifier_needed` on the very
+      # tenant that was just made able to verify.
+      Mox.stub(Loopctl.MockSecrets, :get, fn ^secret_name -> {:ok, Base.encode64(priv)} end)
+      assert {:ok, ^priv} = TenantKeys.get_private_key(tenant.id)
     end
   end
 end


### PR DESCRIPTION
Closes the last residue from the 2026-08 security batch — and, while verifying it, found that #638's own fix was inert under test.

## The residue

`bootstrap_audit_key/1` wrote a tenant's first audit key and busted no cache.

A tenant with no audit key answers `:not_found`, and that failure is cached deliberately: `Dispatches.verifier_seed/2` asks on every request-review, so an uncached miss is a permanent storm against a 3-connection pool. Bootstrap ends that state — but until each peer's entry lapses it keeps answering `:not_found` for a tenant that now has a key, and `verifier_seed/2` fails **closed** on it. The result is a story flagged `verifier_needed` on the very tenant that was just made able to verify.

Bounded by the 15s negative TTL rather than the 300s positive one, which makes it a smaller window than the rotation bug #638 fixed, not a different one. It now busts both caches exactly as `rotate_audit_key/2` does.

**Two sibling sites were reported alongside this one and are deliberately NOT changed**, because neither is the same bug:

- the **signup** paths INSERT the tenant inside the same transaction, so no peer can hold a cached entry for a `tenant_id` that did not exist. Invalidation there is a genuine no-op.
- the **restore** compensation runs only when the transaction FAILED — which is the path on which no invalidation happened — so peers still hold precisely the key being restored. The two can never both occur.

Both are now documented in place so they are not rediscovered as gaps.

## The more serious finding

**PR #638's fix was not covered by any test.** Deleting `TenantKeys.invalidate_cluster/1` from `rotate_audit_key/2` left the full suite green — 7361 tests, 0 failures.

Both halves were covered in isolation: `invalidate_cluster/1` broadcasts, and the supervised owner busts on receipt. Nothing pinned the **wiring** between the rotation and the invalidation. The fix could have been refactored away silently, and the rotation would go back to leaving peers signing with the retired key — which `signing_keys/2` admits only for the window it was live, so the token verifies as `:invalid_signature` and is chained as `capability_forged`, `byzantine: true`.

The sibling `Auth.invalidate_tenant_key_cache/1` call was equally untested, on both sites. Cached `api_key` snapshots embed `audit_signing_public_key` — the key the capability verifier checks signatures against.

## Tests

Three added, each **mutation-verified individually** (guard removed, test confirmed failing, guard restored):

| Test | Pins |
|---|---|
| rotate broadcasts the cluster invalidation | #638's call site |
| rotate busts the api_key cache | the US-33.3 call site |
| bootstrap busts the cached miss | this PR's fix |

The bootstrap test is behavioural rather than a broadcast assertion: it caches the `:not_found`, bootstraps, then reads the key back. Without the bust the stale `:not_found` answers instead — so it fails for the right reason.

`mix precommit` green: 7363 tests, 0 failures.
