### PR TITLE
Judge a ranking change on two objectives, and correct for position first

### DIFF
--- a/docs/runbooks/search-events-analysis.md
+++ b/docs/runbooks/search-events-analysis.md
@@ -106,6 +106,37 @@ payload until they are restarted. If context columns are unexpectedly sparse, ch
 | `rejected` rows by `rejection_reason` | near zero | a client is sending something the API refuses — that is a tool-surface defect, and historically the largest single class |
 | search→open follow-through | 1–7%, flat | the biggest number in this area and the least moved by anything shipped so far. See #652's closing section |
 
+## 3a. Judging a RANKING change — two objectives, and a position correction
+
+Two rules, both from the IR literature this corpus already carries (Bing Liu, *Web Data
+Mining* 2nd ed.; search the wiki for the `bing-liu` tag). Neither is optional, and both exist
+because a single-proxy loop optimises the wrong thing.
+
+**Never judge a ranking change on follow-through alone.** Engagement and relevance are
+distinct objectives — the sponsored-search finding is that a high-CTR/low-relevance result
+earns revenue while destroying trust, and "revenue optimisation alone is insufficient". Our
+analogue: a ranking can lift opens by returning fewer, safer, more clickable results and be
+worse for the agent. So judge on BOTH:
+
+1. observed opens, position-corrected (below), and
+2. `mix loopctl.retrieval.eval` — the golden-question relevance gate.
+
+**A variant that lifts opens while regressing the eval loses.** And remember the other half:
+a missing open is not disinterest. An agent whose question is answered by the snippet
+correctly opens nothing, and that is a success this metric scores as a failure. Follow-through
+is a floor, never a satisfaction rate.
+
+**Correct for position before comparing two arms.** `mode_used` now distinguishes
+`combined_curated` from `combined_retrieved`, and the curated arm puts its winner at rank 1
+BY CONSTRUCTION. Clicks carry position bias, so rank 1 is opened more whatever sits there —
+a higher raw follow-through on the curated arm is therefore not evidence the hoist helped.
+Compare the arms at the SAME rank, using the position-corrected query in the
+`Loopctl.Knowledge.SearchEvent` moduledoc.
+
+One caution specific to our volume: the arms are thin, and automation rows surface results and
+never open anything, which depresses every rank uniformly. Segment on `client_host IS NOT NULL`
+here too, and do not read a few dozen rows as a result.
+
 ## 4. The trap
 
 Search returns; agents do not open. Search-to-read has sat near 27:1, and 1.74% of

--- a/lib/loopctl/knowledge/search_event.ex
+++ b/lib/loopctl/knowledge/search_event.ex
@@ -78,6 +78,30 @@ defmodule Loopctl.Knowledge.SearchEvent do
         FROM search_events s
        WHERE s.tenant_id = $1 AND s.outcome = 'ok';
 
+      -- POSITION-CORRECTED follow-through, which is the only honest way to compare two
+      -- rankings against each other. Compare a rank band, never the bare rate above.
+      --
+      -- Why: `mode_used` distinguishes `combined_curated` from `combined_retrieved`, and it
+      -- is tempting to read a higher follow-through on the curated arm as the hoist working.
+      -- It is not evidence. The curated arm puts its winner at RANK 1 by construction, and
+      -- clicks carry position bias — rank 1 is opened more whatever sits there. Comparing
+      -- the arms at the SAME rank removes the part the hoist creates by construction.
+      SELECT s.mode_used,
+             (a.metadata->>'rank')::int AS rank,
+             count(*) AS surfaced,
+             count(*) FILTER (WHERE EXISTS (
+               SELECT 1 FROM article_access_events o
+                WHERE o.tenant_id = a.tenant_id AND o.article_id = a.article_id
+                  AND o.access_type IN ('get','context','drill')
+                  AND o.accessed_at BETWEEN s.inserted_at AND s.inserted_at + interval '30 minutes'
+             )) AS opened
+        FROM search_events s
+        JOIN article_access_events a
+          ON a.tenant_id = s.tenant_id
+         AND a.metadata->>'search_id' = s.search_id::text
+       WHERE s.tenant_id = $1 AND s.mode_used LIKE 'combined%'
+       GROUP BY 1, 2 ORDER BY 1, 2;
+
   THREE of the `client_*` columns cannot be filled by the client and are enriched offline
   from the session transcript, joined on `client_session_id`:
 
