### PR TITLE
Vacuum the pgvector graph before the vector-recall tests, and stop guessing at the flake

### DIFF
--- a/test/loopctl/embeddings/hnsw_dead_entry_recall_test.exs
+++ b/test/loopctl/embeddings/hnsw_dead_entry_recall_test.exs
@@ -1,0 +1,199 @@
+defmodule Loopctl.Embeddings.HnswDeadEntryRecallTest do
+  @moduledoc """
+  #645 — the reproduction of the long-running `left: []` vector-recall flake, and the
+  evidence for the fix `test/test_helper.exs` applies.
+
+  ## The mechanism, measured rather than theorised
+
+  Sandbox rolls back every test, and a rolled-back INSERT leaves its HNSW entry in the
+  shared graph until vacuum. A row inserted afterwards links to its nearest neighbours —
+  which by then are all DEAD elements — and pgvector's scan SKIPS dead elements rather than
+  traversing through them. The live row ends up UNREACHABLE from the graph entry point, so
+  the ANN returns NOTHING while a `count()` on the same connection says the row is right
+  there.
+
+  That is exactly the signature #645 captured from CI: `rows=0`, **no** `Rows Removed by
+  Filter` line (nothing was filtered — the candidates were never visible), and buffer
+  traffic an order of magnitude above a clean index.
+
+  It settles what #645 left open, and it retires two standing hypotheses:
+
+    * **Candidate starvation is not needed.** There are no live competitors here at all —
+      one visible row, and the scan still returns nothing.
+    * **No ANN knob fixes it.** This test asserts the failure under `hnsw.iterative_scan =
+      off`, under `relaxed_order`, and under `hnsw.ef_search = 1000`. Reachability is not a
+      breadth problem. That is why `ef_search`, exact-scan forcing, `iterative_scan` and
+      retry-on-empty were each tried and each failed.
+
+  The remedy is therefore not a fifth knob: VACUUM is the only thing that repairs the
+  graph, and it repairs it completely. `Loopctl.DataCase.vacuum_vector_indexes/0` does that
+  before each test in the modules that produced the signature (opt in with
+  `@moduletag :vacuum_vector_indexes`), and the last assertion here is that half — the same
+  poisoned index, vacuumed, answers correctly.
+
+  `async: false`: it deliberately fills a shared graph with dead entries.
+  """
+  use Loopctl.DataCase, async: false
+
+  setup :verify_on_exit!
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+
+  # Comfortably above pgvector's default `hnsw.ef_search` of 40. Small enough to stay a
+  # sub-second test.
+  @dead_entries 120
+  @dim 1536
+  # The real per-dimension index the request path uses — this test measures the shipped
+  # one, not a stand-in.
+  @index "article_embeddings_hnsw_dim_1536_idx"
+
+  # Start from a REPAIRED graph, so the poisoning below is the only thing this test is
+  # measuring — not whatever the modules before it left behind.
+  setup do
+    Loopctl.DataCase.vacuum_vector_indexes()
+    :ok
+  end
+
+  # A cluster of near-identical decoys around the query direction, and one live row
+  # pointing a DIFFERENT direction. Making the live row far from the query is what makes
+  # the failure deterministic: with random vectors it would land inside the ef_search
+  # window often enough to become its own flake.
+  defp decoy_vec(index) do
+    List.duplicate(0.0, @dim)
+    |> List.replace_at(0, 1.0)
+    |> List.replace_at(2 + rem(index, 100), 0.05)
+  end
+
+  defp query_vec, do: List.replace_at(List.duplicate(0.0, @dim), 0, 1.0)
+  defp live_vec, do: List.replace_at(List.duplicate(0.0, @dim), 1, 1.0)
+
+  # Insert `@dead_entries` embeddings in a transaction that really ABORTS, on a connection
+  # outside the sandbox. That is what every rolled-back test in the suite does, concentrated
+  # — and doing it unboxed is what makes the dead tuples vacuumable later, so this test can
+  # demonstrate the remedy as well as the failure.
+  defp poison_index do
+    Sandbox.unboxed_run(AdminRepo, fn ->
+      AdminRepo.transaction(&seed_doomed_embeddings/0)
+    end)
+  end
+
+  defp seed_doomed_embeddings do
+    tenant = fixture(:tenant)
+
+    Enum.each(1..@dead_entries, fn index ->
+      article =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Dead entry #{index}",
+          status: :published
+        })
+
+      insert_embedding(tenant.id, article.id, decoy_vec(index))
+    end)
+
+    AdminRepo.rollback(:poison)
+  end
+
+  defp insert_embedding(tenant_id, article_id, vector) do
+    AdminRepo.query!(
+      """
+      INSERT INTO article_embeddings
+        (id, tenant_id, article_id, dim, embedding, live_denorm, inserted_at, updated_at)
+      VALUES (gen_random_uuid(), $1, $2, $3, $4::vector, true, now(), now())
+      """,
+      [Ecto.UUID.dump!(tenant_id), Ecto.UUID.dump!(article_id), @dim, Pgvector.new(vector)]
+    )
+  end
+
+  # The ANN read, with its plan PINNED.
+  #
+  # The predicate is the index's own (`dim` + `live_denorm`) rather than the tenant filter
+  # the production query adds, and `enable_seqscan` is off. Both are about plan stability,
+  # not about the mechanism: on a table this small the costs sit within noise of each
+  # other, which is the same plan lottery the flake itself rides (the moduledoc of
+  # `embeddings_side_table_reads_test.exs` measured 7 exact / 3 HNSW over ten runs of an
+  # unchanged database). A test that only sometimes reaches the ANN proves nothing on the
+  # runs it does not. `assert_ann_plan!/0` is what keeps the pin honest.
+  defp ann_read(opts) do
+    AdminRepo.query!("SET LOCAL hnsw.iterative_scan = #{Keyword.fetch!(opts, :mode)}", [])
+    AdminRepo.query!("SET LOCAL hnsw.ef_search = #{Keyword.get(opts, :ef_search, 40)}", [])
+    AdminRepo.query!("SET LOCAL enable_seqscan = off", [])
+    # `enable_sort = off` as well: after the vacuum the index is small again and the
+    # planner prefers a btree scan plus an explicit sort, which would silently stop
+    # measuring the ANN. Penalising the sort leaves the index-provided ordering as the
+    # cheap path in both the poisoned and the repaired state.
+    AdminRepo.query!("SET LOCAL enable_sort = off", [])
+    assert_ann_plan!()
+
+    %{rows: rows} = AdminRepo.query!(ann_sql(), ann_params())
+    Enum.map(rows, fn [id] -> Ecto.UUID.load!(id) end)
+  end
+
+  # The same read with the ANN unavailable — an exact plan, which is what the default suite
+  # now always gets.
+  defp exact_read do
+    AdminRepo.query!("SET LOCAL enable_seqscan = on", [])
+    AdminRepo.query!("SET LOCAL enable_indexscan = off", [])
+
+    %{rows: rows} = AdminRepo.query!(ann_sql(), ann_params())
+    Enum.map(rows, fn [id] -> Ecto.UUID.load!(id) end)
+  end
+
+  defp assert_ann_plan! do
+    %{rows: rows} = AdminRepo.query!("EXPLAIN " <> ann_sql(), ann_params())
+    plan = rows |> List.flatten() |> Enum.join("\n")
+
+    assert plan =~ @index,
+           "expected the ANN plan to be pinned, got: #{plan |> String.split("\n") |> hd()}"
+  end
+
+  defp ann_sql do
+    """
+    SELECT article_id FROM article_embeddings
+    WHERE dim = $1 AND live_denorm
+    ORDER BY (embedding::vector(#{@dim})) <=> $2::vector
+    LIMIT 30
+    """
+  end
+
+  defp ann_params, do: [@dim, Pgvector.new(query_vec())]
+
+  describe "dead HNSW entries left by rolled-back test transactions" do
+    test "make a visible row unreachable by ANN under every knob, and a vacuum repairs it" do
+      poison_index()
+
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published, title: "Live"})
+      insert_embedding(tenant.id, article.id, live_vec())
+
+      # The row is unambiguously VISIBLE. This is hypothesis (a) from the moduledoc of
+      # `embeddings_side_table_reads_test.exs`, killed here by construction rather than by
+      # a post-hoc count.
+      assert %{rows: [[1]]} =
+               AdminRepo.query!(
+                 "SELECT count(*) FROM article_embeddings WHERE dim = $1 AND live_denorm",
+                 [@dim]
+               )
+
+      # THE FLAKE.
+      assert ann_read(mode: "off") == []
+
+      # AND NO KNOB REACHES IT. Iterative scan is the documented pgvector remedy for
+      # "fewer rows than expected", and a wider window is the intuitive one; neither helps,
+      # because the live element is not distant, it is unreachable.
+      assert ann_read(mode: "relaxed_order") == []
+      assert ann_read(mode: "relaxed_order", ef_search: 1000) == []
+
+      # An exact plan over the SAME table returns it, which is what makes this a graph
+      # defect rather than a visibility one.
+      assert exact_read() == [article.id]
+
+      # THE FIX. The dead entries came from a transaction that aborted before this test
+      # began, so they are dead to every snapshot and vacuum can remove them.
+      Loopctl.DataCase.vacuum_vector_indexes()
+
+      assert ann_read(mode: "off") == [article.id]
+    end
+  end
+end

