### PR TITLE
Make the heavy-read timeout test measure the gap, not a tight wall clock

### DIFF
--- a/test/loopctl/knowledge/heavy_read_statement_timeout_test.exs
+++ b/test/loopctl/knowledge/heavy_read_statement_timeout_test.exs
@@ -49,10 +49,20 @@ defmodule Loopctl.Knowledge.HeavyReadStatementTimeoutTest do
     tenant = fixture(:tenant)
     _art = fixture(:article, %{tenant_id: tenant.id})
 
+    # The sleep is deliberately 10s against a 100ms timeout, and the two numbers are
+    # load-bearing TOGETHER. This assertion separates two outcomes: canceled at the
+    # timeout (~100ms + overhead) versus held for the whole query (10s). The wider the
+    # gap, the more machine load the bound tolerates while still meaning what it says.
+    #
+    # It was pg_sleep(1) with a 600ms bound — a 6x margin — and it flaked at 786ms on a
+    # box running two builds (2026-08-10). Do NOT "fix" a future flake by nudging the
+    # bound toward the sleep: at pg_sleep(1), a bound near 1000ms stops distinguishing
+    # cancellation from completion, which is the whole point of the test. Widen the gap
+    # instead, or make the assertion relative.
     slow =
       from(a in Article,
         where: a.tenant_id == ^tenant.id,
-        where: fragment("pg_sleep(1) IS NULL")
+        where: fragment("pg_sleep(10) IS NULL")
       )
 
     {elapsed_us, _} =
@@ -62,9 +72,15 @@ defmodule Loopctl.Knowledge.HeavyReadStatementTimeoutTest do
         end
       end)
 
-    # Canceled near 100ms, NOT held for the full 1s — proves prompt release, no
-    # pool-starvation re-intro on the override (transaction) path.
-    assert elapsed_us / 1_000 < 600
+    elapsed_ms = elapsed_us / 1_000
+
+    # Canceled near 100ms, NOT held for the full 10s — proves prompt release, no
+    # pool-starvation re-intro on the override (transaction) path. 2_000ms absorbs a
+    # 20x overhead spike; a regression that waits out the query lands at ~10_000ms.
+    assert elapsed_ms < 2_000,
+           "expected the override path to cancel near the 100ms statement_timeout, " <>
+             "but it took #{Float.round(elapsed_ms, 1)}ms — at or past this bound the " <>
+             "query is being held rather than canceled (the sleep is 10s)"
 
     # The connection is back in the pool and immediately reusable.
     ok_query = from(a in Article, where: a.tenant_id == ^tenant.id, select: count())


### PR DESCRIPTION
TC-27.4.3 asserts that the `statement_timeout` override path cancels promptly instead of holding the connection for the whole query. It expressed that as `elapsed < 600ms` against a `pg_sleep(1)` with a 100 ms timeout — a 6× margin over the timeout, and only a **1.7× gap** under the thing it distinguishes itself from.

It measured **786 ms** on a box running two builds (2026-08-10) and failed the entire `precommit` gate; it passes on an idle machine. A wall-clock bound that narrow is a coin flip on a loaded CI runner.

## Why not just raise the bound

The assertion is worth keeping — prompt cancellation is the property US-27.4 exists to prove, and no non-timing assertion demonstrates it. But at `pg_sleep(1)`, a bound nudged toward 1000 ms stops distinguishing *cancellation* from *completion*, which turns the test into decoration that cannot fail.

So this widens the **gap** instead of loosening the bound: `pg_sleep(10)` against the same 100 ms timeout, asserted under 2000 ms. `statement_timeout` is server-side, so cancellation still lands at ~100 ms + overhead and the file still runs in ~0.3 s — while a regression that waits the query out now lands at ~10000 ms. The bound absorbs a 20× overhead spike and still means what it says.

The failure message now names the actual elapsed time and what crossing the bound implies, and a comment tells the next reader not to answer a future flake by moving the bound toward the sleep.

## Verification

- The file passes in 0.3 s; full `mix precommit` green (7364 tests, 0 failures).
- **Mutation-tested:** a copy with the timeout raised to 15 s, so the query runs to completion, fails the assertion at 15012 ms with the new message. The assertion still bites.

Found while landing #642. Two *other* load-sensitive flakes surfaced in `Loopctl.EmbeddingsSideTableReadsTest` during the same runs and are **not** touched here — see the PR discussion; they are a different defect (an async materialization race), not this one.