### PR TITLE
Make tags improvable after capture, concurrently, against the vocabulary the corpus already uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to loopctl are documented here.
 
 ## [Unreleased] — 2026-08-07 — Story lifecycle capability delivery
 
+### Added
+
+- **Retroactive tagging** (`Loopctl.Workers.TagBackfillWorker`). Tags were LLM-generated once
+  at ingest and nothing ever revisited them, so there was no way to improve an article's tags
+  after capture at all. There is now.
+
+  It re-tags against the corpus's **established vocabulary**, which is the entire point.
+  Measured on the hosted instance: 684,883 topical tag instances across **60,141 distinct
+  tags, of which 33,234 (55.3%) are used exactly once** — each capture invented plausible
+  strings for ideas the corpus already had words for. Only 4.5% of that is spelling variants,
+  so normalisation cannot fix it. Coverage is not the problem either (8.66 topical tags per
+  article, 46 published articles below three), which is why a re-tagger that just generates
+  more tags in isolation would make things worse.
+
+  Concurrent (`Task.async_stream`, `:knowledge_tag_backfill_concurrency`, default 4),
+  bounded per run, resumable via `metadata.retagged_at`, and **append-only** — an existing tag
+  is never removed, because they carry provenance ids and the reserved `idem-` namespace a
+  sourcer reads to know an article was already captured. A provider failure leaves the article
+  eligible for the next run rather than silently stamping it as done.
+
+  **Deliberately not on a cron**: one provider call per article, so it is started on purpose:
+
+      Loopctl.Workers.TagBackfillWorker.enqueue_all_tenants(limit: 200)
+
 ### Fixed
 
 - **A migration slower than the database's `idle_in_transaction_session_timeout` no longer

--- a/config/config.exs
+++ b/config/config.exs
@@ -940,6 +940,18 @@ config :loopctl, :knowledge_rrf_graph_seed_count, 10
 # Overall cap on distinct graph-lane neighbors injected into the fusion.
 config :loopctl, :knowledge_rrf_graph_max_neighbors, 20
 
+# Retroactive tagging (`Loopctl.Workers.TagBackfillWorker`). Tags were LLM-generated once at
+# ingest and nothing ever revisited them, so 33,234 of 60,141 distinct topical tags (55.3%)
+# are used exactly ONCE — each capture invented plausible strings for ideas the corpus already
+# had words for. The backfill re-tags against the ESTABLISHED vocabulary, which is the whole
+# mechanism; generating more tags in isolation would make the fragmentation worse.
+#
+# Deliberately NOT on a cron: it costs one provider call per article, so it is started on
+# purpose and bounded per run. Concurrency is small because the constraint is a shared
+# provider rate limit and the AdminRepo pool.
+config :loopctl, :knowledge_tagger, Loopctl.Knowledge.Tagger.Llm
+config :loopctl, :knowledge_tag_backfill_concurrency, 4
+
 # Phase 4 second-stage reranking. OFF by default: it puts an outbound provider call on the
 # DEFAULT search path, and the measurements that motivated the retrieval plan eliminate
 # ranking as the cause of the injected channel's follow-through gap — so a better ranker

--- a/config/test.exs
+++ b/config/test.exs
@@ -850,3 +850,7 @@ config :loopctl, :hnsw_iterative_scan_default, 1
 config :loopctl,
   knowledge_consolidation_max_applies: 2,
   knowledge_consolidation_max_unpublishes: 1
+
+# The re-tagger makes an outbound provider call per article. Tests pass `tagger_impl:`
+# explicitly; this default guarantees a test that forgets cannot reach a provider.
+config :loopctl, :knowledge_tagger, Loopctl.Knowledge.Tagger.Llm

