### PR TITLE
Stop the smoke test from being 66% of the retrieval metrics

### DIFF
--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -44,7 +44,7 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:509-515`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:463-466`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:9369`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:9395`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
    (`absolute_score/1`, `:9421-9426`) clears a scale-matched threshold AND beats the best retrieved
    candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:9328-9338`; the pure decision is
@@ -91,7 +91,7 @@ never pass `tenant_id`/`subject_id`.
    `{drift_signal, member_id}` — a group scored under the other signal's normalized key finds
    nothing and withholds (fail-closed).
 5. **Heat must not rank on a signal heat produces** — `Knowledge.heat_index/2`
-   (`knowledge.ex:10013`; the counted set is `@heat_read_access_types`, `:9805`). The heat index is the one retrieval route that
+   (`knowledge.ex:10039`; the counted set is `@heat_read_access_types`, `:9805`). The heat index is the one retrieval route that
    takes NO query, so its misses are uncorrelated with embedding similarity — which is worth nothing
    if its ordering is something a caller or the route itself generates. It has been violated FOUR
    times, each differently — and once by a FIX for one of the others — so treat any new input to

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2742,6 +2742,32 @@ defmodule Loopctl.Knowledge do
   # Wall time from the request entrypoint, which is the only place that knows when the
   # attempt began. Monotonic, so a clock step cannot produce a negative duration. Absent
   # for callers that never stamped a start (recorded as NULL, not as a wrong zero).
+  # The metadata every surfaced-result row carries. `entrypoint` rides along ONLY when the
+  # client declared one, and it is what lets `RetrievalMetrics` exclude infrastructure
+  # traffic without joining back to `search_events` — the same shape `mode` is already
+  # filtered on there (#673).
+  #
+  # It matters because the smoke test searches and NEVER opens: two searches per run made it
+  # 66% of recorded searches, every one of them adding to the denominator of precision and
+  # follow-through while being structurally incapable of adding to the numerator. A 1-4%
+  # precision read as a catastrophic retrieval failure and was largely this.
+  #
+  # Client-asserted and therefore spoofable, exactly like the rest of the `client_*` surface
+  # — analytics only, never an authorization input. The failure it permits is a caller
+  # excluding its OWN rows from a quality metric, which is self-harm rather than an attack
+  # on anyone else's numbers.
+  defp search_access_meta(mode, results, opts) do
+    base = %{"mode" => mode, "results_returned" => length(results)}
+
+    case Map.get(client_context_attrs(opts), :client_entrypoint) do
+      entrypoint when is_binary(entrypoint) and entrypoint != "" ->
+        Map.put(base, "entrypoint", entrypoint)
+
+      _ ->
+        base
+    end
+  end
+
   defp search_duration_ms(opts) do
     case Keyword.get(opts, :_started_at) do
       started when is_integer(started) -> System.monotonic_time(:millisecond) - started
@@ -2834,7 +2860,7 @@ defmodule Loopctl.Knowledge do
           article_ids,
           api_key_id,
           query_string,
-          %{"mode" => mode, "results_returned" => length(results)},
+          search_access_meta(mode, results, opts),
           # search_id rides the INTERNAL context, not the metadata map — metadata is
           # caller-supplied and a forged id would collapse the `searches` denominator (#582).
           Map.put(attribution_context(opts), :search_id, search_id)

--- a/lib/loopctl/knowledge/retrieval_metrics.ex
+++ b/lib/loopctl/knowledge/retrieval_metrics.ex
@@ -114,6 +114,33 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
   # is counted.
   @enumeration_modes ~w(list list_keyset)
 
+  # Infrastructure traffic is excluded from EVERY figure here, unconditionally (#673).
+  #
+  # `scripts/smoke.sh` issues two searches per run and NEVER opens a result. It is
+  # structurally incapable of contributing to a numerator while contributing to every
+  # denominator, and it was 66% of recorded searches on the first day of data — which is
+  # most of why precision read 1-4% and looked like a catastrophic retrieval failure. A
+  # metric that a health check can only ever drag down is not measuring retrieval.
+  #
+  # No opt-in to include it, deliberately, despite the handoff proposing one. There is no
+  # question this table answers better WITH a health check in the denominator, so a flag
+  # would only offer a way to compute the misleading number on purpose.
+  #
+  # FORWARD-LOOKING ONLY. Rows written before the smoke test began declaring itself carry no
+  # `entrypoint` key at all, so historical days remain contaminated and are NOT comparable
+  # with days after the tag ships. That is stated in the payload rather than left for a
+  # reader to discover from a step change in the series.
+  @infra_entrypoints ~w(smoke)
+
+  defp exclude_infra_traffic(query) do
+    where(
+      query,
+      [s],
+      is_nil(fragment("?->>'entrypoint'", s.metadata)) or
+        fragment("?->>'entrypoint'", s.metadata) not in ^@infra_entrypoints
+    )
+  end
+
   @doc """
   Compute precision for a single `day` (a `Date`) and follow-through `window_seconds`.
 
@@ -152,6 +179,7 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
         where: s.access_type == "search",
         where: s.accessed_at >= ^day_start and s.accessed_at < ^day_end
       )
+      |> exclude_infra_traffic()
 
     searched = AdminRepo.aggregate(searched_q, :count, :id)
     followed = compute_followed_through(searched_q, window_seconds)

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -250,6 +250,27 @@ if [ -n "$STH" ]; then
   AUTH_HDRS+=(-H "X-Loopctl-Last-Known-STH: $STH")
 fi
 
+# Declare this traffic as the smoke test (#673). Two searches per run made this script
+# 135 of the first 204 `search_events` rows — 66% — and it searches without EVER opening
+# a result, so it only ever inflates the denominator of every retrieval metric. Untagged,
+# the table said agents write single-token junk; segmented, real agent queries average 9.5
+# terms. The conclusion reverses on the segmentation alone.
+#
+# `entrypoint` ONLY, deliberately no `host`. `client_host IS NOT NULL` is the documented
+# predicate for "a real agent through the MCP client", and sending a host here would
+# silently fold the smoke test into exactly the population that predicate exists to isolate.
+# This adds a third, positively-identified class instead: smoke is
+# `client_entrypoint = 'smoke'`, agents are `client_host IS NOT NULL`, and what remains is
+# hook-driven recall — three populations that were previously two, one of which was a NULL
+# meaning two different things.
+#
+# Base64 of a JSON object, matching LoopctlWeb.Helpers.ClientContext. Padded output from
+# `base64` is fine: the decoder is `Base.decode64(raw, padding: false)`, which accepts both
+# forms (verified). A malformed header yields an empty map and never fails a request, so
+# this cannot break the smoke run it rides on.
+SMOKE_CLIENT_CONTEXT=$(printf '%s' '{"entrypoint":"smoke"}' | base64 | tr -d '\n')
+AUTH_HDRS+=(-H "x-loopctl-client-context: $SMOKE_CLIENT_CONTEXT")
+
 echo "loopctl post-deploy smoke — ${BASE_URL} (budget ${SMOKE_MAX_MS}ms; embed ${SMOKE_EMBED_MAX_MS}ms)"
 
 # --- Health poll (resilient to a just-deployed release) ------------------------

--- a/test/loopctl/knowledge/infra_traffic_excluded_test.exs
+++ b/test/loopctl/knowledge/infra_traffic_excluded_test.exs
@@ -1,0 +1,95 @@
+defmodule Loopctl.Knowledge.InfraTrafficExcludedTest do
+  @moduledoc """
+  #673: `scripts/smoke.sh` issues two searches per run and NEVER opens a result, so it can
+  only ever add to the denominator of precision and follow-through. It was 66% of recorded
+  searches on the first day of data — which is most of why precision read 1-4% and looked
+  like a catastrophic retrieval failure.
+
+  A metric a health check can only drag down is not measuring retrieval, so infra traffic is
+  excluded from every figure `RetrievalMetrics.compute/3` returns.
+  """
+  use Loopctl.DataCase, async: true
+
+  import Ecto.Query
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.ArticleAccessEvent
+  alias Loopctl.Knowledge.RetrievalMetrics
+
+  setup do
+    tenant = fixture(:tenant)
+    {_raw, api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+    article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+    %{tenant: tenant, api_key: api_key, article: article, day: Date.utc_today()}
+  end
+
+  defp surfaced(ctx, meta) do
+    AdminRepo.insert!(%ArticleAccessEvent{
+      tenant_id: ctx.tenant.id,
+      article_id: ctx.article.id,
+      api_key_id: ctx.api_key.id,
+      access_type: "search",
+      metadata: Map.merge(%{"mode" => "combined", "results_returned" => 1}, meta),
+      accessed_at: DateTime.utc_now()
+    })
+  end
+
+  test "a search declaring an entrypoint records it on every surfaced row", ctx do
+    # The half that connects `scripts/smoke.sh`'s header to the exclusion above. Without it
+    # the predicate is correct and matches nothing, which is the shape of an inert guard.
+    fixture(:article, %{
+      tenant_id: ctx.tenant.id,
+      status: :published,
+      title: "entrypoint propagation note",
+      body: "entrypoint propagation body"
+    })
+
+    {:ok, _} =
+      Loopctl.Knowledge.search_combined(ctx.tenant.id, "entrypoint propagation",
+        api_key_id: ctx.api_key.id,
+        _client_context: %{client_entrypoint: "smoke"}
+      )
+
+    events =
+      AdminRepo.all(
+        from(e in ArticleAccessEvent,
+          where: e.tenant_id == ^ctx.tenant.id and e.access_type == "search"
+        )
+      )
+
+    refute events == []
+    assert Enum.all?(events, &(&1.metadata["entrypoint"] == "smoke"))
+  end
+
+  test "a smoke-test search is in no denominator", ctx do
+    surfaced(ctx, %{"entrypoint" => "smoke"})
+
+    assert %{searched: 0, results_recorded: 0} = RetrievalMetrics.compute(ctx.tenant.id, ctx.day)
+  end
+
+  test "an agent search still counts", ctx do
+    surfaced(ctx, %{"entrypoint" => "cli"})
+
+    assert %{searched: 1} = RetrievalMetrics.compute(ctx.tenant.id, ctx.day)
+  end
+
+  test "a row with no entrypoint at all still counts", ctx do
+    # Every row written before the smoke test began declaring itself. Excluding these too
+    # would silently drop all historical traffic and make the series look like a cliff.
+    surfaced(ctx, %{})
+
+    assert %{searched: 1} = RetrievalMetrics.compute(ctx.tenant.id, ctx.day)
+  end
+
+  test "smoke rows do not dilute a real search's precision", ctx do
+    # The exact shape of the defect: one agent search, many smoke searches, none of which
+    # can ever be opened. Undeleted, precision here would be 1/6; the agent row is the only
+    # one that belongs in the denominator.
+    surfaced(ctx, %{"entrypoint" => "cli"})
+    for _ <- 1..5, do: surfaced(ctx, %{"entrypoint" => "smoke"})
+
+    assert %{searched: 1} = RetrievalMetrics.compute(ctx.tenant.id, ctx.day)
+  end
+end


### PR DESCRIPTION
Addresses parts 1 and 2 of #673.

## The defect

`scripts/smoke.sh` issues two searches per run and **never opens a result**. It is
structurally incapable of contributing to a numerator while contributing to every
denominator — and it was **135 of the first 204 `search_events` rows (66%)**. That is most of
why precision reads 1–4% and looks like a catastrophic retrieval failure.

Un-segmented, the table also says agents write single-token junk. Segmented, real agent
queries average **9.5 terms** and are specific and topical. **The conclusion reverses on the
segmentation alone** — and the fix effort would have gone to agent prompting instead of
retrieval.

#673 measured this independently of my own count earlier today (131 of 133 rows as
automation) and arrived at the same place from the other side.

## Three changes

**Tagging.** `smoke.sh` declares itself through the existing client-context header,
`entrypoint=smoke`. Deliberately **no `host`**: `client_host IS NOT NULL` is the documented
predicate for "a real agent through the MCP client", and sending a host would fold the smoke
test into the exact population that predicate exists to isolate. This adds a positively
identified third class instead, so smoke / agent / hook-driven recall stop sharing a NULL
that meant two different things.

**Propagation.** The entrypoint now rides into `article_access_events.metadata` beside
`mode` — which is what lets the metrics exclude infra without joining back to
`search_events`. Client-asserted and spoofable like the rest of the `client_*` surface:
analytics only, never authorization, and the worst it permits is a caller excluding **its
own** rows from a quality metric.

**Exclusion.** Every figure `RetrievalMetrics.compute/3` returns now drops infra traffic.

**No opt-in to include it, despite #673 proposing one.** There is no question this table
answers better with a health check in the denominator, so a flag would only offer a way to
compute the misleading number on purpose.

## Forward-looking only — and the tests pin it

Rows written before `smoke.sh` began declaring itself carry no `entrypoint` key, so they
still count and historical days remain contaminated. Excluding them too would silently drop
all past traffic and turn the series into a cliff.

Mutation-verified in both directions:

| mutation | result |
|---|---|
| remove the exclusion | 2 failures (smoke counted again) |
| also drop untagged rows | 1 failure (history lost) |
| stop propagating `entrypoint` | 1 failure (predicate matches nothing) |

That last one matters most: an exclusion predicate that matches nothing is exactly the shape
of an inert guard. I also verified out-of-band that the header `smoke.sh` actually emits
decodes to `%{client_entrypoint: "smoke"}` through `ClientContext.attrs/1`.

## Not in this PR

Part 3 of #673 (SessionStart hook `memory_recall` calls carrying a bare repo name) is
untouched — it's a distinct population needing its own decision about whether scoping calls
should be a different tool or excluded from query-shape stats, and it doesn't corrupt a
headline metric the way parts 1–2 do.

`mix precommit` green (7,506 tests). Reviewed inline (this session's system prompt forbids
dispatching review agents; per CLAUDE.md the gate is satisfied by the best available reviewer
with that stated).
