### PR TITLE
Stop the re-tagger being taught to tag format instead of subject

### DIFF
--- a/lib/loopctl/knowledge/provenance_tags.ex
+++ b/lib/loopctl/knowledge/provenance_tags.ex
@@ -51,6 +51,46 @@ defmodule Loopctl.Knowledge.ProvenanceTags do
               chapter- part-
             ) ++ [IdempotencyTag.reserved_prefix()]
 
+  # Whole tags that describe an article's FORMAT or SOURCE TYPE rather than its subject.
+  # Distinct from the prefixes above, which are opaque per-source ids: these are ordinary
+  # words that are simply not what an article is ABOUT. `KnowledgeMocWorker` has excluded
+  # them from hub topics since it was written; the re-tagger needs the same answer, because
+  # showing a model `reference, document, pdf, book, youtube` as the vocabulary to PREFER
+  # teaches it to tag format instead of subject. Measured 2026-08-18: those five were the
+  # top of the hosted corpus's most-used tags, and a verification run of the backfill added
+  # `document` and `code` to articles because of it.
+  @structural ~w(
+                hub moc reference document documents doc book books code repo repository
+                web web-article webpage url file pdf md markdown html htm xml docx txt text
+                epub csv json yaml image png jpg jpeg gif svg video audio youtube newsletter
+                manual agent session_log session-log skill ingestion review_finding
+                review-finding readme gdrive gdoc gsheet onedrive dropbox notion confluence
+                chunk page unknown untagged uncategorized misc miscellaneous general other
+                none na tbd todo
+              )
+
+  @doc """
+  Whole tags naming an article's format or source type rather than its subject.
+
+  Consumers: `KnowledgeMocWorker` (a hub called `Index: pdf` is noise) and
+  `TagBackfillWorker`'s vocabulary (a model told to prefer `pdf` will tag format).
+  """
+  @spec structural() :: [String.t()]
+  def structural, do: @structural
+
+  @doc """
+  Whether a tag names a SUBJECT — neither a provenance id nor a structural descriptor.
+
+  The single predicate both consumers should use, so a tag cannot be topical to one and not
+  the other.
+  """
+  @spec topical?(String.t()) :: boolean()
+  def topical?(tag) when is_binary(tag) do
+    tag not in @structural and not Enum.any?(@prefixes, &String.starts_with?(tag, &1))
+  end
+
+  def topical?(_tag), do: false
+
   @doc "The provenance/chunk-coordinate tag prefixes, each including its trailing hyphen."
   @spec prefixes() :: [String.t()]
   def prefixes, do: @prefixes

--- a/lib/loopctl/workers/knowledge_moc_worker.ex
+++ b/lib/loopctl/workers/knowledge_moc_worker.ex
@@ -72,14 +72,7 @@ defmodule Loopctl.Workers.KnowledgeMocWorker do
   # Exclude them, plus the per-source provenance-id tags (`yt-…`, `doc-…`, …) and
   # non-topical sentinels (`unknown`, `untagged`, `misc`, …).
   # Corpus-specific source collections are added via `:knowledge_moc_excluded_tags`.
-  @structural_tags ~w(
-    hub moc reference document documents doc book books code repo repository
-    web web-article webpage url file pdf md markdown html htm xml docx txt text
-    epub csv json yaml image png jpg jpeg gif svg video audio youtube newsletter
-    manual agent session_log session-log skill ingestion review_finding review-finding
-    readme gdrive gdoc gsheet onedrive dropbox notion confluence chunk page
-    unknown untagged uncategorized misc miscellaneous general other none na tbd todo
-  )
+  @structural_tags ProvenanceTags.structural()
 
   # Provenance-id and chunk-coordinate prefixes (`yt-<id>`, `pp-1-12` = pages 1–12,
   # `chunk-7`, …) — these identify WHERE in a source an article came from, never a topic,

--- a/lib/loopctl/workers/tag_backfill_worker.ex
+++ b/lib/loopctl/workers/tag_backfill_worker.ex
@@ -131,13 +131,24 @@ defmodule Loopctl.Workers.TagBackfillWorker do
 
   Ordered by usage on purpose. Showing a model the whole 60,141-tag vocabulary would be both
   enormous and useless — the point is to offer the tags that already GROUP things, and a tag
