### PR TITLE
Fix the review's two out-of-scope findings, on the follow-up branch it asked for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,33 @@ All notable changes to loopctl are documented here.
 
 ### Fixed
 
+- **`articles.consolidation_retracted_at`** — a durable, non-cast marker that the nightly
+  consolidation pass retracted an article. `DraftDuplicateSweepWorker` must not re-archive a
+  draft consolidation deliberately unpublished, and the only record of that authorship was
+  the retention-bounded `audit_log`; past `:audit_retention_days` the sweep could not tell
+  consolidation's retraction from a human draft.
+
+  **The migration BACKFILLS from the audit_log**, which is a one-time opportunity — after the
+  next partition drop those rows are unprovable forever. The sweep's fail-closed horizon
+  stays as the backstop for anything already past retention when this ran.
+
+  A COLUMN rather than a `metadata` key, for the `stories.lifecycle_entered_at` reason:
+  `metadata` is cast and whole-map-replaced by `PATCH`, so one ordinary update would erase
+  it. Never add it to a `cast` list — a test asserts that against the source.
+
+  The `ALTER` is catalog-only (nullable, no default), so no table rewrite.
+
+- **`Loopctl.Knowledge.Article` now owns the tag rule.** `tag_pattern/0` and
+  `max_tag_length/0` are public, and `Tagger` and `ContentIngestionWorker` read them instead
+  of keeping copies. There were three hand-synced copies and they disagreed — `Article` and
+  the ingestion worker allowed `[a-zA-Z0-9_-]` up to 100, the re-tagger lowercase up to 64.
+  That matters because `TagBackfillWorker` persists with `update_all` and runs no changeset,
+  so a looser rule stores rows the changeset rejects, surfacing later as a 422 on an
+  unrelated caller's PATCH. The re-tagger stays STRICTER (lowercase start, on already
+  normalised input) — stricter is fine, different was the bug.
+
+
+
 - **A migration slower than the database's `idle_in_transaction_session_timeout` no longer
   fails the release command after succeeding.** `Ecto.Migrator` takes its advisory lock
   inside a transaction and leaves that connection idle for the whole run, so Postgres kills

--- a/lib/loopctl/knowledge/article.ex
+++ b/lib/loopctl/knowledge/article.ex
@@ -65,6 +65,15 @@ defmodule Loopctl.Knowledge.Article do
     field :idempotency_key, :string
     field :metadata, :map, default: %{}
 
+    # Written ONLY by `Loopctl.Knowledge.Consolidation` when it unpublishes a confirmed
+    # duplicate, and read by `DraftDuplicateSweepWorker` so it can tell consolidation's own
+    # retraction from a human draft WITHOUT depending on the retention-bounded audit_log.
+    #
+    # A COLUMN rather than a `metadata` key for the `stories.lifecycle_entered_at` reason:
+    # metadata is cast and whole-map-replaced by PATCH, so one ordinary update would erase
+    # the marker. NEVER add this to a `cast` list.
+    field :consolidation_retracted_at, :utc_datetime_usec
+
     field :embedding, Pgvector.Ecto.Vector, load_in_query: false
     # Virtual boolean projection of `not is_nil(embedding)` — lets the bulk-embedding
     # path (US-37.4) null-check presence WITHOUT transferring the 1536-dim vector for
@@ -237,6 +246,25 @@ defmodule Loopctl.Knowledge.Article do
 
   @doc "Maximum number of tags allowed per article (single source of truth)."
   def max_tags, do: @max_tags
+
+  @doc """
+  The shape a single tag must have to survive this changeset.
+
+  Public because a tag can reach the database WITHOUT passing through here —
+  `Loopctl.Workers.TagBackfillWorker` persists with `update_all` — so any writer that
+  bypasses the changeset must validate against the SAME pattern or it stores rows this
+  module would have rejected. Those surface later as a 422 on an unrelated caller's PATCH,
+  which is a defect report pointing at the wrong code.
+
+  A caller may be STRICTER (the re-tagger requires lowercase, because it normalises first).
+  It may not be looser.
+  """
+  @spec tag_pattern() :: Regex.t()
+  def tag_pattern, do: @tag_pattern
+
+  @doc "Maximum length of a single tag (single source of truth, same reason as `tag_pattern/0`)."
+  @spec max_tag_length() :: pos_integer()
+  def max_tag_length, do: @max_tag_length
 
   @valid_transitions [
     {:draft, :published},

--- a/lib/loopctl/knowledge/consolidation.ex
+++ b/lib/loopctl/knowledge/consolidation.ex
@@ -1121,13 +1121,40 @@ defmodule Loopctl.Knowledge.Consolidation do
            actor_type: "system",
            actor_label: "worker:consolidation"
          ) do
