### PR TITLE
Record which search surfaced a read, and stop scoring silence as failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ All notable changes to loopctl are documented here.
 
 ### Added
 
+- **A read now records WHICH search surfaced it**, on two new
+  `article_access_events` columns (`origin_search_id`, `origin_attribution`) resolved
+  SERVER-SIDE at write time and never accepted from a caller — the same rule
+  `metadata.search_id` already follows (#582), because an origin a caller can assert is
+  follow-through a caller can manufacture. `GET /api/v1/knowledge/analytics/retrieval-metrics`
+  and the `knowledge_retrieval_metrics` MCP tool gain five fields, and
+  `retrieval_metric_snapshots` gains the columns behind them (both migrations are additive,
+  default 0, no manual step; historical rows read 0 because the data did not exist, not
+  because it was zero).
+
+  Why it matters to an operator reading the existing series: `followed_through` correlates a
+  search and an open on `api_key_id`, and the injected recall hook searches under a
+  DIFFERENT key from the session that reads it — measured 2026-08-17, the hook's key made
+  1,071 searches and 1 read ever, while the session key made 2,535 reads. So the channel
+  carrying 71% of all search volume has always scored a structural ZERO there, meaning
+  UNMEASURABLE rather than unread. `cross_key_opens` is that population. `direct_opens` is
+  an agent going straight to an article by link or cited id, previously indistinguishable
+  from "surfaced and ignored" — close to its opposite. Unit warning: these count READS,
+  while `followed_through` counts SURFACED RESULTS later opened; they are not comparable and
+  neither replaces the other, so the existing series is unchanged and remains valid across
+  this migration.
+
+  `searches_with_follow_through` / `searches_reformulated` / `searches_quiet` now partition
+  `searches`. Treating every not-opened search as a failure is wrong — an agent answered by
+  the result snippet correctly opens nothing, and that is a success. A reformulation is the
+  one unambiguous failure in that bucket, so it is split out; `quiet` is STILL a mixture of
+  "the snippet sufficed" and "the rows were ignored", and this release does not separate
+  them.
+
 - **Vector-read responses now disclose whether the read ran with `hnsw.iterative_scan`,**
   on a new `meta.ann_iterative_scan` (`off` | `applied` |
   `unavailable`) plus an `ann_iterative_scan_reason` alongside `unavailable` only.

--- a/docs/runbooks/search-events-analysis.md
+++ b/docs/runbooks/search-events-analysis.md
@@ -137,6 +137,38 @@ One caution specific to our volume: the arms are thin, and automation rows surfa
 never open anything, which depresses every rank uniformly. Segment on `client_host IS NOT NULL`
 here too, and do not read a few dozen rows as a result.
 
+## 3b. The follow-through number has a channel-shaped hole — and now a second reading
+
+`search_follow_through` and `followed_through` correlate a search with an open on
+`api_key_id`. The injected recall hook searches under a DIFFERENT key from the session that
+reads: measured 2026-08-17, the hook's key made 1,071 searches and **1** deliberate read
+ever, the MCP/session key 0 such searches and 2,535 reads. **So the channel carrying 71% of
+search volume has always scored a structural zero in those fields, and that zero means
+unmeasurable, not unread.**
+
+Reads now carry `origin_search_id` / `origin_attribution`, resolved server-side at write
+time, and the metrics payload reports:
+
+| field | unit | read it as |
+|---|---|---|
+| `attributed_opens` | READS | opens whose originating search is known |
+| `cross_key_opens` | READS | **the injected channel** — surfaced by one key, read by another |
+| `direct_opens` | READS | agent went straight to the article (link, cited id) — not a miss |
+| `searches_reformulated` | SEARCH CALLS | asked again, in-window, nothing opened — a real failure |
+| `searches_quiet` | SEARCH CALLS | neither opened nor re-asked — **still ambiguous** |
+
+Two things to hold onto when reading them:
+
+- **Units differ from `followed_through`.** That counts SURFACED RESULTS later opened; the
+  `*_opens` fields count READS. They are not comparable and neither supersedes the other.
+- **`quiet` is not "sufficed".** Splitting `reformulated` out removes the one unambiguous
+  failure from the not-opened bucket; it does NOT resolve the snippet-sufficed-vs-ignored
+  ambiguity in step 4 below. Nothing here turns a floor into a satisfaction rate.
+
+Cross-key attribution is circumstantial by construction — two agents in one tenant can reach
+one article independently — which is why it is a separate labelled field rather than folded
+into `attributed_opens`.
+
 ## 4. The trap
 
 Search returns; agents do not open. Search-to-read has sat near 27:1, and 1.74% of

--- a/lib/loopctl/knowledge/analytics.ex
+++ b/lib/loopctl/knowledge/analytics.ex
@@ -52,6 +52,20 @@ defmodule Loopctl.Knowledge.Analytics do
   # `"drill"` exists and why the two allowlists move together (#569).
   @valid_access_types ~w(search get context index drill)
 
+  # The access types that mean "a body was DELIVERED to the agent" — the ones worth
+  # attributing back to a search. Deliberately the same three `RetrievalMetrics` counts as
+  # follow-through, INCLUDING `drill`: #569 split drill out of the heat index so that index
+  # could not rank on reads it caused itself, but "was this read produced by a search" is a
+  # different question and a drill delivers a body like any other read.
+  @attributable_access_types ~w(get context drill)
+
+  # How far back a read looks for the search that surfaced it. Fixed at WRITE time, which is
+  # the one thing that makes `origin_search_id` cheap and stable — but it means the
+  # attributed counters do NOT move with `RetrievalMetrics`' query-time `window_seconds`.
+  # Same default (30 min) so the two agree by construction on the common case; stated in the
+  # metrics payload so nobody reads a divergence as a bug.
+  @origin_window_seconds 1800
+
   @doc """
   The access types `record_access/6` will write.
 
@@ -63,6 +77,22 @@ defmodule Loopctl.Knowledge.Analytics do
   """
   @spec valid_access_types() :: [String.t()]
   def valid_access_types, do: @valid_access_types
+
+  @doc """
+  The access types whose rows get an `origin_search_id` resolved at write time.
+  """
+  @spec attributable_access_types() :: [String.t()]
+  def attributable_access_types, do: @attributable_access_types
+
+  @doc """
+  The write-time lookback, in seconds, for resolving a read's originating search.
+
+  Exposed because it is NOT the same knob as `RetrievalMetrics`' query-time
+  `window_seconds`: this one is baked into each row when it is written and cannot be
+  re-asked of history.
+  """
+  @spec origin_window_seconds() :: pos_integer()
+  def origin_window_seconds, do: @origin_window_seconds
 
   # How many of a search's results get an `article_access_events` row (#582). Rows are
   # written per SURFACED RESULT, so an uncapped search would write an unbounded batch on
@@ -1107,6 +1137,9 @@ defmodule Loopctl.Knowledge.Analytics do
 
     rows =
       Enum.map(items, fn {article_id, meta} ->
+        {origin_search_id, origin_attribution} =
+          resolve_origin(tenant_id, article_id, api_key_id, access_type, now)
+
         %{
           id: Ecto.UUID.generate(),
           tenant_id: tenant_id,
@@ -1116,7 +1149,9 @@ defmodule Loopctl.Knowledge.Analytics do
           story_id: story_id,
           access_type: access_type,
           metadata: ensure_map(meta),
-          accessed_at: now
+          accessed_at: now,
+          origin_search_id: origin_search_id,
+          origin_attribution: origin_attribution
         }
       end)
 
@@ -1138,6 +1173,87 @@ defmodule Loopctl.Knowledge.Analytics do
 
       :ok
   end
+
+  # ---------------------------------------------------------------------------
+  # Origin attribution — which search surfaced the article this read opened
+  # ---------------------------------------------------------------------------
+
+  @doc false
+  # Resolves `{origin_search_id, origin_attribution}` for a READ row, server-side.
+  #
+  # WHY THIS IS NOT A CALLER PARAMETER. `search_id` is already withheld from callers (#582)
+  # because a call-level identity the caller controls is a metric the caller can game. An
+  # `origin_search_id` a caller could assert is strictly worse: it would let one agent
+  # manufacture follow-through for its own article, which is the heat-index failure
+  # (#567/#569) reproduced one table over. The MCP server could technically thread it — it is
+  # one process per session and knows what the last search returned — and that is exactly
+  # what must not be built.
+  #
+  # WHY A LOOKUP AND NOT A JOIN AT READ TIME. `get`/`context`/`drill` rows carry no
+  # `search_id`, so there is nothing to join ON; and the correlation that would substitute
+  # for it binds `api_key_id`, which makes the injected recall hook — a different key from
+  # the session that reads — structurally invisible. Resolving once at write time fixes both
+  # and costs one indexed point query per read
+  # (`article_access_events_surface_lookup_idx`), on a path that is already async and
+  # already best-effort.
+  #
+  # PREFERENCE ORDER, and why it is not "most recent wins": a surfacing by the READER'S OWN
+  # key is direct evidence, so it is taken ahead of any other key's even when the other is
+  # more recent. Only when no same-key surfacing exists does a cross-key one apply, and it is
+  # labelled `cross_key` precisely because it is circumstantial — two agents in one tenant
+  # can reach the same article independently.
+  def resolve_origin(tenant_id, article_id, api_key_id, access_type, now)
+
+  def resolve_origin(_tenant_id, _article_id, _api_key_id, access_type, _now)
+      when access_type not in @attributable_access_types,
+      do: {nil, nil}
+
+  def resolve_origin(tenant_id, article_id, api_key_id, _access_type, now)
+      when is_binary(article_id) and is_binary(api_key_id) do
+    since = DateTime.add(now, -@origin_window_seconds, :second)
+
+    query =
+      from(s in ArticleAccessEvent,
+        where: s.tenant_id == ^tenant_id,
+        where: s.article_id == ^article_id,
+        where: s.access_type == "search",
+        where: s.accessed_at >= ^since and s.accessed_at <= ^now,
+        # Same key first (direct evidence), then most recent. `desc:` on the boolean puts
+        # true ahead of false.
+        order_by: [
+          desc: fragment("? = ?", s.api_key_id, type(^api_key_id, Ecto.UUID)),
+          desc: s.accessed_at
+        ],
+        limit: 1,
+        select: {fragment("?->>'search_id'", s.metadata), s.api_key_id}
+      )
+
+    case AdminRepo.one(query) do
+      nil ->
+        {nil, "none"}
+
+      {nil, _key} ->
+        # A surfacing row from before #582 carries no search_id. The article WAS surfaced,
+        # so this is not `none` — but there is no id to point at, and inventing one would
+        # put an unattributable read in the attributed bucket.
+        {nil, nil}
+
+      {search_id, ^api_key_id} ->
+        {search_id, "same_key"}
+
+      {search_id, _other_key} ->
+        {search_id, "cross_key"}
+    end
+  rescue
+    # Attribution is an enrichment, never a reason to lose the event. The caller's rescue in
+    # `do_record_sync/5` would drop the whole row; this one degrades to an unattributed read.
+    error ->
+      Logger.warning("Knowledge.Analytics origin resolution failed: #{Exception.message(error)}")
+
+      {nil, nil}
+  end
+
+  def resolve_origin(_tenant_id, _article_id, _api_key_id, _access_type, _now), do: {nil, nil}
 
   # ---------------------------------------------------------------------------
   # Attribution resolution

--- a/lib/loopctl/knowledge/article_access_event.ex
+++ b/lib/loopctl/knowledge/article_access_event.ex
@@ -66,6 +66,14 @@ defmodule Loopctl.Knowledge.ArticleAccessEvent do
   # silently unwritable or silently unvalidated), but do not read this list as a gate.
   @access_types ~w(search get context index drill)
 
+  # HOW an `origin_search_id` was established. Recorded rather than inferred at read time so
+  # a consumer never mistakes an inference for an observation — `cross_key` is the injected
+  # recall hook's shape (it searches under one key, the session reads under another) and is
+  # PLAUSIBLE, not proof: two agents in one tenant can reach the same article independently.
+  # `none` is not a failure — it is the agent going straight to an article by link or cited
+  # id, which used to be indistinguishable from "surfaced and ignored".
+  @origin_attributions ~w(same_key cross_key none)
+
   schema "article_access_events" do
     tenant_field()
     belongs_to :article, Loopctl.Knowledge.Article
@@ -77,6 +85,14 @@ defmodule Loopctl.Knowledge.ArticleAccessEvent do
     field :metadata, :map, default: %{}
     field :accessed_at, :utc_datetime_usec
 
+    # Which search surfaced this article to the agent that then opened it, resolved
+    # SERVER-SIDE at write time and never accepted from a caller — the same rule
+    # `metadata["search_id"]` follows (#582), for the same reason: a forged origin lets an
+    # agent manufacture follow-through for its own article. Both are nil on surfacing rows
+    # (`search`, `index`) and on everything written before the column existed.
+    field :origin_search_id, Ecto.UUID
+    field :origin_attribution, :string
+
     # No timestamps() — accessed_at is the only timestamp.
   end
 
@@ -85,6 +101,16 @@ defmodule Loopctl.Knowledge.ArticleAccessEvent do
   """
   @spec access_types() :: [String.t()]
   def access_types, do: @access_types
+
+  @doc """
+  Returns the list of valid `origin_attribution` values.
+
+  Same caveat as `access_types/0`: the production write path is `insert_all` and builds no
+  changeset, so this list is not a gate — `Analytics.resolve_origin/4` is the only writer,
+  and the drift test binds the two.
+  """
+  @spec origin_attributions() :: [String.t()]
+  def origin_attributions, do: @origin_attributions
 
   @doc """
   Changeset for creating a new article access event.
@@ -105,6 +131,11 @@ defmodule Loopctl.Knowledge.ArticleAccessEvent do
       :metadata,
       :accessed_at
     ])
