### PR TITLE
Install from the cached package lists first, so a dark mirror cannot block a deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -785,12 +785,18 @@ jobs:
           #
           # Skip `apt-get update` when the package is already installed: the cached case is
           # the common one on a self-hosted runner, and it is the update that hangs.
+          # Try the INSTALL FIRST, from whatever package lists the runner already has.
+          # `update && install` means an unreachable mirror takes the install down with it,
+          # even when the cached lists were perfectly sufficient — observed 2026-08-18 on
+          # master, where azure.archive.ubuntu.com went dark, every `apt-get update` burned
+          # its full 180s timeout, and the deploy was blocked by a package that was one
+          # cached-list install away. Only refresh the lists when the install actually fails.
           if ! command -v pgbouncer >/dev/null; then
             for attempt in 1 2 3; do
-              timeout 180 sudo apt-get update \
-                && timeout 180 sudo apt-get install -y pgbouncer \
-                && break
-              echo "apt install attempt $attempt failed or timed out; retrying"; sleep 5
+              timeout 180 sudo apt-get install -y pgbouncer && break
+              echo "pgbouncer install attempt $attempt failed; refreshing lists"
+              timeout 180 sudo apt-get update || echo "apt-get update failed; retrying install anyway"
+              sleep 5
             done
           fi
           command -v pgbouncer >/dev/null || { echo "pgbouncer install failed after retries"; exit 1; }
@@ -1140,12 +1146,14 @@ jobs:
         # Skip entirely when jq is there (the normal case on a self-hosted runner), and bound
         # each apt call so a hang becomes a failure the retry can act on.
         run: |
+          # Install first from cached lists; refresh only if that fails. See the pgbouncer
+          # step for why `update && install` is the wrong order when a mirror goes dark.
           if ! command -v jq >/dev/null; then
             for attempt in 1 2 3; do
-              timeout 180 sudo apt-get update \
-                && timeout 180 sudo apt-get install -y jq \
-                && break
-              echo "apt install attempt $attempt failed or timed out; retrying"; sleep 5
+              timeout 180 sudo apt-get install -y jq && break
+              echo "jq install attempt $attempt failed; refreshing lists"
+              timeout 180 sudo apt-get update || echo "apt-get update failed; retrying install anyway"
+              sleep 5
             done
           fi
           command -v jq >/dev/null || { echo "jq install failed after retries"; exit 1; }
@@ -1214,12 +1222,14 @@ jobs:
         # Skip entirely when jq is there (the normal case on a self-hosted runner), and bound
         # each apt call so a hang becomes a failure the retry can act on.
         run: |
+          # Install first from cached lists; refresh only if that fails. See the pgbouncer
+          # step for why `update && install` is the wrong order when a mirror goes dark.
           if ! command -v jq >/dev/null; then
             for attempt in 1 2 3; do
-              timeout 180 sudo apt-get update \
-                && timeout 180 sudo apt-get install -y jq \
-                && break
-              echo "apt install attempt $attempt failed or timed out; retrying"; sleep 5
+              timeout 180 sudo apt-get install -y jq && break
+              echo "jq install attempt $attempt failed; refreshing lists"
+              timeout 180 sudo apt-get update || echo "apt-get update failed; retrying install anyway"
+              sleep 5
             done
           fi
           command -v jq >/dev/null || { echo "jq install failed after retries"; exit 1; }


### PR DESCRIPTION
#699 and #703 stopped apt **hanging**. This fixes what the hang was hiding: the order of the two commands.

Every one of these steps ran `apt-get update && apt-get install`, so an unreachable mirror takes the install down with it — **even when the cached package lists on the runner were perfectly sufficient**.

## It blocked production tonight

Observed on master 2026-08-18: `azure.archive.ubuntu.com` went dark, all three retries burned their full 180s update timeout, and `Pgbouncer e2e` failed on a package that was one cached-list install away. Deploy is gated on it, so **nothing merged after #695 reached production for hours** — #701, #702 and #703 all sat undeployed.

(The #699 guard did its job: it turned a 15-minute hang into a bounded 2m22s failure. It just failed at the wrong thing.)

## Fix

Try the install **first** from whatever lists the runner already has; refresh the lists only when that install actually fails — and even then, don't let a failed `update` abort the next attempt. All three steps get it (pgbouncer and both `jq` installs).

The `command -v` skip from #699/#703 stays, so on a runner that already has the binary none of this runs at all, and the trailing guard still fails the step loudly rather than proceeding without it.

Workflow YAML parse-checked. `mix precommit` green: 7638 tests, 0 failures. Reviewed inline.
