### PR TITLE
Drain the draft queue weekly instead of by hand

### DIFF
--- a/lib/loopctl/oban_config.ex
+++ b/lib/loopctl/oban_config.ex
@@ -606,7 +606,19 @@ defmodule Loopctl.ObanConfig do
            # 03:40 UTC sits between the 03:00 webhook/token cleanups and the 04:00
            # knowledge-lint fan-out rather than piling onto either. Keep in sync with the
            # crontab assertion in oban_plugins_config_test.exs.
-           {"40 3 * * *", Loopctl.Workers.LegacyEmbeddingRetirementWorker}
+           {"40 3 * * *", Loopctl.Workers.LegacyEmbeddingRetirementWorker},
+           # Weekly drain for the DRAFT queue. The capture hook holds every
+           # machine-extracted finding/pattern/playbook as a draft (claude-config#203);
+           # without a drain that hold is a landfill, and the 2026-08-17 manual drain
+           # measured 453 of 530 held drafts to be pure duplicates. This retires the
+           # duplicate majority (published-neighbour similarity >= the worker's
+           # threshold) and leaves the judgement half — does the claim survive contact
+           # with its source? — to an agent that can open a repo. 05:50 UTC Sunday sits
+           # AFTER the 05:00 Sunday KnowledgeMoc fan-out rather than contending with it
+           # for the same :knowledge lane. Keep in sync with the crontab assertion in
+           # oban_plugins_config_test.exs.
+           {"50 5 * * 0", Loopctl.Workers.DraftDuplicateSweepWorker,
+            args: %{"mode" => "all_tenants"}}
          ])},
       # Rescue jobs orphaned in :executing when a node dies mid-run (e.g. a deploy).
       # Without Lifeline these rows stay `executing` forever — 110 such orphans (from