-  used once groups nothing. Provenance families are excluded because they name a source
-  rather than a subject and must never be suggested for an article that did not come from it.
+  used once groups nothing.
+
+  **NON-TOPICAL tags are excluded, and that exclusion is the difference between this working
+  and actively harming the corpus.** Provenance families name a source rather than a subject.
+  STRUCTURAL tags name a format: measured 2026-08-18, the hosted corpus's most-used tags
+  began `reference, document, pdf, book, youtube` — so an unfiltered vocabulary teaches the
+  model to tag FORMAT instead of SUBJECT, which is the opposite of the point. A verification
+  run against production with the unfiltered list added `document` and `code` to real
+  articles before this was caught.
   """
   @spec established_vocabulary(Ecto.UUID.t(), pos_integer()) :: [String.t()]
   def established_vocabulary(tenant_id, limit \\ 150) do
     pattern = ProvenanceTags.sql_pattern()
 
+    # Over-fetch, then filter structural tags in Elixir against the SAME predicate the MOC
+    # worker uses. Passing the ~70-item list as a SQL array would work too, but then the
+    # two consumers would agree only by coincidence — `ProvenanceTags.topical?/1` is the one
+    # definition, and it cannot drift from itself.
     """
     SELECT tag FROM (
       SELECT unnest(tags) AS tag FROM articles
@@ -148,10 +159,13 @@ defmodule Loopctl.Workers.TagBackfillWorker do
     ORDER BY count(*) DESC, tag
     LIMIT $3
     """
-    |> AdminRepo.query([Ecto.UUID.dump!(tenant_id), pattern, limit])
+    |> AdminRepo.query([Ecto.UUID.dump!(tenant_id), pattern, limit * 3])
     |> case do
-      {:ok, %{rows: rows}} -> Enum.map(rows, &hd/1)
-      {:error, _} -> []
+      {:ok, %{rows: rows}} ->
+        rows |> Enum.map(&hd/1) |> Enum.filter(&ProvenanceTags.topical?/1) |> Enum.take(limit)
+
+      {:error, _} ->
+        []
     end
   end
 

--- a/test/loopctl/workers/tag_backfill_worker_test.exs
+++ b/test/loopctl/workers/tag_backfill_worker_test.exs
@@ -138,5 +138,20 @@ defmodule Loopctl.Workers.TagBackfillWorkerTest do
       assert "rare" in vocabulary
       refute "url-42516bb95051" in vocabulary
     end
+
+    test "excludes STRUCTURAL tags, however heavily they are used" do
+      # Measured on production 2026-08-18: the corpus's most-used tags began `reference,
+      # document, pdf, book, youtube`. Offering those as the vocabulary to PREFER teaches
+      # the model to tag FORMAT instead of SUBJECT — the opposite of the point — and a
+      # verification run with them present added `document` and `code` to real articles.
+      # They must lose to a topical tag used far less.
+      tenant = fixture(:tenant)
+      for _ <- 1..8, do: published(tenant.id, ["pdf", "document", "reference"])
+      published(tenant.id, ["kalman-filters"])
+
+      vocabulary = TagBackfillWorker.established_vocabulary(tenant.id)
+
+      assert vocabulary == ["kalman-filters"]
+    end
   end
 end


### PR DESCRIPTION
Caught by **running #702 against production**, not by reading it.

## The defect

The vocabulary the tagger is *shown* is the entire mechanism. The one it was getting began:

```
reference, document, pdf, book, youtube, elixir
```

Five of the top six name a **format or source type, not a subject**. Telling a model to prefer those teaches it to tag what an article *is* rather than what it is *about* — the opposite of what the feature exists for. A five-article verification run added `document` and `code` to real articles before this was caught.

I excluded provenance *prefixes* (`url-`, `book-`, `idem-`) and missed the bare structural *words* — even though `KnowledgeMocWorker` has excluded exactly those from hub topics since it was written, for the same reason. **That is the third time in this area the answer already existed in another module.**

## Fix

The structural list moves to `Loopctl.Knowledge.ProvenanceTags` alongside the prefixes; both consumers read it; and a single `ProvenanceTags.topical?/1` is now the one definition of "names a subject" — a tag cannot be topical to the MOC worker and not to the tagger.

The vocabulary query over-fetches and filters in Elixir against that predicate rather than passing a ~70-item array into SQL, so the two consumers can't agree only by coincidence.

## Verification

Mutation-verified: dropping the filter lets a structural tag used 8 times beat a topical tag used once — which is the test.

The 25 tags the production run added were mostly good (`ai-agents`, `cost-optimization`, `postgresql`, `pattern-matching`); `document` and `code` are the two that came from the polluted vocabulary. They're additive and harmless, and I've left them rather than hand-editing production rows.

`mix precommit` green: 7639 tests, 0 failures. Reviewed inline.
