### PR TITLE
Record search attempts on the two surfaces that recorded none

### DIFF
--- a/lib/loopctl_web/controllers/knowledge_context_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_context_controller.ex
@@ -23,6 +23,7 @@ defmodule LoopctlWeb.KnowledgeContextController do
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
   alias LoopctlWeb.Helpers.ProjectId
+  alias LoopctlWeb.Helpers.SearchTelemetry
   alias LoopctlWeb.Helpers.Visibility
 
   action_fallback LoopctlWeb.FallbackController
@@ -155,11 +156,23 @@ defmodule LoopctlWeb.KnowledgeContextController do
         |> Keyword.put(:api_key_id, api_key_id)
         |> Keyword.merge(Visibility.scope_opts(conn))
 
+      started_at = System.monotonic_time(:millisecond)
+
       case Knowledge.get_context(tenant_id, query, opts) do
         {:ok, result} ->
+          record_attempt(conn, query, started_at, %{
+            result_count: length(Map.get(result, :results, []))
+          })
+
           json(conn, LoopctlWeb.KnowledgeContextJSON.context(result))
 
         {:error, :empty_query} ->
+          record_attempt(conn, query, started_at, %{
+            rejected?: true,
+            rejection_reason: "empty_query",
+            result_count: 0
+          })
+
           {:error, :bad_request, "Query parameter 'query' is required and cannot be empty"}
       end
     end
@@ -291,4 +304,24 @@ defmodule LoopctlWeb.KnowledgeContextController do
   end
 
   defp maybe_add_conversation_id(opts, _), do: opts
+
+  # `get_context` suppresses its INNER combined search's recorder so the candidate-pool
+  # query is not counted as a search of its own, and then recorded nothing for the OUTER
+  # call — so this surface wrote article-access rows while its attempts, and every one of
+  # its misses, stayed invisible in the one table built to show them.
+  defp record_attempt(conn, query, started_at, attrs) do
+    SearchTelemetry.record_attempt(
+      conn,
+      Map.merge(
+        %{
+          query: query,
+          tool: "knowledge_context",
+          mode_requested: "combined",
+          mode_used: "combined",
+          duration_ms: System.monotonic_time(:millisecond) - started_at
+        },
+        attrs
+      )
+    )
+  end
 end

--- a/lib/loopctl_web/controllers/knowledge_progressive_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_progressive_controller.ex
@@ -22,6 +22,7 @@ defmodule LoopctlWeb.KnowledgeProgressiveController do
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
   alias LoopctlWeb.Helpers.BodyWindow
+  alias LoopctlWeb.Helpers.SearchTelemetry
   alias LoopctlWeb.Helpers.Visibility
 
   action_fallback LoopctlWeb.FallbackController
@@ -102,14 +103,24 @@ defmodule LoopctlWeb.KnowledgeProgressiveController do
         |> maybe_add_limit(params["limit"])
         |> Keyword.merge(Visibility.scope_opts(conn))
 
-      case Knowledge.progressive_index(tenant_id, coerce_topic(params["topic"]), opts) do
+      topic = coerce_topic(params["topic"])
+      started_at = System.monotonic_time(:millisecond)
+
+      case Knowledge.progressive_index(tenant_id, topic, opts) do
         {:ok, result} ->
+          record_attempt(conn, topic, started_at, %{
+            result_count: length(Map.get(result, :results, [])),
+            total_count: Map.get(result, :candidate_count)
+          })
+
           json(conn, LoopctlWeb.KnowledgeProgressiveJSON.index(result))
 
         {:error, :empty_query} ->
+          record_rejected(conn, topic, started_at, "empty_query")
           {:error, :bad_request, "Query parameter 'topic' is required and cannot be empty"}
 
         {:error, :bad_request, msg} ->
+          record_rejected(conn, topic, started_at, rejection_reason(msg))
           {:error, :bad_request, msg}
       end
     end
@@ -353,4 +364,51 @@ defmodule LoopctlWeb.KnowledgeProgressiveController do
 
   defp maybe_add_limit(opts, value) when is_integer(value), do: [{:limit, max(value, 1)} | opts]
   defp maybe_add_limit(opts, _), do: opts
