### PR TITLE
Decide curated-vs-retrieved on the default search path, not in a separate tool

### DIFF
--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -44,7 +44,7 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:509-515`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:463-466`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:9290`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:9369`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
    (`absolute_score/1`, `:9421-9426`) clears a scale-matched threshold AND beats the best retrieved
    candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:9328-9338`; the pure decision is
@@ -91,7 +91,7 @@ never pass `tenant_id`/`subject_id`.
    `{drift_signal, member_id}` — a group scored under the other signal's normalized key finds
    nothing and withholds (fail-closed).
 5. **Heat must not rank on a signal heat produces** — `Knowledge.heat_index/2`
-   (`knowledge.ex:9935`; the counted set is `@heat_read_access_types`, `:9805`). The heat index is the one retrieval route that
+   (`knowledge.ex:10013`; the counted set is `@heat_read_access_types`, `:9805`). The heat index is the one retrieval route that
    takes NO query, so its misses are uncorrelated with embedding similarity — which is worth nothing
    if its ordering is something a caller or the route itself generates. It has been violated FOUR
    times, each differently — and once by a FIX for one of the others — so treat any new input to

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -8389,7 +8389,10 @@ defmodule Loopctl.Knowledge do
             # because it needs `tenant_id` (a DB read of the link graph); threaded into
             # `merge_results/5` via opts so that function stays a pure fusion function
             # (no DB) — its arity and public contract are unchanged.
-            merge_opts = put_graph_lane(opts, tenant_id, kw, semantic)
+            merge_opts =
+              opts
+              |> put_graph_lane(tenant_id, kw, semantic)
+              |> put_curated_lane(tenant_id, kw, semantic)
 
             {:ok, merged} =
               merge_results(kw, semantic, keyword_weight, semantic_weight, merge_opts)
@@ -8406,7 +8409,7 @@ defmodule Loopctl.Knowledge do
                 _total_count: merged.meta[:total_count],
                 _ann_iterative_scan: merged.meta[:ann_iterative_scan]
               ),
-              "combined"
+              combined_search_mode(merged.meta[:provenance])
             )
 
             {:ok, merged}
@@ -8649,6 +8652,12 @@ defmodule Loopctl.Knowledge do
       # source_type/tags/status, so merge_results/5 stays a DB-free fusion function.
       |> apply_ranking_priors_fused(opts)
 
+    # #31 follow-up: the curated-vs-retrieved decision runs HERE, on the default path,
+    # rather than only inside `hybrid_search/3`. It is a re-rank of this same fused pool —
+    # not a different search — so exposing it as a separate tool asked every agent to know,
+    # per query, whether a governed answer exists. Finding that out IS the search.
+    {sorted, provenance_meta} = apply_curated_provenance(sorted, opts)
+
     paginated = paginate_results(sorted, opts)
 
     {:ok,
@@ -8697,6 +8706,7 @@ defmodule Loopctl.Knowledge do
          |> Map.merge(
            Map.take(semantic_result.meta, [:ann_iterative_scan, :ann_iterative_scan_reason])
          )
+         |> Map.merge(provenance_meta)
      }}
   end
 
@@ -8908,6 +8918,75 @@ defmodule Loopctl.Knowledge do
   # requested-status article maps in that rank order for the fusion. The neighbor maps carry
   # NO `:relevance_score`/`:similarity_score`, so their hybrid-resolver `absolute_score`
   # is 0.0 — a graph-only hit can never falsely win the curated-vs-retrieved decision.
+
+  # The curated candidate ids for this pool, threaded into `merge_results/5` via opts for
+  # the SAME reason `put_graph_lane/4` is: the lookup is a DB read and `merge_results/5`
+  # stays a pure fusion function. One bounded `SELECT id ... WHERE id = ANY($1)` over a pool
+  # already capped at ~200, on a path that has already paid a keyword search, an embedding
+  # and a vector read.
+  defp put_curated_lane(opts, tenant_id, kw, semantic) do
+    if Keyword.get(opts, :_skip_curated_provenance, false) do
+      opts
+    else
+      case kw.results ++ semantic.results do
+        [] -> opts
+        candidates -> Keyword.put(opts, :_curated_ids, curated_source_ids(tenant_id, candidates))
+      end
+    end
+  end
+
+  # Decides provenance over the FUSED pool, and hoists a winning curated article to the front
+  # of the FIRST page only.
+  #
+  # The decision is a property of the POOL, so it is reported on every page — a paginated
+  # caller that lost `meta.provenance` after page 1 would have to branch on page number to
+  # know whether a governed answer exists, and the whole point of the field is that a caller
+  # branches on provenance alone.
+  #
+  # The HOIST is a property of the page, so it applies at offset 0 only: re-serving the
+  # winner at the top of page 2 would show it twice to a caller paging forward.
+  # `hybrid_search/3` forces `offset: 0` on its inner call for the mirror-image reason — so
+  # a curated article ranked outside the caller's window is still FOUND.
+  defp apply_curated_provenance(sorted, opts) do
+    case Keyword.get(opts, :_curated_ids) do
+      nil ->
+        {sorted, %{}}
+
+      curated_ids ->
+        {ordered, decision} = decide_curated_provenance(sorted, curated_ids)
+        if Keyword.get(opts, :offset, 0) == 0, do: {ordered, decision}, else: {sorted, decision}
+    end
+  end
+
+  defp decide_curated_provenance(sorted, curated_ids) do
+    # `candidate_scores/1` reads the per-lane ABSOLUTE score (`similarity_score` /
+    # `relevance_score`), never the fused `:final_score`. That matters: post-#470 the fused
+    # value is an RRF weight topping out near 0.016, so the configured thresholds — tuned
+    # against a 0..1 scale — would be unreachable and every search would resolve
+    # `:retrieved`. Those per-lane fields ride along through fusion, so the decision here is
+    # the same one `hybrid_search/3` makes on the same pool.
+    scores = candidate_scores(sorted)
+    {curated, retrieved} = Enum.split_with(sorted, &MapSet.member?(curated_ids, &1.id))
+    best_curated = Enum.max_by(curated, &Map.fetch!(scores, &1.id), fn -> nil end)
+    curated_score = best_curated && Map.fetch!(scores, best_curated.id)
+    best_retrieved_score = best_score(retrieved, scores)
+    {threshold, margin} = hybrid_curated_threshold_and_margin(best_curated)
+
+    case resolve_provenance(curated_score, best_retrieved_score, threshold, margin) do
+      :curated ->
+        {hoist_to_front(sorted, best_curated.id),
+         %{
+           provenance: :curated,
+           confidence: curated_score,
+           curated_article_id: best_curated.id
+         }}
+
+      :retrieved ->
+        {sorted,
+         %{provenance: :retrieved, confidence: best_retrieved_score, curated_article_id: nil}}
+    end
+  end
+
   defp put_graph_lane(opts, tenant_id, kw, semantic) do
     # Only the RRF fuser consumes `:_graph_lane_results` — `fuse_min_max/4` ignores
     # graph neighbors entirely. Gate the (DB-backed) lane build on the strategy being
@@ -9301,41 +9380,25 @@ defmodule Loopctl.Knowledge do
       |> Keyword.put(:_skip_record_access, true)
       |> Keyword.put(:limit, @max_relevance_page_size)
       |> Keyword.put(:offset, 0)
+      # The default path now runs this same decision inside `merge_results/5`. Skip it on
+      # the INNER call: this function applies `decide_curated_provenance/2` itself, over
+      # the same pool, so letting the inner one run would pay for the curated lookup twice
+      # to reach the identical answer.
+      |> Keyword.put(:_skip_curated_provenance, true)
 
     with {:ok, %{results: pool_results, meta: pool_meta}} <-
            search_combined(tenant_id, query_string, pool_opts) do
+      # ONE implementation of the decision, shared with the default path — see
+      # `decide_curated_provenance/2`. This function's remaining job is the part that IS
+      # specific to it: forcing the full pool at offset 0 so a curated article ranked
+      # outside the caller's window is still found, then paging the reordered pool.
       curated_ids = curated_source_ids(tenant_id, pool_results)
-      scores = candidate_scores(pool_results)
 
-      {curated_candidates, retrieved_candidates} =
-        Enum.split_with(pool_results, &MapSet.member?(curated_ids, &1.id))
+      {ordered_pool, decision} = decide_curated_provenance(pool_results, curated_ids)
 
-      best_curated = Enum.max_by(curated_candidates, &Map.fetch!(scores, &1.id), fn -> nil end)
-      curated_score = best_curated && Map.fetch!(scores, best_curated.id)
-      best_retrieved_score = best_score(retrieved_candidates, scores)
-
-      {threshold, margin} = hybrid_curated_threshold_and_margin(best_curated)
-
-      provenance = resolve_provenance(curated_score, best_retrieved_score, threshold, margin)
-
-      # (finding: mislabeled-authoritative decoy) When `:curated` wins, the winning
-      # curated article MUST actually be present — and first — in the returned page,
-      # never just a label attached to whatever the pool-relative ranking happened to
-      # place in the requested window. Reordering the FULL pool (not just the page)
-      # keeps `results` sourced from the same ranked pool for every offset (AC-31.2.3
-      # shape parity is unaffected — same map shape, just reordered).
-      {ordered_pool, confidence, curated_article_id} =
-        case provenance do
-          :curated ->
-            {hoist_to_front(pool_results, best_curated.id), curated_score, best_curated.id}
-
-          :retrieved ->
-            # (finding: mislabeled confidence) `best_retrieved_score` — NEVER
-            # `best_score(pool_results, scores)`, which would report a REJECTED
-            # curated candidate's score (a different provenance class) as if it were
-            # the winning retrieved candidate's confidence.
-            {pool_results, best_retrieved_score, nil}
-        end
+      provenance = decision.provenance
+      confidence = decision.confidence
+      curated_article_id = decision.curated_article_id
 
       page = paginate_results(ordered_pool, limit: requested_limit, offset: requested_offset)
 
@@ -9480,6 +9543,21 @@ defmodule Loopctl.Knowledge do
   defp hybrid_curated_threshold_and_margin(_candidate) do
     {hybrid_curated_threshold(), hybrid_curated_margin()}
   end
+
+  # The recorded mode carries the provenance DECISION, exactly as `hybrid_search_mode/1`
+  # already does — because that is what makes the decision measurable. `search_events` joins
+  # to `article_access_events` to answer "did the searcher open anything", so labelling the
+  # branch here turns that join into "when we led with a governed article, did they open it,
+  # and more often than when we did not?". That is the only feedback signal in the system
+  # that is derived from what an agent DID rather than from what a ranker scored.
+  #
+  # `combined` (unlabelled) is still emitted when the curated lane did not run — an
+  # inner/pool call that skipped it, or a search whose pool was empty — so the value is never
+  # a guess. Rows written before this landed carry the bare `combined`; treat that as a third
+  # class, not as `combined_retrieved`.
+  defp combined_search_mode(:curated), do: "combined_curated"
+  defp combined_search_mode(:retrieved), do: "combined_retrieved"
+  defp combined_search_mode(_absent), do: "combined"
 
   defp hybrid_search_mode(:curated), do: "hybrid_curated"
   defp hybrid_search_mode(:retrieved), do: "hybrid_retrieved"

--- a/test/loopctl/knowledge/curated_first_on_default_search_test.exs
+++ b/test/loopctl/knowledge/curated_first_on_default_search_test.exs
@@ -1,0 +1,213 @@
+defmodule Loopctl.Knowledge.CuratedFirstOnDefaultSearchTest do
+  @moduledoc """
+  Epic 31 resolved the curated-vs-retrieved question, and then exposed it as a SEPARATE
+  tool. Measured over 2,101 KB tool calls across this fleet's transcripts, that tool was
+  called ZERO times; `knowledge_search` carried 58% of the traffic.
+
+  The framing was the defect, not the adoption. `hybrid_search/3` is a re-rank of the pool
+  `search_combined/3` already builds — not a different search — so routing to it asked every
+  agent to know, per query, whether a governed answer exists. Finding that out IS the search.
+  Making the corpus smarter is the app's job; the agent's job is to keep sending a query.
+
+  So the decision now runs on the default path, and these tests pin the part that is new:
+  what `search_combined/3` itself returns. `hybrid_search/3`'s own behaviour is unchanged and
+  stays pinned by `knowledge_hybrid_test.exs` / `hybrid_e2e_test.exs`; both now share ONE
+  implementation (`decide_curated_provenance/2`), so they cannot drift apart.
+  """
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Knowledge
+
+  defp direction_a, do: test_vec(1536, :primary)
+  defp direction_medium, do: test_vec(1536, :near)
+
+  defp curated_article(tenant_id, attrs) do
+    article = fixture(:article, Map.merge(%{tenant_id: tenant_id, status: :published}, attrs))
+    {:ok, marked} = Knowledge.mark_curated(tenant_id, article.id, actor_label: "user:admin")
+    marked
+  end
+
+  defp set_embedding(tenant_id, article, vector) do
+    {:ok, updated} = Knowledge.update_embedding(tenant_id, article.id, vector)
+    updated
+  end
+
+  defp stub_embeddings_by_query(mapping) do
+    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
+      case Map.fetch(mapping, text) do
+        {:ok, vector} -> {:ok, vector}
+        :error -> {:ok, List.duplicate(0.1, 1536)}
+      end
+    end)
+  end
+
+  setup do
+    tenant = fixture(:tenant)
+    Knowledge.reset_circuit_breaker(tenant.id)
+    %{tenant: tenant}
+  end
+
+  describe "the recorded search_event carries the decision, so it can be measured" do
+    setup %{tenant: tenant} do
+      {_raw, api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      %{api_key: api_key}
+    end
+
+    defp recorded_modes(tenant_id) do
+      import Ecto.Query
+
+      from(e in Loopctl.Knowledge.SearchEvent,
+        where: e.tenant_id == ^tenant_id,
+        select: e.mode_used
+      )
+      |> Loopctl.AdminRepo.all()
+    end
+
+    test "a curated win is recorded as combined_curated", %{tenant: tenant, api_key: api_key} do
+      query = "measurable refund policy"
+      stub_embeddings_by_query(%{query => direction_a()})
+
+      curated =
+        curated_article(tenant.id, %{
+          title: "Measurable refund policy",
+          body: "measurable refund policy: the governed answer"
+        })
+
+      set_embedding(tenant.id, curated, direction_a())
+
+      {:ok, _} = Knowledge.search_combined(tenant.id, query, limit: 5, api_key_id: api_key.id)
+
+      # This is the feedback signal. `search_events` joins to `article_access_events` to ask
+      # "did the searcher open anything" — labelling the branch turns that into "did leading
+      # with a governed article earn more opens than not leading with one", which is a
+      # judgement made from what an agent DID, not from what a ranker scored.
+      assert recorded_modes(tenant.id) == ["combined_curated"]
+    end
+
+    test "no curated winner is recorded as combined_retrieved", %{
+      tenant: tenant,
+      api_key: api_key
+    } do
+      query = "measurable uncurated topic"
+      stub_embeddings_by_query(%{query => direction_a()})
+
+      plain =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          title: "measurable uncurated topic",
+          body: "measurable uncurated topic, a plain note"
+        })
+
+      set_embedding(tenant.id, plain, direction_a())
+
+      {:ok, _} = Knowledge.search_combined(tenant.id, query, limit: 5, api_key_id: api_key.id)
+
+      assert recorded_modes(tenant.id) == ["combined_retrieved"]
+    end
+  end
+
+  describe "search_combined/3 resolves provenance on the default path" do
+    test "a governed curated article is hoisted to first, with provenance", %{tenant: tenant} do
+      query = "refund policy for annual plans"
+      stub_embeddings_by_query(%{query => direction_a()})
+
+      decoy =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          title: "refund policy chatter",
+          body: "refund policy for annual plans, discussed informally"
+        })
+
+      set_embedding(tenant.id, decoy, direction_medium())
+
+      curated =
+        curated_article(tenant.id, %{
+          title: "Refund policy",
+          body: "refund policy for annual plans: the governed answer"
+        })
+
+      set_embedding(tenant.id, curated, direction_a())
+
+      {:ok, %{results: results, meta: meta}} =
+        Knowledge.search_combined(tenant.id, query, limit: 5)
+
+      # The whole point: an agent that sent an ordinary query, through the ordinary tool,
+      # gets the governed answer first and is TOLD that is what happened.
+      assert meta.provenance == :curated
+      assert meta.curated_article_id == curated.id
+      assert hd(results).id == curated.id
+      assert is_number(meta.confidence)
+      assert decoy.id in Enum.map(results, & &1.id)
+    end
+
+    test "no curated candidate resolves :retrieved, and reorders nothing", %{tenant: tenant} do
+      query = "an entirely uncurated niche topic"
+      stub_embeddings_by_query(%{query => direction_a()})
+
+      a =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          title: "niche topic one",
+          body: "an entirely uncurated niche topic, first note"
+        })
+
+      set_embedding(tenant.id, a, direction_a())
+
+      {:ok, %{results: results, meta: meta}} =
+        Knowledge.search_combined(tenant.id, query, limit: 5)
+
+      assert meta.provenance == :retrieved
+      assert meta.curated_article_id == nil
+      assert a.id in Enum.map(results, & &1.id)
+    end
+
+    test "provenance is reported on a later page, but the hoist is not repeated", %{
+      tenant: tenant
+    } do
+      query = "paged refund policy"
+      stub_embeddings_by_query(%{query => direction_a()})
+
+      for i <- 1..6 do
+        filler =
+          fixture(:article, %{
+            tenant_id: tenant.id,
+            status: :published,
+            title: "paged refund policy note #{i}",
+            body: "paged refund policy, filler note #{i}"
+          })
+
+        set_embedding(tenant.id, filler, direction_medium())
+      end
+
+      curated =
+        curated_article(tenant.id, %{
+          title: "Paged refund policy",
+          body: "paged refund policy: the governed answer"
+        })
+
+      set_embedding(tenant.id, curated, direction_a())
+
+      {:ok, %{results: page1, meta: meta1}} =
+        Knowledge.search_combined(tenant.id, query, limit: 3, offset: 0)
+
+      {:ok, %{results: page2, meta: meta2}} =
+        Knowledge.search_combined(tenant.id, query, limit: 3, offset: 3)
+
+      assert hd(page1).id == curated.id
+
+      # The DECISION is a property of the pool, so it is reported on both pages — a caller
+      # that lost it after page 1 would have to branch on page number to learn whether a
+      # governed answer exists, and branching on provenance alone is the field's contract.
+      assert meta1.provenance == meta2.provenance
+
+      # The HOIST is a property of the page. Repeating it would serve the winner twice to a
+      # caller paging forward.
+      refute curated.id in Enum.map(page2, & &1.id)
+    end
+  end
+end


### PR DESCRIPTION
## The framing was the defect, not the adoption

`hybrid_search/3` is not a different search. It runs `search_combined/3`, splits the pool
into curated and retrieved, decides provenance, and hoists the winner. **It is a re-rank of
a pool the default path already builds and then throws away.**

Exposing that as its own tool asked every agent to know, per query, whether a governed answer
exists. Finding that out *is* the search. Measured across 2,101 KB tool calls in this fleet's
transcripts:

| tool | calls |
|---|---|
| `knowledge_search` | 58% of traffic |
| `hybrid_search` | **0** |
| `progressive_index` | **0** |
| `progressive_drill` | **0** |
| `heat_index` | **0** |

That is not an adoption problem to fix with better prescription in CLAUDE.md — and CLAUDE.md's
own wording ("**two better entrypoints than `knowledge_search`**") encodes the same mistake.
Making results smarter is the app's job; the agent's job is to keep sending a query.

## What changed

The decision runs inside `merge_results/5`, between the priors re-rank and pagination.
`knowledge_search` now reports `provenance`, `confidence` and `curated_article_id`.

Threading follows the existing `put_graph_lane/4` precedent — the curated lookup is a DB read,
so it's computed in `do_combined_search` and passed via opts, keeping `merge_results/5` a pure
fusion function. **Cost: one bounded `SELECT id` over a pool already capped near 200**, on a
path that has already paid a keyword search, an embedding and a vector read.

Two properties are split deliberately:

- **Provenance is a property of the POOL** → reported on every page. A caller that lost it
  after page 1 would have to branch on page number to learn whether a governed answer exists,
  and branching on provenance alone is the field's contract.
- **The hoist is a property of the PAGE** → offset 0 only, or a caller paging forward is
  served the winner twice.

## One implementation, not two

`hybrid_search/3` was recomputing the same decision inline. It now calls the same
`decide_curated_provenance/2` and skips the inner lane so the lookup isn't paid twice. Its
behaviour is unchanged — and because the function is now shared, `hybrid_e2e_test.exs`'s
negative controls (a near-but-wrong curated doc is never mislabeled; removing the curated
article resurfaces the suppressed chunk) **now cover the default path too**.

## The feedback signal

The recorded mode carries the decision — `combined_curated` / `combined_retrieved`, mirroring
the existing `hybrid_curated` / `hybrid_retrieved`.

That's what makes the decision measurable. `search_events` joins to `article_access_events` to
ask whether the searcher opened anything; labelling the branch turns that join into *"did
leading with a governed article earn more opens than not?"* — a judgement from what an agent
**did**, not from what a ranker scored. Rows written before this carry a bare `combined`;
that's a third class, not `combined_retrieved`.

## Verification — and what it does not cover

`mix precommit` green, 7,499 tests, five new ones covering hoist, no-hoist, pagination and
both recorded labels.

**The retrieval eval reports no regression, and I am not offering that as evidence.** Its
golden corpus contains no curated article at all, so the curated lane finds nothing, the
decision resolves `:retrieved`, and the zero delta is true by construction. The deploy gate is
blind to the feature this puts on the default path.

Closing that needs three things, and the third is why it isn't in this PR: a `curated` flag in
the eval harness, a marked doc in the golden set, and **the baseline regenerated in CI** — not
locally, where the run degrades to `keyword_only` and would overwrite the embeddings-arm
baseline, corrupting the gate for everyone.

Reviewed inline (this session's system prompt forbids dispatching review agents; per CLAUDE.md
the gate is satisfied by the best available reviewer with that stated).