@@ -101,6 +125,22 @@ defmodule Loopctl.Knowledge.SearchEvent do
   enrichment only FILLS the two columns whose value no client could ever have sent, never
   overwrites a value a client did send, and refines `client_kind` only from `child` to the
   sub-class the transcript proves. Any future writer here needs the same three properties.
+
+  ## Two objectives, never one
+
+  It is tempting to treat follow-through as THE score and tune retrieval to raise it. Do not.
+  The IR literature this corpus already carries is explicit on both halves of why (Bing Liu,
+  *Web Data Mining*, 2nd ed. — see the `bing-liu` tagged articles in the wiki):
+
+  * **Engagement and relevance are DISTINCT objectives, and optimising engagement alone is
+    insufficient** — the sponsored-search result that a high-CTR/low-relevance ad earns
+    revenue while damaging trust. Our analogue: a ranking can raise opens by returning fewer,
+    safer, more clickable results and be worse. So a change is judged on BOTH observed opens
+    AND `mix loopctl.retrieval.eval`'s golden-question relevance. A variant that lifts opens
+    while regressing the eval loses.
+  * **A missing click is not disinterest.** An agent whose question is answered by the
+    snippet correctly opens nothing, and that is a SUCCESS this metric scores as a failure.
+    Read follow-through as a floor, never as a satisfaction rate.
 
   ## Recording is best-effort and MUST NOT fail a search
 


### PR DESCRIPTION
## What this fixes

#670 labelled the recorded mode with the provenance decision so it could be measured.
**Comparing those two arms naively would have been worse than not measuring at all**, and the
IR literature already in this corpus says why on both counts (Bing Liu, *Web Data Mining* 2nd
ed. — the `bing-liu` tagged articles).

### Position bias

The curated arm puts its winner at **rank 1 by construction**, and clicks carry position bias:
rank 1 is opened more whatever sits there. So a higher raw follow-through on
`combined_curated` is not evidence the hoist helped — it is evidence we moved something to
rank 1. The arms must be compared at the same rank.

That needed **no schema change**. `article_access_events.metadata` already carries a 1-based
`rank` and the `search_id`, verified against prod (2,560 rows over two days carry both). It
needed the right query, which now sits in the `SearchEvent` moduledoc beside the naive one —
and which was **run against prod before being committed**:

```
mode_used   rank  surfaced  opened
combined    1     122       3
combined    2     122       1
combined    4      59       2
```

(All `combined` — the split labels start with #670's deploy. The sample is dominated by
automation that never opens anything, so that is a working query, not a finding.)

### Two objectives, never one

Engagement and relevance are distinct objectives, and optimising engagement alone is
insufficient — the sponsored-search case is a high-CTR/low-relevance ad that earns revenue
while destroying trust. Our analogue: a ranking that lifts opens by returning fewer, safer,
more clickable results and is **worse** for the agent.

So a change is judged on position-corrected opens **AND** `mix loopctl.retrieval.eval`'s
golden-question relevance, and a variant that lifts opens while regressing the eval loses.
Both instruments already existed; what was missing was the rule binding them.

And the other half of the same finding: **a missing click is not disinterest.** An agent whose
question is answered by the snippet correctly opens nothing, which this metric scores as a
failure. Follow-through is a floor, not a satisfaction rate.

## Scope

Docs and one SQL query. No behaviour change. `mix precommit` green (7,494 tests).

Reviewed inline (this session's system prompt forbids dispatching review agents; per CLAUDE.md
the gate is satisfied by the best available reviewer with that stated).

Follows #670.