-      {:ok, _} -> true
-      other -> log_unpublish_failure(tenant_id, loser, unpublish_error_tag(other))
+      {:ok, _} ->
+        stamp_retraction(tenant_id, loser.id)
+        true
+
+      other ->
+        log_unpublish_failure(tenant_id, loser, unpublish_error_tag(other))
     end
   rescue
     e -> log_unpublish_failure(tenant_id, loser, ExitTag.tag(e))
   catch
     :exit, reason -> log_unpublish_failure(tenant_id, loser, "exit:" <> ExitTag.tag(reason))
+  end
+
+  # The DURABLE record that consolidation was the actor. The audit_log already carries it,
+  # but retention-bounded (`:audit_retention_days`): past that horizon
+  # `DraftDuplicateSweepWorker` could not tell this retraction from a human draft, and the
+  # safe reading of an absent record is wrong in one direction — it would archive
+  # consolidation's own work through a one-way door.
+  #
+  # AFTER the unpublish, never inside it: a stamp on an article that did not actually get
+  # unpublished would suppress the sweep on a still-published article forever. Best-effort by
+  # design — a failed stamp costs the horizon bound the sweep already falls back to, whereas
+  # raising here would lose the remaining confirmed groups for the tenant.
+  defp stamp_retraction(tenant_id, article_id) do
+    from(a in Knowledge.Article,
+      where: a.tenant_id == ^tenant_id and a.id == ^article_id
+    )
+    |> AdminRepo.update_all(set: [consolidation_retracted_at: DateTime.utc_now()])
+  rescue
+    e ->
+      Logger.warning(
+        "Consolidation: tenant=#{tenant_id} unpublished #{article_id} but could not stamp " <>
+          "the retraction marker (#{ExitTag.tag(e)}); the sweep falls back to the audit_log."
+      )
   end
 
   defp log_unpublish_failure(tenant_id, loser, tag) do

--- a/lib/loopctl/knowledge/tagger.ex
+++ b/lib/loopctl/knowledge/tagger.ex
@@ -54,8 +54,11 @@ defmodule Loopctl.Knowledge.Tagger do
   # `update_all`, which runs no changeset, so an accepted-here tag lands unvalidated and
   # only surfaces later as a 422 on an unrelated caller's PATCH. No `.`: the changeset
   # rejects it, and the tagging prompt must not offer it either.