--- a/lib/loopctl/knowledge/tagger.ex
+++ b/lib/loopctl/knowledge/tagger.ex
@@ -1,0 +1,121 @@
+defmodule Loopctl.Knowledge.Tagger do
+  @moduledoc """
+  Re-tags an existing article, preferring vocabulary the corpus already uses.
+
+  ## The problem this exists for
+
+  Tags are LLM-generated once at ingest and nothing ever revisited them, so each article's
+  tags were invented in isolation. Measured on the hosted corpus 2026-08-17:
+
+  | | |
+  |---|---:|
+  | topical tag instances | 684,883 |
+  | distinct topical tags | 60,141 |
+  | **used exactly once** | **33,234 (55.3%)** |
+  | collapsible by pure normalisation (case/punctuation/plural) | 2,723 (4.5%) |
+
+  More than half the vocabulary is singletons, and only 4.5% of that is spelling variants —
+  the rest is genuinely different strings for related ideas. A tag used once groups nothing,
+  and since tags entered `articles.search_vector` it also contributes an index lexeme that
+  matches exactly one document.
+
+  Coverage is NOT the problem: the corpus averages 8.66 topical tags per article and only 46
+  published articles carry fewer than three. So a re-tagger that just generates more tags
+  makes the fragmentation worse. **The whole point of this module is the vocabulary it is
+  shown**: the tagger receives the tenant's established tags and is told to reuse them unless
+  the article genuinely needs a new one.
+
+  ## What a re-tag may and may not do
+
+  It MERGES. Existing tags are never removed — an article's provenance ids, its
+  `idem-` reservation and any hand-curated tag survive untouched, and the result is capped at
+  `Article.max_tags/0`. A re-tagger that replaced tags could silently drop the idempotency key
+  a sourcer depends on to know the article was already captured.
+  """
+
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ProvenanceTags
+
+  @type article :: %{id: String.t(), title: String.t(), body: String.t(), tags: [String.t()]}
+
+  @callback suggest(
+              scope_or_tenant_id :: term(),
+              article :: article(),
+              vocabulary :: [String.t()],
+              opts :: keyword()
+            ) :: {:ok, [String.t()]} | {:error, term()}
+
+  require Logger
+
+  # Mirrors `ContentIngestionWorker`'s per-tag validation. A suggestion that would be
+  # rejected by the changeset is dropped here instead, so one malformed tag cannot fail the
+  # whole article's re-tag.
+  @tag_pattern ~r/^[a-z0-9][a-z0-9._-]*$/
+  @max_tag_length 64
+
+  @doc """
+  Suggest tags for `article` and return the MERGED tag list, or the unchanged list.
+
+  Returns `{:ok, tags, added}` where `added` is what the suggestion contributed, or
+  `{:error, reason}`. The caller decides whether an empty `added` is worth a write.
+  """
+  @spec retag(term(), article(), [String.t()], keyword()) ::
+          {:ok, [String.t()], [String.t()]} | {:error, term()}
+  def retag(scope_or_tenant_id, article, vocabulary, opts \\ []) do
+    case impl(opts).suggest(scope_or_tenant_id, article, vocabulary, opts) do
+      {:ok, suggested} ->
+        {tags, added} = merge(article.tags, suggested)
+        {:ok, tags, added}
+
+      {:error, _} = error ->
+        error
+    end
+  rescue
+    error -> {:error, error}
+  end
+
+  @doc """
+  Merge suggested tags into existing ones.
+
+  Existing tags come FIRST and are never dropped: they carry provenance ids and the reserved
+  `idem-` namespace a sourcer uses to know an article was already captured, and losing one
+  causes a re-capture rather than a cosmetic regression. New tags fill the remaining room up
+  to `Article.max_tags/0`, so a verbose suggestion truncates itself rather than the record.
+  """
+  @spec merge([String.t()], [String.t()]) :: {[String.t()], [String.t()]}
+  def merge(existing, suggested) do
+    existing = existing || []
+    known = MapSet.new(existing)
+
+    added =
+      suggested
+      |> Enum.map(&normalize/1)
+      |> Enum.filter(&valid?/1)
+      # A suggestion must never mint a provenance-shaped tag: those identify WHERE an article
+      # came from, and a generated one would be a false claim about its source.
+      |> Enum.reject(&(MapSet.member?(known, &1) or provenance?(&1)))
+      |> Enum.uniq()
+      |> Enum.take(max(Article.max_tags() - length(existing), 0))
+
+    {existing ++ added, added}
+  end
+
+  @doc "The implementation module for this call."
+  @spec impl(keyword()) :: module()
+  def impl(opts \\ []) do
+    Keyword.get(
+      opts,
+      :tagger_impl,
+      Application.get_env(:loopctl, :knowledge_tagger, __MODULE__.Llm)
+    )
+  end
+
+  defp normalize(tag) when is_binary(tag), do: tag |> String.trim() |> String.downcase()
+  defp normalize(_tag), do: ""
+
+  defp valid?(tag),
+    do: tag != "" and String.length(tag) <= @max_tag_length and Regex.match?(@tag_pattern, tag)
+
+  defp provenance?(tag),
+    do: Enum.any?(ProvenanceTags.prefixes(), &String.starts_with?(tag, &1))
+end

