### PR TITLE
TEMP - proving MCP Server Gate reports on a non-mcp PR - do not merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ mcp-server/node_modules/
 # Playwright MCP session output (transient)
 .playwright-mcp/
 .claude/implement-plan.run.json
+


### PR DESCRIPTION
Throwaway. The gate became a required check while only its ran-the-suite branch had been exercised. This PR touches no mcp-server path, so it proves the skipped branch reports pass rather than parking every PR on Expected. Closing as soon as the gate reports.