### PR TITLE
Resolve a project_id that carries a repo name, instead of 422ing the scope away

### DIFF
--- a/lib/loopctl/projects.ex
+++ b/lib/loopctl/projects.ex
@@ -141,6 +141,124 @@ defmodule Loopctl.Projects do
   end
 
   @doc """
+  Resolves a project REFERENCE — the string an agent actually types when it means
+  "this repo" — to a project within a tenant (#652).
+
+  Measured on ~2,100 real agent searches: when a UUID is demanded and an agent
+  supplies something else, it supplies the repo's DIRECTORY name, exactly as the
+  checkout spells it — `home_care_billing` (x24), `loopctl` (x3). Never a name, never
+  a path, never a malformed UUID. `home_care_billing` is not this tenant's slug
+  (`home-care-billing` is) and it is not a resolvable `repo_url` either (a bare basename
+  has no `owner/repo` shape), so neither `get_project_by_slug/2` nor `resolve_project/2`
+  answers the case that actually occurs. This does.
+
+  Three passes, most-specific first:
+
+    1. the exact `slug`;
+    2. the slug NORMALIZED — downcased, `_`/whitespace/`.` folded to `-` — which is
+       precisely the transform between a repo directory and this app's slug format;
+    3. the repo BASENAME of an active project's `repo_url`, compared on the same
+       normalized form. This is what resolves a project whose slug drifted from its
+       repo (`freight-pilot` -> slug `freight-pilot-2`).
+
+  Pass 3 is `:ambiguous` rather than oldest-wins when two active projects share a
+  basename: silently picking one would scope a query to the wrong repo, which is the
+  failure mode this whole change exists to remove.
+
+  Tenant-scoped by an explicit predicate on every pass, so a reference belonging to
+  another tenant is indistinguishable from a typo.
+
+  ## Returns
+
+  - `{:ok, %Project{}, :slug | :normalized_slug | :repo_name}` on a single match
+  - `{:error, :not_found}` when nothing matches (including a blank reference)
+  - `{:error, :ambiguous}` when the basename pass matches more than one project
+  """
+  # Same bound, and for the same reason, as @resolve_candidate_limit below: the tenant's
+  # active-project set is already small (max_projects defaults to 50), so this only keeps
+  # a raised limit from materializing an unbounded set. Declared separately because a
+  # module attribute must exist before the function that reads it.
+  @project_ref_candidate_limit 100
+
+  @spec resolve_project_ref(Ecto.UUID.t(), term()) ::
+          {:ok, Project.t(), :slug | :normalized_slug | :repo_name}
+          | {:error, :not_found | :ambiguous}
+  def resolve_project_ref(tenant_id, ref) when is_binary(ref) do
+    case presence(ref) do
+      nil ->
+        {:error, :not_found}
+
+      trimmed ->
+        normalized = normalize_project_ref(trimmed)
+
+        with :error <- resolve_ref_by_slug(tenant_id, trimmed, :slug),
+             :error <- resolve_ref_by_normalized_slug(tenant_id, trimmed, normalized) do
+          resolve_ref_by_repo_name(tenant_id, normalized)
+        end
+    end
+  end
+
+  def resolve_project_ref(_tenant_id, _ref), do: {:error, :not_found}
+
+  defp resolve_ref_by_slug(tenant_id, slug, matched_by) do
+    case AdminRepo.get_by(Project, slug: slug, tenant_id: tenant_id) do
+      nil -> :error
+      project -> {:ok, project, matched_by}
+    end
+  end
+
+  # Skipped when normalization is a no-op, so the identical lookup is not run twice.
+  defp resolve_ref_by_normalized_slug(_tenant_id, same, same), do: :error
+  defp resolve_ref_by_normalized_slug(_tenant_id, _trimmed, ""), do: :error
+
+  defp resolve_ref_by_normalized_slug(tenant_id, _trimmed, normalized),
+    do: resolve_ref_by_slug(tenant_id, normalized, :normalized_slug)
+
+  defp resolve_ref_by_repo_name(_tenant_id, ""), do: {:error, :not_found}
+
+  defp resolve_ref_by_repo_name(tenant_id, normalized) do
+    # Bounded by the tenant's project count (max_projects defaults to 50) and capped
+    # again here; the basename comparison is on the NORMALIZED form, which no SQL
+    # predicate can express, so the narrowing happens in Elixir over a small set.
+    Project
+    |> where([p], p.tenant_id == ^tenant_id and not is_nil(p.repo_url))
+    |> where([p], p.status == :active)
+    |> order_by([p], asc: p.inserted_at)
+    |> limit(@project_ref_candidate_limit)
+    |> AdminRepo.all()
+    |> Enum.filter(fn project ->
+      normalize_project_ref(repo_basename(project.repo_url)) == normalized
+    end)
+    |> case do
+      [project] -> {:ok, project, :repo_name}
+      [] -> {:error, :not_found}
+      [_ | _] -> {:error, :ambiguous}
+    end
+  end
+
+  # The transform between a repo DIRECTORY name and this app's slug format
+  # (lowercase alphanumeric + hyphens, per `Project.create_changeset/2`).
+  defp normalize_project_ref(nil), do: ""
+
+  defp normalize_project_ref(value) when is_binary(value) do
+    value
+    |> String.trim()
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/u, "-")
+    |> String.trim("-")
+  end
+
+  # Trailing path segment of a repo URL / ssh spec / bare owner/repo, ".git" stripped.
+  defp repo_basename(nil), do: nil
+
+  defp repo_basename(url) when is_binary(url) do
+    url
+    |> normalize_repo_url()
+    |> String.split(~r{[/:]}, trim: true)
+    |> List.last()
+  end
+
+  @doc """
   Resolves a project within a tenant from one or more identifiers.
 
   Intended as the single cheap call the harness uses to turn "I'm working in

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -44,6 +44,18 @@ defmodule Loopctl.TelemetryEvents do
   def audit_log_write, do: [:loopctl, :audit, :write]
 
   @doc """
