### PR TITLE
Rank first-party knowledge above harvested material on near-ties

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -927,8 +927,15 @@ config :loopctl, :knowledge_rrf_graph_max_neighbors, 20
 # `1 - w + w*decay` on the fused score. Default weight 0.3 matches knowledge_context.
 config :loopctl, :knowledge_recency_weight, 0.3
 # Source-authority prior: toggle + magnitude. The factor is
-# `clamp(1 + strength * (category_weight + source_type_weight), 0.9, 1.1)`. Because every
-# category/source_type weight is >= 0 and strength is >= 0, `1 + strength*(cat+src)` is
+# `clamp(1 + strength * (category_weight + source_type_weight + provenance_weight), 0.9, 1.1)`.
+# The provenance term (#251) separates first-party knowledge from third-party HARVESTED
+# material by the structural capture tag a sourcer stamps (`book-`/`url-`/`yt-`/`doc-`
+# prefixes and the bare kind tags) — `source_type` cannot, because ~98% of the corpus
+# carries a NULL one. It earns its place: measured 2026-08-11, first-party articles are read
+# 26.7x more per article than harvested ones (389.7 vs 14.6 reads per 1k), and are 4% of the
+# corpus but 53% of the reads. The weight is deliberately far smaller than that ratio —
+# priors break near-ties here, they do not dominate relevance. Because every
+# category/source_type/provenance weight is >= 0 and strength is >= 0, `1 + strength*(sum)` is
 # always >= 1.0 — so the 0.9 floor is UNREACHABLE and the EFFECTIVE range is [1.0, 1.1].
 # The band is one-sided BY DESIGN: authority only ever BOOSTS a higher-authority doc; it
 # never demotes a low-authority raw note below neutral (demotion comes solely from the

--- a/lib/loopctl/knowledge/ranking_priors.ex
+++ b/lib/loopctl/knowledge/ranking_priors.ex
@@ -110,6 +110,50 @@ defmodule Loopctl.Knowledge.RankingPriors do
   }
   @default_source_authority 0.0
 
+  # Provenance authority (#251). The single strongest measured signal in this table, and
+  # the one the category/source_type weights above could not see.
+  #
+  # Measured on the live corpus 2026-08-11, over 30 days of reads:
+  #
+  #   first-party              3,164 articles   389.7 reads/1k   18.30% ever read
+  #   third-party (harvested) 75,768 articles    14.6 reads/1k    1.09% ever read
+  #
+  # A 26.7x per-article read rate: first-party is 4% of the corpus and 53% of the reads.
+  # The June 2026 bulk harvest added 76k third-party articles, and every query since has
+  # had to pull the ~3k articles anyone actually opens out of that pool.
+  #
+  # Why TAGS and not `source_type`: 83,487 of 85,157 articles carry a NULL `source_type`,
+  # the whole harvest included, so `@source_authority` returns its 0.0 default for
+  # essentially the entire corpus and cannot separate these cohorts at all. The sourcers
+  # DO stamp a structural capture tag (`book-<id>`, `url-<id>`, `yt-<id>`, `doc-<id>`, plus
+  # the bare kind tags below). Verified as a discriminator before being relied on: it marks
+  # 98.5% of the June harvest and 0.4% of the pre-June curated set.
+  #
+  # THIRD-PARTY IS THE POSITIVE TEST, and first-party is the absence of a marker — never the
+  # reverse. A first-party allowlist would have to enumerate every repo/topic tag Mark will
+  # ever use, and each one it missed would silently demote genuinely first-party knowledge.
+  # A missed marker here fails the other way: an unmarked harvest article is merely treated
+  # as neutral, which is exactly today's behaviour.
+  #
+  # The weight is deliberately SMALLER than the measured effect. Priors here break near-ties
+  # (RRF ties by construction), they do not dominate relevance — a 26.7x weight would let
+  # provenance outrank the query. At the default strength 0.05 this is a ~2.5% edge on an
+  # otherwise-equal pair, and it can never flip a cross-lane consensus winner (~2x a
+  # single-lane hit).
+  # SCOPE: these markers are the SOURCERS' own convention (the harvest skills stamp them at
+  # knowledge_create time), not user-authored freeform tags, which is what makes them a
+  # reliable signal. They are nonetheless GLOBAL, like `@category_authority` above, so a
+  # future tenant that uses `book-`/`document` to mean something else would inherit this
+  # prior. The failure is bounded and one-directional — a misread tag costs an article its
+  # 0.5 boost, dropping it to the neutral 0.0 every article gets today — so it can never
+  # demote anything below current behaviour. Revisit if a second real tenant appears; the
+  # right fix then is config-driven weight tables for the whole module, not a special case
+  # for this one term.
+  @harvest_marker_prefixes ~w(book- url- yt- doc-)
+  @harvest_marker_tags ~w(web-article newsletter inbox-harvest youtube document book)
+  @first_party_authority 0.5
+  @third_party_authority 0.0
+
   # A verdict-killed idea and a superseded article are demoted hard regardless of the
   # authority toggle — they are dead doctrine that must not outrank live doctrine.
   @kill_tag "verdict-kill"
