### PR TITLE
Stop the draft sweep from making consolidation's retractions irreversible

### DIFF
--- a/lib/loopctl/workers/draft_duplicate_sweep_worker.ex
+++ b/lib/loopctl/workers/draft_duplicate_sweep_worker.ex
@@ -53,6 +53,25 @@ defmodule Loopctl.Workers.DraftDuplicateSweepWorker do
   "reversible" are different properties, and this worker only has the first. Treat the
   threshold as the safety mechanism it is, and do not lower it without re-measuring.
 
+  ## What it must NOT sweep: another worker's reversible retraction
+
+  `Loopctl.Knowledge.Consolidation` retracts a confirmed duplicate with `unpublish`
+  and never `archive`, deliberately, so an unattended pass keeps an undo
+  (#605/#606/#608). Its output is a DRAFT whose published winner is by construction at
+  or above this worker's similarity threshold — that similarity is *why* it was
+  retracted. So a naive sweep archives exactly the set another worker took care to
+  leave reversible, one week later, unattended, converting a considered
+  `{:published, :draft}` into a terminal `:archived`.
+
+  That is not a hypothetical: on 2026-08-17 a manual drain archived 418 drafts, and all
+  418 turned out to be consolidation retractions from 2026-08-06/07. Zero of the 420
+  consolidation had ever retracted remained reversible afterwards.
+
+  Sparing them costs nothing. A draft is already withheld from every read path, so the
+  queue-hygiene argument for archiving it is weak, while the undo it preserves is the
+  entire reason consolidation chose `unpublish`. Consolidation owns its own output; this
+  worker drains what the CAPTURE path holds.
+
   ## Scope discipline
 
   * Only drafts that HAVE an embedding are considered. An unembedded draft is not
@@ -80,6 +99,10 @@ defmodule Loopctl.Workers.DraftDuplicateSweepWorker do
   alias Loopctl.Tenants.Tenant
 
   @actor_label "worker:draft_duplicate_sweep"
+
+  # The nightly consolidation pass's actor label. Its retractions are SPARED — see
+  # `load_embedded_drafts/2`.
+  @consolidation_actor "worker:consolidation"
 
   # Chosen from the 2026-08-17 drain: every one of the 271 drafts at >= 0.95 that was
   # inspected was a true duplicate, and the ONE inspected article that scored below
@@ -164,11 +187,26 @@ defmodule Loopctl.Workers.DraftDuplicateSweepWorker do
   # for want of a neighbour it was never able to have.
   defp load_embedded_drafts(tenant_id, dimension) do
     from(a in Knowledge.Article,
+      as: :draft,
       join: e in ArticleEmbedding,
       on: e.article_id == a.id and e.tenant_id == a.tenant_id,
       where: a.tenant_id == ^tenant_id,
       where: a.status == :draft,
       where: e.dim == ^dimension and e.live_denorm == true,
+      # Spare consolidation's retractions — the exclusion is applied HERE rather than
+      # before the archive so the sweep does not even spend an ANN read on a draft it
+      # must not touch. There is no marker on the article itself; the audit_log is the
+      # only record that consolidation was the actor.
+      where:
+        not exists(
+          from(al in "audit_log",
+            where: al.entity_id == parent_as(:draft).id,
+            where: al.entity_type == "article",
+            where: al.action == "article.unpublished",
+            where: al.actor_label == ^@consolidation_actor,
+            select: 1
+          )
+        ),
       order_by: [asc: a.inserted_at],
       limit: ^scan_limit(),
       select: %{id: a.id, title: a.title, embedding: e.embedding}

--- a/test/loopctl/workers/draft_duplicate_sweep_worker_test.exs
+++ b/test/loopctl/workers/draft_duplicate_sweep_worker_test.exs
@@ -150,6 +150,53 @@ defmodule Loopctl.Workers.DraftDuplicateSweepWorkerTest do
     end
   end
 
+  describe "sparing another worker's reversible retraction" do
+    # Consolidation retracts a confirmed duplicate with `unpublish`, never `archive`,
+    # so an unattended pass keeps an undo (#605/#606/#608). Its output is BY
+    # CONSTRUCTION a draft above this worker's threshold — that similarity is why it
+    # was retracted — so without the exclusion the sweep archives exactly the set
+    # another worker took care to leave reversible.
+    test "never archives a draft that consolidation unpublished" do
+      tenant = fixture(:tenant)
+      vector = unit_vector(0)
+
+      _published = tenant.id |> article(:published) |> then(&embed(tenant.id, &1, vector))
+      draft = tenant.id |> article(:draft) |> then(&embed(tenant.id, &1, vector))
+
+      AdminRepo.insert_all("audit_log", [
+        %{
+          id: Ecto.UUID.bingenerate(),
+          tenant_id: Ecto.UUID.dump!(tenant.id),
+          entity_type: "article",
+          entity_id: Ecto.UUID.dump!(draft.id),
+          action: "article.unpublished",
+          actor_type: "worker",
+          actor_label: "worker:consolidation",
+          inserted_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+        }
+      ])
+
+      assert :ok = perform_job(DraftDuplicateSweepWorker, %{"tenant_id" => tenant.id})
+
+      assert status_of(draft.id) == :draft,
+             "consolidation chose a REVERSIBLE retraction; this worker must not convert " <>
+               "it into a terminal one a week later"
+    end
+
+    test "still archives an identical draft that consolidation did NOT retract" do
+      tenant = fixture(:tenant)
+      vector = unit_vector(0)
+
+      _published = tenant.id |> article(:published) |> then(&embed(tenant.id, &1, vector))
+      draft = tenant.id |> article(:draft) |> then(&embed(tenant.id, &1, vector))
+
+      assert :ok = perform_job(DraftDuplicateSweepWorker, %{"tenant_id" => tenant.id})
+
+      assert status_of(draft.id) == :archived,
+             "the exclusion must be scoped to consolidation's output, not disable the sweep"
+    end
+  end
+
   describe "absence of evidence" do
     # NB this pins the OUTCOME, not the mechanism. The invariant is protected twice over
     # — the worker's inner join never loads an unembedded draft, and a nil embedding


### PR DESCRIPTION
Fixes a defect I introduced in #685, found while measuring KB usage.

## The bug

`Loopctl.Knowledge.Consolidation` retracts a confirmed duplicate with `unpublish`
and **never** `archive` — deliberately, so an unattended pass keeps an undo
(#605/#606/#608). Its output is a DRAFT whose published winner is, *by
construction*, at or above `DraftDuplicateSweepWorker`'s similarity threshold —
that similarity is exactly why consolidation retracted it.

So the sweeper archives precisely the set another worker took care to leave
reversible, one week later, unattended — converting a considered
`{:published, :draft}` into a terminal `:archived`.

## It already happened

The 2026-08-17 manual drain archived 418 drafts. All 418 were consolidation
retractions from 08-06/07 (confirmed against `audit_log`). Of the 420
consolidation has ever retracted, **zero remained reversible** afterwards. The
sweeper would have repeated this every Sunday.

I originally attributed those 418 to an "aborted June harvest run". That was
wrong — the articles were *created* in April–June and *retracted* in August. I
had even tested a consolidation hypothesis and rejected it, but tested the wrong
table (`kb_curation_events` in the June window) instead of `audit_log` for
unpublish actions at any date.

## The fix

Exclude drafts that consolidation unpublished. Applied at load time rather than
before the archive, so the sweep does not even spend an ANN read on a draft it
must not touch. There is no marker on the article itself — `audit_log` is the
only record of which actor unpublished it.

Sparing them costs nothing: a draft is already withheld from every read path, so
the queue-hygiene argument for archiving it is weak, while the undo it preserves
is the whole reason consolidation chose `unpublish`. Consolidation owns its own
output; this worker drains what the CAPTURE path holds.

## Verification

`mix precommit` green on its own exit status: 7530 tests, 0 failures, credo and
dialyzer clean.

Mutation-verified: deleting the exclusion fails the sparing test. A second test
pins that the exclusion is scoped to consolidation's output rather than disabling
the sweep in general.