+
+  # `progressive_index` is a SEARCH, and until #666's follow-up it was the one search-shaped
+  # surface that recorded nothing at all. That is backwards from what the table is for: its
+  # sibling `progressive_drill` is a READ, already covered by `article_access_events`, while
+  # a progressive_index MISS is invisible everywhere else — and a miss is this surface's
+  # documented weakness, since a paraphrased topic can fail to reach a lexically dissimilar
+  # article. `_skip_record_access: true` on the inner `search_keyword/3` call suppresses the
+  # SEED search so it is not counted as its own query; this records the OUTER attempt, whose
+  # result_count is the top-K the caller actually received.
+  defp record_attempt(conn, topic, started_at, attrs) do
+    SearchTelemetry.record_attempt(
+      conn,
+      Map.merge(
+        %{
+          query: topic,
+          tool: "knowledge_progressive_index",
+          mode_requested: "progressive",
+          mode_used: "progressive",
+          duration_ms: System.monotonic_time(:millisecond) - started_at
+        },
+        attrs
+      )
+    )
+  end
+
+  defp record_rejected(conn, topic, started_at, reason) do
+    record_attempt(conn, topic, started_at, %{
+      rejected?: true,
+      rejection_reason: reason,
+      result_count: 0
+    })
+  end
+
+  # Coarse on purpose, matching the sibling controllers: the question this answers is WHICH
+  # CLASS of malformed call agents keep making, not a per-message taxonomy.
+  #
+  # No catch-all clause, for the same reason KnowledgeHybridSearchController states: dialyzer
+  # proves every rejection this action can produce is a binary message, so a fallback clause
+  # would be unreachable code that reads like a safety net. The `true ->` branch inside the
+  # cond IS the safety net.
+  defp rejection_reason(msg) when is_binary(msg) do
+    cond do
+      String.contains?(msg, "category") -> "invalid_category"
+      String.contains?(msg, "limit") -> "invalid_limit"
+      true -> "bad_request"
+    end
+  end
 end

--- a/test/loopctl/knowledge/hub_demotion_and_sibling_telemetry_test.exs
+++ b/test/loopctl/knowledge/hub_demotion_and_sibling_telemetry_test.exs
@@ -12,7 +12,12 @@ defmodule Loopctl.Knowledge.HubDemotionAndSiblingTelemetryTest do
       (and `knowledge_context` returns FULL BODIES, so an undemoted hub costs more here);
     * `search_events` rows from recall and hybrid search, which were written with a NULL
       agent and mislabelled `tool = "knowledge_search"` — the one table built to tell the