@@ -158,11 +202,42 @@ defmodule Loopctl.Knowledge.RankingPriors do
   def authority_factor(result, strength, floor, ceiling) do
     cat = category_authority(Map.get(result, :category))
     src = source_authority(Map.get(result, :source_type))
+    prov = provenance_authority(Map.get(result, :tags))
 
-    (1.0 + strength * (cat + src))
+    (1.0 + strength * (cat + src + prov))
     |> max(floor)
     |> min(ceiling)
   end
+
+  @doc """
+  The provenance weight for a result's `tags`: `#{@first_party_authority}` for first-party
+  knowledge, `#{@third_party_authority}` for third-party harvested material (#251).
+
+  Third-party is the POSITIVE test — a structural capture tag stamped by a sourcer
+  (`book-`/`url-`/`yt-`/`doc-` prefixes, or a bare kind tag). First-party is the absence of
+  one, so a marker this function does not know leaves the article neutral rather than
+  demoting real first-party knowledge. `nil` tags are first-party (an article no sourcer
+  stamped).
+  """
+  @spec provenance_authority([String.t()] | nil) :: float()
+  def provenance_authority(nil), do: @first_party_authority
+
+  def provenance_authority(tags) when is_list(tags) do
+    if Enum.any?(tags, &harvest_marker?/1) do
+      @third_party_authority
+    else
+      @first_party_authority
+    end
+  end
+
+  def provenance_authority(_), do: @first_party_authority
+
+  defp harvest_marker?(tag) when is_binary(tag) do
+    tag in @harvest_marker_tags or
+      Enum.any?(@harvest_marker_prefixes, &String.starts_with?(tag, &1))
+  end
+
+  defp harvest_marker?(_), do: false
 
   @doc """
   The demotion FACTOR for dead doctrine: `#{@demote_factor}` when the result carries the

--- a/test/loopctl/knowledge/ranking_priors_test.exs
+++ b/test/loopctl/knowledge/ranking_priors_test.exs
@@ -204,4 +204,103 @@ defmodule Loopctl.Knowledge.RankingPriorsTest do
       assert mult(any, recency_weight: 0.0, authority?: false) == 1.0
     end
   end
+
+  describe "#251 provenance prior: first-party outranks harvested material on a near-tie" do
+    alias Loopctl.Knowledge.RankingPriors
+
+    test "an article with no sourcer capture tag is first-party" do
+      assert RankingPriors.provenance_authority([]) > 0.0
+      assert RankingPriors.provenance_authority(["elixir", "oban"]) > 0.0
+      assert RankingPriors.provenance_authority(nil) > 0.0
+    end
+
+    test "each structural capture PREFIX marks third-party" do
+      for tag <- ["book-0be008289fe8", "url-d046e10f48b3", "yt-eCx3SSCcISo", "doc-3941363c04b3"] do
+        assert RankingPriors.provenance_authority([tag]) == 0.0,
+               "expected #{tag} to mark the article as harvested"
+      end
+    end
+
+    test "each bare kind tag marks third-party" do
+      for tag <- ~w(web-article newsletter inbox-harvest youtube document book) do
+        assert RankingPriors.provenance_authority([tag]) == 0.0,
+               "expected #{tag} to mark the article as harvested"
+      end
+    end
+
+    test "one marker among many first-party tags is enough" do
+      assert RankingPriors.provenance_authority(["elixir", "oban", "yt-abc123", "patterns"]) ==
+               0.0
+    end
+
+    test "a prefix must be a PREFIX — a tag merely containing it stays first-party" do
+      # "notebook-lm" contains "book-" but does not start with it; "handbook" likewise.
+      assert RankingPriors.provenance_authority(["notebook-lm"]) > 0.0
+      assert RankingPriors.provenance_authority(["handbook"]) > 0.0
+    end
+
+    test "a first-party doc outranks an otherwise-IDENTICAL harvested doc" do
+      first_party = %{category: :finding, updated_at: @now, tags: ["elixir"], status: :published}
+
+      harvested = %{
+        category: :finding,
+        updated_at: @now,
+        tags: ["web-article"],
+        status: :published
+      }
+
+      assert mult(first_party, []) > mult(harvested, [])
+    end
+
+    test "the prior BREAKS ties but never dominates relevance or category" do
+      # A harvested `decision` must still outrank a first-party `idea`: provenance is a
+      # tiebreaker, not an override of the far larger category spread.
+      harvested_decision = %{
+        category: :decision,
+        updated_at: @now,
+        tags: ["web-article"],
+        status: :published
+      }
+
+      first_party_idea = %{category: :idea, updated_at: @now, tags: [], status: :published}
+
+      assert mult(harvested_decision, []) > mult(first_party_idea, [])
+    end
+
+    test "it stays inside the bounded band — no saturation at the common shape" do
+      # source_type is NULL for ~98% of the corpus, so the realistic maximum is
+      # category(1.0) + provenance(0.5) = 1.5, well under the 2.0 the ceiling needs.
+      best = %{category: :decision, updated_at: @now, tags: [], status: :published}
+
+      factor = RankingPriors.authority_factor(best, 0.05, 0.9, 1.1)
+
+      assert factor < 1.1, "expected headroom below the ceiling, got #{factor}"
+      assert factor > 1.0
+    end
+
+    test "a verdict-kill first-party doc is still demoted below a clean harvested one" do
+      killed_first_party = %{
+        category: :decision,
+        updated_at: @now,
+        tags: ["verdict-kill"],
+        status: :published
+      }
+
+      clean_harvested = %{
+        category: :decision,
+        updated_at: @now,
+        tags: ["web-article"],
+        status: :published
+      }
+
+      assert mult(clean_harvested, []) > mult(killed_first_party, [])
+    end
+
+    test "provenance is gated by the authority toggle like the rest of the prior" do
+      first_party = %{category: :finding, updated_at: @now, tags: [], status: :published}
+      harvested = %{category: :finding, updated_at: @now, tags: ["book-abc"], status: :published}
+
+      assert mult(first_party, authority?: false) == mult(harvested, authority?: false)
+    end
+  end
 end


### PR DESCRIPTION
Rank first-party knowledge above harvested material on near-ties

A KB consumption audit found the corpus is barely read: 1,447 of 78,932 published
articles have ever been opened, 1.8 percent. Retrieval is not the problem. Two
known-item probes both returned the correct article at rank 1. The problem is what
every query has to be pulled out of.

Measured on the live corpus over 30 days of reads, split by provenance:

  first-party               3,164 articles   389.7 reads/1k   18.30 percent ever read
  third-party (harvested)  75,768 articles    14.6 reads/1k    1.09 percent ever read

A 26.7x per-article read rate. First-party is 4 percent of the corpus and 53 percent
of the reads. The June 2026 bulk harvest added 76k third-party articles in one pass,
and search has been pulling the 3k articles anyone actually opens out of that pool
ever since.

The existing authority prior could not see this axis. It reads category and
source_type, and 83,487 of 85,157 articles carry a NULL source_type, the entire
harvest included, so the source term returns its zero default for essentially the
whole corpus. The sourcers do stamp a structural capture tag, so the new provenance
term reads tags instead. Verified as a discriminator before being relied on rather
than after: it marks 98.5 percent of the June harvest and 0.4 percent of the
pre-June curated set.

Third-party is the positive test and first-party is the absence of a marker, never
the reverse. A first-party allowlist would have to enumerate every repo and topic tag
that will ever be used, and each one it missed would silently demote real first-party
knowledge. This direction fails safe: an unrecognized marker costs an article its
boost and leaves it at the neutral weight every article already has, so nothing can
end up below current behaviour.

The weight is deliberately far smaller than the measured ratio. Priors here break
near-ties, which RRF produces by construction, and must never dominate relevance. At
the default strength this is about a 2.5 percent edge on an otherwise-equal pair, it
cannot flip a cross-lane consensus winner, and a test asserts a harvested decision
still outranks a first-party idea. Saturation is not a concern at the realistic
shape: with source_type null the maximum is category 1.0 plus provenance 0.5, well
under the 2.0 the ceiling needs.

Mutation-verified: neutralizing the term fails exactly the one test that depends on
its wiring. Full gate green, 7,381 tests.
