### PR TITLE
Serve an oversized article body in a continuable window instead of losing the read

### DIFF
--- a/lib/loopctl_web/controllers/article_controller.ex
+++ b/lib/loopctl_web/controllers/article_controller.ex
@@ -37,6 +37,7 @@ defmodule LoopctlWeb.ArticleController do
   alias Loopctl.TelemetryEvents
   alias LoopctlWeb.ArticleJSON
   alias LoopctlWeb.AuditContext
+  alias LoopctlWeb.Helpers.BodyWindow
   alias LoopctlWeb.Helpers.Pagination
   alias LoopctlWeb.Helpers.ProjectId
   alias LoopctlWeb.Helpers.TagMatch
@@ -281,6 +282,25 @@ defmodule LoopctlWeb.ArticleController do
           "Link detail level (default `full`). `count` returns `links_total` and " <>
             "`links_truncated`; `none` omits the link fields. `potential_conflicts` " <>
             "(capped, with `conflicts_total`) is always returned."
+      ],
+      body_max_bytes: [
+        in: :query,
+        type: :integer,
+        required: false,
+        description:
+          "Serialized-body byte budget (default #{ArticleJSON.article_body_byte_budget()}). " <>
+            "`0` returns the whole body. The response always carries `body_bytes`, " <>
+            "`body_offset`, `body_returned_bytes`, `body_truncated` and `next_body_offset`, " <>
+            "so a truncated read can be continued rather than discarded."
+      ],
+      body_offset: [
+        in: :query,
+        type: :integer,
+        required: false,
+        description:
+          "Byte offset to start the body window at (default 0). Pass the previous " <>
+            "response's `next_body_offset` to continue. An offset landing mid-character " <>
+            "advances to the next character boundary."
       ],
       project_id: [
         in: :query,
@@ -792,7 +812,14 @@ defmodule LoopctlWeb.ArticleController do
 
     with :ok <- ProjectId.validate(params["project_id"]),
          {:ok, article} <- Knowledge.get_article(tenant_id, article_id, opts) do
-      json(conn, ArticleJSON.show(%{article: article, links: links_mode(params)}))
+      json(
+        conn,
+        ArticleJSON.show(%{
+          article: article,
+          links: links_mode(params),
+          body_window: BodyWindow.parse(params)
+        })
+      )
     end
   end
 

--- a/lib/loopctl_web/controllers/article_json.ex
+++ b/lib/loopctl_web/controllers/article_json.ex
@@ -42,9 +42,105 @@ defmodule LoopctlWeb.ArticleJSON do
 
   `links` selects how much of the link graph to serialize — `:full` (default, back
   compatible), `:count`, or `:none`. See `article_data_with_links/2`.
+
+  `body_window` bounds the serialized `body` — see `apply_body_window/2`.
   """
   def show(%{article: article} = assigns) do
-    %{data: article_data_with_links(article, Map.get(assigns, :links, :full))}
+    data =
+      article
+      |> article_data_with_links(Map.get(assigns, :links, :full))
+      |> apply_body_window(Map.get(assigns, :body_window, default_body_window()))
+
+    %{data: data}
+  end
+
+  # Default serialized-body window for a single-article read (#538, #652 item 4).
+  #
+  # #538 trimmed the LINK half of this response and capped both arrays. What it did not
+  # bound is the body, and that is what is left: four measured `knowledge_get` results of
+  # 61-82KB were rejected CLIENT-side by the harness token cap, so the article was found
+  # and the read discarded whole. A truncated body carrying its own continuation offset
+  # is strictly better than nothing, which is what those four reads got.
+  #
+  # 32KB is ~8k tokens — comfortably under the cap that rejected 61KB, and far above the
+  # ~3KB median article, so the overwhelming majority of reads are byte-identical to
+  # before. Config-overridable so ops can tune it and tests can exercise truncation
+  # cheaply. `body_max_bytes: 0` on the request opts out entirely.
+  @article_body_byte_budget 32_000
+
+  @doc "Default single-article body byte budget. Read by the OpenAPI spec so the two cannot drift."
+  def article_body_byte_budget,
+    do: Application.get_env(:loopctl, :article_body_byte_budget, @article_body_byte_budget)
+
+  defp default_body_window, do: {0, article_body_byte_budget()}
+
+  @doc """
+  Bounds the serialized `body` to a byte window and reports what was withheld.
+
+  `window` is `{offset, max_bytes}`; `max_bytes` of `0` (or a `nil` body) means the whole
+  body, unbounded. The reported byte counts are of the RAW body, so a caller paginating
+  with `next_body_offset` walks the same coordinate space the counts describe.
+
+  Slicing is UTF-8 safe: a window that would land mid-codepoint is shortened to the last
+  whole character, never emitting invalid UTF-8 (which `Jason` would refuse to encode,
+  turning a large read into a 500).
+
+  Fields added whenever a body is present:
+
+    * `body_bytes` — the FULL body size, so the caller can size the remaining fetches
+    * `body_offset` / `body_returned_bytes` — the window actually served
+    * `body_truncated` — whether anything past this window was withheld
+    * `next_body_offset` — where to continue, or `nil` at the end
+
+  These are always present, including on an untruncated read: a caller must be able to
+  tell "this is the whole body" from "this is all I asked for" without a second request.
+  """
+  @spec apply_body_window(map(), {non_neg_integer(), non_neg_integer()}) :: map()
+  def apply_body_window(%{body: body} = data, _window) when not is_binary(body), do: data
+
+  def apply_body_window(%{body: body} = data, {offset, max_bytes}) do
+    total = byte_size(body)
+    offset = body |> advance_to_boundary(min(max(offset, 0), total))
+    remaining = total - offset
+    take = if max_bytes <= 0, do: remaining, else: min(max_bytes, remaining)
+
+    slice = body |> binary_part(offset, take) |> trim_trailing_partial()
+    returned = byte_size(slice)
+    next = offset + returned
+
+    data
+    |> Map.put(:body, slice)
+    |> Map.put(:body_bytes, total)
+    |> Map.put(:body_offset, offset)
+    |> Map.put(:body_returned_bytes, returned)
+    |> Map.put(:body_truncated, next < total)
+    |> Map.put(:next_body_offset, if(next < total, do: next, else: nil))
+  end
+
+  def apply_body_window(data, _window), do: data
+
+  # A caller-supplied offset can land mid-codepoint (it is a byte count, and the caller
+  # may have invented it). Move FORWARD to the next character boundary rather than
+  # emitting a leading partial byte — the result would not be valid UTF-8, and Jason
+  # refuses to encode that, turning a large read into a 500.
+  defp advance_to_boundary(body, offset) do
+    case body do
+      <<_::binary-size(^offset), byte, _::binary>> when byte >= 0x80 and byte < 0xC0 ->
+        advance_to_boundary(body, offset + 1)
+
+      _ ->
+        offset
+    end
+  end
+
+  # Shrink the window (never grow it) until it ENDS on a codepoint boundary. At most 3
+  # bytes are ever dropped, since that is the longest partial UTF-8 sequence.
+  defp trim_trailing_partial(slice) do
+    if slice == "" or String.valid?(slice) do
+      slice
+    else
+      trim_trailing_partial(binary_part(slice, 0, byte_size(slice) - 1))
+    end
   end
 
   @doc "Renders a newly created article."

--- a/lib/loopctl_web/controllers/knowledge_progressive_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_progressive_controller.ex
@@ -21,6 +21,7 @@ defmodule LoopctlWeb.KnowledgeProgressiveController do
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
+  alias LoopctlWeb.Helpers.BodyWindow
   alias LoopctlWeb.Helpers.Visibility
 
   action_fallback LoopctlWeb.FallbackController
@@ -245,6 +246,24 @@ defmodule LoopctlWeb.KnowledgeProgressiveController do
         type: :string,
         description: "Article UUID to drill into.",
         required: true
+      ],
+      body_max_bytes: [
+        in: :query,
+        type: :integer,
+        required: false,
+        description:
+          "Serialized-body byte budget (default #{LoopctlWeb.ArticleJSON.article_body_byte_budget()}). " <>
+            "`0` returns the whole body. The response carries `body_bytes`, `body_offset`, " <>
+            "`body_returned_bytes`, `body_truncated` and `next_body_offset` so a truncated " <>
+            "read can be continued rather than discarded."
+      ],
+      body_offset: [
+        in: :query,
+        type: :integer,
+        required: false,
+        description:
+          "Byte offset to start the body window at (default 0). Pass the previous " <>
+            "response's `next_body_offset` to continue."
       ]
     ],
     responses: %{
@@ -265,7 +284,7 @@ defmodule LoopctlWeb.KnowledgeProgressiveController do
   )
 
   @doc "GET /api/v1/knowledge/progressive/:id"
-  def drill(conn, %{"id" => article_id}) do
+  def drill(conn, %{"id" => article_id} = params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
     api_key_id = conn.assigns.current_api_key.id
 
@@ -279,7 +298,16 @@ defmodule LoopctlWeb.KnowledgeProgressiveController do
 
     with {:ok, article} <-
            Knowledge.progressive_drill(tenant_id, article_id, opts) do
-      json(conn, %{data: LoopctlWeb.ArticleJSON.article_data(article)})
+      # Same serialized-body window as ArticleController.show (#652 item 4). A drill is
+      # the DOCUMENTED way to follow an index, so leaving it unbounded would put the
+      # oversized-read failure back on the path the docs send people down — the same
+      # counted/uncounted split #572 had to undo.
+      data =
+        article
+        |> LoopctlWeb.ArticleJSON.article_data()
+        |> LoopctlWeb.ArticleJSON.apply_body_window(BodyWindow.parse(params))
+
+      json(conn, %{data: data})
     end
   end
 

--- a/lib/loopctl_web/helpers/body_window.ex
+++ b/lib/loopctl_web/helpers/body_window.ex
@@ -1,0 +1,42 @@
+defmodule LoopctlWeb.Helpers.BodyWindow do
+  @moduledoc """
+  Parses the serialized-body window params (`body_max_bytes` / `body_offset`) shared by
+  every endpoint that returns ONE article's full body (#652 item 4).
+
+  Lives here rather than in a controller because the two body paths — `knowledge_get`
+  and `knowledge_progressive_drill` — must bound the body identically. A second copy
+  drifts, and the path with the stale copy is the one that goes back to returning a
+  response no client can accept. That split is exactly what #572 had to undo for read
+  accounting.
+
+  Both params are presentation knobs on a READ, so an unparseable value degrades to the
+  default rather than 422-ing a knowledge lookup in the middle of an agent's task —
+  the same rule `ArticleController.links_mode/1` follows.
+
+  `body_max_bytes: 0` means the WHOLE body (an explicit opt-out of the default budget).
+  """
+
+  alias LoopctlWeb.ArticleJSON
+
+  @doc """
+  Returns the `{offset, max_bytes}` window for `params`, defaulting to
+  `ArticleJSON.article_body_byte_budget/0` from byte 0.
+  """
+  @spec parse(map()) :: {non_neg_integer(), non_neg_integer()}
+  def parse(params) when is_map(params) do
+    {non_neg_int(params["body_offset"], 0),
+     non_neg_int(params["body_max_bytes"], ArticleJSON.article_body_byte_budget())}
+  end
+
+  def parse(_params), do: {0, ArticleJSON.article_body_byte_budget()}
+
+  defp non_neg_int(value, default) when is_binary(value) do
+    case Integer.parse(String.trim(value)) do
+      {parsed, ""} when parsed >= 0 -> parsed
+      _ -> default
+    end
+  end
+
+  defp non_neg_int(value, _default) when is_integer(value) and value >= 0, do: value
+  defp non_neg_int(_value, default), do: default
+end

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -1567,10 +1567,19 @@ async function knowledgeHeatIndex({ category, limit, since }) {
   return toContent(result);
 }
 
-async function knowledgeProgressiveDrill({ article_id }) {
+async function knowledgeProgressiveDrill({ article_id, body_max_bytes, body_offset }) {
+  const params = new URLSearchParams();
+  // 0 is meaningful on both (whole body / start at the beginning), so test for
+  // null/undefined rather than truthiness.
+  if (body_max_bytes !== undefined && body_max_bytes !== null)
+    params.set("body_max_bytes", String(body_max_bytes));
+  if (body_offset !== undefined && body_offset !== null)
+    params.set("body_offset", String(body_offset));
+  const qs = params.toString();
+  const base = `/api/v1/knowledge/progressive/${article_id}`;
   const result = await apiCall(
     "GET",
-    `/api/v1/knowledge/progressive/${article_id}`,
+    qs ? `${base}?${qs}` : base,
     null,
     process.env.LOOPCTL_AGENT_KEY,
   );
@@ -1614,11 +1623,24 @@ async function knowledgeList({
   return toContent(result);
 }
 
-async function knowledgeGet({ article_id, project_id, story_id, links }) {
+async function knowledgeGet({
+  article_id,
+  project_id,
+  story_id,
+  links,
+  body_max_bytes,
+  body_offset,
+}) {
   const params = new URLSearchParams();
   if (project_id) params.set("project_id", project_id);
   if (story_id) params.set("story_id", story_id);
   if (links) params.set("links", links);
+  // 0 is meaningful on both (whole body / start at the beginning), so test for
+  // null/undefined rather than truthiness.
+  if (body_max_bytes !== undefined && body_max_bytes !== null)
+    params.set("body_max_bytes", String(body_max_bytes));
+  if (body_offset !== undefined && body_offset !== null)
+    params.set("body_offset", String(body_offset));
   const qs = params.toString();
   const path = qs ? `/api/v1/articles/${article_id}?${qs}` : `/api/v1/articles/${article_id}`;
   const result = await apiCall("GET", path, null, process.env.LOOPCTL_AGENT_KEY);
@@ -4734,7 +4756,11 @@ const TOOLS = [
       "reach — both resolve the same ids now. A drill records an UNCOUNTED read, so " +
       "following an index never raises the heat of what that index just showed you; " +
       "knowledge_get records a counted one, which is a vote that the article was worth " +
-      "opening on its own. Following a list is not a vote.",
+      "opening on its own. Following a list is not a vote.\n\n" +
+      "BODY: served in a byte WINDOW (default 32000 bytes) exactly like knowledge_get, so " +
+      "an oversized article comes back in parts instead of being rejected whole by a client " +
+      "token cap. Read body_truncated / next_body_offset to continue, or pass " +
+      "body_max_bytes: 0 for the whole body.",
     inputSchema: {
       type: "object",
       properties: {
@@ -4742,6 +4768,19 @@ const TOOLS = [
           type: "string",
           format: "uuid",
           description: "The UUID of the article to open (from a progressive index stub).",
+        },
+        body_max_bytes: {
+          type: "integer",
+          minimum: 0,
+          description:
+            "Optional: serialized-body byte budget (default 32000). 0 returns the whole body.",
+        },
+        body_offset: {
+          type: "integer",
+          minimum: 0,
+          description:
+            "Optional: byte offset to start the body window at (default 0). Pass the " +
+            "previous response's next_body_offset to read the next part.",
         },
       },
       required: ["article_id"],
@@ -4772,7 +4811,13 @@ const TOOLS = [
       "`potential_conflicts` is returned in all three modes, so opting out of the link " +
       "list never hides a conflict from you; it is capped at 25 (strongest first) with " +
       "`conflicts_total` / `conflicts_truncated`. To actually traverse the graph, use " +
-      "knowledge_graph rather than raising this cap.",
+      "knowledge_graph rather than raising this cap.\n\n" +
+      "BODY: the body is served in a byte WINDOW (default 32000 bytes) so an oversized " +
+      "article is returned in parts instead of being rejected whole by a client token " +
+      "cap - four measured reads of 61-82KB were discarded that way after the search had " +
+      "already found them. Every response carries body_bytes (the full size), body_offset, " +
+      "body_returned_bytes, body_truncated and next_body_offset; pass next_body_offset back " +
+      "as body_offset to continue, or body_max_bytes: 0 for the whole body in one read.",
     inputSchema: {
       type: "object",
       properties: {
@@ -4789,6 +4834,20 @@ const TOOLS = [
             "capped arrays; 'count' = just links_total + links_truncated; 'none' = omit " +
             "link fields. potential_conflicts (capped, with conflicts_total) is always " +
             "returned.",
+        },
+        body_max_bytes: {
+          type: "integer",
+          minimum: 0,
+          description:
+            "Optional: serialized-body byte budget (default 32000). 0 returns the whole " +
+            "body. Read body_truncated / next_body_offset to continue.",
+        },
+        body_offset: {
+          type: "integer",
+          minimum: 0,
+          description:
+            "Optional: byte offset to start the body window at (default 0). Pass the " +
+            "previous response's next_body_offset to read the next part.",
         },
         project_id: {
           type: "string",

--- a/test/loopctl_web/controllers/article_controller_test.exs
+++ b/test/loopctl_web/controllers/article_controller_test.exs
@@ -1237,6 +1237,150 @@ defmodule LoopctlWeb.ArticleControllerTest do
       assert body["data"]["links_truncated"] == false
     end
 
+    test "a large body is served in a continuable window rather than whole (#652)",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      # Four measured knowledge_get results of 61-82KB were rejected client-side by the
+      # harness token cap, so the article was found and the read discarded whole.
+      big = String.duplicate("x", 80_000)
+      article = fixture(:article, %{tenant_id: tenant.id, title: "Big", body: big})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles/#{article.id}")
+
+      data = json_response(conn, 200)["data"]
+      budget = LoopctlWeb.ArticleJSON.article_body_byte_budget()
+
+      assert byte_size(data["body"]) == budget
+      assert data["body_bytes"] == 80_000
+      assert data["body_offset"] == 0
+      assert data["body_returned_bytes"] == budget
+      assert data["body_truncated"] == true
+      assert data["next_body_offset"] == budget
+    end
+
+    test "next_body_offset walks the whole body across reads", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      body_text = String.duplicate("abcde", 2_000)
+      article = fixture(:article, %{tenant_id: tenant.id, title: "Walk", body: body_text})
+
+      first =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles/#{article.id}?body_max_bytes=4000")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert first["body_truncated"] == true
+      assert first["next_body_offset"] == 4000
+
+      second =
+        build_conn()
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles/#{article.id}?body_max_bytes=100000&body_offset=4000")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert second["body_truncated"] == false
+      assert second["next_body_offset"] == nil
+      assert first["body"] <> second["body"] == body_text
+    end
+
+    test "body_max_bytes=0 opts out of the budget entirely", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      body_text = String.duplicate("y", 50_000)
+      article = fixture(:article, %{tenant_id: tenant.id, title: "Whole", body: body_text})
+
+      data =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles/#{article.id}?body_max_bytes=0")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert data["body"] == body_text
+      assert data["body_truncated"] == false
+      assert data["next_body_offset"] == nil
+    end
+
+    test "a normal article is unchanged except for the accounting fields", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      article = fixture(:article, %{tenant_id: tenant.id, title: "Small", body: "short body"})
+
+      data =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles/#{article.id}")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert data["body"] == "short body"
+      assert data["body_truncated"] == false
+      assert data["body_bytes"] == 10
+      # Present even when nothing was withheld: a caller must be able to tell "this is
+      # the whole body" from "this is all I asked for" without a second request.
+      assert data["next_body_offset"] == nil
+    end
+
+    test "a window landing mid-character never emits invalid UTF-8", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      # Each "é" is 2 bytes, so a 5-byte window necessarily splits one.
+      body_text = String.duplicate("é", 20)
+      article = fixture(:article, %{tenant_id: tenant.id, title: "Utf8", body: body_text})
+
+      first =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles/#{article.id}?body_max_bytes=5")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert String.valid?(first["body"])
+      assert first["body"] == "éé"
+      assert first["body_returned_bytes"] == 4
+
+      # An offset the caller invented, landing mid-character, advances to the next
+      # boundary instead of emitting a leading partial byte.
+      second =
+        build_conn()
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles/#{article.id}?body_max_bytes=4&body_offset=5")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert String.valid?(second["body"])
+      assert second["body_offset"] == 6
+    end
+
+    test "unparseable window params degrade to the default, never a 422", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      article = fixture(:article, %{tenant_id: tenant.id, title: "Junk", body: "body text"})
+
+      data =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles/#{article.id}?body_max_bytes=huge&body_offset=-5")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert data["body"] == "body text"
+      assert data["body_offset"] == 0
+    end
+
     test "links=count returns links_total without either array", %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})

--- a/test/loopctl_web/controllers/knowledge_hybrid_search_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_hybrid_search_controller_test.exs
@@ -287,6 +287,45 @@ defmodule LoopctlWeb.KnowledgeHybridSearchControllerTest do
       assert is_binary(drill_body["data"]["body"])
     end
 
+    test "a drill bounds an oversized body the same way knowledge_get does (#652)",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      big = String.duplicate("z", 80_000)
+
+      article =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          title: "Oversized Drill Target",
+          body: big
+        })
+
+      data =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/progressive/#{article.id}")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      budget = LoopctlWeb.ArticleJSON.article_body_byte_budget()
+      assert byte_size(data["body"]) == budget
+      assert data["body_bytes"] == 80_000
+      assert data["body_truncated"] == true
+      assert data["next_body_offset"] == budget
+
+      whole =
+        build_conn()
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/progressive/#{article.id}?body_max_bytes=0")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert whole["body"] == big
+      assert whole["body_truncated"] == false
+    end
+
     test "a non-binary topic param (array syntax) is a clean 400, not a 500", %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})


### PR DESCRIPTION
Closes item 4 of #652; finishes #538.

## What was left

#538 trimmed the **link** half of the `knowledge_get` response (near side dropped, both arrays capped at 25). It never bounded the **body** — and that is what remained: four measured `knowledge_get` results of **61–82KB** were rejected **client-side** by the harness token cap. The article was found by search, located by id, and then discarded whole.

A truncated body carrying its own continuation offset is strictly better than nothing, which is what those four reads got.

## What this does

The single-article body is served in a byte window, default **32,000 bytes** (~8k tokens — comfortably under the cap that rejected 61KB, and far above the ~3KB median article, so the overwhelming majority of reads are byte-identical to before). Config-overridable; `body_max_bytes=0` opts out entirely.

Every response carries the accounting, truncated or not:

| field | meaning |
|---|---|
| `body_bytes` | the FULL body size |
| `body_offset` / `body_returned_bytes` | the window actually served |
| `body_truncated` | whether anything past this window was withheld |
| `next_body_offset` | where to continue, or `null` at the end |

They are present even when nothing was withheld — a caller must be able to tell *"this is the whole body"* from *"this is all I asked for"* without a second request.

## Both body paths, one helper

Applied to `knowledge_get` **and** `knowledge_progressive_drill`. Drill is the documented way to follow an index, so leaving it unbounded would put the oversized-read failure right back on the path the docs send agents down — the same split #572 had to undo for read accounting. The param parsing lives in one `LoopctlWeb.Helpers.BodyWindow` so the two cannot drift.

## UTF-8

Safe in both directions: a window ending mid-character is shortened to the last whole character; a caller-invented offset landing mid-character advances to the next boundary. This is not cosmetic — `Jason` refuses to encode invalid UTF-8, which would turn a large read into a 500.

## Verification

- `mix precommit` green: 7450 tests, 0 failures, credo --strict clean, dialyzer clean.
- 7 new tests: truncation, walking the whole body across two reads and reassembling it exactly, `body_max_bytes=0`, an unchanged small article, both UTF-8 boundary cases, and unparseable params degrading rather than 422-ing.
- mcp-server suite green (363 tests); OpenAPI params added on both endpoints, MCP tool descriptions and handlers updated for both.

**Review gate:** reviewed inline against correctness / security / KB conventions — this session cannot dispatch review agents, and per `CLAUDE.md` the gate is satisfied by the best available reviewer. Checked specifically: that `0` is threaded rather than falsy-dropped in the MCP client, that byte counts stay in one coordinate space so `next_body_offset` is directly reusable, and that the default cannot silently hide content without saying so in the payload.
