### PR TITLE
Return the curated decision to the caller, not only to the database

### DIFF
--- a/lib/loopctl_web/controllers/knowledge_search_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_json.ex
@@ -201,6 +201,20 @@ defmodule LoopctlWeb.KnowledgeSearchJSON do
     # transient/provider fallbacks (a key IS configured there, so "configure a key"
     # would be wrong).
     |> maybe_put(:remediation, Remediation.for_fallback_reason(meta[:fallback_reason]))
+    # The curated-vs-retrieved decision (#670). It is made on the DEFAULT path now, not
+    # only inside hybrid search, so it has to reach the caller here or it is computed and
+    # thrown away: the server recorded `combined_curated` while the response said nothing,
+    # and an agent cannot branch on a verdict it never receives.
+    #
+    # Same three keys, same meanings, as `knowledge_hybrid_search` — `:curated` means a
+    # governed article answered and is FIRST in `results` (and named by
+    # `curated_article_id`); `:retrieved` means nothing curated cleared the bar and this is
+    # the best semantic/keyword match. Deliberately NOT rendered as a bare pass-through of
+    # the internal meta: this whitelist exists so an internal atom can never leak, and
+    # these are three explicitly-chosen keys, not an exception to it.
+    |> maybe_put(:provenance, meta[:provenance])
+    |> maybe_put(:confidence, meta[:confidence])
+    |> maybe_put(:curated_article_id, meta[:curated_article_id])
     # `semantic_result_count` (#297): rows the semantic half contributed in combined
     # mode. `0` with no `fallback` = "embed worked but recall is broken" — distinct
     # from a keyword_only fallback.

--- a/test/loopctl/knowledge/curated_first_on_default_search_test.exs
+++ b/test/loopctl/knowledge/curated_first_on_default_search_test.exs
@@ -49,6 +49,37 @@ defmodule Loopctl.Knowledge.CuratedFirstOnDefaultSearchTest do
     %{tenant: tenant}
   end
 
+  describe "the decision reaches the caller, not just the database" do
+    test "render_meta/1 emits the three provenance keys" do
+      rendered =
+        LoopctlWeb.KnowledgeSearchJSON.render_meta(%{
+          total_count: 10,
+          limit: 5,
+          offset: 0,
+          provenance: :curated,
+          confidence: 0.91,
+          curated_article_id: "b1ce8ff7-fae5-4464-aa66-9579df2d4308"
+        })
+
+      # `render_meta/1` is a WHITELIST. #670 computed the decision and recorded
+      # `combined_curated` server-side while the response said nothing at all, so an agent
+      # could not branch on a verdict it never received. Caught by probing prod, not by a
+      # test — hence this one.
+      assert rendered.provenance == :curated
+      assert rendered.confidence == 0.91
+      assert rendered.curated_article_id == "b1ce8ff7-fae5-4464-aa66-9579df2d4308"
+    end
+
+    test "a meta without a decision omits the keys rather than emitting nils" do
+      rendered =
+        LoopctlWeb.KnowledgeSearchJSON.render_meta(%{total_count: 1, limit: 1, offset: 0})
+
+      refute Map.has_key?(rendered, :provenance)
+      refute Map.has_key?(rendered, :confidence)
+      refute Map.has_key?(rendered, :curated_article_id)
+    end
+  end
+
   describe "the recorded search_event carries the decision, so it can be measured" do
     setup %{tenant: tenant} do
       {_raw, api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})


### PR DESCRIPTION
## The half of #670 that didn't ship

#670 moved the curated-vs-retrieved decision onto the default search path, and its PR body
claimed `knowledge_search` now reports provenance. **Half of that was true.**

The server computes the decision and records it — a live probe after the deploy shows
`mode_used = combined_retrieved` on a real prod search from beelink — while the *response*
carries nothing, because `render_meta/1` is a whitelist and I never added the three keys to
it:

```
$ knowledge_search "chain of custody self verify blocked lineage"
meta: { search_mode: "combined", total_count: 101, ... }    # no provenance
```

So the verdict existed everywhere except where it gets acted on. An agent cannot branch on a
provenance it never receives, and branching on provenance alone is the field's entire
contract.

## Fix

`provenance`, `confidence` and `curated_article_id` now render, with the same meanings they
carry on `knowledge_hybrid_search`: `:curated` means a governed article answered and is
**first** in `results` (named by `curated_article_id`); `:retrieved` means nothing curated
cleared the bar. `maybe_put` keeps all three **absent rather than nil** when no decision was
made, so a caller can still tell "no verdict" from "retrieved".

**This is not a hole punched in the whitelist.** That whitelist exists so an internal reason
atom can never leak into a response; these are three explicitly chosen keys added to it, not
a pass-through of the internal meta.

## Verification

`mix precommit` green (7,501 tests). Found by **probing prod after the deploy, not by a
test** — which is exactly why the test added here asserts the rendered keys directly, and
asserts the no-decision case omits them. Removing the three lines again turns it red
(mutation-verified).

Reviewed inline (this session's system prompt forbids dispatching review agents; per CLAUDE.md
the gate is satisfied by the best available reviewer with that stated).

Fixes a gap in #670.
