### PR TITLE
Retire the capture_silence detector, which this corpus makes 100% false-positive

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -240,7 +240,21 @@ config :loopctl,
 # `:reject_window_days` is the rolling window (days) over the `ingestion_write_stats`
 # rollup the reject-rate scan reads.
 config :loopctl, :ingestion_health,
-  monitored_source_types: :all,
+  # capture_silence is RETIRED (owner decision, 2026-08-09): an empty list monitors no
+  # source_type, so `IngestionHealth.detect/0` yields no candidates and the worker flags
+  # nothing. It scopes that detector ONLY — `:high_reject_rate` and `:sweep_stalled` are
+  # separate detectors with their own config and are unaffected.
+  #
+  # Why retire rather than tune: the signal cannot tell a ONE-OFF HARVEST that finished
+  # from a standing feed that broke, and this corpus is built by harvests. Every anomaly
+  # it ever raised (web_article, interview, requirements, repo, newsletter — 5 rows,
+  # 23-31 days stale) was a completed import, so the detector was 100% false-positive
+  # here while `session_log`, the only continuous producer, never tripped it.
+  #
+  # To re-enable for a source that IS a standing feed, name it explicitly rather than
+  # going back to `:all` — e.g. `["session_log"]`. That is the shape this detector is
+  # actually good at.
+  monitored_source_types: [],
   established_threshold: 5,
   staleness_threshold_hours: 72,
   establishment_window_hours: 720,

--- a/test/loopctl/knowledge/ingestion_health_test.exs
+++ b/test/loopctl/knowledge/ingestion_health_test.exs
@@ -100,6 +100,25 @@ defmodule Loopctl.Knowledge.IngestionHealthTest do
       assert IngestionHealth.detect() |> Enum.filter(&(&1.tenant_id == tenant.id)) == []
     end
 
+    test "an EMPTY monitored list retires the detector — no candidate, however stale" do
+      # `config/config.exs` ships `monitored_source_types: []` to retire capture_silence
+      # (owner decision): the signal cannot distinguish a one-off harvest that FINISHED
+      # from a standing feed that BROKE, and every anomaly it raised on this corpus was a
+      # completed import. `[]` must mean "monitor nothing", NOT fall back to `:all` —
+      # `filter_source_types/2`'s list clause builds `source_type in ^[]`, which matches
+      # no row. Without this test the retirement is one `Keyword.get` default away from
+      # silently reverting.
+      tenant = fixture(:tenant)
+      for _ <- 1..10, do: captured(tenant.id, "session_log", @stale_hours)
+
+      assert IngestionHealth.detect(%{
+               monitored_source_types: [],
+               established_threshold: 3,
+               staleness_threshold_hours: 72
+             })
+             |> Enum.filter(&(&1.tenant_id == tenant.id)) == []
+    end
+
     test "honors an explicit config passed to detect/1" do
       tenant = fixture(:tenant)
       for _ <- 1..3, do: captured(tenant.id, "session_log", @stale_hours)


### PR DESCRIPTION
`capture_silence` flags a `source_type` that was producing articles and stopped. It cannot distinguish a **one-off harvest that finished** from a **standing feed that broke** — and this corpus is built by harvests.

Every anomaly it ever raised on the owner's tenant was a completed import: `web_article`, `interview`, `requirements`, `repo`, `newsletter` — five rows carrying `alerted: true` for 23–31 days. Meanwhile `session_log`, the only continuously-running producer and the one source whose silence would mean something, never tripped it. 100% false-positive rate.

An always-open list of alerts that are always wrong is worse than no list: it trains the reader to ignore the surface, so a real one would go unnoticed too.

## The change

`monitored_source_types: []`, which scopes to this detector alone — `filter_source_types/2`'s list clause builds `source_type in ^[]`, matching no row, so `detect/0` yields no candidates.

`high_reject_rate` and `sweep_stalled` are separate detectors with their own config and are **deliberately untouched**. `sweep_stalled` reports that channel-post retention has stopped being enforced — a real operational condition, not a taste call.

## Test

`[]` must keep meaning *nothing* rather than *everything*, and it sits one `Keyword.get` default away from silently reverting. Pinned: ten stale captures well past threshold, empty monitored list, no candidate.

Mutation-verified by adding `defp filter_source_types(query, []), do: query` — exactly the plausible refactor — and the test fails.

## Notes

The five existing rows were archived in production separately by RPC, so this only stops new ones. To re-enable for a source that genuinely is a standing feed, name it explicitly (`["session_log"]`) rather than restoring `:all`.

`mix precommit` green: 7364 tests, 0 failures.