-      surfaces apart could not tell them apart.
+      surfaces apart could not tell them apart;
+    * and, on the third recurrence of the same shape, `progressive_index` and
+      `knowledge_context`, which recorded NO attempt at all. Both suppress their inner
+      search's recorder so a candidate-pool query is not counted as its own search, and
+      neither then recorded the outer call — so on the surface whose documented weakness is
+      a paraphrased miss, every miss was invisible.
   """
   use LoopctlWeb.ConnCase, async: true
 
@@ -209,6 +214,97 @@ defmodule Loopctl.Knowledge.HubDemotionAndSiblingTelemetryTest do
       assert event.outcome == "rejected"
       assert event.tool == "knowledge_hybrid_search"
       assert event.rejection_reason == "missing_query"
+    end
+  end
+
+  describe "progressive_index and knowledge_context record their attempts too" do
+    setup %{tenant: tenant} do
+      agent = fixture(:agent, %{tenant_id: tenant.id})
+
+      {raw, api_key} =
+        fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: agent.id})
+
+      %{agent: agent, api_key: api_key, raw: raw}
+    end
+
+    defp authed_get(raw, path) do
+      Phoenix.ConnTest.build_conn()
+      |> Plug.Conn.put_req_header("authorization", "Bearer #{raw}")
+      |> Phoenix.ConnTest.get(path)
+    end
+
+    test "progressive_index records the OUTER attempt, not its seed search", %{
+      tenant: tenant,
+      agent: agent,
+      raw: raw
+    } do
+      marker = "progtel#{System.unique_integer([:positive])}"
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        status: :published,
+        title: "#{marker} note",
+        body: "#{marker} body"
+      })
+
+      authed_get(raw, ~p"/api/v1/knowledge/progressive_index?topic=#{marker}")
+
+      # Exactly ONE row for the call: the outer attempt, never the seed query as well.
+      #
+      # Two things independently keep the seed out, and mutation testing is what separated
+      # them: removing `_skip_record_access: true` from the inner `search_keyword/3` call
+      # changes nothing here, because that call also never threads an `api_key_id` and the
+      # recorder skips a search without one. So this pins the COUNT, which is the property
+      # that matters; it does not prove the flag is what enforces it.
+      assert [event] = all_search_events(tenant.id)
+      assert event.tool == "knowledge_progressive_index"
+      assert event.agent_id == agent.id
+      assert is_integer(event.duration_ms)
+    end
+
+    test "a progressive_index MISS is recorded as zero_results", %{tenant: tenant, raw: raw} do
+      miss = "progmiss#{System.unique_integer([:positive])}"
+
+      authed_get(raw, ~p"/api/v1/knowledge/progressive_index?topic=#{miss}")
+
+      # This is the whole point of covering this surface: a paraphrased topic failing to
+      # reach a lexically dissimilar article is progressive_index's documented weakness, and
+      # it left no trace anywhere before.
+      assert [event] = all_search_events(tenant.id)
+      assert event.outcome == "zero_results"
+      assert event.result_count == 0
+    end
+
+    test "knowledge_context records its attempt naming its own surface", %{
+      tenant: tenant,
+      agent: agent,
+      raw: raw
+    } do
+      marker = "ctxtel#{System.unique_integer([:positive])}"
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        status: :published,
+        title: "#{marker} note",
+        body: "#{marker} body"
+      })
+
+      authed_get(raw, ~p"/api/v1/knowledge/context?query=#{marker}")
+
+      assert [event] = all_search_events(tenant.id)
+      assert event.tool == "knowledge_context"
+      assert event.agent_id == agent.id
+      assert is_integer(event.duration_ms)
+    end
+
+    test "a knowledge_context MISS is recorded as zero_results", %{tenant: tenant, raw: raw} do
+      miss = "ctxmiss#{System.unique_integer([:positive])}"
+
+      authed_get(raw, ~p"/api/v1/knowledge/context?query=#{miss}")
+
+      assert [event] = all_search_events(tenant.id)
+      assert event.outcome == "zero_results"
+      assert event.result_count == 0
     end
   end
 


### PR DESCRIPTION
## The gap

Probing all five search-shaped KB surfaces against prod and then reading the table:

| surface | records a `search_events` row? |
|---|---|
| `knowledge_search` | yes |
| `knowledge_hybrid_search` | yes |
| `memory_recall` | yes (via `_tool`) |
| `knowledge_progressive_drill` | yes |
| **`knowledge_progressive_index`** | **no** |
| **`knowledge_context`** | **no** |

Confirmed by code, not just by the probe: neither `Knowledge.progressive_index/3` nor
`Knowledge.get_context/3` reaches `maybe_record_search_access/5`. Both suppress their INNER
search's recorder so a candidate-pool query is not counted as a search of its own, and
neither then recorded the OUTER call.

**`progressive_index` is the worse of the two.** Its sibling `progressive_drill` *does*
record — and a drill is a READ, already covered by `article_access_events`, while the index
is the SEARCH whose misses are invisible everywhere else. A paraphrased topic failing to
reach a lexically dissimilar article is this surface's *documented* weakness (CLAUDE.md says
so outright), so every instance of its known failure mode left no trace anywhere.

This is the third recurrence of the shape
`test/loopctl/knowledge/hub_demotion_and_sibling_telemetry_test.exs` already exists for — a
fix verified on the surface it was written for, with the surfaces sharing the underlying
function left behind — so the tests go in that file, and its moduledoc now names all three.

## What changed

Both surfaces record on success and on rejection, naming their own tool, carrying the agent
id and duration the sibling surfaces already carry. A miss now lands as `zero_results`
rather than as nothing.

## Verification

`mix precommit` green (7,494 tests). Mutation-verified: removing either recorder turns two
tests red.

**One comment was corrected because mutation contradicted it.** The progressive test asserts
exactly one row per call, and I had written that this proves the seed query is held out by
its `_skip_record_access: true` flag. Removing that flag changes nothing — the seed call also
never threads an `api_key_id`, and the recorder skips a search without one. The test pins the
count, which is the property that matters; the comment now claims only that.

Dialyzer also removed a `rejection_reason/1` catch-all I had added: it proves every rejection
this action can produce is a binary, so the clause was unreachable code that read like a
safety net. Mirrors the identical note in `KnowledgeHybridSearchController`.

## Review

Reviewed inline rather than via `/review:enhanced-review-workflow` — this session's system
prompt forbids dispatching agents and workflows, and per CLAUDE.md the gate is satisfied by
the best available reviewer with that stated.

No API or response change, no new env var, no migration — nothing operator-facing, so no
CHANGELOG entry and no `operation/2` spec change.

Follow-up to #666.
