### PR TITLE
Add an oban-health skill, and stop the citation checker reading clock times as citations

### DIFF
--- a/.claude/skills/oban-health/SKILL.md
+++ b/.claude/skills/oban-health/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: oban-health
+description: Use when checking whether loopctl's background jobs are actually running and healthy in production — a routine "is everything in order" sweep, an investigation into a worker that seems stuck, or triage of a queue backlog. Covers the state/queue sweep, cron-coverage verification, and the three readings that a naive look gets WRONG (snoozes read as retries, parked crons read as broken, zero-count queues read as healthy). Triggers on: oban health, are jobs running, background jobs, job queue backlog, stuck job, oban_jobs, cron not firing, worker not running, queue starved, orphaned executing, discarded jobs, job failures, oban check.
+---
+
+# Oban Health Check (production)
+
+The sweep below answers "are the background jobs in order?" in about six queries. It exists
+because three of the readings are traps: the raw numbers look like incidents when they are
+correct behaviour, and look correct when they hide a dead producer.
+
+## Connect
+
+Production Postgres is the unmanaged `ecf-postgres` instance (see the `fly-mpg-connect` skill —
+`fly mpg` cannot see it).
+
+```bash
+# proxy (skip if 127.0.0.1:15432 is already listening — check with: ss -ltn | grep 15432)
+flyctl proxy 15432:5432 -a ecf-postgres &
+
+set -a && . ~/.ecf_postgres_env && set +a
+export PGPASSWORD="$LOOPCTL_DB_PW"
+psql -h 127.0.0.1 -p 15432 -U loopctl -d loopctl -X   # -X: skip ~/.psqlrc
+```
+
+`Oban.Plugins.Pruner` deletes terminal jobs older than **7 days**, so every count below is a
+rolling 7-day window. Absence of an old job is pruning, not a failure.
+
+## The sweep
+
+```sql
+-- 1. state x queue: the headline. Anything not 'completed' is worth a look.
+select queue, state, count(*) from oban_jobs group by 1,2 order by 1,2;
+
+-- 2. orphans: jobs wedged in :executing past Lifeline's 30-min rescue window
+select worker, queue, attempt, attempted_at, now()-attempted_at as age
+from oban_jobs where state='executing' order by attempted_at;
+
+-- 3. real failures. `errors` is jsonb[] — use errors[1], NOT errors->0 (that raises).
+select count(*) from oban_jobs where cardinality(errors) > 0;
+
+-- 4. per-worker cadence: the core table. Compare runs_24h against the crontab.
+select replace(worker,'Loopctl.Workers.','') as worker, queue,
+       count(*) as runs_7d,
+       count(*) filter (where inserted_at > now()-interval '24 hours') as runs_24h,
+       max(completed_at)::timestamp(0) as last_run,
+       round(extract(epoch from now()-max(completed_at))/60)::int as mins_ago,
+       round(avg(extract(epoch from (completed_at-attempted_at)))::numeric,2) as avg_secs
+from oban_jobs group by 1,2 order by 6;
+
+-- 5. cron GAPS (the real liveness test — a per-minute worker must never gap)
+with t as (select inserted_at, lag(inserted_at) over (order by inserted_at) prev
+           from oban_jobs where worker='Loopctl.Workers.SystemConfigRefreshWorker')
+select prev::timestamp(0) gap_start, inserted_at::timestamp(0) gap_end,
+       round(extract(epoch from inserted_at-prev)/60)::int gap_mins
+from t where inserted_at - prev > interval '3 minutes' order by 1;
+
+-- 6. leader + table size
+select * from oban_peers;
+select pg_size_pretty(pg_total_relation_size('oban_jobs')), count(*) from oban_jobs;
+```
+
+Then the app's own verdict, which is cheaper than all of the above when it is green:
+
+```bash
+fly checks list -a loopctl
+# healthy output: {"status":"ok","ready":true,
+#   "checks":{"oban":"ok","database":"ok","oban_orphans":"ok","scale_alerts":"ok"}}
+```
+
+## Expected cadence
+
+`Loopctl.ObanConfig.plugins/0` (`lib/loopctl/oban_config.ex`) is the source of truth for the
+crontab — read it rather than trusting a list here, which rots. Derive expected `runs_24h`
+from the schedule: `* * * * *` → 1440, `*/5` → 288, `*/10` → 144, hourly → 24, daily → 1.
+
+Two adjustments before you call a count wrong:
+
+- **`mode: "all_tenants"` workers fan out**, so `runs_24h` is `ticks x (1 + tenants)`, not
+  `ticks`. `ComputeSthWorker`, `KnowledgeLintWorker`, `KnowledgeMocWorker`,
+  `RetrievalMetricsWorker`, `EmbeddingReconciliationWorker` all do this.
+- **`CostAnomalyWorker` is not in the crontab.** It is chained by `CostRollupWorker` after the
+  daily rollup (`lib/loopctl/workers/cost_rollup_worker.ex:12`), which is why it shows up
+  ~5 min after the 02:00 rollup with no schedule of its own.
+
+## The three traps
+
+### 1. `attempt > 1` with an empty `errors` array is a SNOOZE, not a retry
+
+Oban's `snooze_job/3` does `inc: [max_attempts: 1]` — it raises the ceiling as it defers. So a
+snoozed job shows a climbing `attempt`, a `max_attempts` climbing in lockstep, and **no recorded
+error**. Distinguish them:
+
+```sql
+select replace(worker,'Loopctl.Workers.','') w, attempt, max_attempts,
+       cardinality(errors) n_errors, state, count(*)
+from oban_jobs where attempt>1 group by 1,2,3,4,5 order by 6 desc;
+```
+
+`n_errors = 0` and `max_attempts = attempt + N` ⇒ snooze. In loopctl these come from the US-36.2
+per-tenant fair-share gate (`Loopctl.Oban.FairShare`) on `ArticleLinkingWorker` /
+`ArticleEmbeddingWorker`, and they cluster at **04:00–05:00 UTC** where the daily `KnowledgeLint`
+(04:00), `RetrievalMetrics` (04:30) and weekly `KnowledgeMoc` (05:00) all-tenant fan-outs occupy
+the `:knowledge` lane. That is the gate working.
+
+**But verify they cleared** — do not stop at "it's a snooze". A snooze is unbounded by
+construction and cannot exhaust into `discarded`, so a job gated on a permanently-wrong condition
+stalls forever while nothing fails and nothing alerts:
+
+```sql
+select state, count(*) from oban_jobs where attempt>1 group by 1;   -- want: completed only
+```
+
+loopctl is structurally protected here because the fair-share cap has a **floor of 1** (see the
+"always >= 1 slot" invariant in `oban_config.ex`), so the gate can never wedge a queue with every
+job snoozing. Do not remove that floor. Wiki: *"Oban's snooze raises max_attempts, so a job gated
+on a permanently-wrong health check stalls forever and never fails"*.
+
+### 2. Five workers are PARKED on purpose — silence is correct
+
+`ObanConfig.parked_crons/0` keeps `MemoryPromotionSweepWorker`, `MemoryGraduationSweepWorker`,
+`SessionMemoryPruneWorker`, `PromotionEvalWorker` and `IngestionHealthWorker` dormant by default
+(#249, 2026-08-11). Their code is intact; only the schedule is off. They earned it by running
+green and doing nothing — the audit's "level 1" failure, which no success rate surfaces.
+
+A `last_run` frozen at **2026-08-11** for exactly these five is the parking, not an outage.
+Confirm rather than assume, with two checks:
+
+```bash
+fly secrets list -a loopctl | grep -i OBAN_UNPARK_CRONS    # no row ⇒ still parked
+```
+```sql
+select (select count(*) from memories) m, (select count(*) from session_memories) sm;
+```
+
+If `m`/`sm` are still 0, the parking rationale still holds — nothing calls `memory_remember`, so
+the memory sweeps would sweep an empty tier. **If they are non-zero, the parking is now wrong**
+and the memory sweeps should be revived with
+`fly secrets set OBAN_UNPARK_CRONS=Loopctl.Workers.MemoryPromotionSweepWorker,... && fly apps restart loopctl`
+(no deploy needed). Graduation is demand-gated, which is exactly the writer worth reviving.
+
+### 3. A zero-count queue proves nothing until you check its PRODUCER
+
+This is the trap that makes a health check worthless. `webhooks`, `ingestion` and `verification`
+routinely show **zero jobs in 7 days**. Zero is what a healthy quiet week looks like *and* what a
+dead producer looks like. Resolve it by counting the rows that would have enqueued the job:
+
+```sql
+select 'webhooks' t, count(*) n from webhooks                 -- 0 subs  ⇒ 0 deliveries is CORRECT
+union all select 'webhook_events', count(*) from webhook_events
+union all select 'verification_runs', count(*) from verification_runs  -- L3 unused in prod
+union all select 'articles_7d', count(*) from articles
+         where inserted_at > now()-interval '7 days';         -- ingestion path is alive?
+```
+
+Knowledge writes reach loopctl through the **direct `knowledge_create` path**, not the batch
+`ContentIngestionWorker` lane, so an idle `:ingestion` queue alongside a healthy `articles_7d`
+count is normal. Split it by writer:
+
+```sql
+select coalesce(source_type,'(direct)') st, count(*) from articles
+where inserted_at > now()-interval '7 days' group by 1 order by 2 desc;
+```
+
+The rule, from the wiki: **a stall must be as visible as a crash.** If the only observable
+difference between "quiet day" and "totally broken" is a number that is zero either way, you have
+no monitoring — go count the producer.
+
+## Bonus check: the embedding blackout
+
+Not an Oban table, but it is what the hourly `EmbeddingReconciliationWorker` exists to prevent,
+and a gap here is a silent recall blackout that no job failure reports:
+
+```sql
+select count(*) as published_without_embedding from articles a
+where a.status='published'
+  and not exists (select 1 from article_embeddings e where e.article_id=a.id);
+```
+
+Want 0. Non-zero means the reconciliation sweep is falling behind — check its `runs_24h` (expect
+24 x fan-out) before assuming an embedding-provider outage.
+
+## Reading the Fly side
+
+- `fly status -a loopctl` showing one machine `suspended` with a `warning` check whose output is
+  "the machine hasn't started" is the **autostop standby**, not a failure. Judge the `started` one.
+- `oban_peers` should hold one live leader with `expires_at` in the near future; `started_at` is
+  effectively node uptime.
+- Cross-check that the deployed release actually contains the crontab you just read:
+  `fly releases -a loopctl | head -3` against `git log --first-parent -1 --date=iso`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -428,6 +428,7 @@ changes). Refactors, test fixes, and internal hardening stay out — `git log
 | roles, auth pipeline, story lifecycle (report / review-complete / verify), capability tokens, dispatch lineage, WebAuthn / human anchor, audit chain | `.claude/skills/chain-of-custody/SKILL.md` |
 | tenant scoping, RLS policies, migrations, new tables, the three repos, heavy/vector reads | `.claude/skills/tenancy-rls/SKILL.md` |
 | Knowledge Wiki, agent memory, context retriever, hybrid search, novelty gate, embeddings, KB curation permissions | `.claude/skills/knowledge-wiki/SKILL.md` |
+| Oban health in production — are the cron jobs firing, is a queue backed up, is a worker stuck | `.claude/skills/oban-health/SKILL.md` |
 
 ## MCP Server
 

--- a/lib/mix/tasks/loopctl.check_skill_citations.ex
+++ b/lib/mix/tasks/loopctl.check_skill_citations.ex
@@ -224,8 +224,16 @@ defmodule Mix.Tasks.Loopctl.CheckSkillCitations do
   # Qualified: `foo.ex:12`, `foo/bar.ex:12-34`. Bare: `:12`, `:12-34` — these
   # inherit the file of the most recent qualified citation in the document
   # (`current`), which is exactly how the prose reads them.
+  #
+  # The leading `(?<!\w)` is load-bearing. The file half is OPTIONAL, so without it
+  # the bare form matches a `:NN` ANYWHERE in the line — including inside a clock time
+  # (`04:00` -> `:00`), a host:port (`127.0.0.1:15432`), or a port forward
+  # (`15432:5432`). Those reported as ":0: invalid citation range" against prose that
+  # contains no citation at all. A genuine bare citation always follows whitespace, a
+  # backtick, or an opening paren — never a word character — so requiring that is
+  # exact, not a heuristic.
   defp citations_in(line, current) do
-    ~r{(?:([\w./-]+\.exs?))?:(\d+)(?:-(\d+))?}
+    ~r{(?<!\w)(?:([\w./-]+\.exs?))?:(\d+)(?:-(\d+))?}
     |> Regex.scan(line)
     |> Enum.reduce({[], current}, fn match, {acc, current} ->
       {file, start_line, end_line} = parse_match(match)

--- a/test/loopctl/check_skill_citations_test.exs
+++ b/test/loopctl/check_skill_citations_test.exs
@@ -125,6 +125,35 @@ defmodule Loopctl.CheckSkillCitationsTest do
     assert CheckSkillCitations.check([doc]) == []
   end
 
+  @tag :tmp_dir
+  test "does not read a clock time or host port as a bare citation", %{
+    tmp_dir: tmp_dir
+  } do
+    src = write_fixture(tmp_dir)
+
+    doc =
+      write_doc(tmp_dir, """
+      The daily fan-outs run at 04:00, 04:30 and 05:00 UTC, after the 02:00 rollup.
+      Proxy with `flyctl proxy 15432:5432` then connect to 127.0.0.1:15432.
+      The real citation is `#{src}:2`.
+      """)
+
+    # Without the `(?<!\w)` guard each of those `:NN` fragments matched the BARE
+    # citation form, resolved to line 0, and reported ":0: invalid citation range"
+    # against prose containing no citation at all.
+    assert {[], %{checked: 1, skipped: 0}} = CheckSkillCitations.check_with_stats([doc])
+  end
+
+  @tag :tmp_dir
+  test "still reads a genuine bare citation after a backtick or paren", %{
+    tmp_dir: tmp_dir
+  } do
+    src = write_fixture(tmp_dir)
+    doc = write_doc(tmp_dir, "See `#{src}:2`, also (`:4`) and `:2`.")
+
+    assert {[], %{checked: 3, skipped: 0}} = CheckSkillCitations.check_with_stats([doc])
+  end
+
   defp write_doc(tmp_dir, body) do
     path = Path.join(tmp_dir, @tmp_doc)
     File.write!(path, body <> "\n")


### PR DESCRIPTION
## Why

Asked to check whether the Oban jobs are all running and whether a skill existed
for it. Nothing covered it, so the sweep got re-derived from scratch and hit the
same three misreadings on the way.

## The skill

`.claude/skills/oban-health/SKILL.md`, wired into the domain-skill routing table.
It carries the six-query sweep, how to derive expected cadence from the crontab
(including the all_tenants fan-out multiplier and the fact that CostAnomalyWorker
is chained by CostRollupWorker rather than scheduled), and three traps:

1. **A snooze is not a retry.** `attempt` above 1 with an EMPTY errors array is
   Oban's `snooze_job`, which raises `max_attempts` as it defers. It also cannot
   exhaust into `discarded`, so the skill requires confirming the snoozed jobs
   actually reached `completed` rather than stopping at "it is only a snooze".
   The fair-share cap's floor of 1 is what stops a snooze loop wedging a queue.
2. **Five crons are parked on purpose** since 2026-08-11. The skill gives the two
   checks that confirm the parking is still correct, including the memories count
   that would make it wrong and the unpark command.
3. **A zero-count queue proves nothing until its producer is counted** — zero is
   what a quiet week and a dead producer both look like.

## The checker bug this surfaced

`mix loopctl.check_skill_citations` runs in `precommit`, and writing the skill
tripped it. The bare-citation half of its regex has an OPTIONAL file part, so a
bare colon-plus-digits matched anywhere in a line: the clock times `04:00` and
`02:00`, the host and port `127.0.0.1:15432`, and the port forward `15432:5432`
each parsed as a citation to line 0 and were reported as an invalid range against
prose containing no citation at all.

A genuine bare citation always follows whitespace, a backtick or an opening paren,
so a negative lookbehind for a word character fixes it exactly rather than
heuristically. Two regression tests cover both directions - the false positives
stay unmatched, and genuine bare citations after a backtick or paren still resolve.

**Guard is not vacuous:** the checker resolves 94 citations across 5 documents
before this change and 95 across 6 after, with the same 2 skipped. No existing
citation was silently dropped; the one added is the new skill's own.

## Verification

`mix precommit` green: compile with warnings-as-errors, format, credo --strict,
check_skill_citations, check_env_docs, dialyzer, 7516 tests 0 failures.

Production was also swept while writing this and is healthy - 37,523 jobs over the
7-day retention window, all completed, zero recorded errors, zero orphans, no cron
gap over 3 minutes, and zero published articles missing an embedding.

## Review

Reviewed inline by the authoring session rather than via the enhanced-review
pipeline: this session carries harness defaults barring it from dispatching
agents or workflows without an explicit request. Proportionate here - the change
is a markdown skill plus a lookbehind in a dev-only mix task that runs in
precommit and CI only, with no auth, credential, money or data-handling surface.
