### PR TITLE
Stop a slow migration from failing the release command after it has already succeeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to loopctl are documented here.
 
 ## [Unreleased] — 2026-08-07 — Story lifecycle capability delivery
 
+### Fixed
+
+- **A migration slower than the database's `idle_in_transaction_session_timeout` no longer
+  fails the release command after succeeding.** `Ecto.Migrator` takes its advisory lock
+  inside a transaction and leaves that connection idle for the whole run, so Postgres kills
+  it once the migration outlives the timeout — the migration itself commits, then the
+  release command exits non-zero and the deploy aborts.
+
+  Observed on 2026-08-17: the `articles.search_vector` rebuild logged
+  `== Migrated 20260817212906 in 59.8s` against a 60000ms timeout, died with
+  `FATAL 25P03` in `do_lock_for_migrations`, and Fly aborted the deployment. Production was
+  left running the NEW schema with the PREVIOUS release's code — harmless only because that
+  change was additive.
+
+  `Loopctl.Release.migrate/0` and `rollback/1` now disable the timeout for the migrator's
+  own connections. **Scoped to the migrator**: the timeout stays on for the application,
+  where a connection stuck idle in a transaction holds locks and blocks vacuum. No operator
+  action and no database setting change.
+
 ### Added
 
 - **A second-stage reranking seam for combined search** (`Loopctl.Knowledge.Reranker`),

--- a/lib/loopctl/release.ex
+++ b/lib/loopctl/release.ex
@@ -36,11 +36,44 @@ defmodule Loopctl.Release do
     # We specify the path explicitly because AdminRepo defaults to
     # priv/admin_repo/migrations/ but all migrations live in priv/repo/.
     {:ok, _, _} =
-      Ecto.Migrator.with_repo(Loopctl.AdminRepo, fn repo ->
-        path = Ecto.Migrator.migrations_path(Loopctl.Repo)
-        Ecto.Migrator.run(repo, path, :up, all: true)
-      end)
+      Ecto.Migrator.with_repo(
+        Loopctl.AdminRepo,
+        fn repo ->
+          path = Ecto.Migrator.migrations_path(Loopctl.Repo)
+          Ecto.Migrator.run(repo, path, :up, all: true)
+        end,
+        migration_connection_opts()
+      )
   end
+
+  @doc """
+  Connection options for the release-time migration repo.
+
+  **Disables `idle_in_transaction_session_timeout` for the migrator's connections, and
+  nothing else's.** `Ecto.Migrator` takes a Postgres advisory lock inside a transaction and
+  then leaves that connection IDLE for as long as the migration runs. The server's
+  `idle_in_transaction_session_timeout` counts that as an idle transaction and kills the
+  connection — so a migration that takes longer than the timeout FAILS THE RELEASE COMMAND
+  even after the migration itself has fully succeeded.
+
+  That is not hypothetical. On 2026-08-17 the `articles.search_vector` rebuild
+  (`20260817212906`) logged `== Migrated 20260817212906 in 59.8s` against a server whose
+  timeout is 60000ms, then died with `FATAL 25P03 idle_in_transaction_session_timeout` in
+  `do_lock_for_migrations`, and Fly aborted the deployment. Production was left with the new
+  SCHEMA and the previous release's CODE — harmless that time only because the change was
+  additive, which is luck rather than design.
+
+  Scoped deliberately: the timeout is a good guard for the APPLICATION (a connection stuck
+  idle in a transaction holds locks and blocks vacuum), so it stays on there. The migrator
+  is a short-lived release process whose whole job is to hold one lock for the duration, and
+  it is the one caller for which the guard is wrong.
+
+  Public so the setting is assertable — the behaviour it prevents needs a migration slower
+  than the server timeout to reproduce, which no test suite should manufacture.
+  """
+  @spec migration_connection_opts() :: keyword()
+  def migration_connection_opts,
+    do: [parameters: [idle_in_transaction_session_timeout: "0"]]
 
   @doc """
   Rolls back the last migration using AdminRepo.
@@ -49,10 +82,14 @@ defmodule Loopctl.Release do
     load_app()
 
     {:ok, _, _} =
-      Ecto.Migrator.with_repo(Loopctl.AdminRepo, fn repo ->
-        path = Ecto.Migrator.migrations_path(Loopctl.Repo)
-        Ecto.Migrator.run(repo, path, :down, to: version)
-      end)
+      Ecto.Migrator.with_repo(
+        Loopctl.AdminRepo,
+        fn repo ->
+          path = Ecto.Migrator.migrations_path(Loopctl.Repo)
+          Ecto.Migrator.run(repo, path, :down, to: version)
+        end,
+        migration_connection_opts()
+      )
   end
 
   @doc """