--- a/lib/loopctl/workers/draft_duplicate_sweep_worker.ex
+++ b/lib/loopctl/workers/draft_duplicate_sweep_worker.ex
@@ -1,0 +1,278 @@
+defmodule Loopctl.Workers.DraftDuplicateSweepWorker do
+  @moduledoc """
+  Weekly sweep that retires DRAFT articles which duplicate an already-published one.
+
+  ## Why this exists
+
+  The draft queue is a holding area, not a destination: `hooks/knowledge-capture.sh`
+  holds every machine-extracted `finding`/`pattern`/`playbook` as a draft
+  (claude-config#203) so a confidently-wrong extraction cannot reach the recall hook
+  unreviewed. That hold is only half a design — without a drain, held drafts are not
+  a safety mechanism, they are a landfill.
+
+  The 2026-08-17 manual drain measured what the queue is actually made of: of 530
+  drafts, **453 were duplicates** — 418 re-extractions of already-published articles
+  and 35 near-identical siblings of each other (one lesson had been extracted FOUR
+  times from a single session). Only 77 carried anything a reader could not already
+  get from the published corpus.
+
+  That ratio is the whole argument for this worker. The duplicate majority needs no
+  judgement — it is a similarity comparison against the published corpus, which is
+  exactly what the vector index already answers. The judgement half (does this claim
+  survive contact with the source it describes?) needs an agent that can open a repo
+  and run a command, and is deliberately NOT attempted here.
+
+  ## Why the queue accumulated duplicates in the first place
+
+  The novelty gate dedups a proposal against the **published** corpus only, so drafts
+  are invisible to it: the same lesson could be re-extracted indefinitely without
+  anything noticing. Retiring the duplicates is therefore only half the fix — the
+  other half happened when the 77 survivors were PUBLISHED, which makes future
+  re-extractions of those lessons visible to the gate and dedupable at write time.
+
+  ## What it does
+
+  Per tenant, for each draft carrying an embedding at the tenant's active dimension:
+  ask the vector index for the nearest PUBLISHED article
+  (`Loopctl.Knowledge.VectorSearch.nearest/4` already applies `status = :published`
+  as an index-safe residual filter) and retire the draft when that neighbour clears
+  `similarity_threshold/0`.
+
+  ## Retirement is ARCHIVE, and archive is a one-way door
+
+  `:archived` is terminal — `Article`'s `@valid_transitions` has no `{:archived, _}`
+  entry, so nothing this system can call restores an archived row; only a `user`-role
+  PATCH carrying an explicit status brings one back. That is a deliberately stronger
+  action than the nightly consolidation pass takes on PUBLISHED articles, which
+  retracts with `unpublish` (`{:published, :draft}`, undone by `publish`) precisely
+  so an unattended writer keeps an undo (#605/#606/#608).
+
+  There is no equivalent reversible step for a draft: a draft is already unpublished,
+  so archive is the only move down. The row survives and every archive is audited via
+  `Knowledge.bulk_archive/3`, so nothing is destroyed — but "non-destructive" and
+  "reversible" are different properties, and this worker only has the first. Treat the
+  threshold as the safety mechanism it is, and do not lower it without re-measuring.
+
+  ## Scope discipline
+
+  * Only drafts that HAVE an embedding are considered. An unembedded draft is not
+    evidence of novelty — it is absence of evidence — so it is left alone and counted
+    in `skipped_unembedded`, never swept.
+  * `:heavy_read_overloaded` snoozes the whole tenant rather than banking a partial
+    verdict: a shed read is an unknown, and an unknown must not read as "not a
+    duplicate" on a path whose action is terminal.
+  * Bounded per run by `max_archives/0`; a larger backlog drains over later runs.
+  """
+
+  use Oban.Worker, queue: :knowledge, max_attempts: 3
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Embeddings
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.ArticleEmbedding
+  alias Loopctl.Knowledge.KbCuration
+  alias Loopctl.Knowledge.VectorSearch
+  alias Loopctl.Oban.FairShare
+  alias Loopctl.Tenants.Tenant
+
+  @actor_label "worker:draft_duplicate_sweep"
+
+  # Chosen from the 2026-08-17 drain: every one of the 271 drafts at >= 0.95 that was
+  # inspected was a true duplicate, and the ONE inspected article that scored below
+  # 0.92 while still deserving retirement failed for an unrelated reason (it was
+  # trivial, not duplicate) — i.e. 0.95 was not observed to produce a false positive,
+  # and the band below it was where genuine judgement started being required.
+  @default_similarity_threshold 0.95
+
+  # Bounds the terminal action, not the scan: a runaway similarity regression can only
+  # ever cost one run's worth of archives before someone sees the curation event.
+  @default_max_archives 500
+  @default_scan_limit 2000
+
+  @doc "Minimum published-neighbour similarity at which a draft is retired."
+  @spec similarity_threshold() :: float()
+  def similarity_threshold do
+    Application.get_env(
+      :loopctl,
+      :draft_sweep_similarity_threshold,
+      @default_similarity_threshold
+    )
+  end
+
+  @doc "Maximum drafts one run may archive for a single tenant."
+  @spec max_archives() :: pos_integer()
+  def max_archives do
+    Application.get_env(:loopctl, :draft_sweep_max_archives, @default_max_archives)
+  end
+
+  @doc "Maximum drafts one run may examine for a single tenant."
+  @spec scan_limit() :: pos_integer()
+  def scan_limit do
+    Application.get_env(:loopctl, :draft_sweep_scan_limit, @default_scan_limit)
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"mode" => "all_tenants"}}) do
+    tenant_ids =
+      from(t in Tenant, where: t.status == :active, select: t.id)
+      |> AdminRepo.all()
+
+    for tenant_id <- tenant_ids do
+      %{"tenant_id" => tenant_id}
+      |> __MODULE__.new()
+      |> Oban.insert()
+    end
+
+    :ok
+  end
+
+  def perform(%Oban.Job{id: id, args: %{"tenant_id" => tenant_id}}) do
+    # Do NOT gate the all_tenants dispatcher above — it carries no tenant_id.
+    # `id` excludes THIS already-executing job from its own count (US-36.2).
+    case FairShare.gate(tenant_id, :knowledge, id) do
+      {:snooze, _n} = snooze -> snooze
+      :ok -> sweep_tenant(tenant_id)
+    end
+  end
+
+  defp sweep_tenant(tenant_id) do
+    dimension = Embeddings.active_dimension(tenant_id)
+    candidates = load_embedded_drafts(tenant_id, dimension)
+
+    case classify(tenant_id, candidates) do
+      {:error, :heavy_read_overloaded} ->
+        # Snooze the WHOLE tenant. A partial verdict is worse than none here: the
+        # drafts whose reads were shed would be indistinguishable from drafts with no
+        # published neighbour, and the action taken on that reading cannot be undone.
+        Logger.info(
+          "draft_duplicate_sweep shed: tenant=#{tenant_id} reason=heavy_read_overloaded"
+        )
+
+        {:snooze, 300}
+
+      {:ok, duplicates} ->
+        apply_verdicts(tenant_id, duplicates, unembedded_count(tenant_id, dimension))
+    end
+  end
+
+  # Only drafts WITH an embedding at the active dimension are swept. The join is the
+  # filter: an unembedded draft never reaches `classify/2`, so it can never be archived
+  # for want of a neighbour it was never able to have.
+  defp load_embedded_drafts(tenant_id, dimension) do
+    from(a in Knowledge.Article,
+      join: e in ArticleEmbedding,
+      on: e.article_id == a.id and e.tenant_id == a.tenant_id,
+      where: a.tenant_id == ^tenant_id,
+      where: a.status == :draft,
+      where: e.dim == ^dimension and e.live_denorm == true,
+      order_by: [asc: a.inserted_at],
+      limit: ^scan_limit(),
+      select: %{id: a.id, title: a.title, embedding: e.embedding}
+    )
+    |> AdminRepo.all()
+  end
+
+  defp unembedded_count(tenant_id, dimension) do
+    from(a in Knowledge.Article,
+      left_join: e in ArticleEmbedding,
+      on:
+        e.article_id == a.id and e.tenant_id == a.tenant_id and
+          e.dim == ^dimension and e.live_denorm == true,
+      where: a.tenant_id == ^tenant_id,
+      where: a.status == :draft,
+      where: is_nil(e.id),
+      select: count(a.id)
+    )
+    |> AdminRepo.one()
+    |> Kernel.||(0)
+  end
+
+  # Reduces to the first shed rather than continuing: see the snooze rationale above.
+  defp classify(tenant_id, candidates) do
+    threshold = similarity_threshold()
+
+    Enum.reduce_while(candidates, {:ok, []}, fn candidate, {:ok, acc} ->
+      opts = [threshold: threshold, exclude_id: candidate.id, on_overload: :shed]
+
+      case VectorSearch.nearest(tenant_id, candidate.embedding, 1, opts) do
+        {:error, :heavy_read_overloaded} = shed ->
+          {:halt, shed}
+
+        [] ->
+          {:cont, {:ok, acc}}
+
+        [%{similarity_score: score} = neighbour | _] ->
+          {:cont, {:ok, [{candidate, neighbour, score} | acc]}}
+      end
+    end)
+  end
+
+  defp apply_verdicts(tenant_id, [], unembedded) do
+    Logger.info(
+      "draft_duplicate_sweep: tenant=#{tenant_id} duplicates=0 archived=0 " <>
+        "skipped_unembedded=#{unembedded}"
+    )
+
+    :ok
+  end
+
+  defp apply_verdicts(tenant_id, duplicates, unembedded) do
+    # Highest similarity first, so a capped run retires the most certain duplicates
+    # rather than whichever the scan happened to reach first.
+    to_archive =
+      duplicates
+      |> Enum.sort_by(fn {_c, _n, score} -> score end, :desc)
+      |> Enum.take(max_archives())
+
+    ids = Enum.map(to_archive, fn {candidate, _n, _s} -> candidate.id end)
+
+    archived = archive_all(tenant_id, ids)
+
+    KbCuration.record(
+      tenant_id,
+      "draft_duplicate_sweep",
+      "retired #{archived} draft(s) duplicating a published article " <>
+        "(threshold #{similarity_threshold()})",
+      refs: ids,
+      actor: @actor_label,
+      metadata: %{
+        "candidates" => length(duplicates),
+        "archived" => archived,
+        "capped" => length(duplicates) > max_archives(),
+        "skipped_unembedded" => unembedded,
+        "threshold" => similarity_threshold()
+      }
+    )
+
+    Logger.info(
+      "draft_duplicate_sweep: tenant=#{tenant_id} duplicates=#{length(duplicates)} " <>
+        "archived=#{archived} skipped_unembedded=#{unembedded}"
+    )
+
+    :ok
+  end
+
+  # `bulk_archive/3` answers `{:error, :bad_request, _}` for an empty/oversized id
+  # list. Neither is reachable here (the empty case returns via the [] clause of
+  # apply_verdicts/3 and the list is capped at max_archives/0), but a silently
+  # swallowed error on a path that reports how many rows it retired would make a
+  # zero-archive run indistinguishable from a healthy one — so log and count 0.
+  defp archive_all(tenant_id, ids) do
+    case Knowledge.bulk_archive(tenant_id, ids, actor_label: @actor_label) do
+      {:ok, %{counts: %{archived: archived}}} ->
+        archived
+
+      {:error, :bad_request, message} ->
+        Logger.error(
+          "draft_duplicate_sweep archive rejected: tenant=#{tenant_id} " <>
+            "ids=#{length(ids)} reason=#{message}"
+        )
+
+        0
+    end
+  end
+end

