### PR TITLE
Exclude skill-eval, count session-start, and correct the contaminant this plan blamed

### DIFF
--- a/docs/research/kb-retrieval-improvement-plan.md
+++ b/docs/research/kb-retrieval-improvement-plan.md
@@ -16,7 +16,7 @@ Source: `article_access_events` (back to 2026-04-10), `search_events`,
 | Deliberate reads/week | 414 (wk of Jul 6) → **147** (wk of Aug 10) |
 | Results-surfaced → read conversion | 5.18% → **1.67%** (denominator stable at 4.5–5.5 results/search) |
 | Published articles EVER deliberately read | **1,443 of 79,074 — 1.8%** |
-| Share of search traffic that is machine-injected | **71%** (`memory_recall`, 1,053 of 1,486 calls) — but see §2.1: a further ~11% is smoke/canary traffic, so filter `client_entrypoint` |
+| Share of search traffic that is machine-injected | **71%** (`memory_recall`, 1,053 of 1,486 calls) — but see §2.1: a further ~11% is smoke/skill-eval traffic, so filter `client_entrypoint` |
 | Share using the richer entrypoints | **1.1%** (hybrid 15, progressive_index 1, heat_index 0, context 1) |
 | Graph edges | 525,932 over 79,074 articles (~6.6/article); 92% have inbound links |
 | Edge types | `relates_to` 502,315 (**96%**), `potential_conflict` 23,617 |
@@ -99,8 +99,10 @@ this dataset cannot fully separate them; the one comparison holding the tool con
   Cross-key attribution is required, and it is confounded whenever both channels surface the
   same article, so isolate articles only ONE channel surfaced.
 - **`search_events` carries synthetic traffic.** `client_entrypoint = 'smoke'` is the smoke
-  test (86 rows, all 1-term, 0% follow-through by construction), and the canary replays a
-  fixed prompt list — visible as distinct queries each appearing exactly 12 times. Together
+  test (86 rows, all 1-term, 0% follow-through by construction), and `skill-eval` is
+  `bin/skill-trigger-eval.py` — visible as distinct queries each appearing exactly 12 times
+  (4 runs x 3 repeats), whose subjects are killed at their first tool call. (This bullet
+  first attributed the 12x pattern to the recall canary; see §5.) Together
   with SessionStart's bare-repo-name queries these dominate the short-query buckets, which
   is most of what the withdrawn table was measuring. **Filter on `client_entrypoint` before
   drawing any conclusion.** Also note the table is a rolling ~5-day window, not history.