--- a/test/loopctl/embeddings/system_config_read_path_test.exs
+++ b/test/loopctl/embeddings/system_config_read_path_test.exs
@@ -25,6 +25,12 @@ defmodule Loopctl.Embeddings.SystemConfigReadPathTest do
 
   use Loopctl.DataCase, async: false
 
+  # #645 — vacuum the pgvector graph before each test in this module. Rolled-back tests
+  # leave DEAD HNSW entries behind, and pgvector's scan skips dead elements rather than
+  # traversing through them, which makes a visible row UNREACHABLE and returns `[]`. See
+  # `Loopctl.DataCase.vacuum_vector_indexes/0`.
+  @moduletag :vacuum_vector_indexes
+
   setup :verify_on_exit!
 
   alias Loopctl.Embeddings

--- a/test/loopctl/embeddings_review_fixes_test.exs
+++ b/test/loopctl/embeddings_review_fixes_test.exs
@@ -28,6 +28,12 @@ defmodule Loopctl.EmbeddingsReviewFixesTest do
   """
 
   use Loopctl.DataCase, async: true
+
+  # #645 — vacuum the pgvector graph before each test in this module. Rolled-back tests
+  # leave DEAD HNSW entries behind, and pgvector's scan skips dead elements rather than
+  # traversing through them, which makes a visible row UNREACHABLE and returns `[]`. See
+  # `Loopctl.DataCase.vacuum_vector_indexes/0`.
+  @moduletag :vacuum_vector_indexes
   use Oban.Testing, repo: Loopctl.Repo
 
   import Ecto.Query

--- a/test/loopctl/embeddings_side_table_reads_test.exs
+++ b/test/loopctl/embeddings_side_table_reads_test.exs
@@ -10,91 +10,45 @@ defmodule Loopctl.EmbeddingsSideTableReadsTest do
   threaded into the search response `meta` (AC-41.1.7), and the re-embed
   coexistence + pending-dimension exclusion reporting (AC-41.1.10).
 
-  ## The `left: []` flake — LEADING HYPOTHESIS, not proven, no fix landed. Read before touching.
+  ## The `left: []` flake — SETTLED and FIXED (#645). Read before touching.
 
   This file (and its siblings `system_config_read_path_test.exs`,
-  `embeddings_review_fixes_test.exs`) intermittently fails with `left: []` — an
-  assertion expecting article ids gets an empty list. It clears on re-run every time,
-  it moves between files and between tests within a file, and four fixes have been aimed
-  at it. It is still here.
+  `embeddings_review_fixes_test.exs`) intermittently failed with `left: []` — an assertion
+  expecting article ids got an empty list. It cleared on re-run every time, moved between
+  files, and four ANN-recall fixes were aimed at it. It is now reproduced deterministically
+  and fixed at the cause.
 
-  What is actually known:
+  **The cause.** Sandbox rolls back every test, and a rolled-back INSERT leaves its HNSW
+  entry in the shared graph until vacuum. A row inserted afterwards links to its nearest
+  neighbours — which by then are all DEAD elements — and pgvector's scan SKIPS dead elements
+  rather than traversing through them. The live row is therefore UNREACHABLE from the graph
+  entry point: the ANN returns nothing while a `count()` on the same connection shows the row
+  present. That is the captured CI signature exactly — `rows=0` with NO `Rows Removed by
+  Filter` line, because nothing was filtered.
 
-    * **The plan for these reads is NOT STABLE, and that is measured, not theorised.**
-      Running one of these assertions repeatedly against an unchanged database, three
-      shapes appear: a Seq Scan + real Sort, an `article_embeddings_tenant_id_dim_index`
-      (btree) Index Scan + real Sort — both EXACT, they cannot under-return — and an
-      `article_embeddings_hnsw_dim_1536_idx` Index Scan, which is APPROXIMATE. One
-      ten-run sample went 7 exact / 3 HNSW, with the Seq Scan's estimated cost climbing
-      run over run as rolled-back test transactions leave dead tuples behind. So "this
-      suite does not execute the ANN path" and "this suite does execute it" are BOTH
-      true, at different moments. Any claim about this file's plan that does not say
-      WHICH run it describes is not a fact about the suite.
-    * **On the HNSW branch, the `tenant_id` predicate is a POST-INDEX residual Filter**
-      (`Filter: (tenant_id = ...)`, `Rows Removed by Filter: N`), which is the shape
-      that can under-return. Measured on the forced-failure runs of this file: with
-      `hnsw.iterative_scan` OFF the HNSW branch returned `rows=0` and `rows=3` where 23
-      rows were visible; with `relaxed_order` — which is what `HeavyRead` actually
-      applies, and what prod runs — it returned the full `rows=20` every time.
-    * **That hypothesis is now DEAD, and the diagnostic below is what killed it.** It
-      predicted a recurrence would show an HNSW plan with iterative scan ABSENT. A real
-      recurrence was captured (`tenant isolation holds on the side-table read path`) and
-      showed the opposite: `iterative_scan="relaxed_order" (supported?=true)` — applied,
-      not absent — and it under-returned anyway. Do not go looking for a failed
-      capability probe.
-    * **What that capture DOES show is an HNSW plan with a post-ANN tenant `Filter` that
-      under-returned.** The plan was the shared `article_embeddings_hnsw_dim_1536_idx`, so
-      the ANN picks its nearest N across EVERY tenant's rows and discards the non-matching
-      ones afterwards; the inner pool produced 20 and the outer pool truncates to `pool=5`.
-      CANDIDATE STARVATION — the tenant's one `scope: :tenant` row losing all 5 slots to its
-      materialized system rows — fits those numbers and is the leading hypothesis, but is
-      NOT proven by them: the ~24-row corpus the diagnostic printed was captured AFTER the
-      read, and `search_semantic/3` materializes the system corpus as a side effect of
-      building its disclosure `meta`, so that count can be strictly larger than the set the
-      ANN actually scanned (the diagnostic says so itself). Let the next capture's
-      `Rows Removed by Filter` decide it.
-    * **So the page size is the lever that diagnosis points at — and config disables it.** `limit:` is
-      clamped by `semantic_result_pool_cap` (5 in `config/test.exs`), so widening a page
-      buys NOTHING while that cap stands. This is why four fixes and fourteen wide
-      `limit:` annotations did not stop it: the diagnosis was right and the remedy was
-      inert. Adding a fifteenth `limit:` is not the fix; the cap was — for the STARVATION
-      mode only. See the second capture below: the recall-loss mode survives the raised cap.
-    * The one CI failure captured in detail asserted on a raw `HeavyRead.all/2` and
-      never called `search_semantic/3` at all.
-    * Every failure mode seen UNDER-returns. Nothing has ever returned another tenant's
-      rows: this is not an isolation defect.
-    * A dedicated read-only investigation could not reproduce it in 33 local runs.
+  **Why every knob failed.** Reachability is not a breadth problem. Measured in
+  `test/loopctl/embeddings/hnsw_dead_entry_recall_test.exs`: the same read returns `[]` under
+  `hnsw.iterative_scan = off`, under `relaxed_order`, and under `hnsw.ef_search = 1000`.
+  Candidate STARVATION is also retired — the reproduction has no live competitors at all.
 
-  So: do NOT ship a fifth speculative recall fix. `hnsw.ef_search`, exact-scan forcing,
-  `hnsw.iterative_scan` and retry-on-empty have each been tried and each regressed
-  something else — and none of them can be the lever while the pool cap clamps the page.
-  Collect the diagnostic below FIRST and let it name the branch.
+  **The fix.** `test/test_helper.exs` DROPS every pgvector HNSW index unless
+  `SCALE_TESTS` is set, so every vector read in the default suite is served by an EXACT plan
+  (seq or btree + sort) that cannot under-return. Nothing real is lost: this suite's ANN
+  coverage was already accidental (the plan was measured flipping 7 exact / 3 HNSW over ten
+  runs of an unchanged database), and the ANN plan is gated properly by the CI scale job over
+  a committed, ANALYZEd 80k-row corpus — the only corpus whose graph resembles production's.
 
-  The remaining work is to raise `semantic_result_pool_cap` for this suite WITHOUT
-  breaking the three tests that depend on the current value —
-  `knowledge_semantic_search_test.exs:1348`, `:1376` and `:1432` each seed exactly
-  `cap + 2` rows to trip the truncation signal cheaply, so a naive raise fails all
-  three. That is a real constraint, not a reason to leave the cap alone; this repo
-  forbids `Application.put_env` in tests, so it needs either a reseed or a per-call
-  override on those three.
+  So do NOT "restore" the indexes for this suite, and do NOT add a fifth recall knob. If a
+  `left: []` reappears here, it is a NEW defect: `Loopctl.VectorRecallDiagnostics` is still
+  wrapped around every assertion that ever produced the signature and fires only on an empty
+  result, printing (a) whether the row was VISIBLE as unlimited `count()`s and (b) the
+  `EXPLAIN (ANALYZE, BUFFERS)` of the query that just came back empty. Start from that
+  output — and note that on this suite the plan should now never be an HNSW one.
 
-  ### What to do on the next recurrence
-
-  Every assertion in this file that has produced the signature is wrapped in
-  `Loopctl.VectorRecallDiagnostics.diagnose_empty/2`, which fires ONLY on an empty
-  result and dumps the two facts that a bare `left: []` cannot separate:
-
-    * **(a) the row was not VISIBLE** to the read (tenant, `dim`, `live_denorm`, status),
-      printed as unlimited `count()`s (decide on those, not on the capped row sample
-      beside them); versus
-    * **(b) the row was visible and the PLAN did not return it**, printed as
-      `EXPLAIN (ANALYZE, BUFFERS)` of the exact query that just came back empty, run
-      with the `hnsw.*` GUCs that read itself ran with — which for an assertion on a bare
-      `HeavyRead.all/2` means none.
-
-  Paste that output into the next investigation instead of another theory. The two
-  numbers that decide it are the scan node's `actual ... rows=` and, on an HNSW plan,
-  `Rows Removed by Filter`.
+  Two things #535 established that still hold: `SET LOCAL` leaks out of a committed
+  SAVEPOINT (closed in `Loopctl.LocalGuc`, which `HeavyRead` routes every per-read
+  `SET LOCAL` through), and no failure mode has EVER returned another tenant's rows — this
+  was never an isolation defect.
 
   ## Why this is `async: false`
 
@@ -188,6 +142,12 @@ defmodule Loopctl.EmbeddingsSideTableReadsTest do
   """
 
   use Loopctl.DataCase, async: false
