### PR TITLE
Drop the retrieval-eval database too, which the test-job cleanup did not cover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,6 +490,20 @@ jobs:
           exit "$status"
         timeout-minutes: 15
 
+      # This job builds its OWN database (DEV_DB_NAME, run-scoped) and never dropped
+      # it. The drop step added for `test` covered only the ExUnit database, so every
+      # eval run left a `loopctl_ci_eval_<run id>` behind on the shared CI instance
+      # for the reaper to find two days later.
+      #
+      # Same shape as the miss in ecommerce-friendly#101: the port and the run-scoped
+      # NAME were applied to every database-creating job, the DROP to only one, and
+      # the gap is invisible in a diff -- it shows up as a count on the server.
+      - name: Drop this run's eval database
+        if: always()
+        run: |
+          dropdb --if-exists -h localhost -p "${PGPORT}" -U postgres "${DEV_DB_NAME}" 2>&1 || true
+          echo "cleanup: dropped ${DEV_DB_NAME} (best effort)"
+
   security:
     name: Security
     runs-on: [self-hosted, beelink]


### PR DESCRIPTION
`retrieval-eval` builds its **own** run-scoped database via `DEV_DB_NAME` and never dropped it. The cleanup added in #681 covered only the ExUnit database, so every eval run left a `loopctl_ci_eval_<run id>` behind on the shared CI instance for the reaper to find two days later.

**Counted on beelink just now: 64 of them.**

## Worth naming as a pattern, not two coincidences

This is the same shape as [ecommerce-friendly#101](https://github.com/mkreyman/ecommerce-friendly/pull/101), found the same way. When the CI port and the run-scoped **name** were rolled out, they went onto *every* job that creates a database. The **drop** went onto the obvious one.

The gap does not show up in a diff — both workflows look complete. It shows up as a **count on the server**, which is the only place either was found:

```
$ psql -p 5433 -Atqc "select count(*) ... like 'loopctl_ci_eval%'"
64
```

The generalisable check, for any repo adopting end-of-job cleanup: enumerate jobs whose `env` names a database, and assert each has a drop step. Two of five jobs across two repos failed that check after their cleanup PRs merged green.

Reviewed inline (this session cannot dispatch agents/workflows) per the CLAUDE.md gate clause.