--- a/test/loopctl/oban_plugins_config_test.exs
+++ b/test/loopctl/oban_plugins_config_test.exs
@@ -107,6 +107,52 @@ defmodule Loopctl.ObanPluginsConfigTest do
     end
   end
 
+  describe "DraftDuplicateSweepWorker crontab entry" do
+    setup do
+      plugins = Application.get_env(:loopctl, Oban)[:plugins]
+
+      {Oban.Plugins.Cron, cron_opts} =
+        Enum.find(plugins, &match?({Oban.Plugins.Cron, _}, &1))
+
+      entry =
+        Enum.find(cron_opts[:crontab], fn
+          {_schedule, Loopctl.Workers.DraftDuplicateSweepWorker} -> true
+          {_schedule, Loopctl.Workers.DraftDuplicateSweepWorker, _opts} -> true
+          _ -> false
+        end)
+
+      %{entry: entry, crontab: cron_opts[:crontab]}
+    end
+
+    test "the DraftDuplicateSweepWorker entry exists in the crontab", %{entry: entry} do
+      assert entry,
+             "expected a DraftDuplicateSweepWorker crontab entry that drains the draft " <>
+               "queue of published-duplicate holds"
+    end
+
+    test "it runs weekly and fans out across all tenants", %{entry: entry} do
+      assert elem(entry, 0) == "50 5 * * 0"
+      assert {_schedule, _worker, opts} = entry
+      assert opts[:args] == %{"mode" => "all_tenants"}
+    end
+
+    test "it does not collide with the Sunday KnowledgeMoc fan-out", %{
+      entry: entry,
+      crontab: crontab
+    } do
+      # Both target the shared :knowledge lane on a Sunday. The sweep is deliberately
+      # scheduled AFTER the MOC pass rather than at the same minute, so a wide MOC
+      # fan-out is not competing with the sweep for the same queue slots.
+      moc =
+        Enum.find(crontab, fn tuple ->
+          elem(tuple, 1) == Loopctl.Workers.KnowledgeMocWorker
+        end)
+
+      assert moc, "expected a KnowledgeMocWorker crontab entry to compare against"
+      refute elem(entry, 0) == elem(moc, 0)
+    end
+  end
+
   describe "#249: inert KB crons are PARKED by default" do
     setup do
       plugins = Application.get_env(:loopctl, Oban)[:plugins]