--- a/lib/loopctl/knowledge/tagger/llm.ex
+++ b/lib/loopctl/knowledge/tagger/llm.ex
@@ -1,0 +1,119 @@
+defmodule Loopctl.Knowledge.Tagger.Llm do
+  @moduledoc """
+  Suggests tags for an article while SHOWING the model the vocabulary the corpus already uses.
+
+  That list is the entire mechanism. Tagging an article in isolation is what produced 33,234
+  single-use tags out of 60,141 (55.3%) — each capture invents plausible strings for ideas the
+  corpus already has words for. The prompt therefore presents the established vocabulary and
+  makes reuse the default, with a new tag allowed only when nothing offered fits.
+
+  Per-tenant BYO via `Loopctl.Llm.Anthropic.message/5` under `:classification`, so a tenant
+  with no key returns `{:error, :no_api_key}` and the caller leaves the article alone.
+  """
+
+  @behaviour Loopctl.Knowledge.Tagger
+
+  alias Loopctl.Llm.Anthropic
+
+  @body_chars 4_000
+  @max_tokens 300
+
+  # How many established tags to show. Enough to cover a tenant's real topics; small enough
+  # that the vocabulary does not dominate the prompt on every one of thousands of articles.
+  @vocabulary_shown 150
+
+  @system_prompt """
+  You assign topic tags to a knowledge-base article. You will be given the article and a \
+  VOCABULARY of tags this knowledge base already uses.
+
+  Prefer the vocabulary. Reuse an existing tag whenever it fits, even if you would have \
+  phrased it differently — a tag that matches what other articles already carry is what makes \
+  the collection navigable, and a near-synonym nobody else uses is worse than an imperfect \
+  match that many do. Propose a NEW tag only when the article is about something the \
+  vocabulary genuinely does not cover.
+
+  Return between 3 and 8 tags describing what the article is ABOUT. Do not tag the format, \
+  the source or the file type. Each tag must be lowercase, and may contain only letters, \
+  digits, dots, underscores and hyphens.
+
+  Reply with a single compact JSON object with exactly one key, "tags", whose value is an \
+  array of strings. Output nothing except that JSON object.\
+  """
+
+  @doc "The tagging system prompt. Public so tests and any sibling implementation share it."
+  @spec system_prompt() :: String.t()
+  def system_prompt, do: @system_prompt
+
+  @doc "How many established tags the prompt shows."
+  @spec vocabulary_shown() :: pos_integer()
+  def vocabulary_shown, do: @vocabulary_shown
+
+  @doc "The user message for an article and the corpus vocabulary. Public for testing."
+  @spec user_content(map(), [String.t()]) :: String.t()
+  def user_content(article, vocabulary) do
+    shown = vocabulary |> Enum.take(@vocabulary_shown) |> Enum.join(", ")
+
+    """
+    VOCABULARY (prefer these): #{shown}
+
+    ARTICLE
+    Title: #{article.title}
+    #{String.slice(article.body || "", 0, @body_chars)}
+    """
+  end
+
+  @impl true
+  def suggest(scope_or_tenant_id, article, vocabulary, opts) do
+    content = user_content(article, vocabulary)
+
+    body_fun = fn _model ->
+      %{
+        max_tokens: @max_tokens,
+        system: @system_prompt,
+        messages: [%{role: "user", content: content}]
+      }
+    end
+
+    case call(scope_or_tenant_id, opts, body_fun) do
+      {:ok, text} -> parse_tags(text)
+      {:error, _} = error -> error
+    end
+  end
+
+  defp call(scope_or_tenant_id, opts, body_fun) do
+    case {opts[:tagger_api_key], opts[:tagger_model]} do
+      {api_key, model} when is_binary(api_key) and is_binary(model) ->
+        Anthropic.call(scope_or_tenant_id, :classification, api_key, model, body_fun)
+
+      _ ->
+        Anthropic.message(scope_or_tenant_id, :classification, body_fun)
+    end
+  end
+
+  @doc """
+  Parse a model reply into a tag list.
+
+  Shape only — validity and the provenance-namespace rejection belong to
+  `Loopctl.Knowledge.Tagger.merge/2`, which every implementation goes through, so a second
+  implementation cannot skip them by parsing leniently.
+  """
+  @spec parse_tags(String.t() | nil) :: {:ok, [String.t()]} | {:error, atom()}
+  def parse_tags(text) when is_binary(text) do
+    with {:ok, json} <- extract_json_object(text),
+         %{"tags" => tags} when is_list(tags) <- json,
+         true <- Enum.all?(tags, &is_binary/1) do
+      {:ok, tags}
+    else
+      _ -> {:error, :unparseable_tags}
+    end
+  end
+
+  def parse_tags(_text), do: {:error, :unparseable_tags}
+
+  defp extract_json_object(text) do
+    case Regex.run(~r/\{.*\}/s, String.trim(text)) do
+      [json] -> JSON.decode(json)
+      _ -> :error
+    end
+  end
+end

