### PR TITLE
Acknowledge the third cowlib advisory, which has no release to bump to

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,19 +22,26 @@ defmodule Loopctl.MixProject do
       # hex.audit warns when an entry stops matching, so stale ones surface.
       hex: [
         ignore_advisories: [
-          # cowlib 2.18.0 — no patched release exists (2.18.0 is the latest
-          # cowlib), so there is nothing to bump to. cowlib is compiled into the
-          # release as an optional transitive of phoenix / websock_adapter /
-          # open_api_spex / telemetry_metrics_prometheus, but the ONLY component
-          # that starts a Cowboy listener is the TelemetryMetricsPrometheus
-          # reporter on the internal :9568 metrics port (prod-only, Fly private
-          # 6PN). The public API serves on Bandit, never cowboy. That metrics
-          # endpoint sets no cookies and reflects no untrusted structured
-          # headers, so neither vector is reachable. Recheck when cowlib > 2.18.0.
+          # cowlib 2.19.0 — no patched release exists for ANY of the three
+          # advisories below: each is introduced at an old version with no
+          # `fixed` event, and 2.19.0 is the newest cowlib on hex, so there is
+          # nothing to bump to. cowlib is compiled into the release as an
+          # optional transitive of phoenix / websock_adapter / open_api_spex /
+          # telemetry_metrics_prometheus, but the ONLY component that starts a
+          # Cowboy listener is the TelemetryMetricsPrometheus reporter on the
+          # internal :9568 metrics port (prod-only, Fly private 6PN). The public
+          # API serves on Bandit (config/config.exs, Bandit.PhoenixAdapter),
+          # never cowboy. That metrics endpoint sets no cookies, reflects no
+          # untrusted structured headers, and emits no Link headers — loopctl
+          # never calls cow_link — so none of the three vectors is reachable.
+          # Recheck when cowlib > 2.19.0.
           # CVE-2026-43966 (GHSA-w4f7-4cxr-rv3c, MEDIUM): HTTP response splitting.
           "CVE-2026-43966",
           # CVE-2026-43969 (GHSA-g2wm-735q-3f56, LOW): cookie header injection.
-          "CVE-2026-43969"
+          "CVE-2026-43969",
+          # CVE-2026-43971 (MEDIUM): Link header directive smuggling via
+          # unescaped target/rel/attribute keys in cow_link:link/1.
+          "CVE-2026-43971"
         ]
       ],
       dialyzer: [


### PR DESCRIPTION
## What broke

The nightly scheduled CI run on master (run 32208498487, 02:00 UTC) failed its Security job on SHA 488fa56 — the same SHA that had passed on push at 06:19 the previous morning. No deploy, no code change: **EEF-CVE-2026-43971** (MEDIUM, Link header directive smuggling via unescaped target/rel/attribute keys in cow_link:link/1) was published against cowlib overnight, and mix hex.audit exits non-zero on any advisory that is not acknowledged.

Left alone this fails every nightly run and every future PR's Security job, so it blocks merges.

## Why an acknowledgement and not a bump

OSV lists the advisory as introduced at cowlib 2.9.0 with **no fixed event**, and enumerates every published version through 2.19.0 as affected. 2.19.0 is the newest release on hex. There is no version to bump to.

## Reachability, re-verified rather than inherited

Same argument as the two existing entries, checked against the current tree:

- the endpoint runs Bandit.PhoenixAdapter (config/config.exs), not cowboy
- no Plug.Cowboy or direct cowboy listener is started anywhere in lib, test or config
- the only Cowboy listener in the release is the TelemetryMetricsPrometheus reporter on the internal 9568 port (prod-only, Fly private 6PN)
- the new vector requires an application that builds a Link header from untrusted keys; loopctl has zero cow_link call sites

## Also fixed

The comment block claimed 2.18.0 was both the pinned version and the latest cowlib. That went stale when the lock moved to 2.19.0, so a reader was being told there was nothing newer while there was. Refreshed, along with the recheck trigger.

## Verification

- mix hex.audit exits 0, with all three advisories under "Ignored advisories"
- mix precommit green: 7658 tests, 0 failures

## Review

Reviewed inline and self-authored, not through the enhanced-review pipeline: this session's prompt bars dispatching agents or workflows without an explicit request. Flagging that rather than treating it as a satisfied gate by default. Proportionate here — the diff is one build-config string plus a comment, touching no auth, credential, money or PHI surface. Every factual claim in the new comment was verified against the tree and against OSV, listed above.