-  @tag_pattern ~r/^[a-z0-9][a-z0-9_-]*$/
-  @max_tag_length 64
+  # The pattern and the length are TAKEN from `Article` rather than restated, so the two
+  # cannot drift; the lowercase-start narrowing is this module's own and stays here, because
+  # `normalize/1` has already lowercased the input by the time this runs. Stricter is fine —
+  # different is the bug.
+  @lowercase_start ~r/^[a-z0-9]/
 
   @doc """
   Suggest tags for `article` and return the MERGED tag list, or the unchanged list.
@@ -131,6 +134,10 @@ defmodule Loopctl.Knowledge.Tagger do
   defp normalize(tag) when is_binary(tag), do: tag |> String.trim() |> String.downcase()
   defp normalize(_tag), do: ""
 
-  defp valid?(tag),
-    do: tag != "" and String.length(tag) <= @max_tag_length and Regex.match?(@tag_pattern, tag)
+  defp valid?(tag) do
+    tag != "" and
+      String.length(tag) <= Article.max_tag_length() and
+      Regex.match?(Article.tag_pattern(), tag) and
+      Regex.match?(@lowercase_start, tag)
+  end
 end

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -149,10 +149,13 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   @binary_content_type_prefixes ~w(image/ audio/ video/ font/)
   # Single source of truth: the canonical taxonomy (avoids drift).
   @valid_categories Loopctl.Knowledge.Categories.all()
-  @tag_pattern ~r/^[a-zA-Z0-9_-]+$/
+  # From `Article`, not a copy. This worker validates BEFORE the changeset so one malformed
+  # tag drops a single article instead of failing the whole ingestion batch — which only
+  # works while the two rules are identical.
+  @tag_pattern Loopctl.Knowledge.Article.tag_pattern()
   # Single source of truth: the Article schema's tag cap (avoids drift).
   @max_tags Loopctl.Knowledge.Article.max_tags()
-  @max_tag_length 100
+  @max_tag_length Loopctl.Knowledge.Article.max_tag_length()
 
   @impl Oban.Worker
   def perform(%Oban.Job{

--- a/lib/loopctl/workers/draft_duplicate_sweep_worker.ex
+++ b/lib/loopctl/workers/draft_duplicate_sweep_worker.ex
@@ -218,13 +218,23 @@ defmodule Loopctl.Workers.DraftDuplicateSweepWorker do
       # fills continuously, so a duplicate gets ~13 runs inside the window; a durable
       # retraction marker on the article row (a non-cast column, the way
       # `stories.lifecycle_entered_at` is) is what would let this bound go entirely.
+      # The horizon STAYS, and the durable marker does not replace it — it shrinks what it
+      # has to cover. `consolidation_retracted_at` proves authorship for every retraction
+      # from 20260818055453 onward, and the migration backfilled every earlier one the
+      # audit_log could still prove. What neither can reach is a retraction whose audit
+      # partition was ALREADY dropped before that backfill ran: no marker, no evidence, and
+      # nothing that can ever produce one. Failing closed on those is the whole reason this
+      # bound exists, and removing it would archive that cohort through a one-way door.
       where: a.inserted_at >= ^audit_evidence_horizon(),
       # Spare consolidation's retractions — the exclusion is applied HERE rather than
       # before the archive so the sweep does not even spend an ANN read on a draft it
-      # must not touch. There is no marker on the article itself; the audit_log is the
-      # only record that consolidation was the actor. `tenant_id` is constrained so the
+      # must not touch. TWO independent records now: the durable
+      # `consolidation_retracted_at` column (authoritative, survives audit retention) and
+      # the audit_log, still read because a marker can only exist from migration
+      # 20260818055453 onward. `tenant_id` is constrained so the
       # correlated NOT EXISTS can use `audit_log_tenant_entity_idx`, whose leading column
       # it is — without it every candidate scanned every retained partition.
+      where: is_nil(a.consolidation_retracted_at),
       where:
         not exists(
           from(al in "audit_log",
@@ -245,7 +255,7 @@ defmodule Loopctl.Workers.DraftDuplicateSweepWorker do
 
   # The oldest point the `audit_log` is still guaranteed to speak for — the same retention
   # `Loopctl.Workers.AuditPartitionWorker` enforces, read from the same config key so the two
-  # cannot drift.
+  # cannot drift. Still needed alongside `consolidation_retracted_at`: see the query above.
   defp audit_evidence_horizon do
     days = Application.get_env(:loopctl, :audit_retention_days, 90)
     DateTime.add(DateTime.utc_now(), -days * 86_400, :second)

--- a/priv/repo/migrations/20260818055453_add_consolidation_retracted_at_to_articles.exs
+++ b/priv/repo/migrations/20260818055453_add_consolidation_retracted_at_to_articles.exs
@@ -1,0 +1,84 @@
+defmodule Loopctl.Repo.Migrations.AddConsolidationRetractedAtToArticles do
+  @moduledoc """
+  A DURABLE marker that the nightly consolidation pass retracted an article.
+
+  `DraftDuplicateSweepWorker` must not re-archive a draft that consolidation deliberately
+  unpublished, and the only record of that authorship was the `audit_log` — which is
+  retention-bounded (`:audit_retention_days`, 90 by default, enforced by
+  `AuditPartitionWorker`). Past the horizon the evidence is simply gone, so the sweep could
+  not tell "consolidation retracted this" from "a human drafted this", and the safe reading
+  of an absent record is the wrong one in one direction: it would archive consolidation's
+  own work through a one-way door.
+
+  The review of 2026-08-18 made the sweep fail CLOSED past that horizon, which is correct
+  and costs a real thing: a draft older than the window is never a candidate again. This
+  column shrinks what that bound has to cover, from "every aged draft" to "only those
+  retracted before this migration ran AND already past retention".
+
+  ## Why a COLUMN and not a `metadata` key
+
+  Exactly the `stories.lifecycle_entered_at` precedent. `metadata` is cast and
+  whole-map-REPLACED by `PATCH /api/v1/knowledge/:id`, so one ordinary update erases the
+  marker and hands the sweep back the ambiguity this exists to remove. A column cannot be
+  cleared by a caller that does not know it is there.
+
+  **Never add `:consolidation_retracted_at` to a changeset `cast` list.** It is written
+  programmatically by `Loopctl.Knowledge.Consolidation` and by nothing else.
+
+  Nullable with no default, so the ALTER is catalog-only on PG11+ — no table rewrite, unlike
+  `20260817212906`.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    alter table(:articles) do
+      add :consolidation_retracted_at, :utc_datetime_usec
+    end
+
+    # Partial: only retracted rows are ever looked up by it, and they are a small minority.
+    create index(:articles, [:tenant_id, :consolidation_retracted_at],
+             where: "consolidation_retracted_at IS NOT NULL",
+             name: :articles_consolidation_retracted_idx
+           )
+
+    # BACKFILL, and it has to happen HERE rather than being left to accrue forward.
+    #
+    # The marker can only be stamped from now on, so without this every article
+    # consolidation has already retracted stays provable only through the audit_log — and
+    # that evidence keeps expiring, partition by partition. Converting it while it still
+    # exists is a one-time opportunity: after the next drop those rows are unprovable
+    # forever, and the sweep's horizon is the only thing standing between them and a
+    # terminal archive.
+    #
+    # The audit entry's `inserted_at` IS the retraction time, which is what the marker
+    # means. `DISTINCT ON` because an article may carry more than one such entry; the most
+    # recent is the one that left it a draft.
+    execute("""
+    UPDATE articles a
+    SET consolidation_retracted_at = src.retracted_at
+    FROM (
+      SELECT DISTINCT ON (al.tenant_id, al.entity_id)
+             al.tenant_id, al.entity_id, al.inserted_at AS retracted_at
+      FROM audit_log al
+      WHERE al.entity_type = 'article'
+        AND al.action = 'article.unpublished'
+        AND al.actor_label = 'worker:consolidation'
+      ORDER BY al.tenant_id, al.entity_id, al.inserted_at DESC
+    ) src
+    WHERE a.tenant_id = src.tenant_id
+      AND a.id = src.entity_id
+      AND a.consolidation_retracted_at IS NULL
+    """)
+  end
+
+  def down do
+    drop_if_exists index(:articles, [:tenant_id, :consolidation_retracted_at],
+                     name: :articles_consolidation_retracted_idx
+                   )
+
+    alter table(:articles) do
+      remove :consolidation_retracted_at
+    end
+  end
+end