--- a/lib/loopctl/workers/tag_backfill_worker.ex
+++ b/lib/loopctl/workers/tag_backfill_worker.ex
@@ -1,0 +1,255 @@
+defmodule Loopctl.Workers.TagBackfillWorker do
+  @moduledoc """
+  Re-tags existing articles CONCURRENTLY, against the vocabulary the corpus already uses.
+
+  Tags were LLM-generated once at ingest and nothing ever revisited them, so there was no way
+  to improve an article's tags after capture at all. This is that way.
+
+  ## What it selects, and why not "everything"
+
+  By fewest topical tags first. Coverage is mostly fine — the hosted corpus averages 8.66
+  topical tags per article and only 46 published articles carry fewer than three — so a run
+  that swept everything would spend thousands of provider calls to add near-synonyms to
+  articles that are already well tagged, which makes the vocabulary fragmentation WORSE. The
+  ordering means a bounded run does the articles that actually lack tags first, and a
+  `min_tags` filter lets an operator stop there.
+
+  ## Concurrency
+
+  `Task.async_stream` with a small bound. Each article costs one provider call, so a
+  sequential backfill over even a few thousand articles is a few thousand serial round trips.
+  The bound is small because the constraint is a shared provider rate limit and the AdminRepo
+  pool, not CPU here. `timeout: :infinity` on the stream with the real bound coming from the
+  provider client — a stream timeout would kill the task and lose the work while the request
+  kept running and got billed.
+
+  ## Idempotent and resumable
+
+  Every article it touches gets `metadata["retagged_at"]`, and the selection skips anything
+  already carrying it. So a run that dies halfway resumes where it stopped, a re-run is a
+  no-op, and there is no separate cursor to get out of step with the corpus.
+
+  ## It never removes a tag
+
+  `Tagger.merge/2` appends. Existing tags carry provenance ids and the reserved `idem-`
+  namespace a sourcer reads to know an article was already captured — dropping one causes a
+  re-capture, not a cosmetic regression.
+
+  ## Running it
+
+      Loopctl.Workers.TagBackfillWorker.enqueue_all_tenants(limit: 200)
+      Loopctl.Workers.TagBackfillWorker.new(%{"tenant_id" => id, "limit" => 200}) |> Oban.insert()
+
+  Deliberately NOT on a cron. It is a backfill with a per-article provider cost, so it is
+  started on purpose and bounded per run, rather than discovering its own budget nightly.
+  """
+
+  use Oban.Worker, queue: :knowledge, max_attempts: 3
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ProvenanceTags
+  alias Loopctl.Knowledge.Tagger
+  alias Loopctl.Tenants.Tenant
+
+  require Logger
+
+  @default_limit 200
+  @default_min_tags 3
+
+  @doc "Enqueue one job per active tenant."
+  @spec enqueue_all_tenants(keyword()) :: :ok
+  def enqueue_all_tenants(opts \\ []) do
+    %{"mode" => "all_tenants", "limit" => Keyword.get(opts, :limit, @default_limit)}
+    |> __MODULE__.new()
+    |> Oban.insert()
+
+    :ok
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"mode" => "all_tenants"} = args}) do
+    limit = Map.get(args, "limit", @default_limit)
+
+    from(t in Tenant, where: t.status == :active, select: t.id)
+    |> AdminRepo.all()
+    |> Enum.each(fn tenant_id ->
+      %{"tenant_id" => tenant_id, "limit" => limit} |> __MODULE__.new() |> Oban.insert()
+    end)
+
+    :ok
+  end
+
+  def perform(%Oban.Job{args: %{"tenant_id" => tenant_id} = args}) do
+    limit = Map.get(args, "limit", @default_limit)
+    min_tags = Map.get(args, "min_tags", @default_min_tags)
+
+    {:ok, backfill(tenant_id, limit: limit, min_tags: min_tags)}
+  end
+
+  @doc """
+  Re-tag up to `:limit` articles for a tenant. Returns a summary map.
+
+  Public so an operator can run it from a release console and see what it did, rather than
+  inferring a backfill's progress from log lines.
+  """
+  @spec backfill(Ecto.UUID.t(), keyword()) :: %{
+          candidates: non_neg_integer(),
+          retagged: non_neg_integer(),
+          tags_added: non_neg_integer(),
+          skipped: non_neg_integer()
+        }
+  def backfill(tenant_id, opts \\ []) do
+    limit = Keyword.get(opts, :limit, @default_limit)
+    vocabulary = established_vocabulary(tenant_id)
+    candidates = candidates(tenant_id, limit, Keyword.get(opts, :min_tags, @default_min_tags))
+
+    results =
+      candidates
+      |> Task.async_stream(
+        fn article -> retag_one(tenant_id, article, vocabulary, opts) end,
+        max_concurrency: concurrency(),
+        timeout: :infinity,
+        on_timeout: :kill_task,
+        ordered: false
+      )
+      |> Enum.reduce(%{retagged: 0, tags_added: 0, skipped: 0}, fn
+        {:ok, {:ok, added}}, acc when added > 0 ->
+          %{acc | retagged: acc.retagged + 1, tags_added: acc.tags_added + added}
+
+        _other, acc ->
+          %{acc | skipped: acc.skipped + 1}
+      end)
+
+    Map.put(results, :candidates, length(candidates))
+  end
+
+  @doc """
+  The tenant's ESTABLISHED tag vocabulary: topical tags ordered by how many articles use them.
+
+  Ordered by usage on purpose. Showing a model the whole 60,141-tag vocabulary would be both
+  enormous and useless — the point is to offer the tags that already GROUP things, and a tag
+  used once groups nothing. Provenance families are excluded because they name a source
+  rather than a subject and must never be suggested for an article that did not come from it.
+  """
+  @spec established_vocabulary(Ecto.UUID.t(), pos_integer()) :: [String.t()]
+  def established_vocabulary(tenant_id, limit \\ 150) do
+    pattern = ProvenanceTags.sql_pattern()
+
+    """
+    SELECT tag FROM (
+      SELECT unnest(tags) AS tag FROM articles
+      WHERE tenant_id = $1 AND status = 'published'
+    ) t
+    WHERE tag !~ $2
+    GROUP BY tag
+    ORDER BY count(*) DESC, tag
+    LIMIT $3
+    """
+    |> AdminRepo.query([Ecto.UUID.dump!(tenant_id), pattern, limit])
+    |> case do
+      {:ok, %{rows: rows}} -> Enum.map(rows, &hd/1)
+      {:error, _} -> []
+    end
+  end
+
+  defp candidates(tenant_id, limit, min_tags) do
+    pattern = ProvenanceTags.sql_pattern()
+
+    # Fewest TOPICAL tags first — provenance ids inflate the raw array length, so ordering on
+    # `array_length(tags, 1)` would rank a heavily-sourced article as well-tagged.
+    """
+    SELECT id, title, body, tags
+    FROM articles a
+    WHERE a.tenant_id = $1
+      AND a.status = 'published'
+      AND (a.metadata->>'retagged_at') IS NULL
+      AND (SELECT count(*) FROM unnest(a.tags) x WHERE x !~ $2) < $3
+    ORDER BY (SELECT count(*) FROM unnest(a.tags) x WHERE x !~ $2), a.id
+    LIMIT $4
+    """
+    |> AdminRepo.query([Ecto.UUID.dump!(tenant_id), pattern, min_tags, limit])
+    |> case do
+      {:ok, %{rows: rows}} ->
+        Enum.map(rows, fn [id, title, body, tags] ->
+          %{id: Ecto.UUID.load!(id), title: title, body: body, tags: tags || []}
+        end)
+
+      {:error, reason} ->
+        Logger.warning("tag backfill: candidate query failed: #{inspect(reason)}")
+        []
+    end
+  end
+
+  defp retag_one(tenant_id, article, vocabulary, opts) do
+    case Tagger.retag(tenant_id, article, vocabulary, opts) do
+      {:ok, _tags, []} ->
+        # Nothing to add. Still stamp it, or the article sits at the head of every future
+        # run's fewest-tags-first ordering and is paid for again on every pass.
+        stamp_only(tenant_id, article)
+        {:ok, 0}
+
+      {:ok, tags, added} ->
+        case write_tags(tenant_id, article, tags) do
+          {:ok, _} -> {:ok, length(added)}
+          {:error, reason} -> {:error, reason}
+        end
+
+      {:error, reason} ->
+        # NOT stamped: a provider failure must leave the article eligible for the next run.
+        {:error, reason}
+    end
+  end
+
+  # Tags and the stamp in ONE statement. `metadata` is MERGED rather than replaced: a
+  # whole-map write would drop `doc_id`, source fields and anything else a capture put there
+  # — the same defect that made `lifecycle_entered_at` a column instead of a metadata key.
+  defp write_tags(tenant_id, article, tags),
+    do: touch(tenant_id, article, tags: tags, bump_updated_at: true)
+
+  # Nothing was added, so no `updated_at` bump — touching it would move the article in the
+  # recency prior for a write that changed nothing. It is still stamped, or it sits at the
+  # head of every future run's fewest-tags-first ordering and gets paid for again each pass.
+  defp stamp_only(tenant_id, article),
+    do: touch(tenant_id, article, tags: nil, bump_updated_at: false)
+
+  defp touch(tenant_id, article, opts) do
+    now = DateTime.utc_now()
+    stamp = DateTime.to_iso8601(now)
+
+    query =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id and a.id == ^article.id,
+        update: [
+          set: [
+            metadata:
+              fragment(
+                "coalesce(?, '{}'::jsonb) || jsonb_build_object('retagged_at', ?::text)",
+                a.metadata,
+                ^stamp
+              )
+          ]
+        ]
+      )
+
+    query
+    |> maybe_set_tags(opts[:tags])
+    |> maybe_bump(opts[:bump_updated_at], now)
+    |> AdminRepo.update_all([])
+    |> case do
+      {count, _} when count > 0 -> {:ok, count}
+      _ -> {:error, :not_updated}
+    end
+  end
+
+  defp maybe_set_tags(query, nil), do: query
+  defp maybe_set_tags(query, tags), do: update(query, set: [tags: ^tags])
+
+  defp maybe_bump(query, true, now), do: update(query, set: [updated_at: ^now])
+  defp maybe_bump(query, _false, _now), do: query
+
+  defp concurrency,
+    do: Application.get_env(:loopctl, :knowledge_tag_backfill_concurrency, 4)
+end

