### PR TITLE
Make the pgbouncer apt retry handle the failure that actually happens: a hang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -774,10 +774,25 @@ jobs:
       - name: Install and start pgbouncer (transaction pooling) in front of Postgres
         run: |
           # Retry the install so a transient apt-mirror hiccup doesn't block a deploy.
-          for attempt in 1 2 3; do
-            sudo apt-get update && sudo apt-get install -y pgbouncer && break
-            echo "apt install attempt $attempt failed; retrying"; sleep 5
-          done
+          #
+          # Each apt call is wrapped in `timeout` because the retry loop was written for the
+          # wrong failure mode: it handles apt EXITING non-zero, and what actually happens on
+          # this self-hosted runner is apt HANGING — on a dpkg/apt lock held by
+          # unattended-upgrades, or on an unresponsive mirror. A hung call never returns, so
+          # the loop never reaches attempt 2 and the whole job dies on the 15-minute limit
+          # with one attempt made. That happened twice on 2026-08-17 (PRs #694 and #697),
+          # blocking merges both times and needing a manual re-run.
+          #
+          # Skip `apt-get update` when the package is already installed: the cached case is
+          # the common one on a self-hosted runner, and it is the update that hangs.
+          if ! command -v pgbouncer >/dev/null; then
+            for attempt in 1 2 3; do
+              timeout 180 sudo apt-get update \
+                && timeout 180 sudo apt-get install -y pgbouncer \
+                && break
+              echo "apt install attempt $attempt failed or timed out; retrying"; sleep 5
+            done
+          fi
           command -v pgbouncer >/dev/null || { echo "pgbouncer install failed after retries"; exit 1; }
           # The apt package enables/starts a default pgbouncer (own /etc/pgbouncer.ini on
           # :6432 with no loopctl_test db). Stop it so OUR instance owns the port.


### PR DESCRIPTION
`Pgbouncer e2e` failed on **#694** and again on **#697** today. Neither failure had anything to do with pgbouncer or with the diff under test — the step died before any test ran, and both needed a manual re-run to merge.

## The retry loop guards the wrong failure

```bash
for attempt in 1 2 3; do
  sudo apt-get update && sudo apt-get install -y pgbouncer && break
  echo "apt install attempt $attempt failed; retrying"; sleep 5
done
```

That handles apt **exiting non-zero**. What actually happens on this self-hosted runner is apt **hanging** — a dpkg/apt lock held by unattended-upgrades, or an unresponsive mirror. A hung call never returns, so the loop never reaches attempt 2 and the job dies on the 15-minute limit having made exactly one attempt. The retry was inert for the only failure mode observed.

## Fix

Wrap each apt call in `timeout 180`, so a hang becomes a failure the existing retry can act on. Also skip the whole block when the binary is already present — the cached case is the common one on a self-hosted runner, and `apt-get update` is the call that hangs.

The final `command -v pgbouncer` guard is unchanged, so the step still fails loudly rather than proceeding without the binary.

Workflow YAML and the step's shell body both parse-checked locally. Reviewed inline (this session cannot dispatch review agents).
