### PR TITLE
Report the latency the smoke actually judged, not the last probe's

### DIFF
--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -301,6 +301,12 @@ if wait_for_health; then
       best_ms="$TIME_MS"
     fi
   done
+  # Report the number that was JUDGED, not the last probe's. Without this, a run where an
+  # early probe was warm and a later one paid a cold start prints a passing line carrying a
+  # time OVER its own budget — which reads as a broken gate and is how a green check stops
+  # being believed. Observed on master 2026-08-12: `✓ readiness … (6646ms)` against a
+  # 5000ms budget, correct verdict, indefensible number.
+  TIME_MS="$best_ms"
   db_ok="$(jq -r '.checks.database // "missing"' "$BODY" 2>/dev/null || echo missing)"
   status="$(jq -r '.status // "missing"' "$BODY" 2>/dev/null || echo missing)"
 
@@ -380,6 +386,8 @@ for _ in 1 2 3; do
   fi
 done
 
+# Same reason as the health block above: report the judged number.
+TIME_MS="$ready_best_ms"
 ready_scale="$(jq -r '.checks.scale_alerts // "missing"' "$READY_BODY" 2>/dev/null || echo missing)"
 ready_flag="$(jq -r 'if has("ready") then (.ready | tostring) else (.status == "ok" | tostring) end' \
   "$READY_BODY" 2>/dev/null || echo missing)"


### PR DESCRIPTION
Master's post-deploy smoke printed this, and it **passed**:

```
✓ readiness (scale-alerts config-guard, US-32.4) (6646ms)
```

…against a 5000ms budget. The verdict was correct — readiness takes the best of three probes precisely because a deploy-adjacent request pays a cold start (#659), and the best probe was well inside budget. The **number** came from the last probe, because `pass` reports the ambient `TIME_MS`.

A passing line carrying a time over its own budget reads as a broken gate, and a gate nobody believes is a gate nobody acts on — which is the same failure mode #659 and #664 were about, arriving through the display instead of the verdict.

Both best-of-N blocks now set `TIME_MS` to the value they judged before reporting, so the line and the verdict agree. `/health` had the same defect before today and simply had not been caught printing it.

Verified by running the script against a local server: `✓ health (43ms)`, `✓ readiness … (41ms)`.

**Review gate:** reviewed inline — this session cannot dispatch review agents, and per `CLAUDE.md` the gate is satisfied by the best available reviewer. Checked that the reassignment happens after every branch that reads the per-probe value and before any `pass`/`warn`/`fail` that reports one.