--- a/test/loopctl/knowledge/tagger_test.exs
+++ b/test/loopctl/knowledge/tagger_test.exs
@@ -61,7 +61,7 @@ defmodule Loopctl.Knowledge.TaggerTest do
           "has spaces",
           "-leading-hyphen",
           "",
-          String.duplicate("x", 80)
+          String.duplicate("x", Article.max_tag_length() + 1)
         ])
 
       assert added == ["good-tag"]
@@ -128,6 +128,33 @@ defmodule Loopctl.Knowledge.TaggerTest do
       # for one idea, which is the fragmentation this feature exists to reduce.
       assert {["RLS"], []} = Tagger.merge(["RLS"], ["rls"])
     end
+  end
+
+  test "the tag rule is Article's, not a copy — a suggestion the changeset rejects is refused" do
+    # This existed as THREE hand-synced copies that disagreed: Article and the ingestion
+    # worker allowed `[a-zA-Z0-9_-]` up to 100, the tagger allowed lowercase up to 64. It
+    # matters more here than anywhere, because `TagBackfillWorker` persists with
+    # `update_all` and runs no changeset — a tag this module accepts and Article rejects
+    # lands in the database and resurfaces as a 422 on an unrelated caller's PATCH.
+    long = String.duplicate("a", Article.max_tag_length() + 1)
+
+    {_tags, added} = Tagger.merge([], ["has.dot", long, "ok-tag"])
+
+    assert added == ["ok-tag"]
+    refute Regex.match?(Article.tag_pattern(), "has.dot")
+  end
+
+  test "the tagger may be STRICTER than Article, and is — lowercase start" do
+    # Article accepts an uppercase tag; the tagger normalises first, so requiring a
+    # lowercase start is a stricter rule on already-normalised input rather than a
+    # divergent one. Asserting both halves keeps the distinction from being "fixed" away.
+    assert Regex.match?(Article.tag_pattern(), "RLS")
+
+    {_tags, added} = Tagger.merge([], ["RLS"])
+    assert added == ["rls"], "normalised, then accepted"
+
+    {_tags, none} = Tagger.merge([], ["-leading-hyphen"])
+    assert none == []
   end
 
   describe "retag/4" do

--- a/test/loopctl/workers/draft_duplicate_sweep_worker_test.exs
+++ b/test/loopctl/workers/draft_duplicate_sweep_worker_test.exs
@@ -192,6 +192,51 @@ defmodule Loopctl.Workers.DraftDuplicateSweepWorkerTest do
                "it into a terminal one a week later"
     end
 