--- a/test/loopctl/workers/draft_duplicate_sweep_worker_test.exs
+++ b/test/loopctl/workers/draft_duplicate_sweep_worker_test.exs
@@ -1,0 +1,236 @@
+defmodule Loopctl.Workers.DraftDuplicateSweepWorkerTest do
+  @moduledoc """
+  The weekly drain for the draft queue.
+
+  The queue this worker exists to bound was measured on 2026-08-17: 530 held drafts, of
+  which 453 duplicated something already published. The tests below pin the two halves of
+  that judgement — a draft WITH a near-identical published neighbour is retired, and a
+  draft that merely lacks evidence (no embedding, or no close neighbour) is not.
+  """
+  use Loopctl.DataCase, async: true
+  use Oban.Testing, repo: Loopctl.Repo
+
+  setup :verify_on_exit!
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Embeddings
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Workers.DraftDuplicateSweepWorker
+
+  # Two unit vectors that are cosine-identical to themselves and cosine-ORTHOGONAL to each
+  # other, so a test states the similarity it means instead of hoping a random vector lands
+  # on the right side of the threshold.
+  defp unit_vector(hot_index) do
+    dim = Application.get_env(:loopctl, :embedding_dimensions, 1536)
+    for i <- 0..(dim - 1), do: if(i == hot_index, do: 1.0, else: 0.0)
+  end
+
+  # A unit vector at a KNOWN cosine similarity to `unit_vector(0)`: [cos, sin, 0...].
+  # Needed because an ORTHOGONAL vector scores 0.0 and `0.0 > threshold` is false for
+  # every threshold >= 0 — so an orthogonality test passes at ANY threshold and pins
+  # nothing. This one sits in the band the threshold actually decides.
+  defp vector_at_similarity(cosine) do
+    dim = Application.get_env(:loopctl, :embedding_dimensions, 1536)
+    sine = :math.sqrt(1.0 - cosine * cosine)
+
+    for i <- 0..(dim - 1) do
+      case i do
+        0 -> cosine
+        1 -> sine
+        _ -> 0.0
+      end
+    end
+  end
+
+  defp article(tenant_id, status, attrs \\ %{}) do
+    base = %{
+      title: "Article #{System.unique_integer([:positive])}",
+      body: "A body with enough content to be a real article.",
+      category: :finding,
+      status: :draft,
+      tags: []
+    }
+
+    fixture(:article, Map.merge(base, Map.put(attrs, :tenant_id, tenant_id)))
+    |> Ecto.Changeset.change(%{status: status})
+    |> AdminRepo.update!()
+  end
+
+  defp embed(tenant_id, article, vector) do
+    {:ok, _} = Embeddings.upsert_article_embedding(tenant_id, article, vector)
+    article
+  end
+
+  defp status_of(id) do
+    AdminRepo.one(from(a in Article, where: a.id == ^id, select: a.status))
+  end
+
+  describe "retiring published duplicates" do
+    test "archives a draft whose nearest published neighbour clears the threshold" do
+      tenant = fixture(:tenant)
+      vector = unit_vector(0)
+
+      published = tenant.id |> article(:published) |> then(&embed(tenant.id, &1, vector))
+      draft = tenant.id |> article(:draft) |> then(&embed(tenant.id, &1, vector))
+
+      assert :ok =
+               perform_job(DraftDuplicateSweepWorker, %{"tenant_id" => tenant.id})
+
+      assert status_of(draft.id) == :archived,
+             "a draft cosine-identical to a published article must be retired"
+
+      assert status_of(published.id) == :published,
+             "the sweep must never touch the published winner"
+    end
+
+    test "leaves a draft whose nearest published neighbour is below the threshold" do
+      tenant = fixture(:tenant)
+
+      _published = tenant.id |> article(:published) |> then(&embed(tenant.id, &1, unit_vector(0)))
+      draft = tenant.id |> article(:draft) |> then(&embed(tenant.id, &1, unit_vector(1)))
+
+      assert :ok = perform_job(DraftDuplicateSweepWorker, %{"tenant_id" => tenant.id})
+
+      assert status_of(draft.id) == :draft,
+             "an orthogonal draft is novel, not duplicate"
+    end
+
+    test "leaves a draft that is merely SIMILAR, not near-identical (pins the threshold)" do
+      tenant = fixture(:tenant)
+
+      _published = tenant.id |> article(:published) |> then(&embed(tenant.id, &1, unit_vector(0)))
+
+      # 0.90 — close enough that a careless threshold would sweep it, far enough that
+      # the 2026-08-17 drain found genuine judgement was still required in this band.
+      draft =
+        tenant.id
+        |> article(:draft)
+        |> then(&embed(tenant.id, &1, vector_at_similarity(0.90)))
+
+      assert :ok = perform_job(DraftDuplicateSweepWorker, %{"tenant_id" => tenant.id})
+
+      assert status_of(draft.id) == :draft,
+             "0.90 is below the 0.95 retirement threshold — lowering the threshold must " <>
+               "break this test, not silently widen what the sweep destroys"
+    end
+
+    test "archives a draft just ABOVE the threshold" do
+      tenant = fixture(:tenant)
+
+      _published = tenant.id |> article(:published) |> then(&embed(tenant.id, &1, unit_vector(0)))
+
+      draft =
+        tenant.id
+        |> article(:draft)
+        |> then(&embed(tenant.id, &1, vector_at_similarity(0.99)))
+
+      assert :ok = perform_job(DraftDuplicateSweepWorker, %{"tenant_id" => tenant.id})
+
+      assert status_of(draft.id) == :archived,
+             "0.99 clears the threshold — raising the threshold above it must break this " <>
+               "test, so the two bounds are pinned from both sides"
+    end
+
+    test "does not treat another DRAFT as a duplicate source" do
+      tenant = fixture(:tenant)
+      vector = unit_vector(0)
+
+      # Two identical drafts and NOTHING published. Retiring either would be the worker
+      # inventing a winner: only a published article can settle a draft's fate, because
+      # only a published article is what a reader would otherwise already have.
+      first = tenant.id |> article(:draft) |> then(&embed(tenant.id, &1, vector))
+      second = tenant.id |> article(:draft) |> then(&embed(tenant.id, &1, vector))
+
+      assert :ok = perform_job(DraftDuplicateSweepWorker, %{"tenant_id" => tenant.id})
+
+      assert status_of(first.id) == :draft
+      assert status_of(second.id) == :draft
+    end
+  end
+
+  describe "absence of evidence" do
+    # NB this pins the OUTCOME, not the mechanism. The invariant is protected twice over
+    # — the worker's inner join never loads an unembedded draft, and a nil embedding
+    # yields no neighbours anyway — so swapping the join for a left_join is
+    # behaviour-preserving and does NOT fail this test. Verified by mutation, and
+    # recorded here so a later reader does not mistake it for a join guard.
+    test "never archives an UNEMBEDDED draft, even beside an identical published article" do
+      tenant = fixture(:tenant)
+
+      _published = tenant.id |> article(:published) |> then(&embed(tenant.id, &1, unit_vector(0)))
+      # No embedding: the worker cannot know whether this duplicates anything.
+      draft = article(tenant.id, :draft)
+
+      assert :ok = perform_job(DraftDuplicateSweepWorker, %{"tenant_id" => tenant.id})
+
+      assert status_of(draft.id) == :draft,
+             "an unembedded draft is unknown, not novel and not duplicate — leave it"
+    end
+  end
+
+  describe "tenant isolation" do
+    test "a published article in tenant B never retires a draft in tenant A" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      vector = unit_vector(0)
+
+      _b_published =
+        tenant_b.id |> article(:published) |> then(&embed(tenant_b.id, &1, vector))
+
+      a_draft = tenant_a.id |> article(:draft) |> then(&embed(tenant_a.id, &1, vector))
+
+      assert :ok = perform_job(DraftDuplicateSweepWorker, %{"tenant_id" => tenant_a.id})
+
+      assert status_of(a_draft.id) == :draft,
+             "cross-tenant similarity must never settle a draft — that is a data leak " <>
+               "wearing a curation verdict"
+    end
+  end
+
+  describe "all_tenants dispatcher" do
+    # `:manual` rather than the suite-wide `testing: :inline` (config/test.exs): under
+    # inline mode `Oban.insert` RUNS the child instead of enqueueing it, so there is
+    # nothing left to assert the fan-out against.
+    test "enqueues one per-tenant job per ACTIVE tenant, and none for an inactive one" do
+      active_one = fixture(:tenant)
+      active_two = fixture(:tenant)
+      inactive = fixture(:tenant, %{status: :suspended})
+
+      result =
+        Oban.Testing.with_testing_mode(:manual, fn ->
+          DraftDuplicateSweepWorker.perform(%Oban.Job{args: %{"mode" => "all_tenants"}})
+        end)
+
+      assert result == :ok
+
+      enqueued_tenant_ids =
+        all_enqueued(worker: DraftDuplicateSweepWorker)
+        |> Enum.filter(&Map.has_key?(&1.args, "tenant_id"))
+        |> Enum.map(& &1.args["tenant_id"])
+
+      assert active_one.id in enqueued_tenant_ids
+      assert active_two.id in enqueued_tenant_ids
+
+      refute inactive.id in enqueued_tenant_ids,
+             "a suspended tenant must not have its drafts swept"
+    end
+
+    test "the dispatcher itself sweeps nothing" do
+      tenant = fixture(:tenant)
+      vector = unit_vector(0)
+
+      _published = tenant.id |> article(:published) |> then(&embed(tenant.id, &1, vector))
+      draft = tenant.id |> article(:draft) |> then(&embed(tenant.id, &1, vector))
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        DraftDuplicateSweepWorker.perform(%Oban.Job{args: %{"mode" => "all_tenants"}})
+      end)
+
+      assert status_of(draft.id) == :draft,
+             "the dispatcher must fan out, not sweep — sweeping there would bypass the " <>
+               "per-tenant fair-share gate the child clause applies"
+    end
+  end
+end


