### PR TITLE
Cover the service contract and the coordination bus with hermetic e2e journeys

### DIFF
--- a/test/e2e/coordination_handoff_journey_test.exs
+++ b/test/e2e/coordination_handoff_journey_test.exs
@@ -1,0 +1,154 @@
+defmodule Loopctl.E2E.CoordinationHandoffJourneyTest do
+  @moduledoc """
+  End-to-end journey for the repo coordination bus (Epics 39/40): the handoff that lets
+  a session on one machine pass work to a session on another with no human relay.
+
+  The property that matters is EXACTLY-ONCE. A handoff is discovered by many sessions
+  and must be executed by one, so the claim — not the post, and not the reader's good
+  intentions — is what prevents two machines doing the same work. This journey drives
+  the whole path an agent takes (post -> discover -> claim -> second claimant refused
+  -> done) and asserts that a claimed handoff stops being advertised, which is what
+  clears it from every other session's startup context.
+
+  Excluded from the default suite (`@moduletag :e2e`); run with `mix test.e2e`.
+  """
+  use LoopctlWeb.ConnCase, async: true
+
+  @moduletag :e2e
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  # A channel write is project-scoped by MEMBERSHIP (US-40.D3), and membership is
+  # derived from a story assignment — an agent with no story in the project is refused
+  # `ownership_rejected` by the default-deny gate even though its key is valid and
+  # carries an agent identity. Both properties are load-bearing for a handoff: the key
+  # must be attributable (agent_id) AND admitted to the channel (membership).
+  defp member_agent(tenant, project) do
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+
+    {raw, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: agent.id})
+
+    fixture(:story, %{
+      tenant_id: tenant.id,
+      project_id: project.id,
+      assigned_agent_id: agent.id,
+      agent_status: :assigned
+    })
+
+    raw
+  end
+
+  describe "handoff journey: post -> discover -> claim -> done" do
+    test "a posted handoff is discoverable, claimable exactly once, and retired by done",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      # Two DISTINCT member agents — the claim gate is between agents, so one key
+      # cannot demonstrate it.
+      raw_a = member_agent(tenant, project)
+      raw_b = member_agent(tenant, project)
+
+      anchor = "e2e-handoff-#{System.unique_integer([:positive])}"
+      ref = "handoff:#{anchor}"
+
+      # 1) POST the pointer. Body is a TL;DR + where the full context lives — the bus is
+      # a coordination signal, not a document store.
+      posted =
+        conn
+        |> auth_conn(raw_a)
+        |> post(~p"/api/v1/channel/posts", %{
+          project_id: project.id,
+          key: ref,
+          body: "HANDOFF #{anchor}: full context in the durable home."
+        })
+        |> json_response(201)
+
+      assert posted["post"]["key"] == ref
+
+      # 2) DISCOVER — an unclaimed handoff is advertised.
+      listed =
+        conn
+        |> auth_conn(raw_b)
+        |> get(~p"/api/v1/channel/handoffs", %{project_id: project.id})
+        |> json_response(200)
+
+      assert ref in Enum.map(listed["data"], & &1["key"]),
+             "a freshly posted, unclaimed handoff must be discoverable"
+
+      # 3) CLAIM — the first claimant wins.
+      conn
+      |> auth_conn(raw_b)
+      |> post(~p"/api/v1/channel/claims", %{project_id: project.id, ref: ref})
+      |> json_response(201)
+
+      # 4) The anti-double-work gate: a DIFFERENT agent is refused with 409. This is the
+      # single assertion the whole mechanism exists for — without it two machines do the
+      # same work, and the failure is invisible because both succeed.
+      conflict =
+        conn
+        |> auth_conn(raw_a)
+        |> post(~p"/api/v1/channel/claims", %{project_id: project.id, ref: ref})
+
+      assert conflict.status == 409
+
+      # 5) A claimed handoff stops being advertised, so no other session is offered work
+      # that is already owned.
+      after_claim =
+        conn
+        |> auth_conn(raw_a)
+        |> get(~p"/api/v1/channel/handoffs", %{project_id: project.id})
+        |> json_response(200)
+
+      refute ref in Enum.map(after_claim["data"], & &1["key"]),
+             "a claimed handoff must leave the discovery list"
+
+      # 6) DONE is terminal — it must not resurface afterwards.
+      conn
+      |> auth_conn(raw_b)
+      |> post(~p"/api/v1/channel/claims/done", %{project_id: project.id, ref: ref})
+      |> json_response(200)
+
+      after_done =
+        conn
+        |> auth_conn(raw_a)
+        |> get(~p"/api/v1/channel/handoffs", %{project_id: project.id})
+        |> json_response(200)
+
+      refute ref in Enum.map(after_done["data"], & &1["key"])
+    end
+
+    test "re-claiming your OWN active ref is idempotent, so a lost response is safe to retry",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      raw = member_agent(tenant, project)
+
+      ref = "handoff:e2e-idem-#{System.unique_integer([:positive])}"
+
+      conn
+      |> auth_conn(raw)
+      |> post(~p"/api/v1/channel/posts", %{project_id: project.id, key: ref, body: "idempotency"})
+      |> json_response(201)
+
+      first =
+        conn
+        |> auth_conn(raw)
+        |> post(~p"/api/v1/channel/claims", %{project_id: project.id, ref: ref})
+        |> json_response(201)
+
+      # Same agent, same ref: returns the existing claim rather than 409ing itself out of
+      # its own work. A timeout on the first call must not strand the handoff.
+      again =
+        conn
+        |> auth_conn(raw)
+        |> post(~p"/api/v1/channel/claims", %{project_id: project.id, ref: ref})
+
+      assert again.status in [200, 201]
+      assert json_response(again, again.status)["claim"]["id"] == first["claim"]["id"]
+    end
+  end
+end

