### PR TITLE
Give the enrichment step the connection recipe it needs to run at all

### DIFF
--- a/docs/runbooks/search-events-analysis.md
+++ b/docs/runbooks/search-events-analysis.md
@@ -20,11 +20,21 @@ Three columns cannot be filled by the client and are wrong or null until this ru
   un-enriched `client_kind` is not caller-level truth** — do not compute a per-kind rate
   from one.
 
+The task writes through `AdminRepo`, so point `DATABASE_URL` at prod first — same recipe as
+step 1 below, via the `fly-mpg-connect` skill:
+
 ```bash
+flyctl proxy 15432:5432 -a ecf-postgres &          # loopctl's database is named `loopctl`
+export DATABASE_URL=postgres://<user>:<pass>@localhost:15432/loopctl
+
 # on each dev machine that runs agents (transcripts never leave the machine)
 mix loopctl.enrich_search_events --dry-run          # see what would change
 mix loopctl.enrich_search_events --since-days 45    # then write
 ```
+
+Run it on EVERY machine that runs agents, not just one. The task only answers rows whose
+`client_host` is the machine you are on (see below), so another machine's rows stay null
+until you run it there.
 
 It joins on `(client_session_id, query)`, because a subagent's transcript records its
 PARENT's session id — see `Loopctl.Knowledge.SearchEventEnrichment` for why the pair is


### PR DESCRIPTION
Step 0 of the monthly runbook told the operator to run `mix loopctl.enrich_search_events` and never said how to point it at prod. The recipe lived in step 1, for the SQL queries — after the step that needs it.

That is not cosmetic: the task writes through `AdminRepo`, so with no `DATABASE_URL` set it silently enriches the **local dev database** instead of the one being analysed, and reports a perfectly plausible row count while doing it.

Also states explicitly what follows from the machine scoping added in #666 and was only implied: run it on every machine that runs agents, because the query fallback only answers rows whose `client_host` is the machine you are on.

Docs only — no code, no env var, no API change. Reviewed inline (this session's system prompt forbids dispatching review agents; per CLAUDE.md the gate is satisfied by the best available reviewer with that stated).

Follows #666.