--- a/test/loopctl/knowledge/tagger_test.exs
+++ b/test/loopctl/knowledge/tagger_test.exs
@@ -1,0 +1,126 @@
+defmodule Loopctl.Knowledge.TaggerTest do
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.IdempotencyTag
+  alias Loopctl.Knowledge.Tagger
+  alias Loopctl.Knowledge.Tagger.Llm
+
+  defmodule Suggesting do
+    @moduledoc false
+    @behaviour Tagger
+    @impl true
+    def suggest(_scope, _article, _vocabulary, opts),
+      do: {:ok, Keyword.get(opts, :suggestions, ["zettelkasten", "note-taking"])}
+  end
+
+  defmodule Erroring do
+    @moduledoc false
+    @behaviour Tagger
+    @impl true
+    def suggest(_scope, _article, _vocabulary, _opts), do: {:error, :no_api_key}
+  end
+
+  defmodule Raising do
+    @moduledoc false
+    @behaviour Tagger
+    @impl true
+    def suggest(_scope, _article, _vocabulary, _opts), do: raise("boom")
+  end
+
+  defp article(tags),
+    do: %{id: "a", title: "Atomic notes", body: "One idea per note.", tags: tags}
+
+  describe "merge/2 — existing tags are never dropped" do
+    test "an idempotency key survives a re-tag" do
+      # The reserved key is how a sourcer knows an article was already captured. Dropping it
+      # causes a RE-CAPTURE, not a cosmetic regression, which is why merge is append-only.
+      idem = IdempotencyTag.reserved_prefix() <> "url-42516bb95051"
+
+      assert {[^idem, "rls", "zettelkasten"], ["zettelkasten"]} =
+               Tagger.merge([idem, "rls"], ["zettelkasten", "rls"])
+    end
+
+    test "a duplicate suggestion adds nothing" do
+      assert {["rls"], []} = Tagger.merge(["rls"], ["rls", "RLS", "  rls  "])
+    end
+
+    test "a suggestion may never mint a provenance-shaped tag" do
+      # Those identify WHERE an article came from; a generated one is a false claim about
+      # its source, and it would also be excluded from the keyword index as noise.
+      {tags, added} = Tagger.merge([], ["url-deadbeefcafe", "book-0be008289fe8", "chunking"])
+
+      assert added == ["chunking"]
+      assert tags == ["chunking"]
+    end
+
+    test "malformed suggestions are dropped, not fatal to the whole article" do
+      {_tags, added} =
+        Tagger.merge([], [
+          "Good-Tag",
+          "has spaces",
+          "-leading-hyphen",
+          "",
+          String.duplicate("x", 80)
+        ])
+
+      assert added == ["good-tag"]
+    end
+
+    test "the cap truncates the SUGGESTION, never the record" do
+      existing = Enum.map(1..Article.max_tags(), &"existing#{&1}")
+
+      assert {^existing, []} = Tagger.merge(existing, ["brand-new"])
+    end
+
+    test "nil existing tags are treated as empty" do
+      assert {["chunking"], ["chunking"]} = Tagger.merge(nil, ["chunking"])
+    end
+  end
+
+  describe "retag/4" do
+    test "returns the merged list and what the suggestion contributed" do
+      assert {:ok, ["rls", "zettelkasten", "note-taking"], ["zettelkasten", "note-taking"]} =
+               Tagger.retag("t", article(["rls"]), ["rls"], tagger_impl: Suggesting)
+    end
+
+    for {label, impl} <- [{"a provider error", Erroring}, {"a raise", Raising}] do
+      test "leaves the article alone on #{label}" do
+        assert {:error, _} = Tagger.retag("t", article(["rls"]), [], tagger_impl: unquote(impl))
+      end
+    end
+  end
+
+  describe "Llm" do
+    test "the prompt SHOWS the established vocabulary, which is the whole mechanism" do
+      content = Llm.user_content(article([]), ["chunking", "retrieval", "embeddings"])
+
+      assert content =~ "VOCABULARY (prefer these): chunking, retrieval, embeddings"
+      assert content =~ "Atomic notes"
+    end
+
+    test "the vocabulary shown is capped" do
+      vocabulary = Enum.map(1..500, &"tag#{&1}")
+      content = Llm.user_content(article([]), vocabulary)
+
+      shown = content |> String.split("\n") |> hd() |> String.split(", ") |> length()
+      assert shown == Llm.vocabulary_shown()
+    end
+
+    test "the system prompt makes reuse the default rather than a suggestion" do
+      assert Llm.system_prompt() =~ "Prefer the vocabulary"
+      assert Llm.system_prompt() =~ "Propose a NEW tag only when"
+    end
+
+    test "parse_tags/1 accepts a list and rejects everything else" do
+      assert {:ok, ["a", "b"]} = Llm.parse_tags(~s({"tags":["a","b"]}))
+      assert {:ok, ["a"]} = Llm.parse_tags(~s|Here:\n```json\n{"tags": ["a"]}\n```|)
+
+      assert {:error, :unparseable_tags} = Llm.parse_tags(~s({"tags":"a,b"}))
+      assert {:error, :unparseable_tags} = Llm.parse_tags(~s({"tags":[1,2]}))
+      assert {:error, :unparseable_tags} = Llm.parse_tags(~s({"labels":["a"]}))
+      assert {:error, :unparseable_tags} = Llm.parse_tags("no json")
+      assert {:error, :unparseable_tags} = Llm.parse_tags(nil)
+    end
+  end
+end

