### PR TITLE
Make the smoke a gate instead of an after-the-fact detector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -891,13 +891,49 @@ jobs:
             echo "::warning::could not drop $SCALE_DB — reclaim it by hand."
           fi
 
+  # --- Pre-deploy smoke (#652) -------------------------------------------------
+  #
+  # Runs the SAME scripts/smoke.sh against the CURRENTLY-LIVE release, on every PR and
+  # every master push, BEFORE deploy. It exists because the post-deploy smoke below can
+  # only ever tell you something is wrong AFTER the bad release is serving traffic —
+  # "we find out late" — and, running only on master push, it can never report on a PR
+  # head SHA, so it CANNOT be made a required branch-protection check without
+  # deadlocking every merge (a required check that never runs on the PR blocks it
+  # forever). This job can, because it runs on pull_request.
+  #
+  # BE CLEAR ABOUT WHAT IT PROVES. It probes the release already in production, NOT the
+  # code in the PR, so it does not validate your diff. What it does catch, at PR time
+  # instead of post-deploy:
+  #   * production is ALREADY broken — do not deploy on top of it;
+  #   * scripts/smoke.sh itself is broken, or its key/secret has expired or lost the
+  #     privileges the checks need — the detector failing silently is how you end up
+  #     trusting a green that means nothing;
+  #   * the runner cannot reach the app at all, which is exactly the 2026-08-11 failure
+  #     (8/8 checks at HTTP 000 against a demonstrably healthy release).
+  #
+  # It does NOT need the deploy credentials — read-only probes with a low-privilege key.
+  smoke-preflight:
+    name: Pre-deploy Smoke (current release)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Run smoke against the live release
+        env:
+          BASE_URL: https://loopctl.com
+          LOOPCTL_SMOKE_KEY: ${{ secrets.LOOPCTL_SMOKE_KEY }}
+        run: bash scripts/smoke.sh
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
     # pgbouncer-e2e gates deploy (US-27.13): it is the only check that exercises the pgbouncer
     # layer, so a reintroduced pgbouncer-incompatible config must block the deploy, not just
     # go red advisorily.
-    needs: [lint, test, security, dialyzer, pgbouncer-e2e, retrieval-eval]
+    needs: [lint, test, security, dialyzer, pgbouncer-e2e, retrieval-eval, smoke-preflight]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4

--- a/docs/runbooks/post-deploy-smoke.md
+++ b/docs/runbooks/post-deploy-smoke.md
@@ -227,3 +227,39 @@ release never breaks, and so a rollback is always safe:
 Rule of thumb: **a rollback to the previous release must succeed against the
 current database at all times.** If a migration would break the old release,
 it's not expand–contract — split it.
+
+## Pre-deploy smoke (#652) — and why the post-deploy one is not a required check
+
+There are now TWO smoke jobs running the same `scripts/smoke.sh`:
+
+| Job | Runs on | Probes | Can be a required check? |
+|---|---|---|---|
+| `Pre-deploy Smoke (current release)` | every PR + every master push | the release already live | **yes** |
+| `Post-deploy Smoke` | master push, after deploy | the release just shipped | **no** |
+
+The post-deploy job cannot be made a required branch-protection check. It only runs on a
+master push, i.e. *after* the merge, so it never reports on a PR's head SHA — adding it to
+required checks blocks every PR forever waiting for a check that will never arrive. The
+pre-deploy job exists to be the required one, and `deploy` now `needs:` it, so a release
+never lands on top of a production that is already failing its own smoke.
+
+**Be clear about what pre-deploy proves.** It probes the CURRENTLY-LIVE release, not the
+code in the PR, so it does not validate your diff. It catches, at PR time: production
+already broken; `smoke.sh` itself broken or its key expired/under-privileged; and the
+runner being unable to reach the app at all.
+
+## Connection retry (#652)
+
+`http()` retries **only** an `HTTP 000` — a connection-level failure (DNS, connect,
+timeout) that never reached the app and therefore says nothing about the release. A wrong
+*status* (500, 404, a 401 where 200 was expected) is a real finding and fails on the first
+attempt; retrying those is how a detector becomes a lie.
+
+Knobs: `SMOKE_CONNECT_RETRIES` (default 3), `SMOKE_RETRY_DELAY_SECS` (default 5).
+`wait_for_health` sets `HTTP_NO_RETRY=1` for its own loop — it already owns a 10-attempt
+backoff, and letting both run multiplies into a multi-minute stall on an unreachable host.
+
+Why this was added: on 2026-08-11 all 8 checks reported `HTTP 000` on two consecutive runs
+against a release that was demonstrably healthy — the app served its own Fly health check
+every 10s throughout both windows, and the identical script passed from a workstation
+seconds later. A detector that goes red on network weather is one people learn to ignore.

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -36,6 +36,21 @@ SMOKE_MAX_MS="${SMOKE_MAX_MS:-5000}"
 # (an outbound LLM call, ~1-3s), so they get a wider budget than the pure DB paths.
 SMOKE_EMBED_MAX_MS="${SMOKE_EMBED_MAX_MS:-8000}"
 KEY="${LOOPCTL_SMOKE_KEY:-}"