--- a/test/loopctl/release_test.exs
+++ b/test/loopctl/release_test.exs
@@ -32,6 +32,56 @@ defmodule Loopctl.ReleaseTest do
     end
   end
 
+  describe "migration_connection_opts/0" do
+    test "sets a Postgres runtime parameter the server actually honours" do
+      assert [parameters: [idle_in_transaction_session_timeout: "0"]] =
+               Release.migration_connection_opts()
+    end
+
+    test "the parameter name and shape reach the server (not just the keyword list)" do
+      # The failure this guards is a WRONG OPTION rather than a wrong value: a misspelled
+      # parameter, or `parameters:` nested at the wrong level, is silently ignored by
+      # Postgrex and the migrator keeps dying on long migrations exactly as before. So the
+      # assertion is end-to-end against a real connection.
+      #
+      # A PROBE value is used rather than the shipped "0" because the server's own default
+      # differs by environment — 0 on a developer box, 60000ms on the hosted instance — so
+      # asserting "0" would pass vacuously wherever the default is already 0.
+      config = Application.get_env(:loopctl, Loopctl.AdminRepo)
+
+      conn_opts = [
+        hostname: config[:hostname] || "127.0.0.1",
+        port: config[:port] || 5432,
+        username: config[:username],
+        password: config[:password],
+        database: config[:database],
+        parameters: [idle_in_transaction_session_timeout: "12345"]
+      ]
+
+      # `start_link` LINKS the connection to this test process, so it is torn down when the
+      # test ends — no `on_exit` teardown, which is what matters here: this suite shares a
+      # box with two other repos' pools, and a leaked connection per run is how a suite
+      # starts failing on connection exhaustion for reasons nobody can find.
+      {:ok, conn} = Postgrex.start_link(conn_opts)
+
+      assert %{rows: [["12345ms"]]} =
+               Postgrex.query!(conn, "SHOW idle_in_transaction_session_timeout", [])
+    end
+
+    test "both migrate/0 and rollback/1 pass it, so a long DOWN cannot fail the same way" do
+      source = File.read!("lib/loopctl/release.ex")
+
+      # `Ecto.Migrator` holds its advisory lock idle-in-transaction for the whole run in
+      # either direction. Migration 20260817212906's UP took 59.8s against a 60000ms
+      # timeout and killed the release command 0.2s from the finish; its DOWN rebuilds the
+      # same generated column and would do exactly the same thing.
+      assert source
+             |> String.split("migration_connection_opts()")
+             |> length() >= 4,
+             "migrate/0 and rollback/1 must both pass migration_connection_opts/0"
+    end
+  end
+
   describe "rollback/1" do
     test "accepts a version argument for targeted rollback" do
       Code.ensure_loaded!(Release)


### PR DESCRIPTION
`Ecto.Migrator` takes its advisory lock inside a transaction and leaves that connection **idle** for the whole run. Postgres's `idle_in_transaction_session_timeout` counts that as an idle transaction and kills it — so a migration that outlives the timeout fails the release command **even though the migration committed**.

## This happened today, on this repo

```
== Migrated 20260817212906 in 59.8s
FATAL 25P03 (idle_in_transaction_session_timeout) ... in do_lock_for_migrations
Error: release command failed - aborting deployment
```

The server's timeout is `60000`ms. The `articles.search_vector` rebuild took **59.8s** and lost by 0.2 seconds. The migration applied — `schema_migrations` has it, the column carries `loopctl_searchable_tags`, a tag-only keyword query returns hits — but Fly aborted the deploy, leaving production on the **new schema with the previous release's code**. Harmless that time only because the change was additive. The next long migration might not be.

(The following master run deployed successfully, so schema and code have since converged. Verified in production, not from a green badge.)

## The fix, and its scope

`migrate/0` and `rollback/1` disable the timeout for the **migrator's own connections only**. It stays on for the application, where a connection stuck idle in a transaction holds locks and blocks vacuum — the migrator is the one caller for which that guard is wrong. No database setting changes and no operator action.

`rollback/1` gets it too: that migration's `down` rebuilds the same generated column and would die identically.

## Why the test opens a real connection

The failure being guarded is a **wrong option**, not a wrong value — a misspelled parameter, or `parameters:` nested at the wrong level, is silently ignored by Postgrex and the migrator keeps dying exactly as before. So the test asserts end-to-end that the server honours it.

It uses a **probe** value (`12345`) rather than the shipped `"0"`, because the server default is `0` on a developer box and `60000ms` on the hosted instance — asserting `"0"` would pass vacuously wherever the default already is 0. Mutation-verified: misspelling the parameter fails the test.

`mix precommit` green: 7600 tests, 0 failures. Reviewed inline (this session cannot dispatch review agents).