--- a/test/e2e/service_contract_journey_test.exs
+++ b/test/e2e/service_contract_journey_test.exs
@@ -1,0 +1,105 @@
+defmodule Loopctl.E2E.ServiceContractJourneyTest do
+  @moduledoc """
+  End-to-end journey for the service contract every client depends on BEFORE it can
+  do anything useful: is the service up, is it ready, and does it refuse the
+  unauthenticated?
+
+  Why this is an e2e test and not (only) a production probe. These exact checks live
+  in `scripts/smoke.sh`, which probes the DEPLOYED release over HTTP. That probe is a
+  good detector and a bad gate: it can only run after a release is already serving
+  traffic, it cannot run against a pull request at all, and it fails whenever the
+  network between the runner and the app misbehaves — on 2026-08-11 it reported all
+  eight checks down against an app that was demonstrably healthy, because the runner
+  had no working IPv6 route. A required check that can be felled by network weather
+  wedges the repository shut.
+
+  These assertions are hermetic: same contract, no network, runs on every PR, and
+  therefore can gate a merge. The probe still runs against production, where it
+  answers the different question of whether the live release is serving.
+
+  Excluded from the default suite (`@moduletag :e2e`); run with `mix test.e2e`.
+  """
+  use LoopctlWeb.ConnCase, async: true
+
+  @moduletag :e2e
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  describe "liveness and readiness" do
+    test "GET /health answers unauthenticated, and reports its dependency checks",
+         %{conn: conn} do
+      body = conn |> get(~p"/health") |> json_response(200)
+
+      # The smoke's hard requirement: a 200 whose database check is "ok". Oban-only
+      # degradation is deliberately NOT a rollback signal there, so it is not asserted
+      # as healthy here either — only that the field is reported at all.
+      assert body["status"] in ["ok", "degraded"]
+      assert is_map(body["checks"])
+      assert body["checks"]["database"] == "ok"
+
+      # #461 item 5: the running build is deliberately NOT disclosed on this
+      # unauthenticated endpoint. A regression that starts leaking it should fail here.
+      refute Map.has_key?(body, "version")
+    end
+
+    test "GET /health/ready answers, and says whether it is ready", %{conn: conn} do
+      conn = get(conn, ~p"/health/ready")
+
+      # Readiness legitimately reports 503 when a dependency is down — the contract is
+      # that it ANSWERS with a boolean verdict, not that it is always ready.
+      assert conn.status in [200, 503]
+      assert is_boolean(json_response(conn, conn.status)["ready"])
+    end
+  end
+
+  describe "auth boundary" do
+    test "an API route refuses an unauthenticated caller with 401", %{conn: conn} do
+      conn = get(conn, ~p"/api/v1/knowledge/count")
+
+      assert json_response(conn, 401)
+    end
+
+    test "a garbage bearer token is refused with 401, not a 500", %{conn: conn} do
+      # Distinguishes "rejected" from "crashed while rejecting" — a 500 here would mean
+      # an unparseable credential reaches code that assumes a well-formed one.
+      conn =
+        conn
+        |> auth_conn("lc_not_a_real_key_#{System.unique_integer([:positive])}")
+        |> get(~p"/api/v1/knowledge/count")
+
+      assert json_response(conn, 401)
+    end
+
+    test "a valid key from tenant A cannot read tenant B's counts", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {raw_key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :agent})
+
+      marker = "svcjrny#{System.unique_integer([:positive])}"
+
+      for _ <- 1..2 do
+        fixture(:article, %{
+          tenant_id: tenant_b.id,
+          title: "#{marker} #{System.unique_integer([:positive])}",
+          body: "tenant B only",
+          category: :pattern,
+          status: :published
+        })
+      end
+
+      body =
+        conn
+        |> auth_conn(raw_key_a)
+        |> get(~p"/api/v1/knowledge/count")
+        |> json_response(200)
+
+      # A's count must not include B's articles. Asserting on the SEARCH surface too
+      # would only prove the query missed; the count proves the scope.
+      assert body["count"] == 0
+    end
+  end
+end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -131,12 +131,19 @@ defmodule Loopctl.DataCase do
       &NoopBodyProbe.ignore/1
     end)
 