+# Connection-level retry (#652). A check that comes back 000 never reached the app —
+# DNS, connect, or timeout — so it says nothing about the release under test. The app
+# runs with autostop, so a quiet period means the first probe after a deploy can pay a
+# cold start, and a transient network path between the runner and the edge produces the
+# same signature. Both turned master red against a demonstrably healthy release on
+# 2026-08-11: all 8 checks reported 000 while the app was serving its own health check
+# every 10s throughout the window.
+# ONLY 000 is retried. A wrong STATUS (500, 404, 401-where-200-expected) is a real
+# finding about the release and fails on the first attempt — retrying those is how a
+# detector turns into a lie.
+SMOKE_CONNECT_RETRIES="${SMOKE_CONNECT_RETRIES:-3}"
+SMOKE_RETRY_DELAY_SECS="${SMOKE_RETRY_DELAY_SECS:-5}"
+# Warmup budget: how long to wait for the release to answer AT ALL before judging it.
+# Set to 0 to skip (useful when probing a known-warm host).
+SMOKE_WARMUP_SECS="${SMOKE_WARMUP_SECS:-60}"
 
 # ✓ / ⚠ / ✗ markers.
 OK="✓"
@@ -91,16 +106,34 @@ http() {
   local out
   # --max-time gives curl a hard ceiling a few seconds above the widest per-check
   # latency budget so a hung endpoint can't stall the whole run.
-  if out=$(curl -sS -X "$method" \
-      -o "$BODY" -D "$HDRS" \
-      -w '%{http_code} %{time_total}' \
-      --max-time "$CURL_MAX_SECS" \
-      "$@" \
-      "$url" 2>/dev/null); then
-    :
-  else
-    out="000 0"
-  fi
+  local attempt=1
+  while :; do
+    if out=$(curl -sS -X "$method" \
+        -o "$BODY" -D "$HDRS" \
+        -w '%{http_code} %{time_total}' \
+        --max-time "$CURL_MAX_SECS" \
+        "$@" \
+        "$url" 2>/dev/null); then
+      :
+    else
+      out="000 0"
+    fi
+
+    # Retry ONLY a connection-level failure, and only while attempts remain. Any real
+    # HTTP status — including a bad one — is the answer we came for; return it at once.
+    case "${out%% *}" in
+      000)
+        if [ "${HTTP_NO_RETRY:-0}" != "1" ] && [ "$attempt" -lt "$SMOKE_CONNECT_RETRIES" ]; then
+          printf '  … %s %s did not connect (attempt %d/%d), retrying in %ss\n' \
+            "$method" "$url" "$attempt" "$SMOKE_CONNECT_RETRIES" "$SMOKE_RETRY_DELAY_SECS" >&2
+          sleep "$SMOKE_RETRY_DELAY_SECS"
+          attempt=$((attempt + 1))
+          continue
+        fi
+        ;;
+    esac
+    break
+  done
   HTTP_CODE="${out%% *}"
   local secs="${out##* }"
   TIME_MS="$(awk -v t="$secs" 'BEGIN { printf "%d", t * 1000 }')"