+    # `origin_search_id` / `origin_attribution` are deliberately NOT cast, for the same
+    # reason `tenant_id` is not: they are resolved by the writer
+    # (`Analytics.resolve_origin/5`), never supplied. Adding them here would give an API
+    # caller a way to assert which search produced its own read — the forgery #582 closed
+    # for `search_id`, and the self-inflating loop #567/#569 closed for the heat index.
     |> validate_required([:article_id, :api_key_id, :access_type, :accessed_at])
     |> validate_inclusion(:access_type, @access_types)
     |> foreign_key_constraint(:article_id)

--- a/lib/loopctl/knowledge/retrieval_metric_snapshot.ex
+++ b/lib/loopctl/knowledge/retrieval_metric_snapshot.ex
@@ -71,6 +71,18 @@ defmodule Loopctl.Knowledge.RetrievalMetricSnapshot do
     field :retrieved_searched, :integer, default: 0
     field :retrieved_followed_through, :integer, default: 0
     field :retrieved_precision, :float, default: 0.0
+
+    # Unit: READS (get/context/drill rows), NOT surfaced results and NOT search calls.
+    # `followed_through` above counts SURFACED RESULTS that were later opened, so it is not
+    # comparable with these three — the naming keeps the units legible.
+    field :attributed_opens, :integer, default: 0
+    field :cross_key_opens, :integer, default: 0
+    field :direct_opens, :integer, default: 0
+
+    # Unit: SEARCH CALLS. With `searches_with_follow_through` these partition `searches`.
+    field :searches_reformulated, :integer, default: 0
+    field :searches_quiet, :integer, default: 0
+
     field :computed_at, :utc_datetime_usec
 
     timestamps(type: :utc_datetime_usec)
