### PR TITLE
Enhanced review of tonight's retrieval work: 22 confirmed findings, 22 fixed

### DIFF
--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -44,9 +44,9 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:509-515`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:463-466`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:9571`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:9602`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
-   (`absolute_score/1`, `:9686-9689`) clears a scale-matched threshold AND beats the best retrieved
+   (`absolute_score/1`, `:9717-9722`) clears a scale-matched threshold AND beats the best retrieved
    candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:9328-9338`; the pure decision is
    `resolve_provenance/4`, `:9383-9395`) AND is authoritative (not superseded/conflicted — the caller
    passes only `list_curated_sources/2`-filtered scores). Otherwise `:retrieved`. Both branches return identical `results`/`meta`
@@ -91,7 +91,7 @@ never pass `tenant_id`/`subject_id`.
    `{drift_signal, member_id}` — a group scored under the other signal's normalized key finds
    nothing and withholds (fail-closed).
 5. **Heat must not rank on a signal heat produces** — `Knowledge.heat_index/2`
-   (`knowledge.ex:10215`; the counted set is `@heat_read_access_types`, `:10085`). The heat index is the one retrieval route that
+   (`knowledge.ex:10246`; the counted set is `@heat_read_access_types`, `:10116`). The heat index is the one retrieval route that
    takes NO query, so its misses are uncorrelated with embedding similarity — which is worth nothing
    if its ordering is something a caller or the route itself generates. It has been violated FOUR
    times, each differently — and once by a FIX for one of the others — so treat any new input to

--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -44,11 +44,11 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:509-515`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:463-466`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:9602`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:9620`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
-   (`absolute_score/1`, `:9717-9722`) clears a scale-matched threshold AND beats the best retrieved
-   candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:9328-9338`; the pure decision is
-   `resolve_provenance/4`, `:9383-9395`) AND is authoritative (not superseded/conflicted — the caller
+   (`absolute_score/1`, `:9735-9740`) clears a scale-matched threshold AND beats the best retrieved
+   candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:9786-9796`; the pure decision is
+   `resolve_provenance/4`, `:9856-9866`) AND is authoritative (not superseded/conflicted — the caller
    passes only `list_curated_sources/2`-filtered scores). Otherwise `:retrieved`. Both branches return identical `results`/`meta`
    key sets — callers branch on `meta.provenance` alone. A sparse pool must never let a near-but-wrong
    curated doc win.
@@ -91,7 +91,7 @@ never pass `tenant_id`/`subject_id`.
    `{drift_signal, member_id}` — a group scored under the other signal's normalized key finds
    nothing and withholds (fail-closed).
 5. **Heat must not rank on a signal heat produces** — `Knowledge.heat_index/2`
-   (`knowledge.ex:10246`; the counted set is `@heat_read_access_types`, `:10116`). The heat index is the one retrieval route that
+   (`knowledge.ex:10264`; the counted set is `@heat_read_access_types`, `:10134`). The heat index is the one retrieval route that
    takes NO query, so its misses are uncorrelated with embedding similarity — which is worth nothing
    if its ordering is something a caller or the route itself generates. It has been violated FOUR
    times, each differently — and once by a FIX for one of the others — so treat any new input to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,7 +179,9 @@ All notable changes to loopctl are documented here.
   from "surfaced and ignored" — close to its opposite. Unit warning: these count READS,
   while `followed_through` counts SURFACED RESULTS later opened; they are not comparable and
   neither replaces the other, so the existing series is unchanged and remains valid across
-  this migration.
+  this migration. Both open counters drop reads whose SURFACING search declared an infra
+  entrypoint (`smoke`, `skill-eval`), so they describe the same population as
+  `searched`/`searches` rather than a wider one.
 
   `searches_with_follow_through` / `searches_reformulated` / `searches_quiet` now partition
   `searches`. Treating every not-opened search as a failure is wrong — an agent answered by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,8 +154,10 @@ All notable changes to loopctl are documented here.
   `POST /api/v1/recall`, so the injected recall hook gets it too. Additive: consumers that
   ignore `snippet_source` are unaffected, but one that used the ABSENCE of `snippet` to
   detect a semantic-only hit should now read `snippet_source == "lead"`. The fill is
-  bounded to the returned page and runs on the HeavyRead pool, never AdminRepo, and sheds
-  under load — a shed backfill costs a snippet, never a result.
+  bounded to the returned page and runs on the HeavyRead pool, which sheds under load — a
+  shed backfill costs a snippet, never a result. System-scope canonicals are the one
+  exception: their NULL `tenant_id` cannot satisfy the heavy-read tenant guard, so those
+  bodies are read through AdminRepo, and only for the ids the tenant-scoped read left.
 
 - **A read now records WHICH search surfaced it**, on two new
   `article_access_events` columns (`origin_search_id`, `origin_attribution`) resolved
@@ -181,8 +183,10 @@ All notable changes to loopctl are documented here.
 
   `searches_with_follow_through` / `searches_reformulated` / `searches_quiet` now partition
   `searches`. Treating every not-opened search as a failure is wrong — an agent answered by
-  the result snippet correctly opens nothing, and that is a success. A reformulation is the
-  one unambiguous failure in that bucket, so it is split out; `quiet` is STILL a mixture of
+  the result snippet correctly opens nothing, and that is a success. A reformulation — the
+  same key issuing a LATER SEARCH CALL in the window, having opened nothing (compared on
+  search identity, so a verbatim retry counts) — is the closest thing to an unambiguous
+  failure in that bucket, so it is split out; `quiet` is STILL a mixture of
   "the snippet sufficed" and "the rows were ignored", and this release does not separate
   them.
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -948,9 +948,11 @@ config :loopctl, :knowledge_rrf_graph_max_neighbors, 20
 #
 # Deliberately NOT on a cron: it costs one provider call per article, so it is started on
 # purpose and bounded per run. Concurrency is small because the constraint is a shared
-# provider rate limit and the AdminRepo pool.
+# provider rate limit and the AdminRepo pool — and STRICTLY BELOW that pool
+# (`ADMIN_POOL_SIZE`, default 3 in config/runtime.exs), because every authenticated request
+# takes a checkout there too and a backfill that can occupy the whole pool times those out.
 config :loopctl, :knowledge_tagger, Loopctl.Knowledge.Tagger.Llm
-config :loopctl, :knowledge_tag_backfill_concurrency, 4
+config :loopctl, :knowledge_tag_backfill_concurrency, 2
 # Semantic conflict judge (Phase 6). The nightly lint flags a pair on cosine similarity and,
 # until this existed, DISMISSED it on cosine similarity too — so every one of the 23,610
 # verdicts on the hosted instance reads `redundant`, a genuine contradiction included, and
@@ -963,8 +965,11 @@ config :loopctl, :knowledge_tag_backfill_concurrency, 4
 config :loopctl, :knowledge_conflict_judge_enabled, true
 config :loopctl, :knowledge_conflict_judge, Loopctl.Knowledge.ConflictJudge.Llm
 # Concurrent judgements per nightly run. Small on purpose: the limit on the other side is a
-# shared provider rate limit and the AdminRepo pool, not CPU here.
-config :loopctl, :knowledge_conflict_judge_concurrency, 4
+# shared provider rate limit and the AdminRepo pool, not CPU here — and strictly below that
+# pool (`ADMIN_POOL_SIZE`, default 3), which every authenticated request also checks out of.
+# The provider call dominates wall time and holds no connection, so a bound of 2 costs the
+# run very little.
+config :loopctl, :knowledge_conflict_judge_concurrency, 2
 
 # Phase 4 second-stage reranking. OFF by default: it puts an outbound provider call on the
 # DEFAULT search path, and the measurements that motivated the retrieval plan eliminate

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2882,19 +2882,10 @@ defmodule Loopctl.Knowledge do
         results
 
       ids ->
-        query =
-          from(a in Article,
-            where: a.tenant_id == ^tenant_id and a.id in ^ids,
-            select: {a.id, fragment("left(?, ?)", a.body, @snippet_scan_bytes)}
-          )
+        rows = tenant_lead_rows(tenant_id, ids)
+        resolved = MapSet.new(rows, &elem(&1, 0))
 
-        # HeavyRead, NOT AdminRepo: this runs on the public search path, and AdminRepo's
-        # small pool is load-bearing for every authentication — the keyword lane already
-        # spends one connection there per search, and a second would double that for a
-        # cosmetic field. HeavyRead has its own pool and may SHED under load, which is the
-        # correct degradation here: a shed backfill costs a snippet, never a result.
-        tenant_id
-        |> HeavyRead.all(query, semantic_heavy_read_opts())
+        (rows ++ system_lead_rows(Enum.reject(ids, &MapSet.member?(resolved, &1))))
         |> apply_lead_rows(results)
     end
   rescue
@@ -2904,7 +2895,39 @@ defmodule Loopctl.Knowledge do
       results
   end
 
-  defp apply_lead_rows({:error, :heavy_read_overloaded}, results), do: results
+  # HeavyRead, NOT AdminRepo: this runs on the public search path, and AdminRepo's small
+  # pool is load-bearing for every authentication — the keyword lane already spends one
+  # connection there per search, and a second would double that for a cosmetic field.
+  # HeavyRead has its own pool and may SHED under load, which is the correct degradation
+  # here: a shed backfill costs a snippet, never a result.
+  defp tenant_lead_rows(tenant_id, ids) do
+    query =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id and a.id in ^ids,
+        select: {a.id, fragment("left(?, ?)", a.body, @snippet_scan_bytes)}
+      )
+
+    case HeavyRead.all(tenant_id, query, semantic_heavy_read_opts()) do
+      rows when is_list(rows) -> rows
+      _shed -> []
+    end
+  end
+
+  # Every search population here is the DISJUNCTIVE `tenant_id == ^t or scope == :system`, so
+  # a page can carry system canonicals — whose NULL `tenant_id` can never satisfy the
+  # heavy-read tenant guard (the same reason `hydrate_semantic_pool/6` reads them through
+  # AdminRepo). Without this they were the one class of result that still came back with a
+  # bare title. Only the ids the tenant-scoped read did not resolve are asked for, so a page
+  # with no canonical on it spends no second query.
+  defp system_lead_rows([]), do: []
+
+  defp system_lead_rows(ids) do
+    from(a in Article,
+      where: a.id in ^ids and a.scope == :system,
+      select: {a.id, fragment("left(?, ?)", a.body, @snippet_scan_bytes)}
+    )
+    |> AdminRepo.all()
+  end
 
   defp apply_lead_rows(rows, results) when is_list(rows) do
     apply_leads(results, Map.new(rows, fn {id, prefix} -> {id, lead_extract(prefix)} end))
@@ -2968,7 +2991,12 @@ defmodule Loopctl.Knowledge do
     text
     |> String.replace(~r/!\[[^\]]*\]\([^)]*\)/, "")
     |> String.replace(~r/\[([^\]]*)\]\([^)]*\)/, "\\1")
-    |> String.replace(~r/[*_`]+/, "")
+    # Emphasis markers only at token boundaries, and backticks anywhere. An unanchored
+    # `[*_`]+` ate the underscores INSIDE identifiers — `tenant_id` was rendered
+    # `tenantid` — which is most of what this corpus's prose is made of, and a snippet that
+    # shows identifiers the corpus does not contain is worse than no snippet.
+    |> String.replace(~r/`+/, "")
+    |> String.replace(~r/(?<![\p{L}\p{N}])[*_]+|[*_]+(?![\p{L}\p{N}])/u, "")
     |> String.replace(~r/\s+/, " ")
     |> String.trim()
   end
@@ -2977,8 +3005,11 @@ defmodule Loopctl.Knowledge do
     if String.length(text) <= max do
       text
     else
+      # `max - 1` so the ellipsis fits INSIDE the cap. At `max` the result was `max + 1`
+      # graphemes whenever the trailing-word trim found no whitespace to remove, and the
+      # renderer then re-truncated it and appended a SECOND ellipsis.
       text
-      |> String.slice(0, max)
+      |> String.slice(0, max - 1)
       |> String.replace(~r/\s+\S*$/, "")
       |> Kernel.<>("…")
     end

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2882,11 +2882,20 @@ defmodule Loopctl.Knowledge do
         results
 
       ids ->
-        rows = tenant_lead_rows(tenant_id, ids)
-        resolved = MapSet.new(rows, &elem(&1, 0))
+        case tenant_lead_rows(tenant_id, ids) do
+          # A SHED is not "this tenant owns none of these ids". Collapsing it to an empty
+          # list handed EVERY id on the page to `system_lead_rows/1`, so a shed spent an
+          # AdminRepo connection under exactly the load the shed exists to relieve. The
+          # degradation is: a shed backfill costs a snippet, and never a second query.
+          :shed ->
+            results
 
-        (rows ++ system_lead_rows(Enum.reject(ids, &MapSet.member?(resolved, &1))))
-        |> apply_lead_rows(results)
+          rows ->
+            resolved = MapSet.new(rows, &elem(&1, 0))
+
+            (rows ++ system_lead_rows(Enum.reject(ids, &MapSet.member?(resolved, &1))))
+            |> apply_lead_rows(results)
+        end
     end
   rescue
     # A snippet is an aid, never the answer. If the backfill fails the results still stand.
@@ -2909,16 +2918,20 @@ defmodule Loopctl.Knowledge do
 
     case HeavyRead.all(tenant_id, query, semantic_heavy_read_opts()) do
       rows when is_list(rows) -> rows
-      _shed -> []
+      _shed -> :shed
     end
   end
 
   # Every search population here is the DISJUNCTIVE `tenant_id == ^t or scope == :system`, so
   # a page can carry system canonicals — whose NULL `tenant_id` can never satisfy the
-  # heavy-read tenant guard (the same reason `hydrate_semantic_pool/6` reads them through
-  # AdminRepo). Without this they were the one class of result that still came back with a
-  # bare title. Only the ids the tenant-scoped read did not resolve are asked for, so a page
-  # with no canonical on it spends no second query.
+  # heavy-read tenant guard (`HeavyRead.guard!/2` refuses an OR-bypass, which is why
+  # `hydrate_semantic_pool/6` reads them through AdminRepo too). Without this they were the
+  # one class of result that still came back with a bare title.
+  #
+  # This is the one AdminRepo query the comment above tolerates, and it is bounded on both
+  # sides: only the ids the tenant-scoped read did not resolve are asked for, so a page with
+  # no canonical spends nothing, and a SHED never reaches here at all — `backfill_snippets/2`
+  # returns on `:shed` rather than treating the whole page as unresolved.
   defp system_lead_rows([]), do: []
 
   defp system_lead_rows(ids) do
@@ -2991,12 +3004,17 @@ defmodule Loopctl.Knowledge do
     text
     |> String.replace(~r/!\[[^\]]*\]\([^)]*\)/, "")
     |> String.replace(~r/\[([^\]]*)\]\([^)]*\)/, "\\1")
-    # Emphasis markers only at token boundaries, and backticks anywhere. An unanchored
-    # `[*_`]+` ate the underscores INSIDE identifiers — `tenant_id` was rendered
-    # `tenantid` — which is most of what this corpus's prose is made of, and a snippet that
-    # shows identifiers the corpus does not contain is worse than no snippet.
+    # Backticks anywhere; `*` at token boundaries; `_` only when it touches no word
+    # character at all. An unanchored `[*_`]+` ate the underscores INSIDE identifiers
+    # (`tenant_id` rendered `tenantid`), and the token-boundary form still ate the ones at
+    # their EDGES (`__MODULE__` rendered `MODULE`, `_unused` rendered `unused`) — which is
+    # most of what this corpus's prose is made of, and a snippet naming an identifier the
+    # corpus does not contain is worse than no snippet. An underscore emphasis marker is
+    # indistinguishable from those by shape, so it survives as a literal `_`, which is a
+    # character the corpus really does contain.
     |> String.replace(~r/`+/, "")
-    |> String.replace(~r/(?<![\p{L}\p{N}])[*_]+|[*_]+(?![\p{L}\p{N}])/u, "")
+    |> String.replace(~r/(?<![\p{L}\p{N}])\*+|\*+(?![\p{L}\p{N}])/u, "")
+    |> String.replace(~r/(?<![\p{L}\p{N}_])_+(?![\p{L}\p{N}_])/u, "")
     |> String.replace(~r/\s+/, " ")
     |> String.trim()
   end

--- a/lib/loopctl/knowledge/analytics.ex
+++ b/lib/loopctl/knowledge/analytics.ex
@@ -1135,10 +1135,16 @@ defmodule Loopctl.Knowledge.Analytics do
     {project_id, story_id} = resolve_attribution(tenant_id, api_key_id, context)
     now = DateTime.utc_now()
 
+    # ONE lookup for the whole batch, not one per item. A `context` call delivers up to a
+    # page of articles, and a point query per row multiplied this path's `AdminRepo`
+    # checkouts by the batch size — on a 3-connection BYPASSRLS pool (`ADMIN_POOL_SIZE`,
+    # config/runtime.exs) that every authenticated request's rate-limit check also needs.
+    origins =
+      resolve_origins(tenant_id, Enum.map(items, &elem(&1, 0)), api_key_id, access_type, now)
+
     rows =
       Enum.map(items, fn {article_id, meta} ->
-        {origin_search_id, origin_attribution} =
-          resolve_origin(tenant_id, article_id, api_key_id, access_type, now)
+        {origin_search_id, origin_attribution} = origin_for(origins, article_id, access_type)
 
         %{
           id: Ecto.UUID.generate(),
@@ -1192,8 +1198,8 @@ defmodule Loopctl.Knowledge.Analytics do
   # WHY A LOOKUP AND NOT A JOIN AT READ TIME. `get`/`context`/`drill` rows carry no
   # `search_id`, so there is nothing to join ON; and the correlation that would substitute
   # for it binds `api_key_id`, which makes the injected recall hook — a different key from
-  # the session that reads — structurally invisible. Resolving once at write time fixes both
-  # and costs one indexed point query per read
+  # the session that reads — structurally invisible. Resolving at write time fixes both and
+  # costs one indexed lookup per RECORDED BATCH — `resolve_origins/5`, never one per row —
   # (`article_access_events_surface_lookup_idx`), on a path that is already async and
   # already best-effort.
   #
@@ -1202,58 +1208,86 @@ defmodule Loopctl.Knowledge.Analytics do
   # more recent. Only when no same-key surfacing exists does a cross-key one apply, and it is
   # labelled `cross_key` precisely because it is circumstantial — two agents in one tenant
   # can reach the same article independently.
-  def resolve_origin(tenant_id, article_id, api_key_id, access_type, now)
-
-  def resolve_origin(_tenant_id, _article_id, _api_key_id, access_type, _now)
-      when access_type not in @attributable_access_types,
+  def resolve_origin(_tenant_id, article_id, _api_key_id, _access_type, _now)
+      when not is_binary(article_id),
       do: {nil, nil}
 
-  def resolve_origin(tenant_id, article_id, api_key_id, _access_type, now)
-      when is_binary(article_id) and is_binary(api_key_id) do
+  def resolve_origin(tenant_id, article_id, api_key_id, access_type, now) do
+    case resolve_origins(tenant_id, [article_id], api_key_id, access_type, now) do
+      origins when is_map(origins) -> origin_for(origins, article_id, access_type)
+      _unresolvable -> {nil, nil}
+    end
+  end
+
+  @doc false
+  # The batch form: `%{article_id => {origin_search_id, origin_attribution}}` for the ids a
+  # surfacing row was found for, `:unattributable` when the access type gets no attribution
+  # at all, `:unavailable` when the lookup itself failed. An id absent from a returned map
+  # was not surfaced in the window — `origin_for/3` decides what that means.
+  def resolve_origins(_tenant_id, _article_ids, _api_key_id, access_type, _now)
+      when access_type not in @attributable_access_types,
+      do: :unattributable
+
+  def resolve_origins(tenant_id, article_ids, api_key_id, _access_type, now)
+      when is_binary(api_key_id) and is_list(article_ids) do
     since = DateTime.add(now, -@origin_window_seconds, :second)
+    ids = article_ids |> Enum.filter(&is_binary/1) |> Enum.uniq()
 
     query =
       from(s in ArticleAccessEvent,
         where: s.tenant_id == ^tenant_id,
-        where: s.article_id == ^article_id,
+        where: s.article_id in ^ids,
         where: s.access_type == "search",
         where: s.accessed_at >= ^since and s.accessed_at <= ^now,
-        # Same key first (direct evidence), then most recent. `desc:` on the boolean puts
-        # true ahead of false.
+        # One winner per article: same key first (direct evidence), then most recent.
+        # `desc:` on the boolean puts true ahead of false.
+        distinct: s.article_id,
         order_by: [
+          asc: s.article_id,
           desc: fragment("? = ?", s.api_key_id, type(^api_key_id, Ecto.UUID)),
           desc: s.accessed_at
         ],
-        limit: 1,
-        select: {fragment("?->>'search_id'", s.metadata), s.api_key_id}
+        select: {s.article_id, fragment("?->>'search_id'", s.metadata), s.api_key_id}
       )
 
-    case AdminRepo.one(query) do
-      nil ->
-        {nil, "none"}
-
-      {nil, _key} ->
-        # A surfacing row from before #582 carries no search_id. The article WAS surfaced,
-        # so this is not `none` — but there is no id to point at, and inventing one would
-        # put an unattributable read in the attributed bucket.
-        {nil, nil}
-
-      {search_id, ^api_key_id} ->
-        {search_id, "same_key"}
-
-      {search_id, _other_key} ->
-        {search_id, "cross_key"}
-    end
+    query
+    |> AdminRepo.all()
+    |> Map.new(fn
+      # A surfacing row from before #582 carries no search_id. The article WAS surfaced,
+      # so this is not `none` — but there is no id to point at, and inventing one would
+      # put an unattributable read in the attributed bucket.
+      {article_id, nil, _key} -> {article_id, {nil, nil}}
+      {article_id, search_id, ^api_key_id} -> {article_id, {search_id, "same_key"}}
+      {article_id, search_id, _other_key} -> {article_id, {search_id, "cross_key"}}
+    end)
   rescue
     # Attribution is an enrichment, never a reason to lose the event. The caller's rescue in
     # `do_record_sync/5` would drop the whole row; this one degrades to an unattributed read.
     error ->
       Logger.warning("Knowledge.Analytics origin resolution failed: #{Exception.message(error)}")
 
-      {nil, nil}
+      :unavailable
   end
 
-  def resolve_origin(_tenant_id, _article_id, _api_key_id, _access_type, _now), do: {nil, nil}
+  def resolve_origins(_tenant_id, _article_ids, _api_key_id, _access_type, _now), do: :unavailable
+
+  defp origin_for(origins, article_id, access_type) when is_map(origins) do
+    case Map.fetch(origins, article_id) do
+      {:ok, resolved} -> resolved
+      :error -> unsurfaced_origin(access_type)
+    end
+  end
+
+  defp origin_for(_unresolvable, _article_id, _access_type), do: {nil, nil}
+
+  # A read with no surfacing row is `none` — the agent went straight to the article — EXCEPT
+  # for a drill. `progressive_index/3` runs its inner search with `_skip_record_access`, so
+  # the index that surfaced the stub writes no row to find, and calling the documented way of
+  # following an index a `direct_open` would populate that counter with its own opposite.
+  # Unclassified (NULL) instead: it is in neither bucket until an index surfacing is
+  # recorded.
+  defp unsurfaced_origin("drill"), do: {nil, nil}
+  defp unsurfaced_origin(_access_type), do: {nil, "none"}
 
   # ---------------------------------------------------------------------------
   # Attribution resolution

--- a/lib/loopctl/knowledge/article_access_event.ex
+++ b/lib/loopctl/knowledge/article_access_event.ex
@@ -71,7 +71,9 @@ defmodule Loopctl.Knowledge.ArticleAccessEvent do
   # recall hook's shape (it searches under one key, the session reads under another) and is
   # PLAUSIBLE, not proof: two agents in one tenant can reach the same article independently.
   # `none` is not a failure — it is the agent going straight to an article by link or cited
-  # id, which used to be indistinguishable from "surfaced and ignored".
+  # id, which used to be indistinguishable from "surfaced and ignored". It is asserted only
+  # where the absence of a surfacing row MEANS that: a `drill` nothing surfaced stays NULL,
+  # because `progressive_index/3` records no surfacing row for the index that showed the stub.
   @origin_attributions ~w(same_key cross_key none)
 
   schema "article_access_events" do

--- a/lib/loopctl/knowledge/provenance_tags.ex
+++ b/lib/loopctl/knowledge/provenance_tags.ex
@@ -91,6 +91,28 @@ defmodule Loopctl.Knowledge.ProvenanceTags do
 
   def topical?(_tag), do: false
 
+  @doc """
+  Whether a GENERATED tag may be WRITTEN at all. NOT `topical?/1` — hub eligibility drops a
+  whole prefixed class for free and admission cannot (see `Tagger.merge/2`), so a prefix
+  disqualifies only before an OPAQUE id (`url-42516bb95051`); `structural/0` is whole-word.
+  """
+  @spec admissible_suggestion?(String.t()) :: boolean()
+  def admissible_suggestion?(tag) when is_binary(tag) do
+    tag not in @structural and not String.starts_with?(tag, IdempotencyTag.reserved_prefix()) and
+      not Enum.any?(@prefixes, &opaque_id?(tag, &1))
+  end
+
+  def admissible_suggestion?(_tag), do: false
+
+  defp opaque_id?(tag, prefix) do
+    String.starts_with?(tag, prefix) and opaque_suffix?(String.replace_prefix(tag, prefix, ""))
+  end
+
+  defp opaque_suffix?(s) do
+    Regex.match?(~r/^\d+(-\d+)*$/, s) or Regex.match?(~r/^[0-9a-f]{8,}$/, s) or
+      (Regex.match?(~r/^[0-9a-z]{6,}$/, s) and Regex.match?(~r/\d/, s))
+  end
+
   @doc "The provenance/chunk-coordinate tag prefixes, each including its trailing hyphen."
   @spec prefixes() :: [String.t()]
   def prefixes, do: @prefixes

--- a/lib/loopctl/knowledge/retrieval_metrics.ex
+++ b/lib/loopctl/knowledge/retrieval_metrics.ex
@@ -218,6 +218,30 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
     )
   end
 
+  # The read-side half of the same exclusion: drop an open whose SURFACING search declared
+  # an infra entrypoint. The lookback reaches one day before the counted day because an open
+  # is attributed to a search inside the follow-through window, which can cross midnight;
+  # `search_id` is filtered non-null so the `NOT IN` can never go NULL and silently drop the
+  # whole day.
+  defp exclude_infra_origins(query, tenant_id, day_start, day_end) do
+    infra_search_ids =
+      from(s in ArticleAccessEvent,
+        where: s.tenant_id == ^tenant_id,
+        where: s.access_type == "search",
+        where: s.accessed_at >= ^DateTime.add(day_start, -1, :day),
+        where: s.accessed_at < ^day_end,
+        where: fragment("?->>'entrypoint'", s.metadata) in ^@infra_entrypoints,
+        where: not is_nil(fragment("?->>'search_id'", s.metadata)),
+        select: fragment("(?->>'search_id')::uuid", s.metadata)
+      )
+
+    where(
+      query,
+      [o],
+      is_nil(o.origin_search_id) or o.origin_search_id not in subquery(infra_search_ids)
+    )
+  end
+
   @doc """
   Compute precision for a single `day` (a `Date`) and follow-through `window_seconds`.
 
@@ -341,7 +365,16 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
       # families describe different populations — the searches an excluded entrypoint made
       # are gone from `searched`/`searches` while its reads still count here — and an
       # operator comparing them reads a gap that is bookkeeping, not behaviour.
+      #
+      # It takes TWO predicates because a READ row is not a search row. `entrypoint` is
+      # written by `search_access_meta/3` onto `access_type = "search"` rows only, so
+      # `exclude_infra_traffic/1` alone matched nothing here and the exclusion was inert.
+      # The read's own link to the infra channel is `origin_search_id` — resolved
+      # server-side at write time — so an open is dropped when the search that SURFACED it
+      # declared an infra entrypoint. `exclude_infra_traffic/1` still runs, for a read that
+      # carries its own `:access_metadata`.
       |> exclude_infra_traffic()
+      |> exclude_infra_origins(tenant_id, day_start, day_end)
       |> AdminRepo.all()
       |> Map.new()
 

--- a/lib/loopctl/knowledge/retrieval_metrics.ex
+++ b/lib/loopctl/knowledge/retrieval_metrics.ex
@@ -114,9 +114,11 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
   not comparable and neither is a refinement of the other — keep both.
 
   A read whose `origin_attribution` is NULL is in none of the three: pre-migration rows,
-  surfacing rows, and the one case `resolve_origin/5` refuses to classify (a surfacing row
-  predating #582 carries no `search_id`, so the article WAS surfaced — `none` would be false
-  — but there is no id to attribute to).
+  surfacing rows, and the two cases `resolve_origin/5` refuses to classify — a surfacing row
+  predating #582 carries no `search_id` (the article WAS surfaced, so `none` would be false,
+  but there is no id to attribute to), and a `drill` nothing surfaced (the progressive index
+  records no surfacing row, so calling the documented way of following it a direct open
+  would be its opposite).
 
   **Two windows, and they are not the same knob.** `origin_attribution` is baked in at write
   time using `Analytics.origin_window_seconds/0` and cannot be re-asked of history; the
@@ -133,9 +135,10 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
   question is answered by the snippet correctly opens nothing, and that is a success this
   metric scores as a failure."
 
-  A REFORMULATION — the same key issuing a different query inside the window, having opened
-  nothing — is the one member of that bucket that is unambiguously a failure, so it is peeled
-  out. What remains is named `quiet` and is STILL a mixture: "the snippet sufficed" and "the
+  A REFORMULATION — the same key issuing a LATER SEARCH CALL inside the window, having opened
+  nothing — is the one member of that bucket that is closest to an unambiguous failure, so it
+  is peeled out. It is compared on the search identity, not the query text, so a verbatim
+  retry of a degraded search counts here too. What remains is named `quiet` and is STILL a mixture: "the snippet sufficed" and "the
   rows were ignored" are indistinguishable here, and this instrumentation does not resolve
   them. Do not rename it to anything that asserts satisfaction, and do not compute a rate
   that treats it as either. Follow-through remains a floor, never a satisfaction rate.
@@ -321,9 +324,10 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
   #     ignored", which is close to its opposite.
   #
   # A row whose attribution is NULL is neither: pre-migration rows, surfacing rows, and the
-  # one case `resolve_origin/5` deliberately refuses to classify (a surfacing row from before
-  # #582 that carries no `search_id` — the article WAS surfaced, so calling it `none` would
-  # be false, and there is no id to attribute to).
+  # two cases `resolve_origin/5` deliberately refuses to classify — a surfacing row from
+  # before #582 that carries no `search_id` (the article WAS surfaced, so calling it `none`
+  # would be false, and there is no id to attribute to), and a `drill` with no surfacing row
+  # (the progressive index writes none, so `none` would name the index's own opposite).
   defp compute_open_attribution(tenant_id, day_start, day_end) do
     rows =
       from(o in ArticleAccessEvent,
@@ -333,6 +337,11 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
         group_by: o.origin_attribution,
         select: {o.origin_attribution, count(o.id)}
       )
+      # Same infra exclusion as every other counter on this payload. Without it the two
+      # families describe different populations — the searches an excluded entrypoint made
+      # are gone from `searched`/`searches` while its reads still count here — and an
+      # operator comparing them reads a gap that is bookkeeping, not behaviour.
+      |> exclude_infra_traffic()
       |> AdminRepo.all()
       |> Map.new()
 
@@ -363,12 +372,25 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
   #
   # The three partition `searches` exactly, so `quiet` is computed by subtraction rather than
   # by a third query whose predicate could drift out of agreement with the other two.
+  #
+  # THE EXCLUSION IS PER SEARCH CALL, NOT PER ROW, and that distinction is the whole
+  # correctness of the partition. A search writes one row per surfaced result and an agent
+  # typically opens ONE of them, so negating the row-level `follow_through_exists/1` matched
+  # the still-unopened rows of a search that WAS followed through — counting it in two
+  # buckets at once, and (because `quiet` is the remainder) silently zeroing the bucket the
+  # genuinely quiet searches belong to. So the opened SEARCH IDS are subtracted as a set.
   defp compute_dispositions(searched_q, window_seconds, call) do
+    opened_ids =
+      searched_q
+      |> qualifying_calls()
+      |> with_follow_through(window_seconds)
+      |> select([s], fragment("?->>'search_id'", s.metadata))
+
     reformulated =
       searched_q
       |> qualifying_calls()
-      |> where(^dynamic(not (^follow_through_exists(window_seconds))))
       |> where(^reformulation_exists(window_seconds))
+      |> where([s], fragment("?->>'search_id'", s.metadata) not in subquery(opened_ids))
       |> count_distinct_searches()
 
     %{
@@ -465,11 +487,11 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
     )
   end
 
-  # "The same key issued a DIFFERENT query inside the window." Different is compared on the
-  # search identity, not the query text: an agent re-running the identical query (a retry
-  # after a degraded response, say) is not reformulating, but it is also not a distinct
-  # search call in any sense this metric wants to count, and `search_id` already separates
-  # calls from rows.
+  # "The same key issued a LATER SEARCH CALL inside the window." Distinctness is compared on
+  # the search identity, never the query text — `search_id` is minted per call, so an agent
+  # re-running the IDENTICAL query (a retry after a degraded response, say) satisfies this
+  # too. The published descriptions say "a later search call" for that reason; do not
+  # restate them as "a different query" without also comparing the query text here.
   #
   # Bounded on BOTH sides by the window, and strictly after the surfacing row, so a search
   # is never called a reformulation of one that came later.
@@ -489,32 +511,6 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
               fragment(
                 "? <= ? + (? * interval \'1 second\')",
                 r.accessed_at,
-                parent_as(:s).accessed_at,
-                ^window_seconds
-              )
-        )
-      )
-    )
-  end
-
-  # The same correlated-exists `with_follow_through/2` applies, expressed as a `dynamic` so
-  # it can be NEGATED in the disposition query. Kept adjacent to that function so the two
-  # definitions are read together; a change to one that is not made to the other breaks the
-  # partition.
-  defp follow_through_exists(window_seconds) do
-    dynamic(
-      [s],
-      exists(
-        from(o in ArticleAccessEvent,
-          where:
-            o.tenant_id == parent_as(:s).tenant_id and
-              o.api_key_id == parent_as(:s).api_key_id and
-              o.article_id == parent_as(:s).article_id and
-              o.access_type in ["get", "context", "drill"] and
-              o.accessed_at > parent_as(:s).accessed_at and
-              fragment(
-                "? <= ? + (? * interval \'1 second\')",
-                o.accessed_at,
                 parent_as(:s).accessed_at,
                 ^window_seconds
               )

--- a/lib/loopctl/knowledge/tagger.ex
+++ b/lib/loopctl/knowledge/tagger.ex
@@ -101,8 +101,17 @@ defmodule Loopctl.Knowledge.Tagger do
       # A suggestion must never mint a provenance-shaped tag (those identify WHERE an
       # article came from, so a generated one would be a false claim about its source) nor a
       # STRUCTURAL one (`pdf`, `document`): filtering the vocabulary makes those unlikely,
-      # this makes them impossible. `topical?/1` is the single predicate both consumers use.
-      |> Enum.reject(&(MapSet.member?(known, &1) or not ProvenanceTags.topical?(&1)))
+      # this makes them impossible. It asks `admissible_suggestion?/1`, NOT `topical?/1`:
+      # the latter drops EVERYTHING under a provenance prefix, which is right for a hub or
+      # an index lexeme and wrong here — `web-scraping`, `file-upload`, `part-of-speech` and
+      # `doc-generation` are subjects that merely start with one, and dropping them silently
+      # re-tags an article without the tag naming what it is about, so a later tag query for
+      # that subject misses it. There the whole prefixed class costs nothing; here it costs
+      # the tag. That is the moduledoc's "split this into two lists rather than widening
+      # one", and the opaque-id test is what keeps `url-42516bb95051` out regardless.
+      |> Enum.reject(
+        &(MapSet.member?(known, &1) or not ProvenanceTags.admissible_suggestion?(&1))
+      )
       |> Enum.uniq()
       |> Enum.take(max(Article.max_tags() - length(existing), 0))
 

--- a/lib/loopctl/knowledge/tagger.ex
+++ b/lib/loopctl/knowledge/tagger.ex
@@ -47,10 +47,14 @@ defmodule Loopctl.Knowledge.Tagger do
 
   require Logger
 
-  # Mirrors `ContentIngestionWorker`'s per-tag validation. A suggestion that would be
-  # rejected by the changeset is dropped here instead, so one malformed tag cannot fail the
-  # whole article's re-tag.
-  @tag_pattern ~r/^[a-z0-9][a-z0-9._-]*$/
+  # The pattern `Loopctl.Knowledge.Article`'s changeset enforces (`~r/^[a-zA-Z0-9_-]+$/`),
+  # narrowed to the lowercase form `normalize/1` produces. A suggestion the changeset would
+  # reject is dropped HERE, so one malformed tag cannot fail the whole article's re-tag —
+  # and, more importantly, cannot be written at all: `TagBackfillWorker` persists with
+  # `update_all`, which runs no changeset, so an accepted-here tag lands unvalidated and
+  # only surfaces later as a 422 on an unrelated caller's PATCH. No `.`: the changeset
+  # rejects it, and the tagging prompt must not offer it either.
+  @tag_pattern ~r/^[a-z0-9][a-z0-9_-]*$/
   @max_tag_length 64
 
   @doc """
@@ -85,15 +89,20 @@ defmodule Loopctl.Knowledge.Tagger do
   @spec merge([String.t()], [String.t()]) :: {[String.t()], [String.t()]}
   def merge(existing, suggested) do
     existing = existing || []
-    known = MapSet.new(existing)
+    # Compared in the SAME normal form the suggestions are normalised into, or an existing
+    # `RLS` fails to match a suggested `rls` and the article ends up carrying both — two
+    # lexemes for one idea, which is the fragmentation this exists to reduce.
+    known = MapSet.new(existing, &normalize/1)
 
     added =
       suggested
       |> Enum.map(&normalize/1)
       |> Enum.filter(&valid?/1)
-      # A suggestion must never mint a provenance-shaped tag: those identify WHERE an article
-      # came from, and a generated one would be a false claim about its source.
-      |> Enum.reject(&(MapSet.member?(known, &1) or provenance?(&1)))
+      # A suggestion must never mint a provenance-shaped tag (those identify WHERE an
+      # article came from, so a generated one would be a false claim about its source) nor a
+      # STRUCTURAL one (`pdf`, `document`): filtering the vocabulary makes those unlikely,
+      # this makes them impossible. `topical?/1` is the single predicate both consumers use.
+      |> Enum.reject(&(MapSet.member?(known, &1) or not ProvenanceTags.topical?(&1)))
       |> Enum.uniq()
       |> Enum.take(max(Article.max_tags() - length(existing), 0))
 
@@ -115,7 +124,4 @@ defmodule Loopctl.Knowledge.Tagger do
 
   defp valid?(tag),
     do: tag != "" and String.length(tag) <= @max_tag_length and Regex.match?(@tag_pattern, tag)
-
-  defp provenance?(tag),
-    do: Enum.any?(ProvenanceTags.prefixes(), &String.starts_with?(tag, &1))
 end

--- a/lib/loopctl/knowledge/tagger/llm.ex
+++ b/lib/loopctl/knowledge/tagger/llm.ex
@@ -34,7 +34,8 @@ defmodule Loopctl.Knowledge.Tagger.Llm do
 
   Return between 3 and 8 tags describing what the article is ABOUT. Do not tag the format, \
   the source or the file type. Each tag must be lowercase, and may contain only letters, \
-  digits, dots, underscores and hyphens.
+  digits, underscores and hyphens — a dot is rejected by the article changeset, so a tag \
+  carrying one is dropped.
 
   Reply with a single compact JSON object with exactly one key, "tags", whose value is an \
   array of strings. Output nothing except that JSON object.\

--- a/lib/loopctl/release.ex
+++ b/lib/loopctl/release.ex
@@ -30,20 +30,17 @@ defmodule Loopctl.Release do
   """
   def migrate do
     load_app()
+    configure_migration_connections()
 
     # Run migrations from priv/repo/migrations/ using AdminRepo.
     # AdminRepo has BYPASSRLS privilege needed for RLS policy DDL.
     # We specify the path explicitly because AdminRepo defaults to
     # priv/admin_repo/migrations/ but all migrations live in priv/repo/.
     {:ok, _, _} =
-      Ecto.Migrator.with_repo(
-        Loopctl.AdminRepo,
-        fn repo ->
-          path = Ecto.Migrator.migrations_path(Loopctl.Repo)
-          Ecto.Migrator.run(repo, path, :up, all: true)
-        end,
-        migration_connection_opts()
-      )
+      Ecto.Migrator.with_repo(Loopctl.AdminRepo, fn repo ->
+        path = Ecto.Migrator.migrations_path(Loopctl.Repo)
+        Ecto.Migrator.run(repo, path, :up, all: true)
+      end)
   end
 
   @doc """
@@ -68,12 +65,36 @@ defmodule Loopctl.Release do
   is a short-lived release process whose whole job is to hold one lock for the duration, and
   it is the one caller for which the guard is wrong.
 
+  ## Why it is `after_connect` on the REPO CONFIG and not an option to the migrator
+
+  `Ecto.Migrator.with_repo/3` reads exactly TWO keys out of its `opts` — `:mode` and
+  `:pool_size` — and then starts the repo with `repo.start_link(pool_size: pool_size)`
+  (ecto_sql 3.13, `ensure_repo_started/2`). Anything else handed to it, `parameters:`
+  included, is DISCARDED without a word, so the setting has to be on the config the
+  migrator starts the repo FROM. `configure_migration_connections/0` merges it there,
+  in the eval process only, before `with_repo` runs.
+
+  A startup `parameters:` entry would be the wrong shape besides: pgbouncer rejects an
+  unknown startup parameter with `08P01` (see `config/runtime.exs`, and the same reason
+  `HeavyRead` applies its `statement_timeout` per read rather than at connect). A plain
+  `SET` on an established connection is accepted either way.
+
   Public so the setting is assertable — the behaviour it prevents needs a migration slower
   than the server timeout to reproduce, which no test suite should manufacture.
   """
   @spec migration_connection_opts() :: keyword()
   def migration_connection_opts,
-    do: [parameters: [idle_in_transaction_session_timeout: "0"]]
+    do: [
+      after_connect: {Postgrex, :query!, ["SET idle_in_transaction_session_timeout = 0", []]}
+    ]
+
+  # Merges `migration_connection_opts/0` into AdminRepo's application config so the repo the
+  # migrator starts inherits it. Scoped to this OS process: the release `eval` node exits
+  # when the command returns, and serving nodes never run this.
+  defp configure_migration_connections do
+    config = Application.get_env(@app, AdminRepo, [])
+    Application.put_env(@app, AdminRepo, Keyword.merge(config, migration_connection_opts()))
+  end
 
   @doc """
   Rolls back the last migration using AdminRepo.
@@ -81,15 +102,13 @@ defmodule Loopctl.Release do
   def rollback(version) do
     load_app()
 
+    configure_migration_connections()
+
     {:ok, _, _} =
-      Ecto.Migrator.with_repo(
-        Loopctl.AdminRepo,
-        fn repo ->
-          path = Ecto.Migrator.migrations_path(Loopctl.Repo)
-          Ecto.Migrator.run(repo, path, :down, to: version)
-        end,
-        migration_connection_opts()
-      )
+      Ecto.Migrator.with_repo(Loopctl.AdminRepo, fn repo ->
+        path = Ecto.Migrator.migrations_path(Loopctl.Repo)
+        Ecto.Migrator.run(repo, path, :down, to: version)
+      end)
   end
 
   @doc """

--- a/lib/loopctl/release.ex
+++ b/lib/loopctl/release.ex
@@ -77,7 +77,18 @@ defmodule Loopctl.Release do
   A startup `parameters:` entry would be the wrong shape besides: pgbouncer rejects an
   unknown startup parameter with `08P01` (see `config/runtime.exs`, and the same reason
   `HeavyRead` applies its `statement_timeout` per read rather than at connect). A plain
-  `SET` on an established connection is accepted either way.
+  `SET` on an established connection is accepted by pgbouncer in any pool mode.
+
+  ## What this depends on, and what to reach for if it fails again
+
+  Accepted is not the same as PERSISTENT. This is a SESSION-level `SET`, so it holds for the
+  migrator's advisory-lock transaction under **session** pooling — which is what Fly MPG
+  documents as its default (`docs/runbooks/knowledge-scale.md`, "VERIFY the live pgbouncer
+  config"). Under **transaction** pooling a session `SET` lands on whichever server backend
+  served that one implicit transaction, and the lock transaction may open on another. If a
+  release ever dies with `FATAL 25P03` again, read `pool_mode` from the pgbouncer admin
+  console FIRST: the lever for a GUC that must survive a checkout there is a role-scoped
+  `ALTER ROLE`, exactly as the runbook prescribes for `hnsw.ef_search`, not a bigger `SET`.
 
   Public so the setting is assertable — the behaviour it prevents needs a migration slower
   than the server timeout to reproduce, which no test suite should manufacture.
@@ -88,12 +99,20 @@ defmodule Loopctl.Release do
       after_connect: {Postgrex, :query!, ["SET idle_in_transaction_session_timeout = 0", []]}
     ]
 
+  @doc false
+  # The config the migrator's repo is started FROM: AdminRepo's own config plus
+  # `migration_connection_opts/0`. Split out of the writer below so a test can assert the
+  # MERGE — where the setting actually has to land — without mutating application env.
+  @spec migration_repo_config(keyword()) :: keyword()
+  def migration_repo_config(config),
+    do: Keyword.merge(config, migration_connection_opts())
+
   # Merges `migration_connection_opts/0` into AdminRepo's application config so the repo the
   # migrator starts inherits it. Scoped to this OS process: the release `eval` node exits
   # when the command returns, and serving nodes never run this.
   defp configure_migration_connections do
     config = Application.get_env(@app, AdminRepo, [])
-    Application.put_env(@app, AdminRepo, Keyword.merge(config, migration_connection_opts()))
+    Application.put_env(@app, AdminRepo, migration_repo_config(config))
   end
 
   @doc """

--- a/lib/loopctl/workers/draft_duplicate_sweep_worker.ex
+++ b/lib/loopctl/workers/draft_duplicate_sweep_worker.ex
@@ -72,6 +72,10 @@ defmodule Loopctl.Workers.DraftDuplicateSweepWorker do
   entire reason consolidation chose `unpublish`. Consolidation owns its own output; this
   worker drains what the CAPTURE path holds.
 
+  The exemption is read out of the `audit_log`, which is retention-bounded, so the sweep
+  is bounded to match: a draft last touched before `:audit_retention_days` ago is skipped
+  outright rather than judged on evidence that may already have been dropped.
+
   ## Scope discipline
 
   * Only drafts that HAVE an embedding are considered. An unembedded draft is not
@@ -193,13 +197,25 @@ defmodule Loopctl.Workers.DraftDuplicateSweepWorker do
       where: a.tenant_id == ^tenant_id,
       where: a.status == :draft,
       where: e.dim == ^dimension and e.live_denorm == true,
+      # FAIL CLOSED past the audit horizon. The consolidation exemption below is evidence
+      # the RETENTION SWEEP deletes: `audit_log` is range-partitioned on `inserted_at` and
+      # `AuditPartitionWorker` DROPs partitions older than `:audit_retention_days`, while
+      # this worker runs weekly forever and the drafts it protects live forever. Without
+      # this bound, every consolidation retraction became archivable ~90 days after it
+      # happened — the whole aged cohort at once, silently, through the one-way door the
+      # moduledoc says must stay shut. A draft the audit_log can no longer speak for is
+      # left alone; nothing is lost but a late sweep of stale drafts.
+      where: a.updated_at >= ^audit_evidence_horizon(),
       # Spare consolidation's retractions — the exclusion is applied HERE rather than
       # before the archive so the sweep does not even spend an ANN read on a draft it
       # must not touch. There is no marker on the article itself; the audit_log is the
-      # only record that consolidation was the actor.
+      # only record that consolidation was the actor. `tenant_id` is constrained so the
+      # correlated NOT EXISTS can use `audit_log_tenant_entity_idx`, whose leading column
+      # it is — without it every candidate scanned every retained partition.
       where:
         not exists(
           from(al in "audit_log",
+            where: al.tenant_id == parent_as(:draft).tenant_id,
             where: al.entity_id == parent_as(:draft).id,
             where: al.entity_type == "article",
             where: al.action == "article.unpublished",
@@ -212,6 +228,14 @@ defmodule Loopctl.Workers.DraftDuplicateSweepWorker do
       select: %{id: a.id, title: a.title, embedding: e.embedding}
     )
     |> AdminRepo.all()
+  end
+
+  # The oldest point the `audit_log` is still guaranteed to speak for — the same retention
+  # `Loopctl.Workers.AuditPartitionWorker` enforces, read from the same config key so the two
+  # cannot drift.
+  defp audit_evidence_horizon do
+    days = Application.get_env(:loopctl, :audit_retention_days, 90)
+    DateTime.add(DateTime.utc_now(), -days * 86_400, :second)
   end
 
   defp unembedded_count(tenant_id, dimension) do

--- a/lib/loopctl/workers/draft_duplicate_sweep_worker.ex
+++ b/lib/loopctl/workers/draft_duplicate_sweep_worker.ex
@@ -197,15 +197,28 @@ defmodule Loopctl.Workers.DraftDuplicateSweepWorker do
       where: a.tenant_id == ^tenant_id,
       where: a.status == :draft,
       where: e.dim == ^dimension and e.live_denorm == true,
-      # FAIL CLOSED past the audit horizon. The consolidation exemption below is evidence
-      # the RETENTION SWEEP deletes: `audit_log` is range-partitioned on `inserted_at` and
-      # `AuditPartitionWorker` DROPs partitions older than `:audit_retention_days`, while
-      # this worker runs weekly forever and the drafts it protects live forever. Without
-      # this bound, every consolidation retraction became archivable ~90 days after it
-      # happened — the whole aged cohort at once, silently, through the one-way door the
-      # moduledoc says must stay shut. A draft the audit_log can no longer speak for is
-      # left alone; nothing is lost but a late sweep of stale drafts.
-      where: a.updated_at >= ^audit_evidence_horizon(),
+      # FAIL CLOSED past the audit horizon, measured on the draft's CREATION. The
+      # consolidation exemption below is evidence the RETENTION SWEEP deletes: `audit_log`
+      # is range-partitioned on `inserted_at` and `AuditPartitionWorker` DROPs partitions
+      # older than `:audit_retention_days`, while this worker runs weekly forever and the
+      # drafts it protects live forever. Without a bound, every consolidation retraction
+      # became archivable ~90 days after it happened — the whole aged cohort at once,
+      # silently, through the one-way door the moduledoc says must stay shut.
+      #
+      # `inserted_at` and NOT `updated_at`: creation is the only clock that cannot move
+      # after the retraction it is standing in for. A retraction always happens AFTER the
+      # draft exists, so a draft created inside the window still has its audit row. Bounding
+      # on the last WRITE instead re-armed the archive for exactly the draft this protects —
+      # one `knowledge_update` on a long-retracted draft bumped `updated_at` to now while its
+      # `article.unpublished` partition was already dropped, and the correlated NOT EXISTS
+      # then found nothing to spare it with.
+      #
+      # The cost is that a draft older than the retention window is never a candidate again.
+      # That is acceptable only because the worker runs WEEKLY on a queue the capture path
+      # fills continuously, so a duplicate gets ~13 runs inside the window; a durable
+      # retraction marker on the article row (a non-cast column, the way
+      # `stories.lifecycle_entered_at` is) is what would let this bound go entirely.
+      where: a.inserted_at >= ^audit_evidence_horizon(),
       # Spare consolidation's retractions — the exclusion is applied HERE rather than
       # before the archive so the sweep does not even spend an ANN read on a draft it
       # must not touch. There is no marker on the article itself; the audit_log is the

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -442,7 +442,9 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     # into ~450 round trips end to end and a full 2000-pair catch-up run into something that
     # cannot finish inside a nightly window at all. `async_stream` gives bounded concurrency
     # with backpressure; the bound is small because it is a shared provider rate limit and a
-    # shared DB pool on the other side, not because the work is expensive here.
+    # shared DB pool on the other side, not because the work is expensive here — and it is
+    # kept BELOW `ADMIN_POOL_SIZE` (default 3) so a nightly run can never hold every
+    # AdminRepo connection that authentication also needs.
     #
     # `timeout: :infinity` on the stream with the per-task bound coming from the provider
     # client's own timeout — a stream timeout would kill the task and lose the verdict while
@@ -462,7 +464,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   end
 
   defp judge_concurrency,
-    do: Application.get_env(:loopctl, :knowledge_conflict_judge_concurrency, 4)
+    do: Application.get_env(:loopctl, :knowledge_conflict_judge_concurrency, 2)
 
   # Correlated on the enclosing `as: :link`, TRUE when a `conflict_resolutions` row already
   # exists for the pair in EITHER direction. Mirrors `Knowledge.conflict_unresolved_subquery/0`

--- a/lib/loopctl/workers/tag_backfill_worker.ex
+++ b/lib/loopctl/workers/tag_backfill_worker.ex
@@ -264,6 +264,8 @@ defmodule Loopctl.Workers.TagBackfillWorker do
   defp maybe_bump(query, true, now), do: update(query, set: [updated_at: ^now])
   defp maybe_bump(query, _false, _now), do: query
 
+  # Below `ADMIN_POOL_SIZE` (default 3): each task writes through AdminRepo, whose pool
+  # every authenticated request also checks out of.
   defp concurrency,
-    do: Application.get_env(:loopctl, :knowledge_tag_backfill_concurrency, 4)
+    do: Application.get_env(:loopctl, :knowledge_tag_backfill_concurrency, 2)
 end

--- a/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
@@ -355,7 +355,9 @@ defmodule LoopctlWeb.KnowledgeAnalyticsController do
         "`direct_opens` is the agent going straight to an article by link or cited id — " <>
         "previously indistinguishable from 'surfaced and ignored', close to its " <>
         "opposite. A read with no attribution is in none of the three (pre-migration " <>
-        "rows, and a surfacing row predating #582 that carries no search identity).\n\n" <>
+        "rows, a surfacing row predating #582 that carries no search identity, and a " <>
+        "`drill` with no surfacing row — the progressive index records none, so calling " <>
+        "it a direct open would be false).\n\n" <>
         "TWO WINDOWS, NOT ONE KNOB — attribution is baked in at WRITE time and cannot be " <>
         "re-asked of history; the correlated metrics take `window_seconds` at QUERY time. " <>
         "They share a default, so a divergence after passing a different `window_seconds` " <>
@@ -364,8 +366,9 @@ defmodule LoopctlWeb.KnowledgeAnalyticsController do
         "`searches_reformulated` and `searches_quiet` PARTITION `searches`. Treating " <>
         "every not-opened search as a failure is wrong: an agent whose question is " <>
         "answered by the result snippet correctly opens nothing, and that is a success. " <>
-        "A REFORMULATION (same key, different query, inside the window, having opened " <>
-        "nothing) is the one unambiguous failure in that bucket, so it is reported " <>
+        "A REFORMULATION (same key, a LATER SEARCH CALL inside the window, having opened " <>
+        "nothing — compared on search identity, so a verbatim retry counts) is the " <>
+        "closest thing to an unambiguous failure in that bucket, so it is reported " <>
         "separately. What remains is `quiet` and is STILL a mixture of 'the snippet " <>
         "sufficed' and 'the rows were ignored' — this surface does NOT separate them. " <>
         "Do not read `quiet` as either; follow-through is a floor, never a satisfaction " <>

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -6508,8 +6508,9 @@ const TOOLS = [
       "Disposition (unit: SEARCH CALLS): searches_with_follow_through, " +
       "searches_reformulated and searches_quiet PARTITION searches. Treating every " +
       "not-opened search as a failure is wrong — an agent answered by the result snippet " +
-      "correctly opens nothing, and that is a success. A reformulation (same key, different " +
-      "query, in-window, nothing opened) is the one unambiguous failure, so it is split out; " +
+      "correctly opens nothing, and that is a success. A reformulation (same key, a LATER " +
+      "SEARCH CALL in-window, nothing opened — compared on search identity, so a verbatim " +
+      "retry counts) is the closest thing to an unambiguous failure, so it is split out; " +
       "what remains is `quiet` and is STILL a mixture of 'snippet sufficed' and 'rows " +
       "ignored'. This surface does not separate them — do not read quiet as either.",
     inputSchema: {

--- a/test/loopctl/knowledge/infra_traffic_excluded_test.exs
+++ b/test/loopctl/knowledge/infra_traffic_excluded_test.exs
@@ -15,6 +15,7 @@ defmodule Loopctl.Knowledge.InfraTrafficExcludedTest do
   setup :verify_on_exit!
 
   alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.Analytics
   alias Loopctl.Knowledge.ArticleAccessEvent
   alias Loopctl.Knowledge.RetrievalMetrics
 
@@ -109,18 +110,36 @@ defmodule Loopctl.Knowledge.InfraTrafficExcludedTest do
     # `direct_opens` are built straight off `article_access_events`, so without the same
     # exclusion an infra channel's reads counted while its searches did not, and an operator
     # comparing them read a gap that is bookkeeping rather than behaviour.
-    AdminRepo.insert!(%ArticleAccessEvent{
-      tenant_id: ctx.tenant.id,
-      article_id: ctx.article.id,
-      api_key_id: ctx.api_key.id,
-      access_type: "get",
-      origin_attribution: "none",
-      metadata: %{"entrypoint" => "smoke"},
-      accessed_at: DateTime.utc_now()
-    })
+    #
+    # The row is built the way PRODUCTION builds it, not by hand: `entrypoint` is written by
+    # `search_access_meta/3` onto SEARCH rows only, so a `get` carrying that key is a shape
+    # nothing can write, and a test asserting on it passes while the metric is unchanged.
+    # A read's link to the channel is `origin_search_id`, resolved server-side at write time.
+    search_id = Ecto.UUID.generate()
+    surfaced(ctx, %{"entrypoint" => "smoke", "search_id" => search_id})
+
+    Analytics.do_record_sync([{ctx.article.id, %{}}], ctx.tenant.id, ctx.api_key.id, "get")
+
+    assert [%{origin_search_id: ^search_id, origin_attribution: "same_key"}] =
+             AdminRepo.all(
+               from(e in ArticleAccessEvent,
+                 where: e.tenant_id == ^ctx.tenant.id and e.access_type == "get"
+               )
+             )
 
     assert %{direct_opens: 0, attributed_opens: 0} =
              RetrievalMetrics.compute(ctx.tenant.id, ctx.day)
+  end
+
+  test "an ordinary channel's OPEN still counts", ctx do
+    # The other half of the exclusion: a predicate that dropped every open would pass the
+    # test above and report zero reads forever.
+    search_id = Ecto.UUID.generate()
+    surfaced(ctx, %{"entrypoint" => "cli", "search_id" => search_id})
+
+    Analytics.do_record_sync([{ctx.article.id, %{}}], ctx.tenant.id, ctx.api_key.id, "get")
+
+    assert %{attributed_opens: 1} = RetrievalMetrics.compute(ctx.tenant.id, ctx.day)
   end
 
   test "smoke rows do not dilute a real search's precision", ctx do

--- a/test/loopctl/knowledge/infra_traffic_excluded_test.exs
+++ b/test/loopctl/knowledge/infra_traffic_excluded_test.exs
@@ -104,6 +104,25 @@ defmodule Loopctl.Knowledge.InfraTrafficExcludedTest do
     assert %{searched: 1} = RetrievalMetrics.compute(ctx.tenant.id, ctx.day)
   end
 
+  test "an excluded entrypoint's OPEN is out of the attribution counters too", ctx do
+    # The two families on this payload must describe ONE population. `attributed_opens` /
+    # `direct_opens` are built straight off `article_access_events`, so without the same
+    # exclusion an infra channel's reads counted while its searches did not, and an operator
+    # comparing them read a gap that is bookkeeping rather than behaviour.
+    AdminRepo.insert!(%ArticleAccessEvent{
+      tenant_id: ctx.tenant.id,
+      article_id: ctx.article.id,
+      api_key_id: ctx.api_key.id,
+      access_type: "get",
+      origin_attribution: "none",
+      metadata: %{"entrypoint" => "smoke"},
+      accessed_at: DateTime.utc_now()
+    })
+
+    assert %{direct_opens: 0, attributed_opens: 0} =
+             RetrievalMetrics.compute(ctx.tenant.id, ctx.day)
+  end
+
   test "smoke rows do not dilute a real search's precision", ctx do
     # The exact shape of the defect: one agent search, many smoke searches, none of which
     # can ever be opened. Undeleted, precision here would be 1/6; the agent row is the only

--- a/test/loopctl/knowledge/origin_attribution_test.exs
+++ b/test/loopctl/knowledge/origin_attribution_test.exs
@@ -153,6 +153,47 @@ defmodule Loopctl.Knowledge.OriginAttributionTest do
       assert row.origin_attribution == "none"
     end
 
+    test "a DRILL nothing surfaced is UNCLASSIFIED, never a direct open" do
+      # `progressive_index/3` runs its inner search with `_skip_record_access`, so the index
+      # that surfaced the stub writes no row to attribute to. Calling the DOCUMENTED way of
+      # following an index a `direct_open` — "the agent went straight to an article by link
+      # or cited id" — would populate that counter with its own opposite.
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+      key = key_for(tenant.id)
+
+      assert {nil, nil} =
+               Analytics.resolve_origin(tenant.id, article.id, key, "drill", DateTime.utc_now())
+    end
+
+    test "a batch resolves every item's origin in ONE lookup" do
+      # `do_record_sync/5` used to issue a point query PER ROW on the 3-connection AdminRepo
+      # pool that every authenticated request also checks out of. The batch form must return
+      # the same verdicts it did per row.
+      tenant = fixture(:tenant)
+      surfaced_article = fixture(:article, %{tenant_id: tenant.id})
+      unsurfaced = fixture(:article, %{tenant_id: tenant.id})
+      key = key_for(tenant.id)
+      search_id = Ecto.UUID.generate()
+
+      surfacing_row(tenant.id, surfaced_article.id, key, search_id)
+
+      origins =
+        Analytics.resolve_origins(
+          tenant.id,
+          [surfaced_article.id, unsurfaced.id],
+          key,
+          "get",
+          DateTime.utc_now()
+        )
+
+      assert origins[surfaced_article.id] == {search_id, "same_key"}
+      refute Map.has_key?(origins, unsurfaced.id)
+
+      assert {nil, "none"} =
+               Analytics.resolve_origin(tenant.id, unsurfaced.id, key, "get", DateTime.utc_now())
+    end
+
     test "surfacing rows themselves are never attributed" do
       tenant = fixture(:tenant)
       article = fixture(:article, %{tenant_id: tenant.id})
@@ -354,6 +395,57 @@ defmodule Loopctl.Knowledge.OriginAttributionTest do
 
       assert m.searches_reformulated == 0,
              "opened outranks reformulated; the buckets are disjoint"
+    end
+
+    test "a MULTI-RESULT search that was opened is not also a reformulation" do
+      # The shape the single-result tests could not see, and the one production has: a
+      # search surfaces several results and the agent opens ONE. The remaining rows are
+      # unopened, so a ROW-level `not follow_through_exists` matched them and counted the
+      # search in `reformulated` as well as `with_follow_through` — while `quiet`, derived
+      # by subtraction and clamped at 0, silently swallowed the double count and lost the
+      # genuinely quiet search.
+      tenant = fixture(:tenant)
+      opened = fixture(:article, %{tenant_id: tenant.id})
+      ignored = fixture(:article, %{tenant_id: tenant.id})
+      quiet_hit = fixture(:article, %{tenant_id: tenant.id})
+      key = key_for(tenant.id)
+      day = Date.utc_today()
+      base = DateTime.new!(day, ~T[12:00:00.000000], "Etc/UTC")
+
+      # S1 surfaces two results; only one is opened.
+      s1 = Ecto.UUID.generate()
+      search_call(tenant.id, opened.id, key, s1, base)
+      search_call(tenant.id, ignored.id, key, s1, base)
+
+      fixture(:article_access_event, %{
+        tenant_id: tenant.id,
+        article_id: opened.id,
+        api_key_id: key,
+        access_type: "get",
+        accessed_at: DateTime.add(base, 300, :second)
+      })
+
+      # S2, later and in-window, opens nothing — this is the quiet one.
+      search_call(
+        tenant.id,
+        quiet_hit.id,
+        key,
+        Ecto.UUID.generate(),
+        DateTime.add(base, 600, :second)
+      )
+
+      m = RetrievalMetrics.compute(tenant.id, day)
+
+      assert m.searches == 2
+      assert m.searches_with_follow_through == 1
+
+      assert m.searches_reformulated == 0,
+             "S1 was opened; its unopened ROWS must not make the CALL a reformulation"
+
+      assert m.searches_quiet == 1, "S2 is the quiet search and must not be clamped away"
+
+      assert m.searches ==
+               m.searches_with_follow_through + m.searches_reformulated + m.searches_quiet
     end
 
     test "a lone search with no read and no follow-up query is quiet, not reformulated" do

--- a/test/loopctl/knowledge/snippet_backfill_test.exs
+++ b/test/loopctl/knowledge/snippet_backfill_test.exs
@@ -163,8 +163,8 @@ defmodule Loopctl.Knowledge.SnippetBackfillTest do
       tenant = fixture(:tenant)
 
       body =
-        "Every context function takes tenant_id first, and `__MODULE__` wraps it in " <>
-          "*emphasis* that must go."
+        "Every context function takes tenant_id first, and `__MODULE__` with an _unused " <>
+          "arg wraps it in *emphasis* that must go."
 
       article = published(tenant.id, "Identifiers #{System.unique_integer([:positive])}", body)
 
@@ -174,6 +174,12 @@ defmodule Loopctl.Knowledge.SnippetBackfillTest do
       hit = Enum.find(results, &(&1.id == article.id))
 
       assert hit.snippet =~ "tenant_id"
+      # The EDGES too: a token-boundary rule protects only underscores flanked by
+      # alphanumerics on both sides, so `__MODULE__` came back as `MODULE` and `_unused` as
+      # `unused` — identifiers the corpus does not contain, which is the same defect one
+      # character over.
+      assert hit.snippet =~ "__MODULE__"
+      assert hit.snippet =~ "_unused"
       refute hit.snippet =~ "`"
       refute hit.snippet =~ "*emphasis*"
       assert hit.snippet =~ "emphasis"

--- a/test/loopctl/knowledge/snippet_backfill_test.exs
+++ b/test/loopctl/knowledge/snippet_backfill_test.exs
@@ -12,8 +12,10 @@ defmodule Loopctl.Knowledge.SnippetBackfillTest do
 
   setup :verify_on_exit!
 
+  alias Loopctl.AdminRepo
   alias Loopctl.Embeddings
   alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
 
   # The test-mode embedding mock returns a per-tenant CONSTANT vector, so the semantic lane
   # cannot discriminate on its own. Seed a known vector explicitly and query with it — the
@@ -36,7 +38,7 @@ defmodule Loopctl.Knowledge.SnippetBackfillTest do
     article =
       article
       |> Ecto.Changeset.change(%{status: :published})
-      |> Loopctl.AdminRepo.update!()
+      |> AdminRepo.update!()
 
     {:ok, _} = Embeddings.upsert_article_embedding(tenant_id, article, query_vector())
     article
@@ -134,8 +136,9 @@ defmodule Loopctl.Knowledge.SnippetBackfillTest do
       refute hit.snippet =~ "https://example.com"
       assert hit.snippet =~ "link", "link TEXT is kept; only the url is dropped"
 
-      assert String.length(hit.snippet) <= Knowledge.max_snippet_length() + 1,
-             "the +1 is the ellipsis"
+      assert String.length(hit.snippet) <= Knowledge.max_snippet_length(),
+             "the ellipsis fits INSIDE the cap — at cap+1 the renderer re-truncates and " <>
+               "appends a second one"
 
       # The real check: the final token must be a WHOLE word of the source, not a fragment
       # of one. (An earlier version of this test asserted a regex that matched every
@@ -151,6 +154,29 @@ defmodule Loopctl.Knowledge.SnippetBackfillTest do
 
       assert String.match?(body, ~r/(^|\s)#{Regex.escape(last_token)}(\s|$)/),
              "snippet ended on #{inspect(last_token)}, which is not a whole word of the body"
+    end
+
+    test "an identifier's underscores and backticks survive the markup strip" do
+      # An unanchored `[*_`]+` ate the underscores INSIDE identifiers, so `tenant_id` was
+      # shown as `tenantid` — a snippet naming things the corpus does not contain is worse
+      # than no snippet, and the reranker judges relevance on the same text.
+      tenant = fixture(:tenant)
+
+      body =
+        "Every context function takes tenant_id first, and `__MODULE__` wraps it in " <>
+          "*emphasis* that must go."
+
+      article = published(tenant.id, "Identifiers #{System.unique_integer([:positive])}", body)
+
+      {:ok, %{results: results}} =
+        Knowledge.search_semantic(tenant.id, query_vector(), limit: 20)
+
+      hit = Enum.find(results, &(&1.id == article.id))
+
+      assert hit.snippet =~ "tenant_id"
+      refute hit.snippet =~ "`"
+      refute hit.snippet =~ "*emphasis*"
+      assert hit.snippet =~ "emphasis"
     end
   end
 
@@ -188,6 +214,44 @@ defmodule Loopctl.Knowledge.SnippetBackfillTest do
 
       assert hit.snippet_source == "lead"
       assert hit.snippet =~ "Quiescent apparatus"
+    end
+
+    test "a system-scope canonical gets a lead too, not a bare title" do
+      # Every search population here is the DISJUNCTIVE `tenant_id == ^t or scope ==
+      # :system`, so a page can carry system canonicals — whose NULL `tenant_id` cannot
+      # satisfy the heavy-read tenant guard. Filling only the tenant-scoped rows left the
+      # shared canon as exactly the bare-title case this feature exists to remove, and made
+      # one page inconsistent with itself.
+      tenant = fixture(:tenant)
+      stub(Loopctl.MockEmbeddingReadPath, :side_table_reads_enabled?, fn -> true end)
+
+      canonical =
+        %Article{tenant_id: nil, scope: :system}
+        |> Article.create_changeset(%{
+          title: "Shared canonical #{System.unique_integer([:positive])}",
+          body: "Chain of custody separates the implementer from the verifier.",
+          category: :reference,
+          status: :published,
+          scope: :system
+        })
+        |> AdminRepo.insert!()
+
+      {:ok, _} =
+        Embeddings.materialize_system_article_embedding(
+          tenant.id,
+          canonical,
+          query_vector(),
+          "sys",
+          1536
+        )
+
+      {:ok, %{results: results}} =
+        Knowledge.search_semantic(tenant.id, query_vector(), limit: 20)
+
+      hit = Enum.find(results, &(&1.id == canonical.id))
+      assert hit, "the canonical must be retrievable for this assertion to mean anything"
+      assert hit.snippet_source == "lead"
+      assert hit.snippet =~ "Chain of custody"
     end
 
     test "another tenant's body is never used to fill a snippet" do

--- a/test/loopctl/knowledge/tagger_test.exs
+++ b/test/loopctl/knowledge/tagger_test.exs
@@ -76,6 +76,40 @@ defmodule Loopctl.Knowledge.TaggerTest do
     test "nil existing tags are treated as empty" do
       assert {["chunking"], ["chunking"]} = Tagger.merge(nil, ["chunking"])
     end
+
+    test "a tag the Article changeset would reject is never accepted here" do
+      # `TagBackfillWorker` writes with `update_all`, which runs NO changeset — so a tag
+      # accepted here lands in the row unvalidated and surfaces later as a 422 on an
+      # unrelated caller's PATCH, for a tag that caller never supplied. Dots are the case
+      # that shipped: the tagging prompt offered them and `Article`'s pattern rejects them.
+      {tags, added} = Tagger.merge([], ["phoenix.liveview", "ecto.multi", "rls"])
+
+      assert added == ["rls"]
+
+      changeset =
+        Article.update_changeset(
+          %Article{tenant_id: Ecto.UUID.generate(), title: "t", body: "b", category: :pattern},
+          %{tags: tags}
+        )
+
+      assert changeset.valid?, "every merged tag must pass the schema that will store it"
+    end
+
+    test "a STRUCTURAL tag is refused even when the model proposes it unprompted" do
+      # Filtering the vocabulary makes `pdf`/`document` unlikely; this makes them impossible.
+      # They name an article's FORMAT, and since tags entered `search_vector` they cost
+      # precision on the ordinary English queries "document" and "pdf".
+      {_tags, added} = Tagger.merge([], ["document", "pdf", "postgres"])
+
+      assert added == ["postgres"]
+    end
+
+    test "an existing UPPERCASE tag is not duplicated by its lowercase suggestion" do
+      # `Article`'s pattern permits uppercase, so such rows exist. Comparing raw existing
+      # tags against normalised suggestions let `RLS` and `rls` both persist — two lexemes
+      # for one idea, which is the fragmentation this feature exists to reduce.
+      assert {["RLS"], []} = Tagger.merge(["RLS"], ["rls"])
+    end
   end
 
   describe "retag/4" do
@@ -110,6 +144,11 @@ defmodule Loopctl.Knowledge.TaggerTest do
     test "the system prompt makes reuse the default rather than a suggestion" do
       assert Llm.system_prompt() =~ "Prefer the vocabulary"
       assert Llm.system_prompt() =~ "Propose a NEW tag only when"
+    end
+
+    test "the prompt does not offer a character the article changeset rejects" do
+      refute Llm.system_prompt() =~ "dots",
+             "telling the model dots are allowed produced tags `Article` rejects"
     end
 
     test "parse_tags/1 accepts a list and rejects everything else" do

--- a/test/loopctl/knowledge/tagger_test.exs
+++ b/test/loopctl/knowledge/tagger_test.exs
@@ -104,6 +104,24 @@ defmodule Loopctl.Knowledge.TaggerTest do
       assert added == ["postgres"]
     end
 
+    test "a SUBJECT that merely starts with a provenance prefix is kept" do
+      # The prefix list drops `url-42516bb95051` because it is an opaque id, and asking it
+      # "may this be a tag" instead of "is this a hub" also dropped `web-scraping`,
+      # `file-upload`, `part-of-speech` and `doc-generation` — the tags naming what the
+      # article is ABOUT. A later tag query for the subject then misses the article.
+      {_tags, added} =
+        Tagger.merge([], [
+          "web-scraping",
+          "file-upload",
+          "part-of-speech",
+          "doc-generation",
+          "url-42516bb95051",
+          "pp-1-12"
+        ])
+
+      assert added == ["web-scraping", "file-upload", "part-of-speech", "doc-generation"]
+    end
+
     test "an existing UPPERCASE tag is not duplicated by its lowercase suggestion" do
       # `Article`'s pattern permits uppercase, so such rows exist. Comparing raw existing
       # tags against normalised suggestions let `RLS` and `rls` both persist — two lexemes

--- a/test/loopctl/release_test.exs
+++ b/test/loopctl/release_test.exs
@@ -33,20 +33,25 @@ defmodule Loopctl.ReleaseTest do
   end
 
   describe "migration_connection_opts/0" do
-    test "sets a Postgres runtime parameter the server actually honours" do
-      assert [parameters: [idle_in_transaction_session_timeout: "0"]] =
+    test "is an after_connect SET, not an option Ecto.Migrator would discard" do
+      # `Ecto.Migrator.with_repo/3` reads only `:mode` and `:pool_size` out of its opts and
+      # starts the repo with `repo.start_link(pool_size: pool_size)`, so a `parameters:`
+      # keyword handed to it never reaches Postgrex. The setting therefore lives on the repo
+      # CONFIG the migrator starts from, applied as a plain `SET` once the connection is up
+      # (which is also what pgbouncer accepts — it refuses unknown STARTUP parameters with
+      # 08P01).
+      assert [after_connect: {Postgrex, :query!, [sql, []]}] =
                Release.migration_connection_opts()
+
+      assert sql =~ ~r/^SET idle_in_transaction_session_timeout = 0$/
     end
 
-    test "the parameter name and shape reach the server (not just the keyword list)" do
-      # The failure this guards is a WRONG OPTION rather than a wrong value: a misspelled
-      # parameter, or `parameters:` nested at the wrong level, is silently ignored by
-      # Postgrex and the migrator keeps dying on long migrations exactly as before. So the
-      # assertion is end-to-end against a real connection.
-      #
-      # A PROBE value is used rather than the shipped "0" because the server's own default
-      # differs by environment — 0 on a developer box, 60000ms on the hosted instance — so
-      # asserting "0" would pass vacuously wherever the default is already 0.
+    test "the statement it carries actually clears the timeout on a real connection" do
+      # End-to-end against the server, and NOT vacuous: the session is first set to a
+      # non-zero probe, so a statement the server ignored (or a misspelled GUC, which
+      # `SET` would reject outright) leaves 12345ms behind and fails the assertion. The
+      # probe is needed because the server default differs by environment — 0 on a
+      # developer box, 60000ms on the hosted instance.
       config = Application.get_env(:loopctl, Loopctl.AdminRepo)
 
       conn_opts = [
@@ -55,7 +60,6 @@ defmodule Loopctl.ReleaseTest do
         username: config[:username],
         password: config[:password],
         database: config[:database],
-        parameters: [idle_in_transaction_session_timeout: "12345"],
         queue_target: 2_000,
         queue_interval: 5_000,
         connect_timeout: 10_000,
@@ -75,11 +79,17 @@ defmodule Loopctl.ReleaseTest do
       # `start_link` LINKS the connection to this test process, so it is torn down when the
       # test ends — no `on_exit` teardown, and no leaked connection making the next run's
       # exhaustion slightly likelier.
-      assert %{rows: [["12345ms"]]} = show_timeout_with_retry(conn_opts, 5)
+      assert %{rows: [["0"]]} = show_timeout_with_retry(conn_opts, 5)
     end
 
     defp show_timeout_with_retry(conn_opts, attempts_left) do
       {:ok, conn} = Postgrex.start_link(conn_opts)
+      Postgrex.query!(conn, "SET idle_in_transaction_session_timeout = 12345", [])
+
+      {Postgrex, :query!, [sql, params]} =
+        Keyword.fetch!(Release.migration_connection_opts(), :after_connect)
+
+      Postgrex.query!(conn, sql, params)
       Postgrex.query!(conn, "SHOW idle_in_transaction_session_timeout", [], timeout: 10_000)
     rescue
       error in [DBConnection.ConnectionError, Postgrex.Error] ->
@@ -91,17 +101,19 @@ defmodule Loopctl.ReleaseTest do
         end
     end
 
-    test "both migrate/0 and rollback/1 pass it, so a long DOWN cannot fail the same way" do
+    test "both migrate/0 and rollback/1 apply it, so a long DOWN cannot fail the same way" do
       source = File.read!("lib/loopctl/release.ex")
 
       # `Ecto.Migrator` holds its advisory lock idle-in-transaction for the whole run in
       # either direction. Migration 20260817212906's UP took 59.8s against a 60000ms
       # timeout and killed the release command 0.2s from the finish; its DOWN rebuilds the
       # same generated column and would do exactly the same thing.
+      # Two CALL sites (the definition is arity-0 and written without parens), so the split
+      # has three parts.
       assert source
-             |> String.split("migration_connection_opts()")
-             |> length() >= 4,
-             "migrate/0 and rollback/1 must both pass migration_connection_opts/0"
+             |> String.split("configure_migration_connections()")
+             |> length() >= 3,
+             "migrate/0 and rollback/1 must both call configure_migration_connections/0"
     end
   end
 

--- a/test/loopctl/release_test.exs
+++ b/test/loopctl/release_test.exs
@@ -46,12 +46,28 @@ defmodule Loopctl.ReleaseTest do
       assert sql =~ ~r/^SET idle_in_transaction_session_timeout = 0$/
     end
 
-    test "the statement it carries actually clears the timeout on a real connection" do
-      # End-to-end against the server, and NOT vacuous: the session is first set to a
-      # non-zero probe, so a statement the server ignored (or a misspelled GUC, which
-      # `SET` would reject outright) leaves 12345ms behind and fails the assertion. The
-      # probe is needed because the server default differs by environment — 0 on a
-      # developer box, 60000ms on the hosted instance.
+    test "the merge puts it where the migrator reads the repo config from" do
+      # The delivery, which asserting on `migration_connection_opts/0` alone cannot see:
+      # `Ecto.Migrator.with_repo/3` starts the repo from its APPLICATION CONFIG, so the
+      # option has to survive the merge onto AdminRepo's own config — and must not drop the
+      # keys (url, pool_size) without which the migrator cannot connect at all.
+      merged = Release.migration_repo_config(url: "postgres://example", pool_size: 2)
+
+      assert merged[:url] == "postgres://example"
+      assert merged[:pool_size] == 2
+      assert merged[:after_connect] == Release.migration_connection_opts()[:after_connect]
+    end
+
+    test "the option it carries actually clears the timeout on a real connection" do
+      # End-to-end against the server, THROUGH the delivery mechanism: the opts are handed
+      # to the connection as `after_connect` (what a repo started from this config does)
+      # rather than run by hand, so a shape Postgrex would not honour fails here.
+      #
+      # Non-vacuity is bought by the second connection: it runs the same mechanism with a
+      # non-zero probe, so `after_connect` being ignored entirely would show the server
+      # default (0 on a developer box, 60000ms on the hosted instance) instead of 12345 and
+      # fail. Without it, an ignored `after_connect` on a box whose default is already 0
+      # would read as a pass.
       config = Application.get_env(:loopctl, Loopctl.AdminRepo)
 
       conn_opts = [
@@ -79,17 +95,19 @@ defmodule Loopctl.ReleaseTest do
       # `start_link` LINKS the connection to this test process, so it is torn down when the
       # test ends — no `on_exit` teardown, and no leaked connection making the next run's
       # exhaustion slightly likelier.
-      assert %{rows: [["0"]]} = show_timeout_with_retry(conn_opts, 5)
+      after_connect = Keyword.fetch!(Release.migration_repo_config(conn_opts), :after_connect)
+
+      assert %{rows: [["0"]]} =
+               show_timeout_with_retry(Keyword.put(conn_opts, :after_connect, after_connect), 5)
+
+      probe = {Postgrex, :query!, ["SET idle_in_transaction_session_timeout = 12345", []]}
+
+      assert %{rows: [["12345ms"]]} =
+               show_timeout_with_retry(Keyword.put(conn_opts, :after_connect, probe), 5)
     end
 
     defp show_timeout_with_retry(conn_opts, attempts_left) do
       {:ok, conn} = Postgrex.start_link(conn_opts)
-      Postgrex.query!(conn, "SET idle_in_transaction_session_timeout = 12345", [])
-
-      {Postgrex, :query!, [sql, params]} =
-        Keyword.fetch!(Release.migration_connection_opts(), :after_connect)
-
-      Postgrex.query!(conn, sql, params)
       Postgrex.query!(conn, "SHOW idle_in_transaction_session_timeout", [], timeout: 10_000)
     rescue
       error in [DBConnection.ConnectionError, Postgrex.Error] ->

--- a/test/loopctl/workers/draft_duplicate_sweep_worker_test.exs
+++ b/test/loopctl/workers/draft_duplicate_sweep_worker_test.exs
@@ -183,6 +183,31 @@ defmodule Loopctl.Workers.DraftDuplicateSweepWorkerTest do
                "it into a terminal one a week later"
     end
 
+    test "a draft older than the audit retention window is left alone" do
+      # The exemption above is read out of `audit_log`, which `AuditPartitionWorker` DROPs
+      # partition-by-partition past `:audit_retention_days` — while this worker runs weekly
+      # forever and the drafts it protects live forever. Judging an aged draft on evidence
+      # that may already be gone archived the whole aged cohort of consolidation retractions
+      # at once, through a door with no way back. Past the horizon the sweep fails CLOSED.
+      tenant = fixture(:tenant)
+      vector = unit_vector(0)
+      days = Application.get_env(:loopctl, :audit_retention_days, 90)
+      long_ago = DateTime.add(DateTime.utc_now(), -(days + 7) * 86_400, :second)
+
+      _published = tenant.id |> article(:published) |> then(&embed(tenant.id, &1, vector))
+      draft = tenant.id |> article(:draft) |> then(&embed(tenant.id, &1, vector))
+
+      AdminRepo.update_all(
+        from(a in Article, where: a.id == ^draft.id),
+        set: [updated_at: long_ago]
+      )
+
+      assert :ok = perform_job(DraftDuplicateSweepWorker, %{"tenant_id" => tenant.id})
+
+      assert status_of(draft.id) == :draft,
+             "past the audit horizon the exemption cannot be proved, so nothing is archived"
+    end
+
     test "still archives an identical draft that consolidation did NOT retract" do
       tenant = fixture(:tenant)
       vector = unit_vector(0)

--- a/test/loopctl/workers/draft_duplicate_sweep_worker_test.exs
+++ b/test/loopctl/workers/draft_duplicate_sweep_worker_test.exs
@@ -67,6 +67,15 @@ defmodule Loopctl.Workers.DraftDuplicateSweepWorkerTest do
     AdminRepo.one(from(a in Article, where: a.id == ^id, select: a.status))
   end
 
+  defp long_ago do
+    days = Application.get_env(:loopctl, :audit_retention_days, 90)
+    DateTime.add(DateTime.utc_now(), -(days + 7) * 86_400, :second)
+  end
+
+  defp age(id, sets) do
+    AdminRepo.update_all(from(a in Article, where: a.id == ^id), set: sets)
+  end
+
   describe "retiring published duplicates" do
     test "archives a draft whose nearest published neighbour clears the threshold" do
       tenant = fixture(:tenant)
@@ -183,7 +192,7 @@ defmodule Loopctl.Workers.DraftDuplicateSweepWorkerTest do
                "it into a terminal one a week later"
     end
 
-    test "a draft older than the audit retention window is left alone" do
+    test "a draft created before the audit retention window is left alone" do
       # The exemption above is read out of `audit_log`, which `AuditPartitionWorker` DROPs
       # partition-by-partition past `:audit_retention_days` — while this worker runs weekly
       # forever and the drafts it protects live forever. Judging an aged draft on evidence
@@ -191,21 +200,36 @@ defmodule Loopctl.Workers.DraftDuplicateSweepWorkerTest do
       # at once, through a door with no way back. Past the horizon the sweep fails CLOSED.
       tenant = fixture(:tenant)
       vector = unit_vector(0)
-      days = Application.get_env(:loopctl, :audit_retention_days, 90)
-      long_ago = DateTime.add(DateTime.utc_now(), -(days + 7) * 86_400, :second)
 
       _published = tenant.id |> article(:published) |> then(&embed(tenant.id, &1, vector))
       draft = tenant.id |> article(:draft) |> then(&embed(tenant.id, &1, vector))
 
-      AdminRepo.update_all(
-        from(a in Article, where: a.id == ^draft.id),
-        set: [updated_at: long_ago]
-      )
+      age(draft.id, inserted_at: long_ago(), updated_at: long_ago())
 
       assert :ok = perform_job(DraftDuplicateSweepWorker, %{"tenant_id" => tenant.id})
 
       assert status_of(draft.id) == :draft,
              "past the audit horizon the exemption cannot be proved, so nothing is archived"
+    end
+
+    test "an EDIT does not re-arm the archive for a draft whose evidence has aged out" do
+      # `updated_at` was the wrong clock: it advances on every ordinary write, so one
+      # `knowledge_update` on a draft consolidation retracted months ago put it back in the
+      # candidate set with its `article.unpublished` partition already dropped — the sweep
+      # then found no evidence to spare it with and archived it terminally. Creation is the
+      # clock that cannot move after the retraction it stands in for.
+      tenant = fixture(:tenant)
+      vector = unit_vector(0)
+
+      _published = tenant.id |> article(:published) |> then(&embed(tenant.id, &1, vector))
+      draft = tenant.id |> article(:draft) |> then(&embed(tenant.id, &1, vector))
+
+      age(draft.id, inserted_at: long_ago(), updated_at: DateTime.utc_now())
+
+      assert :ok = perform_job(DraftDuplicateSweepWorker, %{"tenant_id" => tenant.id})
+
+      assert status_of(draft.id) == :draft,
+             "a recent edit must not re-open the one-way door on evidence that is gone"
     end
 
     test "still archives an identical draft that consolidation did NOT retract" do


### PR DESCRIPTION
Enhanced review (`wf_f120bd29-b25`) over the 24 commits merged tonight — base `7aa28cdf`, 67 files, +8196/-283. **None of those commits had a review gate run on them**, which is why this ran.

| | round 1 | round 2 | total |
|---|---:|---:|---:|
| raw findings | 19 | 10 | 29 |
| confirmed | 13 | 9 | **22** |
| fixed | 15 | 7 | **22** |
| adjudicated false (quoted disproof) | 0 | 0 | 0 |
| invalid deferrals | — | — | **0** |

`publish.inSync: true` — both fix commits are ancestors of the origin head.

## The finding that justifies the whole run

**My migration-timeout fix in #697 was inert.** `Ecto.Migrator.with_repo/3` reads only `:mode` and `:pool_size` and discards `:parameters`, so the setting never reached Postgrex and a long migration would still die with `FATAL 25P03`. It now goes on AdminRepo's config as an `after_connect SET`.

Worse, **my test was vacuous in exactly the way I spent the night catching elsewhere**: it opened its *own* Postgrex connection with the parameter, which proves Postgrex accepts it — not that `with_repo` passes it through. The test now asserts the GUC reads 0 through the real path.

## Other confirmed defects in code I shipped tonight

- **Tagger accepted tags the `Article` changeset rejects** (dots). `TagBackfillWorker` persists via `update_all`, so they'd bypass validation and surface later as a 422 on an unrelated caller's PATCH.
- **Tagger's dedupe was case-sensitive** — an existing `RLS` admitted a duplicate `rls`.
- **Structural tags were only prefix-filtered**, not refused via `topical?/1`.
- **Dispositions negated a row-level predicate under `COUNT(DISTINCT search_id)`**, breaking the documented three-way partition.
- **`compute_open_attribution/3` skipped `exclude_infra_traffic/1`** — and the round-1 fix for that was itself inert, because only SEARCH rows carry `metadata->>'entrypoint'`; round 2 added `exclude_infra_origins/4` joined on `origin_search_id`.
- **`resolve_origin/5` was an N+1** on the 3-connection AdminRepo pool; now one `DISTINCT ON` per batch.
- **Judge and backfill concurrency 4 → 2**, strictly below `ADMIN_POOL_SIZE` (default 3). My 4 exceeded the pool.
- **`strip_light_markup/1` ate word-internal `_`** — `tenant_id` rendered as `tenantid`.
- **Snippet truncation could exceed the documented 300-char cap** once the ellipsis was added.
- **Round 1 broke the `:heavy_read_overloaded` short-circuit**, so a shed escalated the whole page onto AdminRepo; round 2 caught and fixed it.
- **Draft-duplicate sweep relied on evidence past the 90-day audit retention** — now fails closed past `audit_evidence_horizon()`.

## Out of scope for this branch — being fixed on a follow-up, not filed

1. The tag pattern now exists in a third hand-synced copy; `Article.tag_pattern/0` + `max_tag_length/0` should own it.
2. A durable consolidation marker needs a migration + `consolidation.ex`, both outside this branch's write scope.

Neither is a separate epic or a business decision, so both are rule-0 "fix it". I'm doing them on a follow-up branch without another review run (chain bound).

`mix precommit` green on both fix commits.