### PR DESCRIPTION
Schedules the weekly draft-queue drain the owner asked for, in Oban rather than a
system crontab.

## Why Oban and not the alternatives

- **`/schedule`** creates *cloud* agents that cannot reach local files, local env,
  or (with no connectors configured) the loopctl MCP tools. It could not call
  `knowledge_list`, let alone open a repo to check a claim.
- **`CronCreate`** is session-only, in-memory, and auto-expires after 7 days.
- **A system crontab entry** would work but invents a second scheduler outside the
  product, on one machine.

Oban already runs every other recurring pass here, so a weekly job is a worker
module plus one crontab line.

## The honest limit

**Oban cannot run `/second-brain:kb-review-drafts`.** It is server-side Elixir - it
cannot invoke an agent session or run the shell commands the review's verification
step depends on. So this worker takes only the half that needs no judgement.

That half is most of the queue. The 2026-08-17 manual drain measured 530 held
drafts, of which **453 were duplicates** (418 re-extractions of already-published
articles, 35 near-identical siblings - one lesson extracted four times from a
single session). Only 77 were novel. The judgement half stays with an agent.

## What it does

Per tenant, for each draft carrying an embedding at the tenant's active dimension:
ask the vector index for the nearest PUBLISHED article and retire the draft when
that neighbour clears 0.95. `VectorSearch.nearest/4` already applies
`status = :published` as an index-safe residual filter, so no new query shape.