@@ -92,6 +104,11 @@ defmodule Loopctl.Knowledge.RetrievalMetricSnapshot do
     :retrieved_searched,
     :retrieved_followed_through,
     :retrieved_precision,
+    :attributed_opens,
+    :cross_key_opens,
+    :direct_opens,
+    :searches_reformulated,
+    :searches_quiet,
     :computed_at
   ]
 

--- a/lib/loopctl/knowledge/retrieval_metrics.ex
+++ b/lib/loopctl/knowledge/retrieval_metrics.ex
@@ -85,6 +85,61 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
      set — the modal agent flow — credits the missed search as well as the successful
      one, in exactly the repeated-near-miss case this metric exists to surface.
 
+  ## Exact attribution, and the channel the correlated metric cannot see
+
+  `followed_through` correlates on `(tenant, api_key, article, window)`. That `api_key`
+  binding is deliberate and is pinned by a test ("an open by a DIFFERENT api_key does not
+  count") — but it has a consequence nothing recorded until now: **the injected recall hook
+  searches under a different key from the session that reads.** Measured on prod
+  2026-08-17, the hook's key made 1,071 searches and 1 deliberate read ever, while the
+  session key made 2,535 reads. So the channel carrying 71% of all search volume scores a
+  structural ZERO in `followed_through`, and that zero means "unmeasurable", not "unread" —
+  the same `0.0`-vs-`n/a` distinction `RetrievalEval` already insists on.
+
+  `Analytics.resolve_origin/5` therefore resolves each read's originating search at WRITE
+  time, server-side, into `article_access_events.origin_search_id` / `origin_attribution`,
+  and three counters are reported beside the correlated ones:
+
+  - `attributed_opens` — reads whose originating search is known (`same_key` + `cross_key`).
+  - `cross_key_opens` — the subset surfaced by a different key. **This is the injected
+    channel.** It is circumstantial by construction: two agents in one tenant can reach the
+    same article independently, which is why it is labelled rather than merged into
+    `attributed_opens` blindly.
+  - `direct_opens` — reads nothing surfaced (`none`): the agent went to an article by link
+    or cited id. Previously indistinguishable from "surfaced and ignored", which is close to
+    its opposite.
+
+  **Unit warning, because this is exactly where #582 went wrong once already.** These three
+  count READS. `followed_through` counts SURFACED RESULTS that were later opened. They are
+  not comparable and neither is a refinement of the other — keep both.
+
+  A read whose `origin_attribution` is NULL is in none of the three: pre-migration rows,
+  surfacing rows, and the one case `resolve_origin/5` refuses to classify (a surfacing row
+  predating #582 carries no `search_id`, so the article WAS surfaced — `none` would be false
+  — but there is no id to attribute to).
+
+  **Two windows, and they are not the same knob.** `origin_attribution` is baked in at write
+  time using `Analytics.origin_window_seconds/0` and cannot be re-asked of history; the
+  correlated metrics take `window_seconds` at query time. They share a default so the common
+  case agrees by construction. A divergence between `attributed_opens` and
+  `followed_through` after someone passes a different `window_seconds` is that mismatch, not
+  a bug.
+
+  ## What `quiet` does NOT mean
+
+  `searches_with_follow_through`, `searches_reformulated` and `searches_quiet` partition
+  `searches`. The partition exists because treating every not-opened search as a failure is
+  wrong, and `docs/runbooks/search-events-analysis.md` says so outright: "an agent whose
+  question is answered by the snippet correctly opens nothing, and that is a success this
+  metric scores as a failure."
+
+  A REFORMULATION — the same key issuing a different query inside the window, having opened
+  nothing — is the one member of that bucket that is unambiguously a failure, so it is peeled
+  out. What remains is named `quiet` and is STILL a mixture: "the snippet sufficed" and "the
+  rows were ignored" are indistinguishable here, and this instrumentation does not resolve
+  them. Do not rename it to anything that asserts satisfaction, and do not compute a rate
+  that treats it as either. Follow-through remains a floor, never a satisfaction rate.
+
   ## The proxy is gameable in one direction — never optimise it alone
 
   `precision` rises when a search returns FEWER results, with no better retrieval
@@ -198,6 +253,8 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
     retrieved_precision = safe_precision(retrieved_followed, retrieved_searched)
 
     call = compute_call_level(searched_q, window_seconds)
+    opens = compute_open_attribution(tenant_id, day_start, day_end)
+    dispositions = compute_dispositions(searched_q, window_seconds, call)
 
     %{
       day: day,
@@ -215,7 +272,89 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
       curated_precision: curated_precision,
       retrieved_searched: retrieved_searched,
       retrieved_followed_through: retrieved_followed,
-      retrieved_precision: retrieved_precision
+      retrieved_precision: retrieved_precision,
+      attributed_opens: opens.attributed_opens,
+      cross_key_opens: opens.cross_key_opens,
+      direct_opens: opens.direct_opens,
+      searches_reformulated: dispositions.searches_reformulated,
+      searches_quiet: dispositions.searches_quiet
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # Exact attribution (unit: READS) and search disposition (unit: SEARCH CALLS)
+  # ---------------------------------------------------------------------------
+
+  # Counts READ rows by how their originating search was established
+  # (`ArticleAccessEvent.origin_attribution/0`, resolved server-side at write time).
+  #
+  # This is the counterpart to `followed_through`, not a replacement, and the two are NOT
+  # comparable: `followed_through` counts SURFACED RESULTS that were later opened, this
+  # counts the OPENS themselves. Both are kept because each answers a question the other
+  # cannot:
+  #
+  #   * `followed_through` correlates on `api_key_id`, so the injected recall hook — which
+  #     searches under one key while the session reads under another — scores a structural
+  #     ZERO there. `cross_key_opens` is exactly that population, and it was unrepresentable
+  #     before the column existed.
+  #   * `direct_opens` (`origin_attribution = "none"`) is the agent going straight to an
+  #     article by link or cited id. It used to be indistinguishable from "surfaced and
+  #     ignored", which is close to its opposite.
+  #
+  # A row whose attribution is NULL is neither: pre-migration rows, surfacing rows, and the
+  # one case `resolve_origin/5` deliberately refuses to classify (a surfacing row from before
+  # #582 that carries no `search_id` — the article WAS surfaced, so calling it `none` would
+  # be false, and there is no id to attribute to).
+  defp compute_open_attribution(tenant_id, day_start, day_end) do
+    rows =
+      from(o in ArticleAccessEvent,
+        where: o.tenant_id == ^tenant_id,
+        where: o.accessed_at >= ^day_start and o.accessed_at < ^day_end,
+        where: not is_nil(o.origin_attribution),
+        group_by: o.origin_attribution,
+        select: {o.origin_attribution, count(o.id)}
+      )
+      |> AdminRepo.all()
+      |> Map.new()
+
+    same = Map.get(rows, "same_key", 0)
+    cross = Map.get(rows, "cross_key", 0)
+
+    %{
+      attributed_opens: same + cross,
+      cross_key_opens: cross,
+      direct_opens: Map.get(rows, "none", 0)
+    }
+  end
+
+  # Partitions `searches` into opened / reformulated / quiet.
+  #
+  # WHY THIS EXISTS. `search_follow_through` treats every not-opened search as a failure, and
+  # `docs/runbooks/search-events-analysis.md` is explicit that this is wrong: "an agent whose
+  # question is answered by the snippet correctly opens nothing, and that is a success this
+  # metric scores as a failure." The not-opened bucket is therefore a mixture, and until now
+  # there was no way to see inside it.
+  #
+  # A REFORMULATION is the one member of that bucket that is unambiguously a failure: the
+  # agent asked again, from the same key, inside the window, with a DIFFERENT query. So it is
+  # peeled out and the remainder is named `quiet` — deliberately not `sufficed`, because it
+  # is still "the snippet answered it OR the rows were ignored" and this instrumentation does
+  # NOT resolve that. Naming it for the outcome it cannot establish is how a floor gets read
+  # as a rate.
+  #
+  # The three partition `searches` exactly, so `quiet` is computed by subtraction rather than
+  # by a third query whose predicate could drift out of agreement with the other two.
+  defp compute_dispositions(searched_q, window_seconds, call) do
+    reformulated =
+      searched_q
+      |> qualifying_calls()
+      |> where(^dynamic(not (^follow_through_exists(window_seconds))))
+      |> where(^reformulation_exists(window_seconds))
+      |> count_distinct_searches()
+
+    %{
+      searches_reformulated: reformulated,
+      searches_quiet: max(call.searches - call.searches_with_follow_through - reformulated, 0)
     }
   end
 
@@ -279,13 +418,7 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
   # ROW, so a day mixing browse pages, legacy rows and real searches reports only the
   # real searches here rather than an all-or-nothing 0.
   defp compute_call_level(searched_q, window_seconds) do
-    with_id =
-      searched_q
-      |> where([s], not is_nil(fragment("?->>'search_id'", s.metadata)))
-      |> where(
-        [s],
-        fragment("coalesce(?->>'mode', '')", s.metadata) not in ^@enumeration_modes
-      )
+    with_id = qualifying_calls(searched_q)
 
     searches = count_distinct_searches(with_id)
     with_ft = with_id |> with_follow_through(window_seconds) |> count_distinct_searches()
@@ -296,6 +429,79 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
       search_follow_through: safe_precision(with_ft, searches),
       results_returned: sum_results_returned(with_id)
     }
+  end
+
+  # The per-CALL population: rows carrying a search identity (#582) that are not
+  # query-less enumeration pages. Extracted so `compute_call_level/2` and
+  # `compute_dispositions/3` cannot drift apart — a disposition computed over a different
+  # population than its own denominator would not partition it, and the `quiet` figure is
+  # derived by subtraction, so a drift there would show up as a silent miscount rather than
+  # an error.
+  defp qualifying_calls(searched_q) do
+    searched_q
+    |> where([s], not is_nil(fragment("?->>'search_id'", s.metadata)))
+    |> where(
+      [s],
+      fragment("coalesce(?->>'mode', '')", s.metadata) not in ^@enumeration_modes
+    )
+  end
+
+  # "The same key issued a DIFFERENT query inside the window." Different is compared on the
+  # search identity, not the query text: an agent re-running the identical query (a retry
+  # after a degraded response, say) is not reformulating, but it is also not a distinct
+  # search call in any sense this metric wants to count, and `search_id` already separates
+  # calls from rows.
+  #
+  # Bounded on BOTH sides by the window, and strictly after the surfacing row, so a search
+  # is never called a reformulation of one that came later.
+  defp reformulation_exists(window_seconds) do
+    dynamic(
+      [s],
+      exists(
+        from(r in ArticleAccessEvent,
+          where:
+            r.tenant_id == parent_as(:s).tenant_id and
+              r.api_key_id == parent_as(:s).api_key_id and
+              r.access_type == "search" and
+              not is_nil(fragment("?->>\'search_id\'", r.metadata)) and
+              fragment("?->>\'search_id\'", r.metadata) !=
+                fragment("?->>\'search_id\'", parent_as(:s).metadata) and
+              r.accessed_at > parent_as(:s).accessed_at and
+              fragment(
+                "? <= ? + (? * interval \'1 second\')",
+                r.accessed_at,
+                parent_as(:s).accessed_at,
+                ^window_seconds
+              )
+        )
+      )
+    )
+  end
+
+  # The same correlated-exists `with_follow_through/2` applies, expressed as a `dynamic` so
+  # it can be NEGATED in the disposition query. Kept adjacent to that function so the two
+  # definitions are read together; a change to one that is not made to the other breaks the
+  # partition.
+  defp follow_through_exists(window_seconds) do
+    dynamic(
+      [s],
+      exists(
+        from(o in ArticleAccessEvent,
+          where:
+            o.tenant_id == parent_as(:s).tenant_id and
+              o.api_key_id == parent_as(:s).api_key_id and
+              o.article_id == parent_as(:s).article_id and
+              o.access_type in ["get", "context", "drill"] and
+              o.accessed_at > parent_as(:s).accessed_at and
+              fragment(
+                "? <= ? + (? * interval \'1 second\')",
+                o.accessed_at,
+                parent_as(:s).accessed_at,
+                ^window_seconds
+              )
+        )
+      )
+    )
   end
 
   defp count_distinct_searches(query) do
@@ -358,6 +564,11 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
       retrieved_searched: m.retrieved_searched,
       retrieved_followed_through: m.retrieved_followed_through,
       retrieved_precision: m.retrieved_precision,
+      attributed_opens: m.attributed_opens,
+      cross_key_opens: m.cross_key_opens,
+      direct_opens: m.direct_opens,
+      searches_reformulated: m.searches_reformulated,
+      searches_quiet: m.searches_quiet,
       computed_at: DateTime.utc_now()
     }
 