--- a/test/loopctl/workers/tag_backfill_worker_test.exs
+++ b/test/loopctl/workers/tag_backfill_worker_test.exs
@@ -1,0 +1,142 @@
+defmodule Loopctl.Workers.TagBackfillWorkerTest do
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Workers.TagBackfillWorker
+
+  defmodule Suggesting do
+    @moduledoc false
+    @behaviour Loopctl.Knowledge.Tagger
+    @impl true
+    def suggest(_scope, _article, vocabulary, _opts) do
+      # Echo the vocabulary back so a test can prove the worker actually SHOWED it. A tagger
+      # that invents strings is exactly the behaviour this feature exists to stop.
+      {:ok, Enum.take(vocabulary, 2)}
+    end
+  end
+
+  defmodule Erroring do
+    @moduledoc false
+    @behaviour Loopctl.Knowledge.Tagger
+    @impl true
+    def suggest(_scope, _article, _vocabulary, _opts), do: {:error, :no_api_key}
+  end
+
+  defp published(tenant_id, tags) do
+    fixture(:article, %{tenant_id: tenant_id, status: :published, tags: tags})
+  end
+
+  defp reload(id), do: AdminRepo.get!(Article, id)
+
+  describe "backfill/2" do
+    test "re-tags the thin article, from the established vocabulary" do
+      tenant = fixture(:tenant)
+      # Three well-tagged articles establish the vocabulary...
+      for _ <- 1..3, do: published(tenant.id, ["chunking", "retrieval", "embeddings"])
+      # ...and one thin one is the candidate.
+      thin = published(tenant.id, ["rls"])
+
+      assert %{candidates: 1, retagged: 1, tags_added: 2} =
+               TagBackfillWorker.backfill(tenant.id, tagger_impl: Suggesting)
+
+      tags = reload(thin.id).tags
+      assert "rls" in tags, "an existing tag must never be dropped"
+      assert length(tags) == 3
+      # The added tags came from the vocabulary the corpus already uses, not from thin air.
+      assert Enum.all?(tags -- ["rls"], &(&1 in ["chunking", "retrieval", "embeddings"]))
+    end
+
+    test "a well-tagged article is not a candidate" do
+      tenant = fixture(:tenant)
+      published(tenant.id, ["chunking", "retrieval", "embeddings"])
+
+      assert %{candidates: 0, retagged: 0} =
+               TagBackfillWorker.backfill(tenant.id, tagger_impl: Suggesting)
+    end
+
+    test "is idempotent: a second run finds nothing" do
+      tenant = fixture(:tenant)
+      for _ <- 1..3, do: published(tenant.id, ["chunking", "retrieval", "embeddings"])
+      published(tenant.id, ["rls"])
+
+      assert %{retagged: 1} = TagBackfillWorker.backfill(tenant.id, tagger_impl: Suggesting)
+      assert %{candidates: 0} = TagBackfillWorker.backfill(tenant.id, tagger_impl: Suggesting)
+    end
+
+    test "a provider failure leaves the article ELIGIBLE for the next run" do
+      # The opposite would be worse than doing nothing: a transient outage would permanently
+      # exclude every article it touched, silently, with no way to tell which.
+      tenant = fixture(:tenant)
+      for _ <- 1..3, do: published(tenant.id, ["chunking", "retrieval", "embeddings"])
+      thin = published(tenant.id, ["rls"])
+
+      assert %{candidates: 1, retagged: 0, skipped: 1} =
+               TagBackfillWorker.backfill(tenant.id, tagger_impl: Erroring)
+
+      assert reload(thin.id).metadata["retagged_at"] == nil
+      assert %{candidates: 1} = TagBackfillWorker.backfill(tenant.id, tagger_impl: Erroring)
+    end
+
+    test "the stamp MERGES into metadata rather than replacing it" do
+      # A whole-map write would drop `doc_id` and the source fields a capture put there —
+      # the same defect that made `lifecycle_entered_at` a column instead of a metadata key.
+      tenant = fixture(:tenant)
+      for _ <- 1..3, do: published(tenant.id, ["chunking", "retrieval", "embeddings"])
+
+      thin =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          tags: ["rls"],
+          metadata: %{"doc_id" => "keep-me", "source_type" => "web"}
+        })
+
+      TagBackfillWorker.backfill(tenant.id, tagger_impl: Suggesting)
+
+      metadata = reload(thin.id).metadata
+      assert metadata["doc_id"] == "keep-me"
+      assert metadata["source_type"] == "web"
+      assert is_binary(metadata["retagged_at"])
+    end
+
+    test "tenant isolation: another tenant's thin article is untouched" do
+      a = fixture(:tenant)
+      b = fixture(:tenant)
+      for _ <- 1..3, do: published(a.id, ["chunking", "retrieval", "embeddings"])
+      published(a.id, ["rls"])
+      theirs = published(b.id, ["rls"])
+
+      assert %{candidates: 1} = TagBackfillWorker.backfill(a.id, tagger_impl: Suggesting)
+
+      assert reload(theirs.id).tags == ["rls"]
+      assert reload(theirs.id).metadata["retagged_at"] == nil
+    end
+
+    test "the limit bounds one run, and the next resumes" do
+      tenant = fixture(:tenant)
+      for _ <- 1..3, do: published(tenant.id, ["chunking", "retrieval", "embeddings"])
+      for _ <- 1..3, do: published(tenant.id, ["rls"])
+
+      assert %{candidates: 2, retagged: 2} =
+               TagBackfillWorker.backfill(tenant.id, limit: 2, tagger_impl: Suggesting)
+
+      assert %{candidates: 1, retagged: 1} =
+               TagBackfillWorker.backfill(tenant.id, limit: 2, tagger_impl: Suggesting)
+    end
+  end
+
+  describe "established_vocabulary/2" do
+    test "ranks by how many articles use a tag, and excludes provenance ids" do
+      tenant = fixture(:tenant)
+      for _ <- 1..3, do: published(tenant.id, ["common", "url-42516bb95051"])
+      published(tenant.id, ["rare"])
+
+      vocabulary = TagBackfillWorker.established_vocabulary(tenant.id)
+
+      assert hd(vocabulary) == "common", "a tag that groups more must be offered first"
+      assert "rare" in vocabulary
+      refute "url-42516bb95051" in vocabulary
+    end
+  end
+end