Threshold 0.95, single run, no corroboration gate - the owner's explicit choice.
Every one of the 271 drafts at or above 0.95 inspected during the manual drain was
a true duplicate.

## Scope discipline, and the one-way door

`:archived` is terminal - unlike the nightly consolidation pass, which retracts
published articles with `unpublish` specifically to keep an undo (#605/#606/#608).
A draft is already unpublished, so archive is the only move down. The row survives
and every archive is audited, but "non-destructive" and "reversible" are different
properties and this worker only has the first. The threshold is the safety
mechanism, and the tests pin it from both sides.

- An UNEMBEDDED draft is never swept - absence of evidence is not evidence of
  novelty.
- Another DRAFT never settles a draft's fate; only a published article can.
- `:heavy_read_overloaded` snoozes the whole tenant rather than banking a partial
  verdict - a shed read is an unknown, and an unknown must not read as "not a
  duplicate" on a path whose action cannot be undone.
- Bounded per run; a larger backlog drains over later runs, highest similarity
  first so a capped run retires the most certain duplicates.

## Verification

`mix precommit` green on the task's own exit status (not through a pipe): 7528
tests, 0 failures, credo --strict clean, dialyzer clean.

**Mutation-verified, and it caught a vacuous test.** The first version of the
"leaves a dissimilar draft" test used an ORTHOGONAL vector - which scores 0.0, and
`0.0 > threshold` is false at every threshold, so the test passed even with the
threshold neutered to 0.0 and pinned nothing. Replaced with vectors at known
cosine similarity (0.90 and 0.99), which now fail under both mutations: lowering
the threshold to 0.50 breaks the 0.90 case, raising it to 0.995 breaks the 0.99
case.

One guard is honestly weaker than it looks and is documented as such in the test:
swapping the inner join for a left_join does NOT fail the unembedded-draft test,
because a nil embedding independently yields no neighbours. That invariant is
protected twice over; the test pins the outcome, not the join.

## Review

Reviewed inline by the authoring session - harness defaults bar agent/workflow
dispatch without an explicit request. Flagging that this is the largest of the
three inline-reviewed changes today and the only one with an unattended terminal
write, so it is the one most worth a second pair of eyes if you want one.