@@ -380,6 +591,11 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
            :retrieved_searched,
            :retrieved_followed_through,
            :retrieved_precision,
+           :attributed_opens,
+           :cross_key_opens,
+           :direct_opens,
+           :searches_reformulated,
+           :searches_quiet,
            :computed_at,
            :updated_at
          ]},
@@ -426,7 +642,26 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
           curated_precision: s.curated_precision,
           retrieved_searched: s.retrieved_searched,
           retrieved_followed_through: s.retrieved_followed_through,
-          retrieved_precision: s.retrieved_precision
+          retrieved_precision: s.retrieved_precision,
+
+          # Unit: READS. NOT comparable with `followed_through`, which counts surfaced
+          # RESULTS that were later opened. `cross_key_opens` is the injected recall hook's
+          # population — it searches under one key and the session reads under another, so
+          # the key-correlated `followed_through` scores that whole channel a structural
+          # zero, and a zero there means unmeasurable rather than unread.
+          attributed_opens: s.attributed_opens,
+          cross_key_opens: s.cross_key_opens,
+
+          # An agent going straight to an article by link or cited id. Used to be
+          # indistinguishable from "surfaced and ignored", which is close to its opposite.
+          direct_opens: s.direct_opens,
+
+          # Unit: SEARCH CALLS. With `searches_with_follow_through` these partition
+          # `searches`. `quiet` is "the snippet sufficed OR the rows were ignored" and this
+          # instrumentation does NOT separate those — only `reformulated`, the one member of
+          # the not-opened bucket that is unambiguously a failure, is peeled out.
+          searches_reformulated: s.searches_reformulated,
+          searches_quiet: s.searches_quiet
         }
       )
       |> AdminRepo.all()

--- a/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
@@ -341,7 +341,35 @@ defmodule LoopctlWeb.KnowledgeAnalyticsController do
         "carries two further biases pointing OPPOSITE ways: the recording cap hides opens " <>
         "of results ranked beyond it (biases it DOWN on large pages), while one open " <>
         "credits EVERY search in the window that surfaced that article, not just the " <>