@@ -451,11 +453,17 @@ otherwise be asked to compensate for it and cannot.
 - Phase 2b — **DONE.** golden_v3 + `corpus_ref` paired questions; baseline regenerated. Its
   result retires Phase 2's premise rather than confirming it (see above).
 - Phase 2c — **DONE, deployed v523** (#689), and **verified on real traffic** — see below.
-  The injected channel is now measurable instead of scoring a structural zero. One
-  contaminant is still open: the recall canary declares `client_entrypoint: "hook"`,
-  identical to real traffic, so its fixed prompt list sits inside the new counters. Not
-  fixable here (the caller must declare itself, as `smoke.sh` does): handed to
-  claude-config#317.
+  The injected channel is now measurable instead of scoring a structural zero.
+
+  **The contaminant is identified and excluded, and this plan named the wrong culprit.** It
+  blamed the recall canary; claude-config#322 established the canary issues no request to
+  loopctl at all (every hook invocation is pinned to `http://127.0.0.1:9` behind a recording
+  curl shim). The real source is `bin/skill-trigger-eval.py`, which runs each eval query
+  through a real `claude -p` subject whose recall hooks search for real and which is then
+  KILLED at its first tool call — so those searches can never follow through while landing in
+  every denominator. It now declares `client_entrypoint: skill-eval`, which loopctl excludes
+  alongside `smoke`. `session-start` also began declaring itself and is deliberately COUNTED,
+  as its own channel.
 - Phase 2d — **DONE, deployed v523** (#690). Every search result carries a snippet.
 - Phase 3 — **DONE for the lexical half.** Tags are indexed at weight C; the LLM-generated
   context half is refused on a stated argument with a stated overturn condition (above).
@@ -502,8 +510,9 @@ confirmed from the other direction: the shipped same-key metric could not have c
 of the injected channel's opens, and the zero it reported was `n/a`.
 
 **Three hours is a mechanism check, not a rate**, and no phase ordering should move on it.
-The evaluation window is 1-2 weeks from the cutover (2026-08-17T18:00Z), with `smoke` and
-`session-start` excluded and the canary contaminant (claude-config#317) resolved first.
+The evaluation window is 1-2 weeks from the cutover (2026-08-17T18:00Z). `smoke` and
+`skill-eval` are excluded server-side (`@infra_entrypoints`); `session-start` is COUNTED as
+its own channel. claude-config#317 is closed — see §5 for what it corrected.
 
 The audit also re-ran §3.1's own failure live: the entrypoint segmentation joins
 `search_events.search_id`, NOT `search_events.id` — different columns — and the wrong one

--- a/docs/runbooks/search-events-analysis.md
+++ b/docs/runbooks/search-events-analysis.md
@@ -209,9 +209,25 @@ the shorter-lived table), not that attribution is broken — bound the window an
 Three hours is not a rate and must not be quoted as one. What it does establish is
 MECHANISM: every hook open is `cross_key` and every cli open is `same_key`, which is the
 predicted split, and it confirms the old same-key metric could not have counted a single one
-of the hook's. Also note `session-start` is now its own entrypoint rather than sitting inside
-`unattributed`; its queries are bare repo names by construction, so it belongs with `smoke`
-in the filter-me-out class, not with real traffic.
+of the hook's.
+
+**Correction (2026-08-17):** an earlier version of this paragraph said `session-start`
+"belongs with `smoke` in the filter-me-out class". **It does not, and it is not excluded.**
+It is one auto-query per session from `hooks/session-start.sh`, issued by a real session that
+goes on to do real work — a channel to be measured, not infrastructure. It began declaring
+itself in claude-config#322; before that it sent no client context and sat in the NULL
+bucket, so expect a step change out of NULL dated 2026-08-17 that is bookkeeping rather than
+behaviour.
+
+What IS excluded alongside `smoke` is `skill-eval` (`@infra_entrypoints`):
+`bin/skill-trigger-eval.py` runs each eval query through a real `claude -p` subject whose
+recall hooks search for real, and **the subject is killed at its first tool call** — those
+searches can never follow through while landing in every denominator. Two of its queries were
+identifiable as distinct strings appearing exactly 12 times (4 runs x 3 repeats).
+
+The retrieval plan blamed the recall CANARY for this contamination and was wrong: the canary
+pins every hook invocation to `http://127.0.0.1:9` behind a recording curl shim and issues no
+request to loopctl at all.
 
 ## 4. The trap
 

--- a/lib/loopctl/knowledge/retrieval_metrics.ex
+++ b/lib/loopctl/knowledge/retrieval_metrics.ex
@@ -185,7 +185,26 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
   # `entrypoint` key at all, so historical days remain contaminated and are NOT comparable
   # with days after the tag ships. That is stated in the payload rather than left for a
   # reader to discover from a step change in the series.
-  @infra_entrypoints ~w(smoke)
+  #
+  # `skill-eval` joined on 2026-08-17 (claude-config#322). It is the same SHAPE of traffic as
+  # `smoke` and for a sharper reason: `bin/skill-trigger-eval.py` runs each eval query through
+  # a real `claude -p` subject whose recall hooks then search for real, and **the subject is
+  # killed at its first tool call** — so those searches are structurally incapable of ever
+  # following through, while contributing to every denominator. Two of its queries were
+  # visible in the data as distinct strings appearing exactly 12 times (4 runs x 3 repeats).
+  #
+  # This corrects an attribution I got wrong: the plan blamed the recall CANARY, which turns
+  # out to issue no request to loopctl at all — every one of its hook invocations is pinned to
+  # `http://127.0.0.1:9` behind a recording curl shim. Giving the canary a label would have
+  # changed nothing.
+  #
+  # `session-start` is deliberately NOT here. It is one auto-query per session from
+  # `hooks/session-start.sh`, which began declaring itself in the same change; before that it
+  # sent no client context at all and sat in the NULL bucket. It is REAL traffic from a real
+  # session that goes on to do real work, so it is its own channel to be measured, not infra
+  # to be excluded. Expect a step change out of NULL dated 2026-08-17 that is bookkeeping
+  # rather than behaviour.
+  @infra_entrypoints ~w(smoke skill-eval)
 
   defp exclude_infra_traffic(query) do
     where(

--- a/test/loopctl/knowledge/infra_traffic_excluded_test.exs
+++ b/test/loopctl/knowledge/infra_traffic_excluded_test.exs
@@ -83,6 +83,27 @@ defmodule Loopctl.Knowledge.InfraTrafficExcludedTest do
     assert %{searched: 1} = RetrievalMetrics.compute(ctx.tenant.id, ctx.day)
   end
 
+  test "a skill-eval search is in no denominator either", ctx do
+    # `bin/skill-trigger-eval.py` runs each eval query through a real `claude -p` subject
+    # whose recall hooks search for real, and the subject is KILLED at its first tool call.
+    # Structurally the same defect as the smoke test: it can never contribute to a numerator
+    # while contributing to every denominator (claude-config#322).
+    surfaced(ctx, %{"entrypoint" => "skill-eval"})
+
+    assert %{searched: 0, results_recorded: 0} = RetrievalMetrics.compute(ctx.tenant.id, ctx.day)
+  end
+
+  test "session-start is COUNTED, not excluded", ctx do
+    # One auto-query per session from `hooks/session-start.sh` — a real session that goes on
+    # to do real work, so it is a channel to measure rather than infrastructure to drop.
+    # It began declaring itself in claude-config#322; before that it sat in the NULL bucket.
+    # The runbook briefly claimed it belonged with `smoke`; this asserts the opposite so the
+    # claim cannot drift back.
+    surfaced(ctx, %{"entrypoint" => "session-start"})
+
+    assert %{searched: 1} = RetrievalMetrics.compute(ctx.tenant.id, ctx.day)
+  end
+
   test "smoke rows do not dilute a real search's precision", ctx do
     # The exact shape of the defect: one agent search, many smoke searches, none of which
     # can ever be opened. Undeleted, precision here would be 1/6; the agent row is the only


### PR DESCRIPTION
Two loopctl-side asks left by claude-config#322, plus a correction to a diagnosis I got wrong and wrote into two documents.

## `skill-eval` is excluded

`bin/skill-trigger-eval.py` runs each eval query through a real `claude -p` subject whose recall hooks then search loopctl for real — and **the subject is killed at its first tool call**. Those searches are structurally incapable of ever following through while contributing to every denominator: the same defect the smoke test had, for a sharper reason. Two of its queries were identifiable in the data as distinct strings appearing exactly **12 times** (4 runs × 3 repeats).

## `session-start` is COUNTED

One auto-query per session from a real session that goes on to do real work — a channel to measure, not infrastructure to drop. It began declaring itself in the same change; before that it sent no client context and sat in the NULL bucket, so expect a step change out of NULL dated today that is **bookkeeping, not behaviour**.

`docs/runbooks/search-events-analysis.md` said it "belongs with `smoke` in the filter-me-out class". That was mine and it was wrong; corrected in place with the correction visible rather than quietly edited, and pinned by a test so it cannot drift back.

## The canary was not the contaminant

The retrieval plan blamed it, in two places. Every one of the canary's hook invocations is pinned to `http://127.0.0.1:9` behind a recording curl shim, so it issues **no request to loopctl at all** and labelling it would have changed nothing. Both documents corrected.

## The spot check #322 asked for

It flagged that it could not verify from its side whether the labels land in the column loopctl counts. They do — and it was worth checking rather than assuming, because they are two different columns and only the first gates the denominator:

| column | `skill-eval` | `session-start` |
|---|---:|---:|
| `article_access_events.metadata->>'entrypoint'` (what `RetrievalMetrics` filters) | 5 | 70 |
| `search_events.client_entrypoint` | 1 | 14 |

Mutation-verified: removing `skill-eval` from `@infra_entrypoints` fails the new test.

`mix precommit` green: 7602 tests, 0 failures. Reviewed inline (this session cannot dispatch review agents).