+  A client-supplied `project_id` carrying a project REFERENCE (a slug, or the repo
+  directory name) was resolved to that project's UUID at the API boundary (#652).
+
+  Metadata: `%{tenant_id, project_id, ref, matched_by, path}` where `matched_by` is
+  `:slug`, `:normalized_slug` or `:repo_name`. Every emission is one request
+  that would previously have 422'd — and, measured, would then have been retried
+  with the scope dropped entirely. A rising count means agents are still reaching
+  for the slug; a falling one means the tool surface taught them the UUID.
+  """
+  def project_ref_resolved, do: [:loopctl, :project_id, :ref_resolved]
+
+  @doc """
   A vector-search read under-filled (US-27.6b): it returned fewer than the
   requested `k` candidates AND above-threshold (near) neighbors the inner ANN
   surfaced were hidden by the already-linked anti-join — `above_threshold >

--- a/lib/loopctl_web/controllers/analytics_controller.ex
+++ b/lib/loopctl_web/controllers/analytics_controller.ex
@@ -39,7 +39,11 @@ defmodule LoopctlWeb.AnalyticsController do
       "Returns per-agent cost metrics including efficiency ranking. " <>
         "Filterable by project_id and date range.",
     parameters: [
-      project_id: [in: :query, type: :string, description: "Filter by project UUID"],
+      project_id: [
+        in: :query,
+        type: :string,
+        description: "Filter by project: UUID, slug, or repo directory name"
+      ],
       since: [in: :query, type: :string, description: "Start date (YYYY-MM-DD)"],
       until: [in: :query, type: :string, description: "End date (YYYY-MM-DD)"],
       page: [in: :query, type: :integer, description: "Page number"],
@@ -68,7 +72,11 @@ defmodule LoopctlWeb.AnalyticsController do
       "Returns per-epic cost breakdown including budget utilization and model breakdown. " <>
         "Filterable by project_id.",
     parameters: [
-      project_id: [in: :query, type: :string, description: "Filter by project UUID"],
+      project_id: [
+        in: :query,
+        type: :string,
+        description: "Filter by project: UUID, slug, or repo directory name"
+      ],
       page: [in: :query, type: :integer, description: "Page number"],
       page_size: [in: :query, type: :integer, description: "Items per page"]
     ],
@@ -117,7 +125,11 @@ defmodule LoopctlWeb.AnalyticsController do
       "Returns per-model token usage, cost, and verification correlation metrics. " <>
         "Filterable by project_id and date range.",
     parameters: [
-      project_id: [in: :query, type: :string, description: "Filter by project UUID"],
+      project_id: [
+        in: :query,
+        type: :string,
+        description: "Filter by project: UUID, slug, or repo directory name"
+      ],
       since: [in: :query, type: :string, description: "Start date (YYYY-MM-DD)"],
       until: [in: :query, type: :string, description: "End date (YYYY-MM-DD)"],
       page: [in: :query, type: :integer, description: "Page number"],
@@ -151,7 +163,11 @@ defmodule LoopctlWeb.AnalyticsController do
         type: :string,
         description: "Grouping: 'daily' (default) or 'weekly'"
       ],
-      project_id: [in: :query, type: :string, description: "Filter by project UUID"],
+      project_id: [
+        in: :query,
+        type: :string,
+        description: "Filter by project: UUID, slug, or repo directory name"
+      ],
       since: [in: :query, type: :string, description: "Start date (YYYY-MM-DD)"],
       until: [in: :query, type: :string, description: "End date (YYYY-MM-DD)"],
       page: [in: :query, type: :integer, description: "Page number"],
@@ -182,7 +198,11 @@ defmodule LoopctlWeb.AnalyticsController do
         "mixed-model vs single-model agent averages. " <>
         "Filterable by project_id, agent_id, and date range.",
     parameters: [
-      project_id: [in: :query, type: :string, description: "Filter by project UUID"],
+      project_id: [
+        in: :query,
+        type: :string,
+        description: "Filter by project: UUID, slug, or repo directory name"
+      ],
       agent_id: [in: :query, type: :string, description: "Filter by agent UUID"],
       since: [in: :query, type: :string, description: "Start date (YYYY-MM-DD)"],
       until: [in: :query, type: :string, description: "End date (YYYY-MM-DD)"]
@@ -224,7 +244,11 @@ defmodule LoopctlWeb.AnalyticsController do
         "Filterable by project_id and date range.",
     parameters: [
       id: [in: :path, type: :string, description: "Agent UUID"],
-      project_id: [in: :query, type: :string, description: "Filter by project UUID"],
+      project_id: [
+        in: :query,
+        type: :string,
+        description: "Filter by project: UUID, slug, or repo directory name"
+      ],
       since: [in: :query, type: :string, description: "Start date (YYYY-MM-DD)"],
       until: [in: :query, type: :string, description: "End date (YYYY-MM-DD)"]
     ],

--- a/lib/loopctl_web/controllers/article_workflow_controller.ex
+++ b/lib/loopctl_web/controllers/article_workflow_controller.ex
@@ -232,7 +232,11 @@ defmodule LoopctlWeb.ArticleWorkflowController do
       "Lists draft articles ordered by inserted_at desc. " <>
         "Includes source_type and source_id for review queue visibility. Role: orchestrator+.",
     parameters: [
-      project_id: [in: :query, type: :string, description: "Filter by project UUID"],
+      project_id: [
+        in: :query,
+        type: :string,
+        description: "Filter by project: UUID, slug, or repo directory name"
+      ],
       limit: [
         in: :query,
         type: :integer,

--- a/lib/loopctl_web/controllers/cost_anomaly_controller.ex
+++ b/lib/loopctl_web/controllers/cost_anomaly_controller.ex
@@ -36,7 +36,11 @@ defmodule LoopctlWeb.CostAnomalyController do
         type: :string,
         description: "Filter by anomaly type: high_cost, suspiciously_low, budget_exceeded"
       ],
-      project_id: [in: :query, type: :string, description: "Filter by project UUID"],
+      project_id: [
+        in: :query,
+        type: :string,
+        description: "Filter by project: UUID, slug, or repo directory name"
+      ],
       include_archived: [
         in: :query,
         type: :boolean,

--- a/lib/loopctl_web/controllers/knowledge_context_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_context_controller.ex
@@ -53,7 +53,7 @@ defmodule LoopctlWeb.KnowledgeContextController do
       project_id: [
         in: :query,
         type: :string,
-        description: "Filter by project UUID",
+        description: "Filter by project: UUID, slug, or repo directory name",
         required: false
       ],
       limit: [

--- a/lib/loopctl_web/controllers/knowledge_facets_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_facets_controller.ex
@@ -51,7 +51,11 @@ defmodule LoopctlWeb.KnowledgeFacetsController do
       source_type: [in: :query, type: :string, description: "Filter by source_type"],
       source_id: [in: :query, type: :string, description: "Filter by source_id"],
       idempotency_key: [in: :query, type: :string, description: "Filter by idempotency_key"],
-      project_id: [in: :query, type: :string, description: "Filter by project UUID"]
+      project_id: [
+        in: :query,
+        type: :string,
+        description: "Filter by project: UUID, slug, or repo directory name"
+      ]
     ],
     responses: %{
       200 =>
@@ -104,7 +108,11 @@ defmodule LoopctlWeb.KnowledgeFacetsController do
       status: [in: :query, type: :string, description: "Filter by status"],
       tags: [in: :query, type: :string, description: "Filter by tags (comma-separated)"],
       match: [in: :query, type: :string, description: "Tag match mode: any (default) or all"],
-      project_id: [in: :query, type: :string, description: "Filter by project UUID"],
+      project_id: [
+        in: :query,
+        type: :string,
+        description: "Filter by project: UUID, slug, or repo directory name"
+      ],
       limit: [
         in: :query,
         type: :integer,

--- a/lib/loopctl_web/controllers/knowledge_search_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_controller.ex
@@ -75,7 +75,7 @@ defmodule LoopctlWeb.KnowledgeSearchController do
       project_id: [
         in: :query,
         type: :string,
-        description: "Filter by project UUID",
+        description: "Filter by project: UUID, slug, or repo directory name",
         required: false
       ],
       category: [

--- a/lib/loopctl_web/helpers/project_id.ex
+++ b/lib/loopctl_web/helpers/project_id.ex
@@ -21,6 +21,13 @@ defmodule LoopctlWeb.Helpers.ProjectId do
       value that could raise. Rejecting them here would needlessly break clients
       that send array-style params.
 
+  Since #652, `LoopctlWeb.Plugs.ResolveProjectRef` runs LAST in the `:authenticated`
+  pipeline and rewrites a `project_id` that carries a project reference (a slug, or the
+  repo directory name an agent actually types) into that project's UUID first. So by the
+  time this runs, a 422 means genuinely unresolvable — not merely "not a UUID". Keep the
+  two in that order: validating first would 422 the exact values the plug exists to
+  rescue.
+
   The canonical 36-char form is required on purpose: `Ecto.UUID.cast/1` also
   accepts a raw 16-byte binary, so a 16-char junk segment would otherwise coerce
   into a bogus-but-valid UUID and silently narrow (or leak nothing from) a query

--- a/lib/loopctl_web/plugs/resolve_project_ref.ex
+++ b/lib/loopctl_web/plugs/resolve_project_ref.ex
@@ -1,0 +1,131 @@
+defmodule LoopctlWeb.Plugs.ResolveProjectRef do
+  @moduledoc """
+  Resolves a `project_id` param that carries a project REFERENCE — a slug, or the repo
+  directory name an agent actually types — into that project's UUID, scoped to the
+  caller's tenant (#652).
+
+  ## Why this exists
+
+  Mining ~2,100 real agent searches off two machines turned up 27 failures with an
+  unambiguous shape: where a UUID is demanded, agents pass the repo's DIRECTORY name
+  exactly as the checkout spells it — `home_care_billing` (x24), `loopctl` (x3). Never a
+  name, never a path, never a malformed UUID.
+
+  Note that `home_care_billing` is NOT that tenant's slug (`home-care-billing` is) and is
+  not a resolvable `repo_url` either, so the pre-existing `resolve_project/2` would have
+  answered only one of the two observed spellings. `Projects.resolve_project_ref/2` is
+  the resolver that covers what agents actually type; see its docs for the three passes.
+
+  The recovery behaviour is what makes this worth fixing at the boundary rather than in
+  an error message. 26 of the 27 recovered by DROPPING `project_id` and retrying
+  unscoped. Nobody ever fixed the value. The search then succeeds and the scope intent is
+  silently abandoned — a confidently wrong answer, which is strictly worse than the 422
+  that preceded it. A better error message would at best teach agents to do faster what
+  they already do.
+
+  ## Contract
+
+  Runs in the `:authenticated` pipeline, so it only ever touches an authenticated
+  request. It rewrites `conn.params["project_id"]` (and `conn.path_params`, so a
+  `/projects/:project_id/...` route resolves too) IN PLACE when ALL of:
+
+    * the value is a non-empty binary that is not already a canonical 36-char UUID,
+    * the key's tenant is known (superadmin keys, `tenant_id: nil`, are skipped), and
+    * `Projects.resolve_project_ref/2` finds exactly one project in THAT tenant.
+
+  Anything else — including an AMBIGUOUS reference — is left untouched, so
+  `LoopctlWeb.Helpers.ProjectId.validate/1` still returns its 422 for a genuinely
+  unresolvable value. Resolution is tenant-scoped by an explicit predicate on every
+  pass, so a reference belonging to another tenant does not resolve and cannot be used
+  as a cross-tenant existence oracle: it produces the same 422 as a typo.
+
+  Deliberately narrow: only the `project_id` key. `id` is the resource key on every
+  route and rewriting it would silently change the meaning of unrelated requests.
+  """
+
+  @behaviour Plug
+
+  require Logger
+
+  alias Loopctl.Projects
+  alias Loopctl.TelemetryEvents
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(%Plug.Conn{params: %{"project_id" => value}} = conn, _opts) when is_binary(value) do
+    with {:ok, tenant_id} <- tenant_id(conn),
+         :ref <- classify(value),
+         {:ok, project, matched_by} <- lookup(tenant_id, value) do
+      emit_resolved(conn, value, project, matched_by)
+
+      conn
+      |> put_param("project_id", project.id)
+      |> put_path_param("project_id", value, project.id)
+    else
+      _ -> conn
+    end
+  end
+
+  def call(conn, _opts), do: conn
+
+  defp tenant_id(conn) do
+    case conn.assigns[:current_api_key] do
+      %{tenant_id: tenant_id} when is_binary(tenant_id) -> {:ok, tenant_id}
+      _ -> :error
+    end
+  end
+
+  # A canonical 36-char UUID is already the thing the query wants — never touch it.
+  # An empty value means "no filter" and is handled downstream.
+  defp classify(""), do: :skip
+
+  defp classify(value) when byte_size(value) == 36 do
+    case Ecto.UUID.cast(value) do
+      {:ok, _uuid} -> :skip
+      :error -> :ref
+    end
+  end
+
+  defp classify(_value), do: :ref
+
+  defp lookup(tenant_id, ref) do
+    Projects.resolve_project_ref(tenant_id, ref)
+  rescue
+    # A reference lookup must never be able to fail a request that would otherwise have
+    # produced a clean 422.
+    _ -> :error
+  end
+
+  defp put_param(conn, key, value), do: %{conn | params: Map.put(conn.params, key, value)}
+
+  # Only rewrite the path param when the SAME slug is what the router matched. A route
+  # can carry `project_id` in the query string while `path_params` holds something else.
+  defp put_path_param(%Plug.Conn{path_params: %{"project_id" => raw}} = conn, key, raw, value),
+    do: %{conn | path_params: Map.put(conn.path_params, key, value)}
+
+  defp put_path_param(conn, _key, _raw, _value), do: conn
+
+  defp emit_resolved(conn, ref, project, matched_by) do
+    :telemetry.execute(
+      TelemetryEvents.project_ref_resolved(),
+      %{count: 1},
+      %{
+        tenant_id: project.tenant_id,
+        project_id: project.id,
+        ref: ref,
+        matched_by: matched_by,
+        path: conn.request_path
+      }
+    )
+
+    # Values are inlined in the message rather than passed as Logger metadata: these
+    # keys are not in the prod metadata allowlist (config/config.exs), so as metadata
+    # they would be silently dropped exactly where this line is meant to be read.
+    Logger.info(
+      "project_id reference resolved: #{inspect(ref)} -> #{project.id} " <>
+        "(matched_by=#{matched_by}, path=#{conn.request_path})"
+    )
+  end
+end

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -48,6 +48,11 @@ defmodule LoopctlWeb.Router do
     plug LoopctlWeb.Plugs.UpdateLastSeen
     plug LoopctlWeb.Plugs.ValidateWitnessHeader
     plug LoopctlWeb.Plugs.CheckCustodyHalt
+    # #652 — LAST in the pipeline: needs the resolved key (for the tenant) and must
+    # not run for a request that auth, rate limiting or the custody halt already
+    # refused. Rewrites a `project_id` param that carries a project reference (a slug,
+    # or the repo directory name agents actually type) into that project's UUID.
+    plug LoopctlWeb.Plugs.ResolveProjectRef
   end
 
   # Landing page — browser pipeline (HTML)

--- a/test/loopctl/projects/projects_test.exs
+++ b/test/loopctl/projects/projects_test.exs
@@ -216,6 +216,133 @@ defmodule Loopctl.ProjectsTest do
     end
   end
 
+  describe "resolve_project_ref/2" do
+    test "resolves an exact slug" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id, slug: "loopctl"})
+
+      assert {:ok, found, :slug} = Projects.resolve_project_ref(tenant.id, "loopctl")
+      assert found.id == project.id
+    end
+
+    test "resolves the underscored repo directory name against a hyphenated slug" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id, slug: "home-care-billing"})
+
+      assert {:ok, found, :normalized_slug} =
+               Projects.resolve_project_ref(tenant.id, "home_care_billing")
+
+      assert found.id == project.id
+    end
+
+    test "resolves by repo basename when the slug drifted from the repo" do
+      tenant = fixture(:tenant)
+
+      project =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "freight-pilot-2",
+          repo_url: "https://github.com/mkreyman/freight-pilot"
+        })
+
+      assert {:ok, found, :repo_name} =
+               Projects.resolve_project_ref(tenant.id, "freight_pilot")
+
+      assert found.id == project.id
+    end
+
+    test "matches a repo basename through the ssh spec and a .git suffix" do
+      tenant = fixture(:tenant)
+
+      project =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "harness-kit-2",
+          repo_url: "git@github.com:mkreyman/claude-harness-kit.git"
+        })
+
+      assert {:ok, found, :repo_name} =
+               Projects.resolve_project_ref(tenant.id, "claude-harness-kit")
+
+      assert found.id == project.id
+    end
+
+    test "an exact slug wins over another project's repo basename" do
+      tenant = fixture(:tenant)
+
+      wanted = fixture(:project, %{tenant_id: tenant.id, slug: "api"})
+
+      _decoy =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "decoy",
+          repo_url: "https://github.com/acme/api"
+        })
+
+      assert {:ok, found, :slug} = Projects.resolve_project_ref(tenant.id, "api")
+      assert found.id == wanted.id
+    end
+
+    test "two active projects sharing a repo basename are :ambiguous, not oldest-wins" do
+      tenant = fixture(:tenant)
+
+      _one =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "api-a",
+          repo_url: "https://github.com/acme/api"
+        })
+
+      _two =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "api-b",
+          repo_url: "https://gitlab.com/other/api"
+        })
+
+      assert {:error, :ambiguous} = Projects.resolve_project_ref(tenant.id, "api")
+    end
+
+    test "an archived project does not resolve by repo basename" do
+      tenant = fixture(:tenant)
+
+      project =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "retired-2",
+          repo_url: "https://github.com/acme/retired"
+        })
+
+      {:ok, _archived} = Projects.archive_project(tenant.id, project)
+
+      assert {:error, :not_found} = Projects.resolve_project_ref(tenant.id, "retired")
+    end
+
+    test "does not cross tenants" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      _theirs = fixture(:project, %{tenant_id: tenant_b.id, slug: "home-care-billing"})
+
+      assert {:error, :not_found} =
+               Projects.resolve_project_ref(tenant_a.id, "home_care_billing")
+    end
+
+    test "blank and non-binary references are :not_found, never a crash" do
+      tenant = fixture(:tenant)
+
+      for ref <- ["", "   ", nil, 123, ["a"]] do
+        assert {:error, :not_found} = Projects.resolve_project_ref(tenant.id, ref)
+      end
+    end
+
+    test "a reference that normalizes to nothing is :not_found" do
+      tenant = fixture(:tenant)
+      _project = fixture(:project, %{tenant_id: tenant.id, slug: "loopctl"})
+
+      assert {:error, :not_found} = Projects.resolve_project_ref(tenant.id, "___")
+    end
+  end
+
   describe "resolve_project/2" do
     test "resolves by exact slug" do
       tenant = fixture(:tenant)

--- a/test/loopctl_web/controllers/knowledge_search_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_search_controller_test.exs
@@ -855,6 +855,47 @@ defmodule LoopctlWeb.KnowledgeSearchControllerTest do
       assert Enum.any?(body["data"], &(&1["title"] == "Scoped Ecto Pattern"))
     end
 
+    test "a project_id carrying the repo directory name scopes the search (#652)",
+         %{conn: conn} do
+      # The measured failure: agents pass the checkout directory name, get a 422, and
+      # then retry with project_id DROPPED — losing the scope silently. Resolving at
+      # the boundary means the scope intent survives.
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      project = fixture(:project, %{tenant_id: tenant.id, slug: "home-care-billing"})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        project_id: project.id,
+        title: "Scoped By Slug Ecto",
+        body: "Use Ecto.Multi for atomic operations.",
+        category: :pattern,
+        status: :published
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Other Project Ecto",
+        body: "Use Ecto.Multi for atomic operations.",
+        category: :pattern,
+        status: :published
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{
+          q: "Ecto",
+          mode: "keyword",
+          project_id: "home_care_billing"
+        })
+
+      body = json_response(conn, 200)
+      titles = Enum.map(body["data"], & &1["title"])
+      assert "Scoped By Slug Ecto" in titles
+      refute "Other Project Ecto" in titles
+    end
+
     test "an absent project_id returns 200 tenant-wide", %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})

--- a/test/loopctl_web/plugs/resolve_project_ref_test.exs
+++ b/test/loopctl_web/plugs/resolve_project_ref_test.exs
@@ -1,0 +1,245 @@
+defmodule LoopctlWeb.Plugs.ResolveProjectRefTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Auth.ApiKey
+  alias LoopctlWeb.Helpers.ProjectId
+  alias LoopctlWeb.Plugs.ResolveProjectRef
+
+  defp keyed(conn, tenant_id) do
+    assign(conn, :current_api_key, %ApiKey{tenant_id: tenant_id, role: :agent})
+  end
+
+  describe "call/2" do
+    test "resolves an exact project slug to that project's UUID", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, tenant_id: tenant.id, slug: "home-care-billing")
+
+      conn =
+        conn
+        |> keyed(tenant.id)
+        |> Map.put(:params, %{"project_id" => "home-care-billing", "q" => "rls"})
+        |> ResolveProjectRef.call([])
+
+      assert conn.params["project_id"] == project.id
+      # Untouched neighbours: the plug rewrites one key, not the param map.
+      assert conn.params["q"] == "rls"
+      # The whole point: what the plug produced now clears the 422 gate.
+      assert ProjectId.validate(conn.params["project_id"]) == :ok
+    end
+
+    test "resolves a slug carried in the ROUTE, not just the query string", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, tenant_id: tenant.id, slug: "loopctl")
+
+      conn =
+        conn
+        |> keyed(tenant.id)
+        |> Map.put(:params, %{"project_id" => "loopctl"})
+        |> Map.put(:path_params, %{"project_id" => "loopctl"})
+        |> ResolveProjectRef.call([])
+
+      assert conn.params["project_id"] == project.id
+      assert conn.path_params["project_id"] == project.id
+    end
+
+    test "leaves path_params alone when the route matched a DIFFERENT value", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, tenant_id: tenant.id, slug: "loopctl")
+      story_id = Ecto.UUID.generate()
+
+      conn =
+        conn
+        |> keyed(tenant.id)
+        |> Map.put(:params, %{"project_id" => "loopctl", "id" => story_id})
+        |> Map.put(:path_params, %{"id" => story_id})
+        |> ResolveProjectRef.call([])
+
+      assert conn.params["project_id"] == project.id
+      assert conn.path_params == %{"id" => story_id}
+    end
+
+    test "a canonical UUID is passed through untouched", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, tenant_id: tenant.id, slug: "loopctl")
+
+      conn =
+        conn
+        |> keyed(tenant.id)
+        |> Map.put(:params, %{"project_id" => project.id})
+        |> ResolveProjectRef.call([])
+
+      assert conn.params["project_id"] == project.id
+    end
+
+    test "an unresolvable value is left alone, so the 422 still fires", %{conn: conn} do
+      tenant = fixture(:tenant)
+
+      conn =
+        conn
+        |> keyed(tenant.id)
+        |> Map.put(:params, %{"project_id" => "no_such_project"})
+        |> ResolveProjectRef.call([])
+
+      assert conn.params["project_id"] == "no_such_project"
+      assert {:error, :unprocessable_entity, _} = ProjectId.validate(conn.params["project_id"])
+    end
+
+    test "another tenant's slug does NOT resolve (no cross-tenant oracle)", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      _theirs = fixture(:project, tenant_id: tenant_b.id, slug: "their-secret-repo")
+
+      conn =
+        conn
+        |> keyed(tenant_a.id)
+        |> Map.put(:params, %{"project_id" => "their-secret-repo"})
+        |> ResolveProjectRef.call([])
+
+      # Byte-identical to the typo case above: a foreign slug and a nonexistent one
+      # are indistinguishable to the caller.
+      assert conn.params["project_id"] == "their-secret-repo"
+    end
+
+    test "a superadmin key (no tenant) is skipped", %{conn: conn} do
+      tenant = fixture(:tenant)
+      _project = fixture(:project, tenant_id: tenant.id, slug: "loopctl")
+
+      conn =
+        conn
+        |> assign(:current_api_key, %ApiKey{tenant_id: nil, role: :superadmin})
+        |> Map.put(:params, %{"project_id" => "loopctl"})
+        |> ResolveProjectRef.call([])
+
+      assert conn.params["project_id"] == "loopctl"
+    end
+
+    test "an unauthenticated conn is skipped without a lookup", %{conn: conn} do
+      tenant = fixture(:tenant)
+      _project = fixture(:project, tenant_id: tenant.id, slug: "loopctl")
+
+      conn =
+        conn
+        |> Map.put(:params, %{"project_id" => "loopctl"})
+        |> ResolveProjectRef.call([])
+
+      assert conn.params["project_id"] == "loopctl"
+    end
+
+    test "an empty or non-binary project_id is untouched", %{conn: conn} do
+      tenant = fixture(:tenant)
+
+      for value <- ["", ["a", "b"], 123] do
+        conn =
+          conn
+          |> keyed(tenant.id)
+          |> Map.put(:params, %{"project_id" => value})
+          |> ResolveProjectRef.call([])
+
+        assert conn.params["project_id"] == value
+      end
+    end
+
+    test "a conn with no project_id param at all is untouched", %{conn: conn} do
+      tenant = fixture(:tenant)
+
+      conn =
+        conn
+        |> keyed(tenant.id)
+        |> Map.put(:params, %{"q" => "rls"})
+        |> ResolveProjectRef.call([])
+
+      refute Map.has_key?(conn.params, "project_id")
+    end
+
+    test "resolves the repo DIRECTORY name agents actually type (home_care_billing)",
+         %{conn: conn} do
+      # The measured case, x24: the underscored checkout directory, against a
+      # hyphenated slug. Neither get_project_by_slug/2 nor resolve_project/2 answers it.
+      tenant = fixture(:tenant)
+      project = fixture(:project, tenant_id: tenant.id, slug: "home-care-billing")
+
+      conn =
+        conn
+        |> keyed(tenant.id)
+        |> Map.put(:params, %{"project_id" => "home_care_billing"})
+        |> ResolveProjectRef.call([])
+
+      assert conn.params["project_id"] == project.id
+    end
+
+    test "resolves by repo BASENAME when the slug has drifted from the repo",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+
+      project =
+        fixture(:project,
+          tenant_id: tenant.id,
+          slug: "freight-pilot-2",
+          repo_url: "https://github.com/mkreyman/freight-pilot"
+        )
+
+      conn =
+        conn
+        |> keyed(tenant.id)
+        |> Map.put(:params, %{"project_id" => "freight_pilot"})
+        |> ResolveProjectRef.call([])
+
+      assert conn.params["project_id"] == project.id
+    end
+
+    test "an AMBIGUOUS repo basename is left alone rather than guessing", %{conn: conn} do
+      tenant = fixture(:tenant)
+
+      _one =
+        fixture(:project,
+          tenant_id: tenant.id,
+          slug: "api-a",
+          repo_url: "https://github.com/acme/api"
+        )
+
+      _two =
+        fixture(:project,
+          tenant_id: tenant.id,
+          slug: "api-b",
+          repo_url: "https://gitlab.com/other/api"
+        )
+
+      conn =
+        conn
+        |> keyed(tenant.id)
+        |> Map.put(:params, %{"project_id" => "api"})
+        |> ResolveProjectRef.call([])
+
+      assert conn.params["project_id"] == "api"
+    end
+
+    test "emits [:loopctl, :project_id, :ref_resolved] on a rescue", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, tenant_id: tenant.id, slug: "loopctl")
+
+      :telemetry.attach(
+        "resolve-project-ref-test",
+        Loopctl.TelemetryEvents.project_ref_resolved(),
+        fn event, measurements, metadata, pid ->
+          send(pid, {:telemetry, event, measurements, metadata})
+        end,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach("resolve-project-ref-test") end)
+
+      conn
+      |> keyed(tenant.id)
+      |> Map.put(:params, %{"project_id" => "loopctl"})
+      |> ResolveProjectRef.call([])
+
+      assert_receive {:telemetry, [:loopctl, :project_id, :ref_resolved], %{count: 1}, metadata}
+      assert metadata.ref == "loopctl"
+      assert metadata.matched_by == :slug
+      assert metadata.project_id == project.id
+      assert metadata.tenant_id == tenant.id
+    end
+  end
+end


### PR DESCRIPTION
Closes item 1 of #652.

## The failure

27 measured failures across two machines, all the same shape: where a UUID is demanded, agents pass the repo's directory name exactly as the checkout spells it — `home_care_billing` x24, `loopctl` x3. Never a name, never a path, never a malformed UUID.

26 of the 27 recovered by **dropping `project_id` and searching unscoped**. Nobody ever fixed the value, so the search survives and the scope intent is silently abandoned — a confidently wrong answer, which is worse than the 422 that preceded it.

## Why the obvious fix would have missed

`home_care_billing` is **not** this tenant's slug (`home-care-billing` is), and it is not a resolvable `repo_url` either — a bare basename has no `owner/repo` shape. So neither `get_project_by_slug/2` nor `resolve_project/2` answers the case that actually occurs. (`resolve_project/2` was also called zero times before, during or after any of the 27 failures: it is not failing, it is unknown.)

## What this does

`Projects.resolve_project_ref/2` — three passes, most specific first:

1. exact `slug`
2. slug NORMALIZED (`_`/whitespace/`.` folded to `-`) — precisely the transform between a repo directory and this app's slug format
3. repo BASENAME of an active project's `repo_url` — catches a project whose slug drifted from its repo (`freight-pilot` → slug `freight-pilot-2`)

Two active projects sharing a basename is `:ambiguous`, never oldest-wins.

Applied as `LoopctlWeb.Plugs.ResolveProjectRef`, **last in the `:authenticated` pipeline**, so one change covers every controller using the `ProjectId` helper and raw API callers too.

## Safety

- Every pass is tenant-scoped by an explicit predicate — another tenant's slug is byte-identical to a typo, so this is not a cross-tenant existence oracle.
- Unresolved or ambiguous → param untouched → the existing 422 still fires. It now means *genuinely unresolvable* rather than *not a UUID*.
- Superadmin (tenant-less) and unauthenticated conns are skipped without a lookup.
- Only the `project_id` key. `id` is the resource key on every route and rewriting it would change unrelated requests.

## Verification

- `mix precommit` green: 7443 tests, 0 failures, credo --strict clean, dialyzer clean.
- Mutation-verified the wiring is not inert: removing the plug from the router turns the new end-to-end test (`project_id=home_care_billing` → 200 scoped) back into a 422.
- OpenAPI `project_id` descriptions updated on every endpoint that declares one.

**Review gate:** reviewed inline against correctness / security / KB conventions — this session cannot dispatch review agents, and per `CLAUDE.md` the gate is satisfied by the best available reviewer. Specific things checked: tenant scoping on all three passes, ambiguity handling, plug ordering vs `RequireAuth`/`CheckCustodyHalt`, and that a rescue can never fail a request that would otherwise have produced a clean 422.