+    test "the durable marker spares a retraction the audit_log can no longer prove" do
+      # The point of `consolidation_retracted_at`: authorship survives the audit window. An
+      # aged draft with the marker is spared on the marker alone — no audit entry needed —
+      # which is what shrinks the horizon bound from "every aged draft" to "only those
+      # retracted before the column existed AND already past retention".
+      tenant = fixture(:tenant)
+      vector = unit_vector(0)
+
+      _published = tenant.id |> article(:published) |> then(&embed(tenant.id, &1, vector))
+      draft = tenant.id |> article(:draft) |> then(&embed(tenant.id, &1, vector))
+
+      Loopctl.AdminRepo.update_all(
+        from(a in Article, where: a.id == ^draft.id),
+        set: [consolidation_retracted_at: DateTime.utc_now()]
+      )
+
+      assert :ok = perform_job(DraftDuplicateSweepWorker, %{"tenant_id" => tenant.id})
+
+      assert status_of(draft.id) == :draft,
+             "a marked retraction must be spared whatever the audit_log still holds"
+    end
+
+    test "the marker is NOT castable — a PATCH cannot clear it" do
+      # The `stories.lifecycle_entered_at` lesson: `metadata` is cast and whole-map-replaced
+      # by PATCH, so a marker living there is erased by one ordinary update and the sweep
+      # gets its ambiguity back. Asserted against the SOURCE because Ecto exposes no
+      # introspection for `cast/3`'s permitted list.
+      src = File.read!("lib/loopctl/knowledge/article.ex")
+
+      # Both the inline list and the @cast_fields module attribute it uses.
+      permitted =
+        Regex.scan(~r/cast\(attrs,\s*(\[[^\]]*\]|@cast_fields)/s, src) ++
+          Regex.scan(~r/@cast_fields\s*(\[[^\]]*\]|~w\([^)]*\)[a-z]*)/s, src)
+
+      assert length(permitted) >= 3,
+             "found too few cast sources to check — the assertion below would pass vacuously"
+
+      for [_, list] <- permitted do
+        refute list =~ "consolidation_retracted_at",
+               "consolidation_retracted_at must never be castable"
+      end
+
+      assert :consolidation_retracted_at in Article.__schema__(:fields)
+    end
+
     test "a draft created before the audit retention window is left alone" do
       # The exemption above is read out of `audit_log`, which `AuditPartitionWorker` DROPs
       # partition-by-partition past `:audit_retention_days` — while this worker runs weekly


### PR DESCRIPTION
The enhanced review routed two findings out of scope because they needed files outside its write scope — **not because they were optional**. SOUL rule 0 allows fixed, provably false, or a separate epic with sign-off; neither of these is the third. No further review run on this branch: the chain bound refuses the review hop, not the work.

## 1. `Article` now owns the tag rule

There were **three hand-synced copies and they disagreed**:

| | pattern | max length |
|---|---|---|
| `Article` | `[a-zA-Z0-9_-]` | 100 |
| `ContentIngestionWorker` | `[a-zA-Z0-9_-]` | 100 |
| `Tagger` | lowercase-start | **64** |

That matters more than ordinary duplication because `TagBackfillWorker` persists with `update_all` and runs **no changeset** — so a looser rule stores rows the changeset rejects, which surface later as a 422 on an unrelated caller's PATCH. A defect report pointing at the wrong code.

`tag_pattern/0` and `max_tag_length/0` are now public on `Article`; the other two read them. The re-tagger stays **stricter** (lowercase start, applied to already-normalised input) — stricter is fine, *different* was the bug. One existing test hardcoded 80 chars against my invented 64 and now expresses the rule rather than a number.

## 2. A durable retraction marker

`articles.consolidation_retracted_at`, stamped by `Consolidation` when it unpublishes a confirmed duplicate, so `DraftDuplicateSweepWorker` can tell consolidation's own retraction from a human draft without depending on the retention-bounded `audit_log`.

**The migration backfills from the audit_log, and that part has a deadline.** The marker can only be stamped going forward, so every already-retracted article is provable only through entries that keep expiring. After the next partition drop those rows are unprovable forever.

**The fail-closed horizon stays.** It now covers a much smaller set — only retractions already past retention when this ran, which no evidence can ever reach — instead of every aged draft. Removing it outright would archive that cohort through a one-way door, which is the hazard the review's round-1 fix existed to close.

A **column, not a `metadata` key**, for the `stories.lifecycle_entered_at` reason: `metadata` is cast and whole-map-replaced by PATCH, so one ordinary update would erase it. The `ALTER` is catalog-only (nullable, no default) — no table rewrite.

## Verification

A test asserts the field appears in **no** cast list, checked against the source because Ecto exposes no introspection for `cast/3`'s permitted list. It carries a vacuity guard — which caught my first regex matching nothing — and is mutation-verified by adding the field to `@cast_fields` and watching it fail.

`mix precommit` green: 7658 tests, 0 failures.
