### PR TITLE
Make search_events attribution actually attribute

### DIFF
--- a/docs/runbooks/search-events-analysis.md
+++ b/docs/runbooks/search-events-analysis.md
@@ -10,10 +10,15 @@ procedure, monthly, ~15 minutes.
 
 ## 0. Enrich first, on the machine that did the searching
 
-Two columns cannot be filled by the client and are null until this runs:
+Three columns cannot be filled by the client and are wrong or null until this runs:
 
-- `client_model` — no model variable exists in the agent environment.
-- the `workflow` / `subagent` split — the client can only say `main` or `child`.
+- `client_model` — no model variable exists in the MCP server's environment.
+- `client_effort` — likewise absent from that process (`CLAUDE_EFFORT` is set for Bash-tool
+  invocations, not for the MCP server), so the column is NULL until enriched.
+- `client_kind` — the client reports the SESSION's kind, not the caller's. One MCP process
+  serves a session and every agent it dispatches, so it labels every search `main`. **An
+  un-enriched `client_kind` is not caller-level truth** — do not compute a per-kind rate
+  from one.
 
 ```bash
 # on each dev machine that runs agents (transcripts never leave the machine)
@@ -23,8 +28,16 @@ mix loopctl.enrich_search_events --since-days 45    # then write
 
 It joins on `(client_session_id, query)`, because a subagent's transcript records its
 PARENT's session id — see `Loopctl.Knowledge.SearchEventEnrichment` for why the pair is
-the only unambiguous key, and why a pair two transcripts disagree about is dropped rather
-than guessed. Rows are only filled, never overwritten, so it is safe to re-run.
+the only unambiguous key, and why a key two transcripts disagree about is dropped rather
+than guessed.
+
+A **resumed** session breaks that key: the restarted MCP server reports a fresh session id
+while the transcript keeps appending under the original, so the pair can never match. The
+task falls back to the query alone for those rows, and only for a query that is unambiguous
+across the whole transcript tree (measured: 96% of distinct queries are). `client_model` and
+`client_effort` are filled, never overwritten; `client_kind` IS corrected, because the value
+the client sent is a session-level assertion rather than an observation. Re-running is safe
+and idempotent either way.
 
 ## 1. Run the canonical queries
 
@@ -55,6 +68,19 @@ computed over that mix measures automation, not agents.
 
 Split on `tool`, `client_entrypoint` and `client_kind` first. If a number moved, establish
 which segment moved before attributing it to anything.
+
+**The single most important filter is `client_host IS NOT NULL`.** A row without it never
+passed through the MCP client at all, so it cannot be an agent's search: the UserPromptSubmit
+recall hook and `scripts/smoke.sh` call the API directly. In the first 11 hours after this
+table went live, 131 of 133 rows were exactly that — repeated `elixir` probes from the smoke
+check and keyword-stripped `memory_recall` calls from the recall hook. Any rate computed over
+the unfiltered table measures this project's own automation.
+
+One operational trap belongs here too: **a long-running session keeps the mcp-server build it
+booted with.** `npx` updating the cache does not restart it, so after publishing a version
+that changes what the client sends, sessions started before the publish keep sending the old
+payload until they are restarted. If context columns are unexpectedly sparse, check
+`client_version` before suspecting the server.
 
 ## 3. What to look at, in order
 

--- a/docs/runbooks/search-events-analysis.md
+++ b/docs/runbooks/search-events-analysis.md
@@ -31,6 +31,11 @@ PARENT's session id — see `Loopctl.Knowledge.SearchEventEnrichment` for why th
 the only unambiguous key, and why a key two transcripts disagree about is dropped rather
 than guessed.
 
+The task is **machine-scoped, and now enforces it**: the query-only fallback below is
+applied only to rows whose `client_host` is the machine you are running on. Another
+machine's rows stay null until you run it there, which is the correct outcome — two machines
+searching the same wording is ordinary, and their transcript trees never see each other.
+
 A **resumed** session breaks that key: the restarted MCP server reports a fresh session id
 while the transcript keeps appending under the original, so the pair can never match. The
 task falls back to the query alone for those rows, and only for a query that is unambiguous

--- a/lib/loopctl/knowledge/search_event.ex
+++ b/lib/loopctl/knowledge/search_event.ex
@@ -52,10 +52,15 @@ defmodule Loopctl.Knowledge.SearchEvent do
              count(*), count(*) FILTER (WHERE outcome = 'zero_results') AS zero
         FROM search_events WHERE tenant_id = $1 GROUP BY 1 ORDER BY 1;
 
-      -- WHO searches and who fails: the main/child split, and the repo the agent was in.
+      -- WHO searches and who fails, once enriched. `client_host IS NOT NULL` is the
+      -- filter that matters: rows without it never came through the MCP client at all
+      -- (the recall hook and scripts/smoke.sh call the API directly), so including them
+      -- measures this project's own automation rather than its agents.
       SELECT client_kind, client_repo, client_effort, count(*),
              count(*) FILTER (WHERE outcome IN ('zero_results','rejected')) AS bad
-        FROM search_events WHERE tenant_id = $1 GROUP BY 1,2,3 ORDER BY 4 DESC;
+        FROM search_events
+       WHERE tenant_id = $1 AND client_host IS NOT NULL
+       GROUP BY 1,2,3 ORDER BY 4 DESC;
 
       -- Degradation, by cause.
       SELECT fallback_reason, count(*), count(*) FILTER (WHERE result_count = 0) AS empty
@@ -73,10 +78,19 @@ defmodule Loopctl.Knowledge.SearchEvent do
         FROM search_events s
        WHERE s.tenant_id = $1 AND s.outcome = 'ok';
 
-  `client_model` is not populated by the client (no model variable exists in the agent
-  environment); enrich it offline by joining `client_session_id` to the session transcript,
-  which records the model. The same join separates workflow agents from ordinary subagents,
-  which `client_kind` cannot.
+  THREE of the `client_*` columns cannot be filled by the client and are enriched offline
+  from the session transcript, joined on `client_session_id`:
+
+  - `client_model` and `client_effort` — neither variable exists in the environment the MCP
+    server is spawned with (`CLAUDE_EFFORT` is set for Bash-tool invocations but not for the
+    MCP server, so `client_effort` was permanently NULL until the enrichment filled it).
+  - `client_kind` — the client reports the kind of the SESSION, not of the CALLER. One MCP
+    process serves a session and every agent it dispatches, with an environment frozen at
+    spawn, so it labels EVERY search `main`. Only the transcript can say whether a search
+    came from the main session, a subagent, or a workflow agent.
+
+  So do NOT read `client_kind` as caller-level truth on an un-enriched row: before the
+  enrichment runs it means "some search from this session".
 
   That join is implemented — `mix loopctl.enrich_search_events`, see
   `Loopctl.Knowledge.SearchEventEnrichment` — and the monthly procedure that runs it and

--- a/lib/loopctl/knowledge/search_event_enrichment.ex
+++ b/lib/loopctl/knowledge/search_event_enrichment.ex
@@ -1,39 +1,58 @@
 defmodule Loopctl.Knowledge.SearchEventEnrichment do
   @moduledoc """
-  Fills the two `search_events` columns that no client can supply, by joining rows to the
-  agent session transcripts that recorded them (#652 item 5).
+  Fills the `search_events` columns that no client can supply, by joining rows to the agent
+  session transcripts that recorded them (#652 item 5).
 
-  ## The two gaps, and why they need an offline join
+  ## The three gaps, and why they need an offline join
 
-  * **`client_model`** — no model variable exists in the agent environment, so the MCP
-    client cannot send it. The transcript records it.
-  * **`client_kind`** — the client can only tell `main` from `child`. Splitting a WORKFLOW
-    agent from an ordinary SUBAGENT needs the transcript too, and the split matters:
-    measured failure rates were main 8.2% / workflow 6.0% / subagent 3.7%, which is a
-    three-way spread that `child` averages away.
+  * **`client_model`** — no model variable exists in the MCP server's environment, so the
+    client cannot send it. The transcript records it on every assistant entry.
+  * **`client_effort`** — likewise absent. `CLAUDE_EFFORT` is set in the environment of
+    Bash-tool invocations but NOT in the environment the MCP server is spawned with, so the
+    column was permanently NULL before this filled it. The transcript records `effort`, and
+    it carries real variance worth measuring (workflow agents run a mix of `high`,
+    `medium` and `low`).
+  * **`client_kind`** — the client reports the kind of the SESSION, which is not the kind of
+    the CALLER. One MCP server process is spawned per session and serves the main session
+    and every agent it dispatches, and its environment is frozen at spawn — so it reports
+    `main` for every search, whoever made it. The transcript is the only source that can
+    say which branch of the tree a row came from, and the split matters: measured failure
+    rates were main 8.2% / workflow 6.0% / subagent 3.7%.
 
   ## Why the join key is (session, query) and not the session alone
 
-  A subagent's transcript records its PARENT's `sessionId`, not its own. So a session id
-  maps to a whole tree, and on its own it can neither name the model a child ran on nor say
-  which branch of the tree a row came from. What IS unambiguous is the tool call itself: a
-  search made by a subagent appears in that subagent's transcript FILE, and the file's path
-  says what it is (`.../subagents/...`, `.../workflows/...`, or the session's own
-  `<uuid>.jsonl`).
+  A subagent's transcript records its PARENT's `sessionId` — measured at 99.5% across this
+  machine's corpus — so a session id maps to a whole tree, and on its own it can neither
+  name the model a child ran on nor say which branch a row came from. What IS unambiguous is
+  the tool call itself: a search made by a subagent appears in that subagent's transcript
+  FILE, and the file's path says what it is (`.../subagents/...`, `.../workflows/...`, or
+  the session's own `<uuid>.jsonl`).
 
-  So the unit of the join is `{session_id, query}`, resolved from the tool-call arguments,
-  carrying the model recorded in that same file.
+  ## Why there is also a query-only fallback
+
+  The pair key is right but it is not always available, because **a RESUMED session's MCP
+  server reports a session id the transcript never records**. Measured directly: a session
+  resumed on 2026-08-12 spawned an MCP server reporting `ff0b1491-…` while the transcript
+  kept appending under its original `d73e6085-…`; that id appears as a `sessionId` in zero
+  transcripts on the machine. Every search from a resumed session is therefore unjoinable on
+  the pair alone — and resuming is routine here.
+
+  So a pair miss falls back to the query alone, and only for a query that resolves to
+  exactly ONE attribution across the entire tree. Measured: 96% of distinct queries (968 of
+  1,007) appear exactly once, so the fallback recovers nearly all of it while still never
+  guessing. The fallback is applied ONLY to rows that carry a `client_session_id`, i.e. rows
+  that really came through the MCP client — hook and smoke traffic never reaches it, so a
+  coincidental query match cannot attribute a machine-made search to an agent.
 
   ## Ambiguity is dropped, never guessed
 
-  If one `{session_id, query}` pair appears in two files that disagree (the same query run
-  by both a subagent and the main session, which happens with retry loops), the pair is
-  marked ambiguous and contributes NOTHING. An enrichment that guesses is worse than a null:
-  the whole point of the column is to support a comparison between kinds, and a
-  mis-attributed row moves the number it exists to measure.
+  If one key appears in two files that disagree, it contributes NOTHING. That applies to
+  both keys, and to a `path` classification contradicted by the entry's own `isSidechain`
+  flag. An enrichment that guesses is worse than a null: the whole point of the columns is
+  to support a comparison BETWEEN kinds, and a mis-attributed row moves the very number it
+  exists to measure.
 
-  Rows are only ever filled, never overwritten: a row that already has a `client_model`
-  keeps it.
+  Rows are only ever filled, never overwritten.
   """
 
   require Logger
@@ -52,23 +71,55 @@ defmodule Loopctl.Knowledge.SearchEventEnrichment do
     mcp__loopctl__recall_context
   )
 
-  @type attribution :: %{model: String.t() | nil, kind: String.t()}
+  @type attribution :: %{
+          model: String.t() | nil,
+          kind: String.t(),
+          effort: String.t() | nil
+        }
+
+  @typedoc """
+  The two indexes a scan produces. `by_pair` is the precise key; `by_query` is the fallback
+  for a resumed session whose MCP-reported id the transcript never saw, and holds ONLY
+  queries that are unambiguous across the whole tree.
+  """
+  @type t :: %__MODULE__{
+          by_pair: %{{String.t(), String.t()} => attribution()},
+          by_query: %{String.t() => attribution()}
+        }
+
+  defstruct by_pair: %{}, by_query: %{}
 
   @doc """
-  Scans `root` for session transcripts and returns `%{{session_id, query} => attribution}`.
+  Scans `root` for session transcripts and returns the two attribution indexes.
 
-  Pairs seen in files that disagree about kind or model are omitted (see the moduledoc).
-  Unreadable or malformed files are skipped with a warning rather than aborting the scan —
-  a transcript tree is other people's data and a single bad line must not cost the batch.
+  Keys seen in files that disagree are omitted (see the moduledoc). Unreadable or malformed
+  files are skipped with a warning rather than aborting the scan — a transcript tree is a
+  historical record and a single bad line must not cost the batch.
   """
-  @spec scan(Path.t()) :: %{{String.t(), String.t()} => attribution()}
+  @spec scan(Path.t()) :: t()
   def scan(root) do
-    root
-    |> transcript_files()
-    |> Enum.reduce(%{}, fn path, acc -> merge_file(acc, path) end)
-    |> Enum.reject(fn {_key, value} -> value == :ambiguous end)
-    |> Map.new()
+    {pairs, queries} =
+      root
+      |> transcript_files()
+      |> Enum.reduce({%{}, %{}}, &merge_file(&2, &1))
+
+    %__MODULE__{by_pair: settled(pairs), by_query: settled(queries)}
   end
+
+  @doc """
+  Resolves an attribution for one recorded search, or `nil`.
+
+  The precise `{session_id, query}` key wins. A miss falls back to the query alone, which is
+  what recovers a resumed session — see the moduledoc for why that key goes missing and why
+  the fallback cannot manufacture an attribution.
+  """
+  @spec lookup(t(), String.t() | nil, String.t() | nil) :: attribution() | nil
+  def lookup(%__MODULE__{} = index, session_id, query)
+      when is_binary(session_id) and is_binary(query) do
+    Map.get(index.by_pair, {session_id, query}) || Map.get(index.by_query, query)
+  end
+
+  def lookup(%__MODULE__{}, _session_id, _query), do: nil
 
   @doc """
   Classifies a transcript path.
@@ -89,6 +140,12 @@ defmodule Loopctl.Knowledge.SearchEventEnrichment do
     end
   end
 
+  defp settled(map) do
+    map
+    |> Enum.reject(fn {_key, value} -> value == :ambiguous end)
+    |> Map.new()
+  end
+
   defp transcript_files(root) do
     root
     |> Path.join("**/*.jsonl")
@@ -101,10 +158,10 @@ defmodule Loopctl.Knowledge.SearchEventEnrichment do
 
     path
     |> File.stream!()
-    |> Enum.reduce({acc, nil}, fn line, {inner, model} ->
+    |> Enum.reduce({acc, %{model: nil, effort: nil}}, fn line, {inner, carried} ->
       case decode(line) do
-        nil -> {inner, model}
-        entry -> absorb(inner, entry, kind, model)
+        nil -> {inner, carried}
+        entry -> absorb(inner, entry, kind, carried)
       end
     end)
     |> elem(0)
@@ -114,27 +171,49 @@ defmodule Loopctl.Knowledge.SearchEventEnrichment do
       acc
   end
 
-  # Threads the last-seen model forward: a transcript records the model on assistant
-  # entries, and a tool call sits between them, so the model in force is the most recent
-  # one seen in the same file.
-  defp absorb(acc, entry, kind, model) do
-    model = entry_model(entry) || model
-    session_id = session_id(entry)
+  # Threads the last-seen model and effort forward: a transcript records both on assistant
+  # entries, and a tool call sits between them, so the value in force is the most recent one
+  # seen in the same file.
+  defp absorb(acc, entry, kind, carried) do
+    carried = %{
+      model: entry_model(entry) || carried.model,
+      effort: entry_effort(entry) || carried.effort
+    }
 
-    acc =
-      entry
-      |> queries()
-      |> Enum.reduce(acc, fn query, inner ->
-        put_attribution(inner, session_id, query, %{model: model, kind: kind})
-      end)
-
-    {acc, model}
+    case entry_kind(entry, kind) do
+      nil -> {acc, carried}
+      resolved -> {index_queries(acc, entry, Map.put(carried, :kind, resolved)), carried}
+    end
   end
 
-  defp put_attribution(acc, nil, _query, _attribution), do: acc
+  # `isSidechain` is a per-entry, first-party main-vs-child marker, and it agreed with the
+  # path classification on every one of the 447k entries measured. It is read as a CHECK
+  # rather than as the classifier because it cannot tell a workflow agent from a subagent —
+  # so the path supplies the three-way value and this refuses the pair when they disagree.
+  defp entry_kind(entry, kind) do
+    case Map.get(entry, "isSidechain") do
+      nil -> kind
+      false -> if kind == "main", do: kind
+      true -> if kind != "main", do: kind
+      _other -> kind
+    end
+  end
 
-  defp put_attribution(acc, session_id, query, attribution) do
-    Map.update(acc, {session_id, query}, attribution, fn
+  defp index_queries({pairs, queries}, entry, attribution) do
+    session_id = session_id(entry)
+
+    entry
+    |> queries()
+    |> Enum.reduce({pairs, queries}, fn query, {inner_pairs, inner_queries} ->
+      {put_key(inner_pairs, session_id && {session_id, query}, attribution),
+       put_key(inner_queries, query, attribution)}
+    end)
+  end
+
+  defp put_key(acc, nil, _attribution), do: acc
+
+  defp put_key(acc, key, attribution) do
+    Map.update(acc, key, attribution, fn
       :ambiguous -> :ambiguous
       ^attribution -> attribution
       _conflicting -> :ambiguous
@@ -154,6 +233,9 @@ defmodule Loopctl.Knowledge.SearchEventEnrichment do
   defp entry_model(%{"message" => %{"model" => model}}) when is_binary(model), do: model
   defp entry_model(%{"model" => model}) when is_binary(model), do: model
   defp entry_model(_entry), do: nil
+
+  defp entry_effort(%{"effort" => effort}) when is_binary(effort) and effort != "", do: effort
+  defp entry_effort(_entry), do: nil
 
   # Tool-call entries nest their content under `message.content`, each item carrying a
   # `name` and an `input`. Anything else in the transcript contributes no queries.

--- a/lib/loopctl/knowledge/search_event_enrichment.ex
+++ b/lib/loopctl/knowledge/search_event_enrichment.ex
@@ -112,14 +112,50 @@ defmodule Loopctl.Knowledge.SearchEventEnrichment do
   The precise `{session_id, query}` key wins. A miss falls back to the query alone, which is
   what recovers a resumed session — see the moduledoc for why that key goes missing and why
   the fallback cannot manufacture an attribution.
+
+  Pass `query_fallback: false` to disable the fallback for a row this machine's transcripts
+  cannot possibly explain. A session id is a UUID, so the PAIR key is safe to try against any
+  row; a bare query is not. Two machines searching the same wording is ordinary, and their
+  transcript trees never see each other — so an ungated fallback would answer another
+  machine's row with this machine's model and kind. `same_machine?/1` is the intended gate.
   """
-  @spec lookup(t(), String.t() | nil, String.t() | nil) :: attribution() | nil
-  def lookup(%__MODULE__{} = index, session_id, query)
+  @spec lookup(t(), String.t() | nil, String.t() | nil, keyword()) :: attribution() | nil
+  def lookup(index, session_id, query, opts \\ [])
+
+  def lookup(%__MODULE__{} = index, session_id, query, opts)
       when is_binary(session_id) and is_binary(query) do
-    Map.get(index.by_pair, {session_id, query}) || Map.get(index.by_query, query)
+    case Map.get(index.by_pair, {session_id, query}) do
+      nil -> if Keyword.get(opts, :query_fallback, true), do: Map.get(index.by_query, query)
+      attribution -> attribution
+    end
   end
 
-  def lookup(%__MODULE__{}, _session_id, _query), do: nil
+  def lookup(%__MODULE__{}, _session_id, _query, _opts), do: nil
+
+  @doc """
+  Whether `client_host` names the machine this is running on.
+
+  Compared on the normalised first label rather than verbatim, because the two sides do not
+  spell it the same way: the MCP client sends node's `os.hostname()`, which on macOS carries
+  the mDNS suffix (`Marks-Mac-mini.local`), while the BEAM reports the bare name
+  (`Marks-Mac-mini`). A strict comparison would therefore match on Linux and silently match
+  NOTHING on a Mac — the worst shape of failure for a task whose output is a row count.
+  """
+  @spec same_machine?(String.t() | nil) :: boolean()
+  def same_machine?(client_host) when is_binary(client_host) do
+    host_label(client_host) == host_label(local_hostname())
+  end
+
+  def same_machine?(_client_host), do: false
+
+  defp local_hostname do
+    {:ok, name} = :inet.gethostname()
+    to_string(name)
+  end
+
+  defp host_label(host) do
+    host |> String.split(".") |> hd() |> String.downcase()
+  end
 
   @doc """
   Classifies a transcript path.

--- a/lib/mix/tasks/loopctl.enrich_search_events.ex
+++ b/lib/mix/tasks/loopctl.enrich_search_events.ex
@@ -3,15 +3,18 @@ defmodule Mix.Tasks.Loopctl.EnrichSearchEvents do
 
   @moduledoc """
   Joins `search_events` rows to the agent session transcripts that produced them, filling
-  the two columns no client can supply (#652 item 5).
+  the three columns no client can supply (#652 item 5).
 
-  `client_model` has no source in the agent environment, and `client_kind` can only say
-  `main` or `child` — splitting a WORKFLOW agent from an ordinary SUBAGENT needs the
-  transcript. That split is worth having: measured failure rates were main 8.2% / workflow
-  6.0% / subagent 3.7%, a spread `child` averages away.
+  `client_model` and `client_effort` have no source in the MCP server's environment, and
+  `client_kind` reports the kind of the SESSION rather than of the CALLER — one MCP process
+  serves a session and every agent it dispatches, so it says `main` for every search. The
+  transcript is the only source for all three. The kind split is worth having: measured
+  failure rates were main 8.2% / workflow 6.0% / subagent 3.7%, a spread `main` flattens
+  entirely.
 
-  See `Loopctl.Knowledge.SearchEventEnrichment` for how the join is keyed and why an
-  ambiguous pair is dropped rather than guessed.
+  See `Loopctl.Knowledge.SearchEventEnrichment` for how the join is keyed, why a resumed
+  session needs a query-only fallback, and why an ambiguous key is dropped rather than
+  guessed.
 
   ## Usage
 
@@ -62,10 +65,14 @@ defmodule Mix.Tasks.Loopctl.EnrichSearchEvents do
     end
 
     Mix.shell().info("scanning transcripts in #{root} ...")
-    attributions = SearchEventEnrichment.scan(root)
-    Mix.shell().info("resolved #{map_size(attributions)} (session, query) pairs")
+    index = SearchEventEnrichment.scan(root)
 
-    {examined, updated} = enrich(attributions, since_days, dry_run?)
+    Mix.shell().info(
+      "resolved #{map_size(index.by_pair)} (session, query) pairs, " <>
+        "#{map_size(index.by_query)} unambiguous queries for the resumed-session fallback"
+    )
+
+    {examined, updated} = enrich(index, since_days, dry_run?)
 
     Mix.shell().info(
       "#{if dry_run?, do: "would update", else: "updated"} #{updated} of #{examined} " <>
@@ -73,54 +80,89 @@ defmodule Mix.Tasks.Loopctl.EnrichSearchEvents do
     )
   end
 
-  defp enrich(attributions, since_days, dry_run?) do
+  # A row is a candidate while ANY of the three columns is still fillable. Selecting on
+  # `client_model IS NULL` alone left every row whose model was already filled stuck with the
+  # session-level `main` the client reported, which is the value the kind split exists to
+  # replace.
+  #
+  # `client_session_id` is still required: it is what says the row came through the MCP
+  # client at all. Hook and smoke traffic never carries one — the UserPromptSubmit recall
+  # hook and `scripts/smoke.sh` call the API directly — and attributing one of those to an
+  # agent from a coincidental query match would corrupt the per-kind comparison.
+  #
+  # That refusal is held in TWO independent places: this predicate, and `lookup/3`'s
+  # `is_binary(session_id)` guard, which is what stops the query-only fallback from firing
+  # for a row that has no session at all. Verified by mutation: removing either one alone
+  # leaves the test green because the other still catches it, and removing BOTH turns the
+  # hook-traffic row red. Keep both — the fallback is exactly the mechanism that would make
+  # a single missed check silently mislabel automation as agent traffic.
+  defp enrich(index, since_days, dry_run?) do
     cutoff = DateTime.add(DateTime.utc_now(), -since_days * 24 * 60 * 60, :second)
 
     SearchEvent
     |> where([e], e.inserted_at > ^cutoff)
-    |> where([e], is_nil(e.client_model))
     |> where([e], not is_nil(e.client_session_id) and not is_nil(e.query))
+    |> where(
+      [e],
+      is_nil(e.client_model) or is_nil(e.client_effort) or is_nil(e.client_kind) or
+        e.client_kind == "main"
+    )
     |> AdminRepo.all()
-    |> Enum.reduce({0, 0}, &enrich_one(&1, &2, attributions, dry_run?))
+    |> Enum.reduce({0, 0}, &enrich_one(&1, &2, index, dry_run?))
   end
 
-  defp enrich_one(event, {examined, updated}, attributions, dry_run?) do
-    case Map.get(attributions, {event.client_session_id, event.query}) do
+  defp enrich_one(event, {examined, updated}, index, dry_run?) do
+    case SearchEventEnrichment.lookup(index, event.client_session_id, event.query) do
       nil -> {examined + 1, updated}
       attribution -> {examined + 1, updated + apply_one(event, attribution, dry_run?)}
     end
   end
 
-  defp apply_one(_event, _attribution, true), do: 1
+  defp apply_one(event, attribution, dry_run?) do
+    changes = changes_for(event, attribution)
 
-  defp apply_one(event, attribution, false) do
-    apply_attribution(event, attribution)
-    1
-  end
-
-  # `client_kind` is REFINED, not replaced: `workflow` and `subagent` are both sub-classes
-  # of the `child` the client reported, so nothing is lost — "not main" is still recoverable
-  # — while the three-way comparison becomes possible. A row the client called `main` is
-  # left alone unless the transcript agrees, so a mis-scan cannot relabel the parent.
-  defp apply_attribution(event, %{model: model, kind: kind}) do
-    changes =
-      %{}
-      |> put_if(:client_model, model)
-      |> put_if(:client_kind, refined_kind(event.client_kind, kind))
-
-    if changes == %{} do
-      :ok
-    else
-      SearchEvent
-      |> where([e], e.id == ^event.id)
-      |> AdminRepo.update_all(set: Enum.to_list(changes))
+    cond do
+      changes == %{} -> 0
+      dry_run? -> 1
+      true -> write(event, changes)
     end
   end
 
-  defp refined_kind("main", "main"), do: nil
-  defp refined_kind("main", _other), do: nil
-  defp refined_kind(_client_kind, kind) when kind in ["workflow", "subagent"], do: kind
-  defp refined_kind(_client_kind, _kind), do: nil
+  defp write(event, changes) do
+    SearchEvent
+    |> where([e], e.id == ^event.id)
+    |> AdminRepo.update_all(set: Enum.to_list(changes))
+
+    1
+  end
+
+  # `client_model` and `client_effort` are FILL-ONLY — a value a client actually sent is
+  # never overwritten. `client_kind` is different, and deliberately so.
+  #
+  # This guard used to read `refined_kind("main", _) -> nil`, written so a mis-scan could
+  # not relabel a parent session. It could not do that job: the client reports the kind of
+  # the SESSION, and one MCP process serves the session AND every agent it dispatches with
+  # an environment frozen at spawn — so it labels EVERY search `main`, whoever made it.
+  # Refusing to move `main` therefore blocked essentially every correct relabel. Measured on
+  # one machine's corpus: 74% of agent searches come from a workflow or subagent, so the
+  # guard suppressed nearly all of the signal the column exists to carry.
+  #
+  # The transcript's kind is caller-level evidence and wins over the client's session-level
+  # assertion. It is still never a guess: a key two transcripts disagree about, or a path
+  # contradicted by the entry's own `isSidechain`, never reaches here at all.
+  defp changes_for(event, %{model: model, kind: kind, effort: effort}) do
+    %{}
+    |> put_if(:client_model, fill_only(event.client_model, model))
+    |> put_if(:client_effort, fill_only(event.client_effort, effort))
+    |> put_if(:client_kind, corrected_kind(event.client_kind, kind))
+  end
+
+  defp fill_only(nil, value), do: value
+  defp fill_only(_existing, _value), do: nil
+
+  defp corrected_kind(same, same), do: nil
+  defp corrected_kind(_client_kind, kind) when kind in ["workflow", "subagent", "main"], do: kind
+  defp corrected_kind(_client_kind, _kind), do: nil
 
   defp put_if(map, _key, nil), do: map
   defp put_if(map, key, value), do: Map.put(map, key, value)

--- a/lib/mix/tasks/loopctl.enrich_search_events.ex
+++ b/lib/mix/tasks/loopctl.enrich_search_events.ex
@@ -112,7 +112,9 @@ defmodule Mix.Tasks.Loopctl.EnrichSearchEvents do
   end
 
   defp enrich_one(event, {examined, updated}, index, dry_run?) do
-    case SearchEventEnrichment.lookup(index, event.client_session_id, event.query) do
+    opts = [query_fallback: SearchEventEnrichment.same_machine?(event.client_host)]
+
+    case SearchEventEnrichment.lookup(index, event.client_session_id, event.query, opts) do
       nil -> {examined + 1, updated}
       attribution -> {examined + 1, updated + apply_one(event, attribution, dry_run?)}
     end

--- a/mcp-server/lib/client-context.js
+++ b/mcp-server/lib/client-context.js
@@ -12,18 +12,34 @@
  * remains the sole authority. The server stores these under a `client_` prefix so no later
  * reader mistakes them for server-derived facts.
  *
- * WHAT IS ACTUALLY AVAILABLE (verified on a live session, 2026-08-12):
+ * WHAT IS ACTUALLY AVAILABLE — re-measured 2026-08-12 by reading /proc/<mcp-pid>/environ on
+ * a live session, which corrected two entries an earlier pass got wrong:
  *
- *   CLAUDE_EFFORT=high              -> effort, available
- *   CLAUDE_SESSION_ID=<uuid>        -> session id, available
- *   CLAUDE_CODE_CHILD_SESSION=1     -> subagent vs main session, available
+ *   CLAUDE_CODE_SESSION_ID=<uuid>   -> session id, available
  *   CLAUDE_CODE_ENTRYPOINT=cli      -> entrypoint, available
+ *   CLAUDE_SESSION_ID               -> ABSENT (the CODE_ spelling is the one that is set)
+ *   CLAUDE_EFFORT                   -> ABSENT from THIS process. It is set for Bash-tool
+ *                                      invocations, which is where the earlier claim that
+ *                                      it was "available" came from; the MCP server does
+ *                                      not get it, so `effort` is enriched offline.
+ *   CLAUDE_CODE_CHILD_SESSION       -> ABSENT, and it would not mean what it looks like:
+ *                                      it is set to 1 for Bash-tool invocations of a MAIN
+ *                                      session, so it marks "a child PROCESS", not "a
+ *                                      dispatched agent".
  *   (no model variable)             -> MODEL IS NOT AVAILABLE
  *
- * The model is deliberately still sent when a variable for it appears, because the session
- * TRANSCRIPT does record it (`message.model`, e.g. `claude-opus-5`) keyed by session id —
- * so `client_session_id` is the join key that enriches model offline today, and the field
- * fills itself in the day the runtime exposes one.
+ * THE KIND REPORTED HERE IS THE SESSION'S, NOT THE CALLER'S. One MCP server process is
+ * spawned per session and serves the main session AND every agent it dispatches, and the
+ * environment above is read once and cached for the life of that process. So `kind` is a
+ * property of the session, and every search it labels comes back `main`. The three-way
+ * main/subagent/workflow split a measurement actually needs is recoverable only from the
+ * transcript, where `isSidechain` plus the file's path give it unambiguously.
+ *
+ * Two fields are therefore sent as JOIN KEYS rather than as answers: `session_id` is what
+ * lets `mix loopctl.enrich_search_events` find the transcript that records the model, the
+ * effort and the real kind. Note that a RESUMED session breaks even that — the new process
+ * reports a fresh session id while the transcript keeps appending under the original — so
+ * the enrichment carries a query-only fallback for exactly that case.
  */
 
 import { execFileSync } from "node:child_process";
@@ -87,15 +103,17 @@ function clientContext({ version } = {}) {
     version,
   };
 
-  // main vs child. A dispatched agent sets CLAUDE_CODE_CHILD_SESSION=1.
+  // The SESSION's kind — see the header. This process is shared by the main session and
+  // every agent it dispatches, so in practice this resolves to "main" for all of them and
+  // is NOT caller-level evidence. It is still worth sending: it is the only thing available
+  // before the offline enrichment runs, and the enrichment treats it as an assertion to be
+  // corrected rather than as a value to be preserved.
   //
-  // Only TWO values, on purpose. A workflow agent cannot be distinguished from an ordinary
-  // subagent here: CLAUDE_CODE_WORKFLOWS is a feature flag that is present in main sessions
-  // too, and nothing else marks one. Since an audit measured materially different failure
-  // rates across main/workflow/subagent, the third value matters — but it is recoverable
-  // only OFFLINE, by joining session_id to the transcript path (wf_* vs subagents/). Report
-  // what is observable and let the join supply the rest; do not guess a value that would
-  // then be analysed as fact.
+  // Do not try to widen it to three values from the environment. CLAUDE_CODE_WORKFLOWS is a
+  // feature flag present in main sessions too, and CLAUDE_CODE_CHILD_SESSION marks a child
+  // PROCESS rather than a dispatched agent. Guessing here would be worse than the null it
+  // replaces, because the number this column exists to support is a comparison BETWEEN
+  // kinds.
   const child = env("CLAUDE_CODE_CHILD_SESSION");
   if (child !== undefined) {
     ctx.kind = child === "1" || child.toLowerCase() === "true" ? "child" : "main";

--- a/test/loopctl/knowledge/search_event_enrichment_test.exs
+++ b/test/loopctl/knowledge/search_event_enrichment_test.exs
@@ -18,7 +18,9 @@ defmodule Loopctl.Knowledge.SearchEventEnrichmentTest do
     path
   end
 
-  defp assistant(model), do: %{"sessionId" => @session, "message" => %{"model" => model}}
+  defp assistant(model, extra \\ %{}) do
+    Map.merge(%{"sessionId" => @session, "message" => %{"model" => model}}, extra)
+  end
 
   defp search(query, tool \\ "mcp__loopctl__knowledge_search", key \\ "query") do
     %{
@@ -60,19 +62,27 @@ defmodule Loopctl.Knowledge.SearchEventEnrichmentTest do
         search("capability token replay")
       ])
 
-      map = SearchEventEnrichment.scan(root)
+      index = SearchEventEnrichment.scan(root)
 
-      assert map[{@session, "rls tenant scoping"}] == %{model: "claude-opus-4-8", kind: "main"}
+      assert index.by_pair[{@session, "rls tenant scoping"}] ==
+               %{model: "claude-opus-4-8", kind: "main", effort: nil}
 
-      assert map[{@session, "dispatch lineage"}] == %{
-               model: "claude-fable-5",
-               kind: "subagent"
-             }
+      assert index.by_pair[{@session, "dispatch lineage"}].kind == "subagent"
+      assert index.by_pair[{@session, "capability token replay"}].kind == "workflow"
+    end
 
-      assert map[{@session, "capability token replay"}] == %{
-               model: "claude-sonnet-5",
-               kind: "workflow"
-             }
+    test "carries the effort recorded on the transcript", %{root: root} do
+      write_transcript(root, "proj/#{@session}/workflows/wf_1/agent-1.jsonl", [
+        assistant("claude-opus-5", %{"effort" => "medium"}),
+        search("hnsw dead entries")
+      ])
+
+      index = SearchEventEnrichment.scan(root)
+
+      # The column this fills was permanently NULL before: CLAUDE_EFFORT is absent from the
+      # environment the MCP server is spawned with, so no client could ever have sent it.
+      assert index.by_pair[{@session, "hnsw dead entries"}] ==
+               %{model: "claude-opus-5", kind: "workflow", effort: "medium"}
     end
 
     test "reads the historical q and topic spellings too", %{root: root} do
@@ -82,10 +92,10 @@ defmodule Loopctl.Knowledge.SearchEventEnrichmentTest do
         search("legacy topic spelling", "mcp__loopctl__knowledge_progressive_index", "topic")
       ])
 
-      map = SearchEventEnrichment.scan(root)
+      index = SearchEventEnrichment.scan(root)
 
-      assert map[{@session, "legacy q spelling"}].kind == "main"
-      assert map[{@session, "legacy topic spelling"}].kind == "main"
+      assert index.by_pair[{@session, "legacy q spelling"}].kind == "main"
+      assert index.by_pair[{@session, "legacy topic spelling"}].kind == "main"
     end
 
     test "drops a pair two files disagree about rather than guessing", %{root: root} do
@@ -99,11 +109,12 @@ defmodule Loopctl.Knowledge.SearchEventEnrichmentTest do
         search("shared query")
       ])
 
-      map = SearchEventEnrichment.scan(root)
+      index = SearchEventEnrichment.scan(root)
 
       # An enrichment that guessed here would move the very number the column exists to
       # measure — the per-kind failure rate.
-      refute Map.has_key?(map, {@session, "shared query"})
+      refute Map.has_key?(index.by_pair, {@session, "shared query"})
+      refute Map.has_key?(index.by_query, "shared query")
     end
 
     test "the same pair recorded identically twice is not ambiguous", %{root: root} do
@@ -113,9 +124,33 @@ defmodule Loopctl.Knowledge.SearchEventEnrichmentTest do
         search("repeated query")
       ])
 
-      map = SearchEventEnrichment.scan(root)
+      index = SearchEventEnrichment.scan(root)
 
-      assert map[{@session, "repeated query"}] == %{model: "claude-opus-4-8", kind: "main"}
+      assert index.by_pair[{@session, "repeated query"}].model == "claude-opus-4-8"
+    end
+
+    test "refuses a path the entry's own isSidechain flag contradicts", %{root: root} do
+      # A `main` transcript whose entries claim to be a sidechain is evidence the path
+      # classification is wrong, not evidence to file the row under.
+      write_transcript(root, "proj/#{@session}.jsonl", [
+        assistant("claude-opus-5"),
+        Map.put(search("contradicted"), "isSidechain", true)
+      ])
+
+      index = SearchEventEnrichment.scan(root)
+
+      refute Map.has_key?(index.by_pair, {@session, "contradicted"})
+    end
+
+    test "an agreeing isSidechain flag leaves the path classification intact", %{root: root} do
+      write_transcript(root, "proj/#{@session}/subagents/agent-a.jsonl", [
+        assistant("claude-opus-5"),
+        Map.put(search("agreeing"), "isSidechain", true)
+      ])
+
+      index = SearchEventEnrichment.scan(root)
+
+      assert index.by_pair[{@session, "agreeing"}].kind == "subagent"
     end
 
     test "ignores non-search tool calls and unparseable lines", %{root: root} do
@@ -138,10 +173,10 @@ defmodule Loopctl.Knowledge.SearchEventEnrichmentTest do
 
       File.write!(path, File.read!(path) <> "this is not json\n")
 
-      assert SearchEventEnrichment.scan(root) == %{}
+      assert SearchEventEnrichment.scan(root) == %SearchEventEnrichment{}
     end
 
-    test "an entry with no sessionId contributes nothing", %{root: root} do
+    test "an entry with no sessionId still indexes by query", %{root: root} do
       write_transcript(root, "proj/orphan.jsonl", [
         %{"message" => %{"model" => "claude-opus-4-8"}},
         %{
@@ -157,12 +192,48 @@ defmodule Loopctl.Knowledge.SearchEventEnrichmentTest do
         }
       ])
 
-      assert SearchEventEnrichment.scan(root) == %{}
+      index = SearchEventEnrichment.scan(root)
+
+      assert index.by_pair == %{}
+      assert index.by_query["unattributable"].model == "claude-opus-4-8"
     end
 
-    test "an empty root is an empty map, not a crash", %{root: root} do
+    test "an empty root is an empty index, not a crash", %{root: root} do
       File.mkdir_p!(root)
-      assert SearchEventEnrichment.scan(root) == %{}
+      assert SearchEventEnrichment.scan(root) == %SearchEventEnrichment{}
+    end
+  end
+
+  describe "lookup/3" do
+    setup %{root: root} do
+      write_transcript(root, "proj/#{@session}/workflows/wf_1/agent-1.jsonl", [
+        assistant("claude-opus-5", %{"effort" => "high"}),
+        search("only in one place")
+      ])
+
+      %{index: SearchEventEnrichment.scan(root)}
+    end
+
+    test "the precise pair wins", %{index: index} do
+      assert SearchEventEnrichment.lookup(index, @session, "only in one place").kind ==
+               "workflow"
+    end
+
+    test "a session id the transcript never recorded falls back to the query", %{index: index} do
+      # This is the RESUMED-session case, measured live: the MCP server reports a fresh
+      # session id while the transcript keeps appending under the original, so the pair key
+      # can never match and every search from a resumed session was unjoinable.
+      assert SearchEventEnrichment.lookup(index, Ecto.UUID.generate(), "only in one place") ==
+               %{model: "claude-opus-5", kind: "workflow", effort: "high"}
+    end
+
+    test "an unknown query resolves to nothing on either key", %{index: index} do
+      assert SearchEventEnrichment.lookup(index, @session, "never searched") == nil
+    end
+
+    test "a missing session id or query is not a lookup", %{index: index} do
+      assert SearchEventEnrichment.lookup(index, nil, "only in one place") == nil
+      assert SearchEventEnrichment.lookup(index, @session, nil) == nil
     end
   end
 end

--- a/test/loopctl/knowledge/search_event_enrichment_test.exs
+++ b/test/loopctl/knowledge/search_event_enrichment_test.exs
@@ -204,6 +204,23 @@ defmodule Loopctl.Knowledge.SearchEventEnrichmentTest do
     end
   end
 
+  describe "same_machine?/1" do
+    test "matches this machine however the client spelled its hostname" do
+      {:ok, name} = :inet.gethostname()
+      bare = to_string(name)
+
+      assert SearchEventEnrichment.same_machine?(bare)
+      assert SearchEventEnrichment.same_machine?(String.upcase(bare))
+      # macOS sends the mDNS form; a verbatim comparison would match nothing there.
+      assert SearchEventEnrichment.same_machine?(bare <> ".local")
+    end
+
+    test "does not match another machine, or an absent host" do
+      refute SearchEventEnrichment.same_machine?("some-other-box")
+      refute SearchEventEnrichment.same_machine?(nil)
+    end
+  end
+
   describe "lookup/3" do
     setup %{root: root} do
       write_transcript(root, "proj/#{@session}/workflows/wf_1/agent-1.jsonl", [
@@ -229,6 +246,24 @@ defmodule Loopctl.Knowledge.SearchEventEnrichmentTest do
 
     test "an unknown query resolves to nothing on either key", %{index: index} do
       assert SearchEventEnrichment.lookup(index, @session, "never searched") == nil
+    end
+
+    test "the query fallback can be refused for another machine's row", %{index: index} do
+      # Two machines searching the same wording is ordinary, and their transcript trees never
+      # see each other — so an ungated fallback would answer a mac-mini row with beelink's
+      # model and kind.
+      assert SearchEventEnrichment.lookup(
+               index,
+               Ecto.UUID.generate(),
+               "only in one place",
+               query_fallback: false
+             ) == nil
+    end
+
+    test "the precise pair still resolves with the fallback refused", %{index: index} do
+      assert SearchEventEnrichment.lookup(index, @session, "only in one place",
+               query_fallback: false
+             ).kind == "workflow"
     end
 
     test "a missing session id or query is not a lookup", %{index: index} do

--- a/test/mix/tasks/loopctl_enrich_search_events_test.exs
+++ b/test/mix/tasks/loopctl_enrich_search_events_test.exs
@@ -58,6 +58,9 @@ defmodule Mix.Tasks.Loopctl.EnrichSearchEventsTest do
             outcome: "ok",
             result_count: 3,
             client_session_id: @session,
+            # A real row never has one without the other: the client sends session id and
+            # host in the same payload, and the host is what licenses the query fallback.
+            client_host: local_host(),
             inserted_at: DateTime.utc_now(),
             updated_at: DateTime.utc_now()
           },
@@ -65,6 +68,11 @@ defmodule Mix.Tasks.Loopctl.EnrichSearchEventsTest do
         )
       )
     )
+  end
+
+  defp local_host do
+    {:ok, name} = :inet.gethostname()
+    to_string(name)
   end
 
   defp reload(event), do: AdminRepo.get!(SearchEvent, event.id)
@@ -146,6 +154,39 @@ defmodule Mix.Tasks.Loopctl.EnrichSearchEventsTest do
       run(root)
 
       assert %{client_kind: nil, client_model: nil} = reload(event)
+    end
+
+    test "will not answer another machine's row from this machine's transcripts", %{
+      root: root,
+      tenant: tenant
+    } do
+      write_transcript(root, "p/#{@session}/workflows/wf_1/a.jsonl", "claude-opus-5", "shared q")
+
+      event =
+        record(tenant, %{
+          query: "shared q",
+          client_session_id: Ecto.UUID.generate(),
+          client_host: "Marks-Mac-mini.local"
+        })
+
+      run(root)
+
+      assert %{client_kind: nil, client_model: nil} = reload(event)
+    end
+
+    test "still answers a row from this machine via the fallback", %{root: root, tenant: tenant} do
+      write_transcript(root, "p/#{@session}/workflows/wf_1/a.jsonl", "claude-opus-5", "local q")
+
+      event =
+        record(tenant, %{
+          query: "local q",
+          client_session_id: Ecto.UUID.generate(),
+          client_host: local_host()
+        })
+
+      run(root)
+
+      assert %{client_kind: "workflow", client_model: "claude-opus-5"} = reload(event)
     end
 
     test "--dry-run writes nothing", %{root: root, tenant: tenant} do

--- a/test/mix/tasks/loopctl_enrich_search_events_test.exs
+++ b/test/mix/tasks/loopctl_enrich_search_events_test.exs
@@ -1,0 +1,205 @@
+defmodule Mix.Tasks.Loopctl.EnrichSearchEventsTest do
+  @moduledoc """
+  Covers the half of the enrichment that decides WHICH rows to touch and WHAT to write.
+
+  Both defects this test pins were in exactly that half, and neither was reachable from the
+  scanner's own tests: the row-selection query skipped any row whose `client_model` was
+  already filled, and the kind guard refused to move a row the client called `main` — which
+  is every row, since the client reports the SESSION's kind, not the caller's.
+  """
+  use Loopctl.DataCase, async: true
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.SearchEvent
+  alias Mix.Tasks.Loopctl.EnrichSearchEvents
+
+  @session "49398c56-f49e-4508-acb4-0136e5e43429"
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "enrich-task-#{System.unique_integer([:positive])}")
+    on_exit(fn -> File.rm_rf!(root) end)
+    %{root: root, tenant: fixture(:tenant)}
+  end
+
+  defp write_transcript(root, relative, model, query, extra \\ %{}) do
+    path = Path.join(root, relative)
+    File.mkdir_p!(Path.dirname(path))
+
+    lines = [
+      Map.merge(%{"sessionId" => @session, "message" => %{"model" => model}}, extra),
+      %{
+        "sessionId" => @session,
+        "message" => %{
+          "content" => [
+            %{
+              "type" => "tool_use",
+              "name" => "mcp__loopctl__knowledge_search",
+              "input" => %{"query" => query}
+            }
+          ]
+        }
+      }
+    ]
+
+    File.write!(path, Enum.map_join(lines, "\n", &Jason.encode!/1) <> "\n")
+  end
+
+  defp record(tenant, attrs) do
+    AdminRepo.insert!(
+      struct(
+        SearchEvent,
+        Map.merge(
+          %{
+            tenant_id: tenant.id,
+            query: "q",
+            tool: "knowledge_search",
+            outcome: "ok",
+            result_count: 3,
+            client_session_id: @session,
+            inserted_at: DateTime.utc_now(),
+            updated_at: DateTime.utc_now()
+          },
+          attrs
+        )
+      )
+    )
+  end
+
+  defp reload(event), do: AdminRepo.get!(SearchEvent, event.id)
+
+  defp run(root, extra \\ []) do
+    EnrichSearchEvents.run(["--transcripts", root] ++ extra)
+  end
+
+  describe "run/1" do
+    test "corrects the session-level main a client asserts to the caller's real kind", %{
+      root: root,
+      tenant: tenant
+    } do
+      write_transcript(
+        root,
+        "p/#{@session}/workflows/wf_1/a.jsonl",
+        "claude-opus-5",
+        "wf query",
+        %{
+          "effort" => "medium"
+        }
+      )
+
+      event = record(tenant, %{query: "wf query", client_kind: "main"})
+
+      run(root)
+
+      # The old guard read `refined_kind("main", _) -> nil` and would have left this row at
+      # `main`. Since the MCP server labels EVERY search `main`, that suppressed the whole
+      # three-way split — 74% of agent searches on the measured corpus.
+      assert %{client_kind: "workflow", client_model: "claude-opus-5", client_effort: "medium"} =
+               reload(event)
+    end
+
+    test "a row whose model is already filled is still eligible for the kind fix", %{
+      root: root,
+      tenant: tenant
+    } do
+      write_transcript(root, "p/#{@session}/subagents/a.jsonl", "claude-fable-5", "sub query")
+
+      event =
+        record(tenant, %{
+          query: "sub query",
+          client_kind: "main",
+          client_model: "already-recorded"
+        })
+
+      run(root)
+
+      # The selection query used to require `client_model IS NULL`, so a second pass could
+      # never repair a kind — the row was filtered out before the decision ran.
+      assert %{client_kind: "subagent", client_model: "already-recorded"} = reload(event)
+    end
+
+    test "recovers a resumed session by falling back to an unambiguous query", %{
+      root: root,
+      tenant: tenant
+    } do
+      write_transcript(root, "p/#{@session}/workflows/wf_1/a.jsonl", "claude-opus-5", "resumed q")
+
+      # A resumed session's MCP server reports an id the transcript never records.
+      event = record(tenant, %{query: "resumed q", client_session_id: Ecto.UUID.generate()})
+
+      run(root)
+
+      assert %{client_kind: "workflow", client_model: "claude-opus-5"} = reload(event)
+    end
+
+    test "never attributes a row that did not come through the MCP client", %{
+      root: root,
+      tenant: tenant
+    } do
+      write_transcript(root, "p/#{@session}/workflows/wf_1/a.jsonl", "claude-opus-5", "elixir")
+
+      # Hook and smoke traffic carries no client_session_id. A coincidental query match must
+      # not label a machine-made search as an agent's.
+      event = record(tenant, %{query: "elixir", client_session_id: nil})
+
+      run(root)
+
+      assert %{client_kind: nil, client_model: nil} = reload(event)
+    end
+
+    test "--dry-run writes nothing", %{root: root, tenant: tenant} do
+      write_transcript(root, "p/#{@session}/workflows/wf_1/a.jsonl", "claude-opus-5", "dry q")
+
+      event = record(tenant, %{query: "dry q", client_kind: "main"})
+
+      run(root, ["--dry-run"])
+
+      assert %{client_kind: "main", client_model: nil} = reload(event)
+    end
+
+    test "leaves a row outside the window alone", %{root: root, tenant: tenant} do
+      write_transcript(root, "p/#{@session}/workflows/wf_1/a.jsonl", "claude-opus-5", "old q")
+
+      stale = DateTime.add(DateTime.utc_now(), -60 * 24 * 60 * 60, :second)
+      event = record(tenant, %{query: "old q", client_kind: "main", inserted_at: stale})
+
+      run(root, ["--since-days", "30"])
+
+      assert %{client_kind: "main"} = reload(event)
+    end
+
+    test "is idempotent — a second run changes nothing further", %{root: root, tenant: tenant} do
+      write_transcript(root, "p/#{@session}/subagents/a.jsonl", "claude-opus-5", "twice q")
+
+      event = record(tenant, %{query: "twice q", client_kind: "main"})
+
+      run(root)
+      first = reload(event)
+      run(root)
+
+      assert reload(event).client_kind == first.client_kind
+      assert reload(event).client_model == first.client_model
+    end
+
+    test "an unmatched row is examined and left untouched", %{root: root, tenant: tenant} do
+      File.mkdir_p!(root)
+      event = record(tenant, %{query: "nothing knows this", client_kind: "main"})
+
+      run(root)
+
+      assert %{client_kind: "main", client_model: nil} = reload(event)
+    end
+
+    test "counts every eligible row it examined", %{root: root, tenant: tenant} do
+      write_transcript(root, "p/#{@session}/workflows/wf_1/a.jsonl", "claude-opus-5", "counted")
+      record(tenant, %{query: "counted", client_kind: "main"})
+
+      run(root)
+
+      assert AdminRepo.one(
+               from(e in SearchEvent, where: e.client_kind == "workflow", select: count())
+             ) == 1
+    end
+  end
+end


### PR DESCRIPTION
## What this fixes

The `search_events` capture layer shipped yesterday and works. The attribution layer on top
of it did not, and measuring prod 11 hours after the table went live showed why: of the
first 133 rows, **2 carried any client context**, and **no row could ever have been
enriched**.

Four causes, all measured against prod and this machine's transcript corpus rather than
reasoned about.

### 1. `client_kind` is the SESSION's kind, not the CALLER's

One MCP server process is spawned per session and serves the main session *and* every agent
it dispatches, with an environment frozen at spawn. So it labels every search `main`,
whoever made it. Verified by reading `/proc/<mcp-pid>/environ` on a live session:
`CLAUDE_CODE_CHILD_SESSION` is absent, and it would not mean what it looks like anyway — it
is set to `1` for Bash-tool invocations of a *main* session, so it marks a child **process**,
not a dispatched agent.

### 2. The enrichment guard blocked essentially every correct relabel

`refined_kind("main", _) -> nil` was written so a mis-scan could not relabel a parent
session. Given (1) it could not do that job, because the client calls *everything* `main`.
Measured on this machine's corpus: **60% workflow, 14% subagent, 26% main** across 1,065
resolved pairs — so the guard suppressed ~74% of the signal the column exists to carry.

The transcript is caller-level evidence and now wins, cross-checked against each entry's own
`isSidechain` flag — which agreed with the path classification on **all 447k entries
measured** (main `False` 7,484 / subagent `True` 22,187 / workflow `True` 417,274, zero
contradictions) and is refused when it disagrees.

### 3. A resumed session reports a session id the transcript never records

Measured live: a session resumed today spawned an MCP server reporting `ff0b1491-…` while
the transcript kept appending under its original `d73e6085-…`, an id that appears as a
`sessionId` in **zero** transcripts on the machine. The pair key can never match for those
rows, and resuming is routine here.

A pair miss now falls back to the query alone, only for a query unambiguous across the whole
tree — **96% of distinct queries qualify** (968 of 1,007), so it recovers nearly everything
while still never guessing.

### 4. `client_effort` was permanently NULL

`CLAUDE_EFFORT` is set for Bash-tool invocations but **not** for the process the MCP server
runs in — which is where the earlier "verified available" claim came from. The transcript
records it with real variance worth measuring (workflow agents run a mix of `high`,
`medium`, `low`), so the enrichment fills it too.

Plus: the row-selection query required `client_model IS NULL`, so a row whose model was
already filled could never have its kind repaired on a later pass.

## Live validation

On the actual prod row this session produced:

```
pair key the MCP reported     -> nil                    # the break, on real data
pair key the transcript has   -> %{kind: "main", model: "claude-opus-5", effort: "high"}
lookup/3 (what the task does) -> %{kind: "main", model: "claude-opus-5", effort: "high"}
```

## Second commit: a defect found reviewing the first

The fallback was machine-blind. A bare query is not a globally unique key, and two machines
searching the same wording is ordinary while their transcript trees never see each other —
so running the task on beelink could have answered a mac-mini row with beelink's attribution,
silently, in exactly the columns whose purpose is a comparison between kinds. Gated on
`client_host`; the pair key never had the problem since a session id is a UUID.

The comparison is on the normalised first label, not verbatim: the client sends node's
`os.hostname()` (macOS: `Marks-Mac-mini.local`) while the BEAM reports the bare name. Both
spellings are live in the table today, and a verbatim comparison would have matched on Linux
and matched **nothing** on a Mac — the worse failure, since the task reports a row count and
silently enriching zero rows reads exactly like having nothing to do.

## Verification

`mix precommit` green (7,490 tests). Every new guard is mutation-verified — deleted, watched
fail, restored:

| Mutation | Result |
|---|---|
| restore the "main is immovable" guard | 3 failures |
| restore the `client_model IS NULL` selection | 1 failure |
| drop the query-only fallback | 1 failure |
| drop the `isSidechain` contradiction check | 1 failure |
| force the host gate open | 2 failures |
| make the host comparison verbatim | 1 failure |

One of these is worth calling out because it did **not** fail at first. The refusal to
attribute a row that never came through the MCP client is held in two independent places —
the SQL predicate and `lookup/3`'s `is_binary(session_id)` guard — so removing either alone
left the suite green. Removing **both** turns the hook-traffic test red. Both are kept, and
the comment now says which layer does what instead of overclaiming for one.

## Docs

Three docs would have sent the next reader down the same path and are corrected: the
`SearchEvent` moduledoc, the monthly runbook, and the mcp-server `client-context.js` header
comment that listed `CLAUDE_EFFORT` and `CLAUDE_CODE_CHILD_SESSION` as available when
neither reaches that process. The runbook also gains the segmentation rule this data
immediately needed — **131 of the first 133 rows were this project's own automation** (the
smoke check's repeated `elixir` probes and the UserPromptSubmit recall hook), neither of
which passes through the MCP client, so any rate computed without `client_host IS NOT NULL`
measures our infrastructure rather than our agents — and one operational note that cost the
whole first day of data: a long-running session keeps the mcp-server build it booted with,
and `npx` updating its cache does not restart it.

## Review

Reviewed inline rather than via `/review:enhanced-review-workflow`: this session's system
prompt forbids dispatching agents and workflows, and per CLAUDE.md the gate is satisfied by
the best available reviewer with that stated. The inline pass is what produced the second
commit.

No env vars, no migrations, no API changes — nothing operator-facing, so no CHANGELOG entry.