@@ -186,6 +219,11 @@ echo "loopctl post-deploy smoke — ${BASE_URL} (budget ${SMOKE_MAX_MS}ms; embed
 # on the first attempt.
 wait_for_health() {
   local attempt=1 max=10 delay=1
+  # This loop IS the connection retry for /health, so the inner per-request retry is
+  # suppressed here (#652). Leaving both on multiplies them — 10 outer attempts x
+  # SMOKE_CONNECT_RETRIES inner x the curl ceiling is a multi-minute stall on a host
+  # that is simply unreachable, which is the case this loop exists to end quickly.
+  local HTTP_NO_RETRY=1
   while [ "$attempt" -le "$max" ]; do
     http GET "$BASE_URL/health"
     if [ "$HTTP_CODE" = "200" ]; then

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -51,6 +51,13 @@ SMOKE_RETRY_DELAY_SECS="${SMOKE_RETRY_DELAY_SECS:-5}"
 # Warmup budget: how long to wait for the release to answer AT ALL before judging it.
 # Set to 0 to skip (useful when probing a known-warm host).
 SMOKE_WARMUP_SECS="${SMOKE_WARMUP_SECS:-60}"
+# IP version pin. loopctl.com publishes BOTH an A and a AAAA record (Fly gives the app a
+# dedicated v4 and v6 ingress). A host that has an IPv6 address configured but no working
+# IPv6 ROUTE — the normal shape of a GitHub Actions runner — can stall on the v6 attempt
+# instead of falling back, which surfaces as HTTP 000 on every check against an app that
+# is demonstrably healthy from anywhere else. Pinning v4 removes that whole class.
+# Set SMOKE_IP_VERSION="" to let curl choose, or "-6" to force v6.
+SMOKE_IP_VERSION="${SMOKE_IP_VERSION:--4}"
 
 # ✓ / ⚠ / ✗ markers.
 OK="✓"
@@ -108,7 +115,7 @@ http() {
   # latency budget so a hung endpoint can't stall the whole run.
   local attempt=1
   while :; do
-    if out=$(curl -sS -X "$method" \
+    if out=$(curl -sS ${SMOKE_IP_VERSION:+"$SMOKE_IP_VERSION"} -X "$method" \
         -o "$BODY" -D "$HDRS" \
         -w '%{http_code} %{time_total}' \
         --max-time "$CURL_MAX_SECS" \


### PR DESCRIPTION
Make the smoke a gate instead of an after-the-fact detector, and stop it going red on network weather

Two problems, one root: the only smoke ran AFTER the deploy, so it could only ever
report that a bad release was already serving traffic, and it had no retry, so it
also went red when nothing was wrong.

On 2026-08-11 all eight checks reported HTTP 000 on two consecutive runs against a
release that was demonstrably healthy. The app served its own Fly health check every
ten seconds throughout both windows with no errors, and the identical script passed
from a workstation seconds later, all eight checks green in under a second each. HTTP
000 is a connection-level failure that never reached the app, so it says nothing at
all about the release under test. A detector that goes red on network weather is one
people learn to ignore, which is worse than not having it.

RETRY. http() now retries only an HTTP 000, three attempts by default, tunable via
SMOKE_CONNECT_RETRIES and SMOKE_RETRY_DELAY_SECS. A wrong STATUS is never retried. A
500, a 404, a 401 where 200 was expected are real findings about the release and fail
on the first attempt; retrying those is how a detector turns into a lie. Both halves
are verified rather than assumed: against an unreachable host the retry fires, and
against a host answering real statuses it fires exactly zero times.

wait_for_health sets HTTP_NO_RETRY for its own loop. It already owns a ten-attempt
backoff, and leaving both on multiplies them into a multi-minute stall on precisely
the unreachable host that loop exists to give up on quickly.

PRE-DEPLOY SMOKE. A new job runs the same script against the currently-live release
on every PR and every master push, and deploy now needs it, so a release cannot land
on top of a production that is already failing its own smoke.

It is deliberately a second job rather than making the existing one required. The
post-deploy job runs only on a master push, after the merge, so it never reports on a
PR head SHA. Adding it to required branch-protection checks would block every PR
forever, waiting for a check that can never arrive. The new job runs on pull_request,
so it can carry that role.

What pre-deploy proves is narrower than it looks and the runbook says so: it probes
the live release, not the code in the PR, so it does not validate the diff. It catches
production already being broken, the smoke script itself being broken or its key
expired or under-privileged, and the runner being unable to reach the app at all,
which is exactly the failure above, at PR time instead of after a deploy.
