### PR TITLE
Read progressive_index's real result shape, not its siblings'

### DIFF
--- a/lib/loopctl_web/controllers/knowledge_progressive_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_progressive_controller.ex
@@ -109,8 +109,13 @@ defmodule LoopctlWeb.KnowledgeProgressiveController do
       case Knowledge.progressive_index(tenant_id, topic, opts) do
         {:ok, result} ->
           record_attempt(conn, topic, started_at, %{
-            result_count: length(Map.get(result, :results, [])),
-            total_count: Map.get(result, :candidate_count)
+            # `progressive_index/3` returns `%{stubs: [...], meta: %{candidate_count: n}}`,
+            # NOT the `:results` / top-level shape its sibling surfaces use. Reading the
+            # wrong keys recorded every SUCCESSFUL index as `result_count: 0`, which
+            # `derive_outcome/1` then classified `zero_results` — so the surface would have
+            # reported a 100% miss rate, which is worse than the silence it replaced.
+            result_count: length(Map.get(result, :stubs, [])),
+            total_count: get_in(result, [:meta, :candidate_count])
           })
 
           json(conn, LoopctlWeb.KnowledgeProgressiveJSON.index(result))

--- a/test/loopctl/knowledge/hub_demotion_and_sibling_telemetry_test.exs
+++ b/test/loopctl/knowledge/hub_demotion_and_sibling_telemetry_test.exs
@@ -260,6 +260,15 @@ defmodule Loopctl.Knowledge.HubDemotionAndSiblingTelemetryTest do
       assert event.tool == "knowledge_progressive_index"
       assert event.agent_id == agent.id
       assert is_integer(event.duration_ms)
+
+      # The COUNT, not just the row. Asserting only tool/agent/duration let a first cut ship
+      # that read `:results` and `:candidate_count` off a result shaped
+      # `%{stubs: [...], meta: %{candidate_count: n}}` — so every successful index recorded
+      # `result_count: 0` and derived `zero_results`, and this test stayed green while the
+      # surface would have reported a 100% miss rate.
+      assert event.result_count > 0
+      assert event.outcome == "ok"
+      assert event.total_count > 0
     end
 
     test "a progressive_index MISS is recorded as zero_results", %{tenant: tenant, raw: raw} do


### PR DESCRIPTION
Self-inflicted, in #667, caught before the analysis it feeds was ever run.

`progressive_index/3` returns `%{stubs: [...], meta: %{candidate_count: n}}` — not the `%{results: [...]}` shape every other search surface returns. #667 read `:results` and a top-level `:candidate_count` off it, so both came back empty: `result_count` was **0 on every successful index**, `derive_outcome/1` classified it `zero_results`, and `total_count` was always nil.

**The effect is worse than the silence #667 replaced.** A surface that records nothing is visibly absent from the table. A surface that records a 100% miss rate looks like a measurement — and the miss rate on `progressive_index` is precisely the number that surface was added to the table to supply.

**The test is what let it through.** It asserted the row existed and named its tool, agent and duration, and never asserted the count, so it stayed green against a result shape the code was misreading entirely. It now asserts `result_count`, `total_count` and `outcome` on the success path; reverting the two keys turns it red (mutation-verified).

`mix precommit` green (7,494 tests). Reviewed inline (this session's system prompt forbids dispatching review agents; per CLAUDE.md the gate is satisfied by the best available reviewer with that stated).

Fixes a defect in #667.