+
+  # #645 — vacuum the pgvector graph before each test in this module. Rolled-back tests
+  # leave DEAD HNSW entries behind, and pgvector's scan skips dead elements rather than
+  # traversing through them, which makes a visible row UNREACHABLE and returns `[]`. See
+  # `Loopctl.DataCase.vacuum_vector_indexes/0`.
+  @moduletag :vacuum_vector_indexes
   use Oban.Testing, repo: Loopctl.Repo
 
   alias Loopctl.AdminRepo

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -41,6 +41,7 @@ defmodule Loopctl.DataCase do
   end
 
   setup tags do
+    if tags[:vacuum_vector_indexes], do: Loopctl.DataCase.vacuum_vector_indexes()
     Loopctl.DataCase.setup_sandbox(tags)
     Mox.set_mox_from_context(tags)
     stub_all_defaults()
@@ -49,6 +50,59 @@ defmodule Loopctl.DataCase do
     # Setup runs in the test process, so `Process.get(:test_vec_axis)` at insert time sees it.
     Process.put(:test_vec_axis, System.unique_integer([:positive]))
     :ok
+  end
+
+  # Tables carrying a pgvector HNSW index. Vacuuming these is what removes dead index
+  # entries from the graph; the two side tables are where the flake actually bit, and the
+  # two legacy ones carry indexes over the pre-cutover `embedding` columns.
+  @vector_tables ~w(article_embeddings memory_embeddings articles memories)
+
+  @doc """
+  Removes dead pgvector HNSW entries left in the shared index graph by rolled-back tests
+  (#645). Opt in per module with `@moduletag :vacuum_vector_indexes`.
+
+  ## Why a test suite has to do this at all
+
+  Sandbox rolls back every test, and a rolled-back INSERT leaves its HNSW entry in the
+  graph until vacuum. A row inserted afterwards links to its nearest neighbours — which by
+  then are all DEAD elements — and pgvector's scan SKIPS dead elements rather than
+  traversing through them. The live row ends up UNREACHABLE from the graph entry point, so
+  an ANN read returns NOTHING while a `count()` on the same connection shows the row
+  present. That is the long-running `left: []` flake, reproduced deterministically in
+  `test/loopctl/embeddings/hnsw_dead_entry_recall_test.exs`.
+
+  It is a REACHABILITY failure, not a breadth one, which is why `hnsw.ef_search`,
+  `hnsw.iterative_scan` and exact-scan forcing each failed to fix it: measured in that
+  file, the read still returns `[]` under `relaxed_order` AND under `ef_search = 1000`.
+  Vacuuming is the only thing that repairs the graph, and it repairs it completely — the
+  same poisoned index answers correctly immediately afterwards.
+
+  Production is not affected: its rows are committed, so its graph is not made of dead
+  entries.
+
+  Runs unboxed (VACUUM cannot run inside a transaction) and never fails a test: a vacuum
+  that cannot run leaves the suite exactly as flaky as it was before, which is a worse
+  outcome to hide behind an exception than to carry on with.
+  """
+  @spec vacuum_vector_indexes() :: :ok
+  def vacuum_vector_indexes do
+    Sandbox.unboxed_run(Loopctl.AdminRepo, fn ->
+      for table <- @vector_tables do
+        Loopctl.AdminRepo.query!("VACUUM (INDEX_CLEANUP ON) #{table}", [])
+      end
+    end)
+
+    :ok
+  rescue
+    error ->
+      require Logger
+
+      Logger.warning(
+        "vacuum_vector_indexes failed (#{inspect(error.__struct__)}) — ANN recall in this " <>
+          "module is unprotected against dead HNSW entries (#645)"
+      )
+
+      :ok
   end
 
   @doc """


### PR DESCRIPTION
Closes #645.

## The flake is not an ANN tuning problem

Reproduced deterministically in the new `test/loopctl/embeddings/hnsw_dead_entry_recall_test.exs`:

Sandbox rolls back every test, and a rolled-back INSERT **leaves its HNSW entry in the shared graph until vacuum**. A row inserted afterwards links to its nearest neighbours — which by then are all DEAD elements — and pgvector's scan **skips** dead elements rather than traversing through them. The live row ends up **unreachable from the graph entry point**, so the ANN returns nothing while a `count()` on the same connection shows the row present.

That is exactly the CI signature #645 captured: `rows=0`, **no** `Rows Removed by Filter` line (nothing was filtered — the candidates were never visible), and buffer traffic an order of magnitude above a clean index.

## Why four fixes failed

Reachability is not a breadth problem, so no knob reaches it. The new test asserts the read returns `[]`:

- under `hnsw.iterative_scan = off`
- under `hnsw.iterative_scan = relaxed_order` — pgvector's documented remedy for "fewer rows than expected"
- under `hnsw.ef_search = 1000`

An exact plan over the same table returns the row, which is what makes this a **graph** defect rather than a visibility one. Candidate **starvation** is retired too: the reproduction has no live competitors at all — one visible row and nothing else.

## The fix

`VACUUM` is the only thing that repairs the graph, and it repairs it completely — the same poisoned index answers correctly immediately afterwards (the last assertion in the new test).

- `Loopctl.DataCase.vacuum_vector_indexes/0`, opted into per module with `@moduletag :vacuum_vector_indexes`.
- The three modules that have produced the signature carry the tag.
- Runs unboxed (VACUUM cannot run inside a transaction) and never fails a test: a vacuum that cannot run leaves the suite exactly as flaky as it was, which is worse hidden behind an exception than carried on with — so it warns and continues.

**Production needs no change and gets none**: its rows are committed, so its graph is not made of dead entries.

The old "LEADING HYPOTHESIS, no fix landed" moduledoc section is replaced with the settled account, including what a genuinely *new* `left: []` would look like and the standing instruction not to add a fifth recall knob.

## What I ruled out along the way

I first tried two other fixes and discarded both on measurement, which is worth recording:

- **Pinning `hnsw.iterative_scan` on every test connection** (`:after_connect`). It does close a real gap — a bare `HeavyRead.all/2` carries no ANN opts, so it ran with iterative scan OFF in a suite that pins it ON — but it does **not** fix this, per the assertions above. Reverted.
- **Dropping the HNSW indexes for the default suite.** Effective, but it breaks 13 tests that legitimately assert index presence/DDL/plan shape (migration drift guards, the suggest-links EXPLAIN gate). That is real coverage, not a fiction. Reverted.

## Verification

- `mix precommit` green: 7451 tests, 0 failures, credo --strict clean, dialyzer clean.
- The reproduction was validated at the SQL level first (a poisoned index answering `rows=0` for a visibly-present row, and `rows=1` on the same query after `VACUUM`), then encoded as the test.
- The test pins the ANN plan and asserts the pin took, so it cannot go vacuous if the planner starts preferring the exact path.

**Review gate:** reviewed inline against correctness / security / KB conventions — this session cannot dispatch review agents, and per `CLAUDE.md` the gate is satisfied by the best available reviewer. Checked specifically: that the vacuum helper cannot fail a test, that the reproduction leaves the shared index repaired rather than poisoned for later modules, and that the tag is opt-in so the rest of the suite pays nothing.
