### PR TITLE
Record the first traffic through the new counters, and the join key that is not the primary key

### DIFF
--- a/docs/research/kb-retrieval-improvement-plan.md
+++ b/docs/research/kb-retrieval-improvement-plan.md
@@ -308,12 +308,12 @@ otherwise be asked to compensate for it and cannot.
   same day (§2.1, §3.1); the fix is still worth having, on a ~4x effect rather than 11x.
 - Phase 2b — **DONE.** golden_v3 + `corpus_ref` paired questions; baseline regenerated. Its
   result retires Phase 2's premise rather than confirming it (see above).
-- Phase 2c — **DONE, deployed v523** (#689). The injected channel is now measurable instead
-  of scoring a structural zero. **Nothing can be concluded from it yet**: it measures forward
-  only, so it needs a week or two of real traffic, and one contaminant is still open —
-  the recall canary declares `client_entrypoint: "hook"`, identical to real traffic, so its
-  fixed prompt list sits inside the new counters. Not fixable here (the caller must declare
-  itself, as `smoke.sh` does): handed to claude-config#317.
+- Phase 2c — **DONE, deployed v523** (#689), and **verified on real traffic** — see below.
+  The injected channel is now measurable instead of scoring a structural zero. One
+  contaminant is still open: the recall canary declares `client_entrypoint: "hook"`,
+  identical to real traffic, so its fixed prompt list sits inside the new counters. Not
+  fixable here (the caller must declare itself, as `smoke.sh` does): handed to
+  claude-config#317.
 - Phase 2d — **DONE, deployed v523** (#690). Every search result carries a snippet.
 - Phases 3–7 — not started, and the ordering has moved on the evidence:
   - **Phase 4 (reranking) is the weakest-motivated of them.** Ranking, query length and
@@ -327,6 +327,32 @@ otherwise be asked to compensate for it and cannot.
   - **The honest sequencing note:** Phase 2c's whole point is to make phases 3–5 falsifiable
     on production traffic rather than only on a synthetic eval corpus. Starting them before
     it has collected anything would forfeit exactly the check it was built to provide.
+
+### 5.1 First traffic against the new counters (2026-08-17, ~3h post-cutover)
+
+The Phase 2c check was "`cross_key_opens` non-zero on real traffic — i.e. the channel is
+visible at all". It **passes**, and the shape is the predicted one:
+
+| entrypoint | searches | searches opened | attribution of the opens |
+|---|---:|---:|---|
+| `hook` / `memory_recall` | 31 | 2 | 3 reads, **all `cross_key`** |
+| `cli` / `knowledge_search` | 6 | 3 | 3 reads, `same_key` |
+| `cli` / `knowledge_hybrid_search` | 6 | 2 | 2 reads, `same_key` |
+| `smoke`, `session-start` | 24 | 0 | - |
+
+Every hook open is cross-key and every cli open is same-key. That is the diagnosis in §2.1
+confirmed from the other direction: the shipped same-key metric could not have counted ONE
+of the injected channel's opens, and the zero it reported was `n/a`.
+
+**Three hours is a mechanism check, not a rate**, and no phase ordering should move on it.
+The evaluation window is 1-2 weeks from the cutover (2026-08-17T18:00Z), with `smoke` and
+`session-start` excluded and the canary contaminant (claude-config#317) resolved first.
+
+The audit also re-ran §3.1's own failure live: the entrypoint segmentation joins
+`search_events.search_id`, NOT `search_events.id` — different columns — and the wrong one
+returns a clean, plausible, entirely false "0 opens" for every entrypoint. The corrected
+query and its integrity check are now in `docs/runbooks/search-events-analysis.md` §3c so the
+next person joins the right column instead of rediscovering this.
 
 ### 3.1 What the ordering cost us to learn, twice
 

--- a/docs/runbooks/search-events-analysis.md
+++ b/docs/runbooks/search-events-analysis.md
@@ -169,6 +169,50 @@ Cross-key attribution is circumstantial by construction — two agents in one te
 one article independently — which is why it is a separate labelled field rather than folded
 into `attributed_opens`.
 
+## 3c. Segmenting opens by entrypoint — and the join key that is not the primary key
+
+`origin_search_id` is what finally lets an open be attributed to the CHANNEL that surfaced
+it, because `client_entrypoint` lives on `search_events` and nothing on the read row carries
+it. The join is:
+
+```sql
+JOIN search_events se ON se.search_id = a.origin_search_id
+```
+
+**`search_events.search_id`, never `search_events.id`.** They are different columns: `id` is
+the row's primary key, `search_id` is the per-call correlation id the search site mints once
+and threads to BOTH the `search_events` row and every surfaced `article_access_events` row.
+Joining on `id` returns zero matches for every entrypoint, which reads exactly like "nothing
+follows through" — the failure that produced the withdrawn table in the retrieval plan's
+§3.1, made again on 2026-08-17 by the person who had just written that section. Sanity-check
+any such query with
+
+```sql
+SELECT count(*) FROM article_access_events a
+WHERE a.origin_search_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM search_events se WHERE se.search_id = a.origin_search_id);
+```
+
+which must be 0. A non-zero count means retention has already pruned `search_events` (it is
+the shorter-lived table), not that attribution is broken — bound the window and re-run.
+
+### First traffic (v523, 2026-08-17 18:00-21:00 UTC)
+
+| entrypoint | tool | searches | searches opened | attribution of the opens |
+|---|---|---:|---:|---|
+| `hook` | `memory_recall` | 31 | 2 | 3 reads, ALL `cross_key` |
+| `cli` | `knowledge_search` | 6 | 3 | 3 reads, `same_key` |
+| `cli` | `knowledge_hybrid_search` | 6 | 2 | 2 reads, `same_key` |
+| `smoke` | `knowledge_search` | 14 | 0 | - |
+| `session-start` | `memory_recall` | 10 | 0 | - |
+
+Three hours is not a rate and must not be quoted as one. What it does establish is
+MECHANISM: every hook open is `cross_key` and every cli open is `same_key`, which is the
+predicted split, and it confirms the old same-key metric could not have counted a single one
+of the hook's. Also note `session-start` is now its own entrypoint rather than sitting inside
+`unattributed`; its queries are bare repo names by construction, so it belongs with `smoke`
+in the filter-me-out class, not with real traffic.
+
 ## 4. The trap
 
 Search returns; agents do not open. Search-to-read has sat near 27:1, and 1.74% of


### PR DESCRIPTION
Phase 2c shipped in v523 at 18:00 UTC today. Three hours of production traffic now exists on the other side of that cutover, so the check it was built for can be answered instead of predicted.

## The check passes

| entrypoint | searches | searches opened | attribution of the opens |
|---|---:|---:|---|
| hook / memory_recall | 31 | 2 | 3 reads, **all cross_key** |
| cli / knowledge_search | 6 | 3 | 3 reads, same_key |
| cli / knowledge_hybrid_search | 6 | 2 | 2 reads, same_key |
| smoke, session-start | 24 | 0 | - |

Every injected-hook open is cross-key and every cli open is same-key. That is the section 2.1 diagnosis confirmed from the other direction: the shipped same-key metric could not have counted one of the hook's opens, so the zero it reported was n/a rather than zero.

Integrity is clean too - orphan origins are 0, and the cutover is visible to the hour (all NULL before 18:00, all attributed after).

## Three hours is not a rate

The doc says so explicitly and names the evaluation window (1-2 weeks from 2026-08-17T18:00Z) plus what has to be excluded from it first: smoke, session-start, and the canary contaminant handed to claude-config#317.

## The mistake the audit made, recorded so the next person does not

Segmenting opens by entrypoint requires joining search_events.search_id, NOT search_events.id. They are different columns - id is the row PK, search_id is the per-call correlation id threaded to both tables - and joining the wrong one returns a clean, plausible, entirely false "0 opens" for every entrypoint.

That is the same shape as the withdrawn follow-through table in the plan's section 3.1, made again on the same day by the same person who wrote section 3.1. So it goes in the runbook as section 3c with the corrected join and an integrity check that must return 0.

Also notes that session-start is now its own entrypoint rather than sitting inside unattributed; its queries are bare repo names by construction, so it belongs in the filter-me-out class.

## Review

Docs only, no code paths touched. Reviewed inline against the live production data it reports - every number in both files was produced by a query run against prod in this session, and the join-key claim was verified by the orphan-origins check returning 0. This session cannot dispatch review agents, so the gate was satisfied inline; see the delivery-loop note in CLAUDE.md.

mix precommit green.