+    # Shape MUST match `Loopctl.HealthCheck.Default.check/0`. It notably carries NO
+    # `version` key: #461 item 5 removed the app version from this response on purpose,
+    # because /health is the highest-frequency unauthenticated probe and there is no
+    # reason to hand a version fingerprint to every caller. The stub used to return
+    # `version: "0.1.0-test"`, so every test asserting on the health payload was
+    # asserting against a field the real endpoint deliberately does not emit — a test
+    # double that quietly re-adds what production removed cannot catch its removal
+    # regressing.
     Mox.stub(Loopctl.MockHealthChecker, :check, fn ->
       {:ok,
        %{
          status: "ok",
          ready: true,
-         version: "0.1.0-test",
          checks: %{database: "ok", oban: "ok"}
        }}
     end)


### PR DESCRIPTION
Cover the service contract and the coordination bus with hermetic e2e journeys

The e2e suite covered the context retriever heavily and custody well, but the two
things every client touches first were untested: whether the service says it is up
and refuses the unauthenticated, and whether a handoff can be claimed exactly once.

Those first checks existed only in scripts/smoke.sh, which probes the deployed
release over HTTP. That probe is a good detector and a bad gate. It cannot run
against a pull request at all, it only runs after a bad release is already serving
traffic, and it fails on network weather: on 2026-08-11 it reported all eight checks
down against an app that was demonstrably healthy, because the runner had no working
IPv6 route. A required check that network weather can fell wedges the repository
shut. The same contract asserted hermetically runs on every PR and can gate a merge,
which is what makes this suite match the home_care_billing shape.

SERVICE CONTRACT. Liveness and readiness answer and report a dependency verdict; an
API route refuses an unauthenticated caller with 401; a malformed bearer token is
refused with 401 rather than crashing into a 500, which distinguishes rejected from
crashed while rejecting; and a valid key from one tenant reads a zero count while
another tenant holds articles. The count is the assertion rather than a search,
because a search returning nothing only proves the query missed, while the count
proves the scope.

COORDINATION BUS. The full path an agent walks: post, discover, claim, second
claimant refused with 409, claimed handoff leaves the discovery list, done is
terminal. The 409 is the single assertion the mechanism exists for, since without it
two machines do the same work and the failure is invisible because both succeed.
Writing it surfaced two product constraints worth having pinned: a channel post is
attributed, so an agent-ROLE key with no agent identity is refused, and writes are
project-scoped by membership derived from a story assignment, so a valid attributed
key that is not a member is refused as well.

A TEST DOUBLE THAT CONTRADICTED PRODUCTION. Writing the health assertion failed
against the mock, not the app. 461 item 5 deliberately removed the app version from
the health response, because it is the highest-frequency unauthenticated probe and
there is no reason to hand a version fingerprint to every caller. The Mox stub in
DataCase still returned one, so every test asserting on the health payload was
asserting against a field the real endpoint does not emit, and nothing could have
caught that removal regressing. The stub now matches the real shape, and the new
test asserts the absence.

Suite goes from 17 to 24 tests, all green, and full precommit is green.