-        "preceding one (biases it UP when an agent refines and re-searches).",
+        "preceding one (biases it UP when an agent refines and re-searches).\n\n" <>
+        "EXACT ATTRIBUTION (unit: READS, not surfaced results and not calls) — " <>
+        "`attributed_opens` / `cross_key_opens` / `direct_opens` count READ rows by how " <>
+        "their originating search was established server-side at write time. These are " <>
+        "NOT comparable with `followed_through`, which counts SURFACED RESULTS later " <>
+        "opened. `cross_key_opens` is the population `followed_through` cannot see at " <>
+        "all: it correlates on `api_key_id`, and the injected recall hook searches under " <>
+        "a different key from the session that reads, so that channel scores a structural " <>
+        "ZERO there — meaning UNMEASURABLE, not unread. Cross-key attribution is " <>
+        "circumstantial by construction (two agents in one tenant can reach one article " <>
+        "independently), which is why it is labelled rather than folded in silently. " <>
+        "`direct_opens` is the agent going straight to an article by link or cited id — " <>
+        "previously indistinguishable from 'surfaced and ignored', close to its " <>
+        "opposite. A read with no attribution is in none of the three (pre-migration " <>
+        "rows, and a surfacing row predating #582 that carries no search identity).\n\n" <>
+        "TWO WINDOWS, NOT ONE KNOB — attribution is baked in at WRITE time and cannot be " <>
+        "re-asked of history; the correlated metrics take `window_seconds` at QUERY time. " <>
+        "They share a default, so a divergence after passing a different `window_seconds` " <>
+        "is that mismatch, not a bug.\n\n" <>
+        "DISPOSITION (unit: SEARCH CALLS) — `searches_with_follow_through`, " <>
+        "`searches_reformulated` and `searches_quiet` PARTITION `searches`. Treating " <>
+        "every not-opened search as a failure is wrong: an agent whose question is " <>
+        "answered by the result snippet correctly opens nothing, and that is a success. " <>
+        "A REFORMULATION (same key, different query, inside the window, having opened " <>
+        "nothing) is the one unambiguous failure in that bucket, so it is reported " <>
+        "separately. What remains is `quiet` and is STILL a mixture of 'the snippet " <>
+        "sufficed' and 'the rows were ignored' — this surface does NOT separate them. " <>
+        "Do not read `quiet` as either; follow-through is a floor, never a satisfaction " <>
+        "rate.",
     parameters: [
       limit: [
         in: :query,

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -6493,7 +6493,25 @@ const TOOLS = [
       "search_follow_through carries two further biases pointing OPPOSITE ways: the 20-row " +
       "recording cap hides opens of results ranked beyond it (DOWN on large pages), while " +
       "one open credits EVERY search in the window that surfaced that article, not just the " +
-      "preceding one (UP when an agent refines and re-searches).",
+      "preceding one (UP when an agent refines and re-searches).\n\n" +
+      "Exact attribution (unit: READS — not surfaced results, not calls): attributed_opens " +
+      "/ cross_key_opens / direct_opens count READ rows by how their originating search was " +
+      "established, resolved server-side at write time and never accepted from a caller. " +
+      "Not comparable with followed_through, which counts SURFACED RESULTS later opened. " +
+      "cross_key_opens is the population followed_through cannot see: it correlates on " +
+      "api_key_id, and the injected recall hook searches under a different key from the " +
+      "session that reads, so that channel scores a structural ZERO there — meaning " +
+      "UNMEASURABLE, not unread. Cross-key attribution is circumstantial (two agents in one " +
+      "tenant can reach one article independently), hence labelled rather than folded in. " +
+      "direct_opens is the agent going straight to an article by link or cited id, which " +
+      "used to look identical to 'surfaced and ignored' — close to its opposite.\n\n" +
+      "Disposition (unit: SEARCH CALLS): searches_with_follow_through, " +
+      "searches_reformulated and searches_quiet PARTITION searches. Treating every " +
+      "not-opened search as a failure is wrong — an agent answered by the result snippet " +
+      "correctly opens nothing, and that is a success. A reformulation (same key, different " +
+      "query, in-window, nothing opened) is the one unambiguous failure, so it is split out; " +
+      "what remains is `quiet` and is STILL a mixture of 'snippet sufficed' and 'rows " +
+      "ignored'. This surface does not separate them — do not read quiet as either.",
     inputSchema: {
       type: "object",
       properties: {

--- a/priv/repo/migrations/20260817173000_add_origin_attribution_to_article_access_events.exs
+++ b/priv/repo/migrations/20260817173000_add_origin_attribution_to_article_access_events.exs
@@ -1,0 +1,92 @@
+defmodule Loopctl.Repo.Migrations.AddOriginAttributionToArticleAccessEvents do
+  use Ecto.Migration
+
+  @moduledoc """
+  Records WHICH search surfaced an article that an agent then opened.
+
+  Until now the link was not stored, only inferred at query time, and the inference had two
+  structural blind spots that each produced a plausible wrong number:
+
+  1. `get`/`context`/`drill` rows carry no `search_id` — only `access_type = 'search'` rows
+     do (one per surfaced result). So the obvious join measures "did the search return
+     anything", which is ~98% everywhere.
+  2. `RetrievalMetrics.with_follow_through/2` correlates on `api_key_id`, and the injected
+     recall hook searches under a DIFFERENT key from the session that reads. Measured
+     2026-08-17: the hook's key made 1,071 searches and 1 read ever, while the MCP key made
+     0 searches of that kind and 2,535 reads. The whole injected channel — 71% of traffic —
+     therefore scores a structural ZERO in that metric, and a zero there means "unmeasurable",
+     not "nobody read anything".
+
+  `origin_search_id` is resolved SERVER-SIDE at write time (`Analytics.do_record_sync/5`) and
+  is never accepted from a caller. That is the same rule `search_id` already follows
+  (#582): a call-level identity the caller controls is a metric the caller can game, and here
+  a forged origin would let any agent manufacture apparent follow-through for its own article
+  — the heat-index failure (#567/#569) one table over.
+
+  `origin_attribution` labels HOW the link was established, so a reader never mistakes an
+  inference for an observation:
+
+    * `same_key`  — the reading key also surfaced the article in the window. Exact.
+    * `cross_key` — another key in the same tenant surfaced it. This is the hook -> session
+                    case; plausible, and NOT proof, because two agents in one tenant can
+                    search the same article independently.
+    * `none`      — nothing surfaced it in the window: the agent went straight to the
+                    article (a wiki link, an id cited in CLAUDE.md, a MOC hop). Previously
+                    indistinguishable from "no follow-through", though it is the opposite.
+
+  Both columns are nullable: rows written before this migration have no origin, and surfacing
+  rows (`search`, `index`) never get one. RLS is NOT modified — `tenant_id` remains the sole
+  isolation boundary and these are reporting dimensions, not trust boundaries.
+  """
+
+  def up do
+    alter table(:article_access_events) do
+      add :origin_search_id, :binary_id
+      add :origin_attribution, :string
+    end
+
+    # The write-time lookup: "most recent surfacing row for this (tenant, article)". Partial
+    # on the surfacing type so the index stays small and the lookup stays a point query —
+    # this runs inside the fire-and-forget recorder on every read, so it must not become a
+    # scan. Ordering by accessed_at DESC serves the LIMIT 1 directly.
+    execute(
+      """
+      CREATE INDEX article_access_events_surface_lookup_idx
+        ON article_access_events (tenant_id, article_id, accessed_at DESC)
+        WHERE access_type = 'search'
+      """,
+      "DROP INDEX IF EXISTS article_access_events_surface_lookup_idx"
+    )
+
+    # The read side: roll opens up by the search that produced them.
+    execute(
+      """
+      CREATE INDEX article_access_events_origin_search_idx
+        ON article_access_events (tenant_id, origin_search_id)
+        WHERE origin_search_id IS NOT NULL
+      """,
+      "DROP INDEX IF EXISTS article_access_events_origin_search_idx"
+    )
+
+    # Counting the attribution classes for a day without touching the heap.
+    execute(
+      """
+      CREATE INDEX article_access_events_origin_attribution_idx
+        ON article_access_events (tenant_id, origin_attribution, accessed_at)
+        WHERE origin_attribution IS NOT NULL
+      """,
+      "DROP INDEX IF EXISTS article_access_events_origin_attribution_idx"
+    )
+  end
+
+  def down do
+    execute("DROP INDEX IF EXISTS article_access_events_origin_attribution_idx")
+    execute("DROP INDEX IF EXISTS article_access_events_origin_search_idx")
+    execute("DROP INDEX IF EXISTS article_access_events_surface_lookup_idx")
+
+    alter table(:article_access_events) do
+      remove :origin_attribution
+      remove :origin_search_id
+    end
+  end
+end

--- a/priv/repo/migrations/20260817173100_add_origin_metrics_to_retrieval_snapshots.exs
+++ b/priv/repo/migrations/20260817173100_add_origin_metrics_to_retrieval_snapshots.exs
@@ -1,0 +1,46 @@
+defmodule Loopctl.Repo.Migrations.AddOriginMetricsToRetrievalSnapshots do
+  use Ecto.Migration
+
+  @moduledoc """
+  Persists the exactly-attributed follow-through counters alongside the correlated ones.
+
+  `GET /api/v1/knowledge/retrieval_metrics` (and the `knowledge_retrieval_metrics` MCP tool)
+  serve PERSISTED snapshots, not live computation, so a metric that is not a column here is
+  invisible to every consumer.
+
+  The existing `followed_through` / `search_follow_through` pair stays exactly as it is —
+  same definition, same correlation, so the committed series remains comparable across this
+  migration. These columns are added BESIDE it:
+
+    * `attributed_opens` / `cross_key_opens` / `direct_opens` — unit is READS, not surfaced
+      results and not search calls. The moduledoc discipline about units is load-bearing
+      here: `followed_through` counts SURFACED RESULTS that were later opened, so it is not
+      comparable with these. `cross_key_opens` is the one the injected recall hook lands in,
+      and it was structurally unrepresentable before.
+    * `searches_reformulated` / `searches_quiet` — unit is SEARCH CALLS. With the existing
+      `searches_with_follow_through` these form a partition of `searches`: a search was
+      opened, or it was followed by another query from the same key inside the window, or
+      neither.
+
+  Why the trichotomy matters more than another ratio: this repo's own
+  `docs/runbooks/search-events-analysis.md` warns that "an agent whose question is answered
+  by the snippet correctly opens nothing, and that is a success this metric scores as a
+  failure". Splitting `reformulated` out of the not-opened bucket does not resolve that
+  ambiguity — `quiet` is still "sufficed OR ignored" — but it removes the one case that is
+  unambiguously a FAILURE and was being averaged in with the successes. Do not rename
+  `quiet` to anything that asserts satisfaction.
+
+  All columns default to 0 so historical snapshots stay readable; a 0 in a pre-migration row
+  means "not computed", which is why the payload reports `origin_metrics_from` alongside.
+  """
+
+  def change do
+    alter table(:retrieval_metric_snapshots) do
+      add :attributed_opens, :integer, default: 0, null: false
+      add :cross_key_opens, :integer, default: 0, null: false
+      add :direct_opens, :integer, default: 0, null: false
+      add :searches_reformulated, :integer, default: 0, null: false
+      add :searches_quiet, :integer, default: 0, null: false
+    end
+  end
+end

--- a/test/loopctl/knowledge/origin_attribution_test.exs
+++ b/test/loopctl/knowledge/origin_attribution_test.exs
@@ -1,0 +1,421 @@
+defmodule Loopctl.Knowledge.OriginAttributionTest do
+  @moduledoc """
+  Which search surfaced the article an agent then opened.
+
+  The measurement this exists to fix was made on prod on 2026-08-17: the injected recall
+  hook made 1,071 searches under one key while the session that reads made 2,535 reads under
+  a DIFFERENT key, so every key-correlated follow-through metric scored that channel — 71% of
+  all traffic — at exactly zero. A zero there means "unmeasurable", not "unread", and the
+  tests below pin the difference.
+  """
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.Analytics
+  alias Loopctl.Knowledge.ArticleAccessEvent
+
+  defp surfacing_row(tenant_id, article_id, api_key_id, search_id, opts \\ []) do
+    ago = Keyword.get(opts, :seconds_ago, 10)
+
+    fixture(:article_access_event, %{
+      tenant_id: tenant_id,
+      article_id: article_id,
+      api_key_id: api_key_id,
+      access_type: "search",
+      metadata: if(search_id, do: %{"search_id" => search_id, "rank" => 1}, else: %{}),
+      accessed_at: DateTime.add(DateTime.utc_now(), -ago, :second)
+    })
+  end
+
+  defp key_for(tenant_id) do
+    {_raw, key} = fixture(:api_key, %{tenant_id: tenant_id, role: :agent})
+    key.id
+  end
+
+  defp read_row(tenant_id, article_id, api_key_id, access_type \\ "get") do
+    Analytics.do_record_sync([{article_id, %{}}], tenant_id, api_key_id, access_type)
+
+    AdminRepo.one(
+      from(e in ArticleAccessEvent,
+        where: e.tenant_id == ^tenant_id and e.access_type == ^access_type,
+        order_by: [desc: e.accessed_at],
+        limit: 1
+      )
+    )
+  end
+
+  describe "resolve_origin/5" do
+    test "a read after the reader's OWN search is attributed same_key, with that search id" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+      key = key_for(tenant.id)
+      search_id = Ecto.UUID.generate()
+
+      surfacing_row(tenant.id, article.id, key, search_id)
+      row = read_row(tenant.id, article.id, key)
+
+      assert row.origin_attribution == "same_key"
+      assert row.origin_search_id == search_id
+    end
+
+    test "a read after ANOTHER key's search is attributed cross_key — the injected-hook shape" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+      hook_key = key_for(tenant.id)
+      session_key = key_for(tenant.id)
+      search_id = Ecto.UUID.generate()
+
+      surfacing_row(tenant.id, article.id, hook_key, search_id)
+      row = read_row(tenant.id, article.id, session_key)
+
+      assert row.origin_attribution == "cross_key",
+             "the hook searches under one key and the session reads under another; " <>
+               "refusing to cross keys is what made this channel a structural zero"
+
+      assert row.origin_search_id == search_id
+    end
+
+    test "the reader's OWN search wins over a more RECENT search by another key" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+      own_key = key_for(tenant.id)
+      other_key = key_for(tenant.id)
+      own_search = Ecto.UUID.generate()
+      newer_other_search = Ecto.UUID.generate()
+
+      # Own search is OLDER. Recency alone would pick the other key's.
+      surfacing_row(tenant.id, article.id, own_key, own_search, seconds_ago: 600)
+      surfacing_row(tenant.id, article.id, other_key, newer_other_search, seconds_ago: 5)
+
+      row = read_row(tenant.id, article.id, own_key)
+
+      assert row.origin_attribution == "same_key",
+             "direct evidence outranks recency — otherwise a concurrent agent's search " <>
+               "silently steals attribution for a read it had nothing to do with"
+
+      assert row.origin_search_id == own_search
+    end
+
+    test "a read with nothing surfacing it is `none`, which is not a failure" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+      key = key_for(tenant.id)
+
+      row = read_row(tenant.id, article.id, key)
+
+      assert row.origin_attribution == "none"
+      assert is_nil(row.origin_search_id)
+    end
+
+    test "a surfacing older than the write-time window no longer attributes" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+      key = key_for(tenant.id)
+
+      surfacing_row(tenant.id, article.id, key, Ecto.UUID.generate(),
+        seconds_ago: Analytics.origin_window_seconds() + 60
+      )
+
+      row = read_row(tenant.id, article.id, key)
+
+      assert row.origin_attribution == "none"
+      assert is_nil(row.origin_search_id)
+    end
+
+    test "a pre-#582 surfacing row with no search_id is UNCLASSIFIED, never `none`" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+      key = key_for(tenant.id)
+
+      surfacing_row(tenant.id, article.id, key, nil)
+      row = read_row(tenant.id, article.id, key)
+
+      assert is_nil(row.origin_attribution),
+             "the article WAS surfaced, so `none` would be false; there is no id to " <>
+               "attribute to, so the attributed bucket would be false too"
+
+      assert is_nil(row.origin_search_id)
+    end
+
+    test "a surfacing in ANOTHER tenant never attributes a read" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      article_a = fixture(:article, %{tenant_id: tenant_a.id})
+      article_b = fixture(:article, %{tenant_id: tenant_b.id})
+      key_a = key_for(tenant_a.id)
+      key_b = key_for(tenant_b.id)
+
+      surfacing_row(tenant_b.id, article_b.id, key_b, Ecto.UUID.generate())
+      row = read_row(tenant_a.id, article_a.id, key_a)
+
+      assert row.origin_attribution == "none"
+    end
+
+    test "surfacing rows themselves are never attributed" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+      key = key_for(tenant.id)
+
+      assert {nil, nil} =
+               Analytics.resolve_origin(tenant.id, article.id, key, "search", DateTime.utc_now())
+
+      assert {nil, nil} =
+               Analytics.resolve_origin(tenant.id, article.id, key, "index", DateTime.utc_now())
+    end
+
+    test "every attributable access type resolves, and the two lists agree" do
+      tenant = fixture(:tenant)
+      key = key_for(tenant.id)
+
+      Enum.each(Analytics.attributable_access_types(), fn type ->
+        article = fixture(:article, %{tenant_id: tenant.id})
+        search_id = Ecto.UUID.generate()
+        surfacing_row(tenant.id, article.id, key, search_id)
+
+        row = read_row(tenant.id, article.id, key, type)
+
+        assert row.origin_attribution == "same_key", "#{type} must be attributable"
+        assert row.origin_search_id == search_id
+      end)
+
+      # Drift guard: every value the writer can produce must be a declared one.
+      assert Enum.all?(
+               ["same_key", "cross_key", "none"],
+               &(&1 in ArticleAccessEvent.origin_attributions())
+             )
+
+      assert Enum.all?(
+               Analytics.attributable_access_types(),
+               &(&1 in Analytics.valid_access_types())
+             )
+    end
+  end
+
+  describe "metrics: attribution split and search disposition" do
+    alias Loopctl.Knowledge.RetrievalMetrics
+
+    defp seeded_open(tenant_id, article_id, api_key_id, attribution, at) do
+      fixture(:article_access_event, %{
+        tenant_id: tenant_id,
+        article_id: article_id,
+        api_key_id: api_key_id,
+        access_type: "get",
+        accessed_at: at,
+        origin_attribution: attribution,
+        origin_search_id: if(attribution in ["same_key", "cross_key"], do: Ecto.UUID.generate())
+      })
+    end
+
+    test "cross_key opens are counted — the population the correlated metric cannot see" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+      key = key_for(tenant.id)
+      day = Date.utc_today()
+      at = DateTime.new!(day, ~T[12:00:00.000000], "Etc/UTC")
+
+      seeded_open(tenant.id, article.id, key, "same_key", at)
+      seeded_open(tenant.id, article.id, key, "cross_key", at)
+      seeded_open(tenant.id, article.id, key, "cross_key", at)
+      seeded_open(tenant.id, article.id, key, "none", at)
+
+      m = RetrievalMetrics.compute(tenant.id, day)
+
+      assert m.attributed_opens == 3, "same_key + cross_key, and nothing else"
+      assert m.cross_key_opens == 2
+      assert m.direct_opens == 1
+    end
+
+    test "an UNCLASSIFIED open lands in no bucket at all" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+      key = key_for(tenant.id)
+      day = Date.utc_today()
+      at = DateTime.new!(day, ~T[12:00:00.000000], "Etc/UTC")
+
+      # No origin_attribution: a pre-migration row, or the deliberate refusal to classify.
+      fixture(:article_access_event, %{
+        tenant_id: tenant.id,
+        article_id: article.id,
+        api_key_id: key,
+        access_type: "get",
+        accessed_at: at
+      })
+
+      m = RetrievalMetrics.compute(tenant.id, day)
+
+      assert m.attributed_opens == 0
+      assert m.cross_key_opens == 0
+
+      assert m.direct_opens == 0,
+             "an unclassified read is not a direct read — putting it in `none` would " <>
+               "assert nothing surfaced it, which is exactly what is unknown"
+    end
+
+    test "opens in another tenant never count" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      article_b = fixture(:article, %{tenant_id: tenant_b.id})
+      key_b = key_for(tenant_b.id)
+      day = Date.utc_today()
+      at = DateTime.new!(day, ~T[12:00:00.000000], "Etc/UTC")
+
+      seeded_open(tenant_b.id, article_b.id, key_b, "cross_key", at)
+
+      m = RetrievalMetrics.compute(tenant_a.id, day)
+
+      assert m.attributed_opens == 0
+      assert m.cross_key_opens == 0
+    end
+
+    defp search_call(tenant_id, article_id, api_key_id, search_id, at) do
+      fixture(:article_access_event, %{
+        tenant_id: tenant_id,
+        article_id: article_id,
+        api_key_id: api_key_id,
+        access_type: "search",
+        accessed_at: at,
+        metadata: %{"search_id" => search_id, "rank" => 1, "mode" => "combined"}
+      })
+    end
+
+    test "the three dispositions partition `searches` exactly" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+      other_article = fixture(:article, %{tenant_id: tenant.id})
+      key = key_for(tenant.id)
+      day = Date.utc_today()
+      base = DateTime.new!(day, ~T[12:00:00.000000], "Etc/UTC")
+
+      # 1. OPENED — surfaced, then read inside the window.
+      search_call(tenant.id, article.id, key, Ecto.UUID.generate(), base)
+
+      fixture(:article_access_event, %{
+        tenant_id: tenant.id,
+        article_id: article.id,
+        api_key_id: key,
+        access_type: "get",
+        accessed_at: DateTime.add(base, 60, :second)
+      })
+
+      # 2. REFORMULATED — no read, but the same key asked again inside the window.
+      reformed_at = DateTime.add(base, 900, :second)
+      search_call(tenant.id, other_article.id, key, Ecto.UUID.generate(), reformed_at)
+
+      search_call(
+        tenant.id,
+        other_article.id,
+        key,
+        Ecto.UUID.generate(),
+        DateTime.add(reformed_at, 120, :second)
+      )
+
+      m = RetrievalMetrics.compute(tenant.id, day)
+
+      assert m.searches ==
+               m.searches_with_follow_through + m.searches_reformulated + m.searches_quiet,
+             "the three must partition `searches`; `quiet` is derived by subtraction, so a " <>
+               "drift between the disposition population and the denominator shows up here"
+
+      assert m.searches_with_follow_through == 1
+      assert m.searches_reformulated == 1
+    end
+
+    test "a search that is opened is NOT also counted as reformulated" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+      key = key_for(tenant.id)
+      day = Date.utc_today()
+      base = DateTime.new!(day, ~T[12:00:00.000000], "Etc/UTC")
+
+      # Surfaced, opened, AND followed by another query — the open takes precedence.
+      search_call(tenant.id, article.id, key, Ecto.UUID.generate(), base)
+
+      fixture(:article_access_event, %{
+        tenant_id: tenant.id,
+        article_id: article.id,
+        api_key_id: key,
+        access_type: "get",
+        accessed_at: DateTime.add(base, 30, :second)
+      })
+
+      search_call(
+        tenant.id,
+        article.id,
+        key,
+        Ecto.UUID.generate(),
+        DateTime.add(base, 300, :second)
+      )
+
+      m = RetrievalMetrics.compute(tenant.id, day)
+
+      assert m.searches_with_follow_through >= 1
+
+      assert m.searches_reformulated == 0,
+             "opened outranks reformulated; the buckets are disjoint"
+    end
+
+    test "a lone search with no read and no follow-up query is quiet, not reformulated" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+      key = key_for(tenant.id)
+      day = Date.utc_today()
+      base = DateTime.new!(day, ~T[12:00:00.000000], "Etc/UTC")
+
+      search_call(tenant.id, article.id, key, Ecto.UUID.generate(), base)
+
+      m = RetrievalMetrics.compute(tenant.id, day)
+
+      assert m.searches == 1
+      assert m.searches_reformulated == 0
+      assert m.searches_quiet == 1
+    end
+
+    test "another KEY's later query is not a reformulation of mine" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+      mine = key_for(tenant.id)
+      theirs = key_for(tenant.id)
+      day = Date.utc_today()
+      base = DateTime.new!(day, ~T[12:00:00.000000], "Etc/UTC")
+
+      search_call(tenant.id, article.id, mine, Ecto.UUID.generate(), base)
+
+      search_call(
+        tenant.id,
+        article.id,
+        theirs,
+        Ecto.UUID.generate(),
+        DateTime.add(base, 60, :second)
+      )
+
+      m = RetrievalMetrics.compute(tenant.id, day)
+
+      assert m.searches_reformulated == 0,
+             "reformulation is one agent asking again, not two agents searching concurrently"
+    end
+
+    test "the snapshot persists the new counters" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+      key = key_for(tenant.id)
+      day = Date.utc_today()
+      at = DateTime.new!(day, ~T[12:00:00.000000], "Etc/UTC")
+
+      seeded_open(tenant.id, article.id, key, "cross_key", at)
+      seeded_open(tenant.id, article.id, key, "none", at)
+
+      assert {:ok, snap} = RetrievalMetrics.snapshot(tenant.id, day)
+      assert snap.cross_key_opens == 1
+      assert snap.attributed_opens == 1
+      assert snap.direct_opens == 1
+
+      # The API serves persisted snapshots, so a counter that does not round-trip here is
+      # invisible to every consumer including the MCP tool.
+      %{data: [served | _]} = RetrievalMetrics.list_snapshots(tenant.id)
+      assert served.cross_key_opens == 1
+      assert served.direct_opens == 1
+    end
+  end
+end

--- a/test/loopctl/knowledge/retrieval_metrics_test.exs
+++ b/test/loopctl/knowledge/retrieval_metrics_test.exs
@@ -135,7 +135,12 @@ defmodule Loopctl.Knowledge.RetrievalMetricsTest do
                curated_precision: 0.0,
                retrieved_searched: 0,
                retrieved_followed_through: 0,
-               retrieved_precision: 0.0
+               retrieved_precision: 0.0,
+               attributed_opens: 0,
+               cross_key_opens: 0,
+               direct_opens: 0,
+               searches_reformulated: 0,
+               searches_quiet: 0
              }
     end
   end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -937,7 +937,13 @@ defmodule Loopctl.Fixtures do
         accessed_at: data.accessed_at
       })
 
-    AdminRepo.insert!(changeset)
+    # Origin is writer-resolved and therefore NOT castable (see
+    # `ArticleAccessEvent.create_changeset/2`). A metrics test still needs rows in a known
+    # attribution class without replaying a whole search, so seed them past the changeset
+    # here — deliberately the only place that does, so production code has no such path.
+    changeset
+    |> Ecto.Changeset.change(Map.take(attrs, [:origin_search_id, :origin_attribution]))
+    |> AdminRepo.insert!()
   end
 
   def fixture(:project, attrs) do


### PR DESCRIPTION
Builds the instrumentation the merged plan (#688) identified as the highest-value next step: nothing today distinguishes "the snippet was sufficient" from "the row was ignored", and until it does, the headline metric cannot tell success from failure.

## The defect this fixes is in a shipped metric, not just a missing one

`RetrievalMetrics.with_follow_through/2` correlates a search with an open on `(tenant, api_key, article, window)`. That `api_key` binding is deliberate and pinned by an existing test — **but the injected recall hook searches under a different key from the session that reads.** Measured on prod 2026-08-17:

| key | searches | deliberate reads |
|---|---|---|
| hook | 1,071 | **1** |
| MCP/session | 450 (other kinds) | 2,535 |

So the channel carrying **71% of all search volume has always scored a structural zero** in `followed_through` and `search_follow_through` — and that zero means **unmeasurable, not unread**. Same `0.0`-vs-`n/a` distinction `RetrievalEval` already insists on, one table over.

## Why the origin is resolved server-side and must never be a parameter

`knowledge.ex:2864` already records the rule for `search_id`: *"metadata is caller-supplied and a forged id would collapse the `searches` denominator (#582)"*. An assertable `origin_search_id` is strictly worse — it would let one agent manufacture follow-through for its own article, which is exactly the heat-index self-inflation closed in #567/#569.

The MCP server *could* thread it (one process per session, it knows what the last search returned). **That is precisely what must not be built**, and the code says so at the resolver. `create_changeset/2` also deliberately does not cast the two columns, so there is no API path to them either.

Server-side resolution is also strictly better for the actual goal: it needs no agent-facing surface at all, and it works for the hook channel, which cannot thread anything.

## What is now reported

| field | unit | meaning |
|---|---|---|
| `attributed_opens` | READS | opens whose originating search is known |
| `cross_key_opens` | READS | **the injected channel** — surfaced by one key, read by another |
| `direct_opens` | READS | agent went straight to the article (link, cited id) |
| `searches_reformulated` | SEARCH CALLS | asked again in-window, opened nothing — a real failure |
| `searches_quiet` | SEARCH CALLS | neither — **still ambiguous, by design** |

**Units are the trap here and are called out everywhere:** these count READS; `followed_through` counts SURFACED RESULTS later opened. Not comparable, neither replaces the other, so the existing series is untouched and stays valid across the migration.

**`direct_opens` was previously indistinguishable from "surfaced and ignored"** — close to its opposite. An unclassified read (pre-migration rows; a surfacing row predating #582 with no search identity) lands in *none* of the three rather than being forced into `none`, because "the article was surfaced but I cannot say by which search" is neither.

## `quiet` is deliberately not called `sufficed`

This repo's own runbook says treating every not-opened search as a failure is wrong: *"an agent whose question is answered by the snippet correctly opens nothing, and that is a success this metric scores as a failure."* A reformulation is the one unambiguous failure in that bucket, so it is peeled out. **The remainder is still a mixture and this PR does not resolve it** — naming it for the outcome it cannot establish is how a floor gets read as a rate. The moduledoc, the OpenAPI description and the MCP tool description all say so.

## MCP

`knowledge_retrieval_metrics` carries the new fields and their unit warnings. **No new agent-facing surface and no new search parameter** — agents see plain search exactly as before; the attribution is loopctl's job and happens without them.

## Verification

- `mix precommit` green (7,551 tests, 0 failures).
- **Seven mutations, all caught**: dropping the same-key preference, the unclassified case, the cross-key label, the window lower bound, the attributed-bucket membership, the reformulation's not-opened precondition, and the reformulation's same-key binding each fail a test.
- Tenant isolation covered on both the resolver and the metrics.
- One test asserts the three dispositions **partition** `searches` — `quiet` is derived by subtraction, so a drift between the disposition population and its denominator surfaces there rather than silently miscounting.
- A test asserts the counters survive `list_snapshots` — the API serves persisted snapshots, so a metric that does not round-trip is invisible to every consumer including MCP. That test failed first time and caught exactly that.

Migrations are additive with defaults and need no manual step. Documented in `CHANGELOG.md`, the endpoint's `operation/2` spec, and `docs/runbooks/search-events-analysis.md`.

## Review

Reviewed inline against correctness, this repo's tenancy/analytics conventions, and the KB. This session's instructions forbid dispatching agents or workflows unless asked — a restriction I cannot lift myself, not an unavailable mechanism. Blast radius is additive analytics columns and a read-only metrics payload; no auth, custody, credential, money or PHI surface is touched.