### PR DESCRIPTION
Tags were LLM-generated once at ingest and nothing ever revisited them, so there was **no way to improve an article's tags after capture at all**. This is that way.

## What the corpus actually needs is not more tags

Measured before building, and it changed the design:

| | |
|---|---:|
| avg topical tags per published article | **8.66** |
| published articles with fewer than 3 | **46** |
| topical tag instances | 684,883 |
| distinct topical tags | 60,141 |
| **used exactly once** | **33,234 (55.3%)** |
| collapsible by pure normalisation | 2,723 (4.5%) |

Coverage is fine. **Fragmentation is the problem**: more than half the vocabulary is singletons, and only 4.5% of that is spelling variants — the rest is genuinely different strings for related ideas, produced by tagging each article in isolation. A tag used once groups nothing, and since tags entered `articles.search_vector` it now also contributes an index lexeme matching exactly one document.

So a re-tagger that just generates more tags in isolation makes things worse. **The mechanism is the vocabulary it is shown**: the tenant's established tags ranked by how many articles use them, with reuse the default and a new tag allowed only when nothing offered fits. Selection is fewest-topical-tags-first for the same reason.

## Concurrency

`Task.async_stream` with a small bound (`:knowledge_tag_backfill_concurrency`, default 4). Each article costs a provider call, so a sequential backfill over thousands of articles is thousands of serial round trips. The bound is small because the constraint is a shared provider rate limit and the AdminRepo pool, not CPU. `timeout: :infinity` on the stream with the real bound from the provider client — a stream timeout would kill the task and lose the work while the request kept running and got billed.

## Append-only, and why that is not a nicety

An existing tag is **never** removed. They carry provenance ids and the reserved `idem-` namespace a sourcer reads to know an article was already captured — dropping one causes a **re-capture**, not a cosmetic regression. A suggestion may also never mint a provenance-shaped tag, which would be a false claim about where the article came from.

## Resumable, failing safe in the right direction

`metadata.retagged_at`, **merged** into metadata rather than replacing it — a whole-map write would drop `doc_id` and the source fields, the same defect that made `lifecycle_entered_at` a column instead of a metadata key.

A provider failure deliberately does **not** stamp, so a transient outage cannot permanently and silently exclude every article it touched. Mutation-verified: stamping on error fails the test.

## Running it

Deliberately **not** on a cron — one provider call per article, so it is started on purpose and bounded per run:

    Loopctl.Workers.TagBackfillWorker.enqueue_all_tenants(limit: 200)

`backfill/2` is public and returns a summary (`candidates`, `retagged`, `tags_added`, `skipped`) so an operator sees what a run did rather than inferring it from log lines.

Split out of #701, which I had accidentally built on the same branch — that PR is the conflict judge only.

Reviewed inline (this session cannot dispatch review agents). `mix precommit` green: 7621 tests, 0 failures.
