### PR TITLE
Stop the reformulation metric measuring how busy the system is

### DIFF
--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -44,7 +44,7 @@ never pass `tenant_id`/`subject_id`.
    caller passing `on_gate_unavailable: :skip` gets `{:error, :gate_unavailable}` and nothing is
    created (`:509-515`). The assessor is config-injected (`Loopctl.Knowledge.ProposalGate`, `:463-466`)
    — do not hardcode it.
-2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:9620`).
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3` (`knowledge.ex:9633`).
    `:curated` wins ONLY when a governed curated source's **absolute** (never pool-relative) confidence
    (`absolute_score/1`, `:9735-9740`) clears a scale-matched threshold AND beats the best retrieved
    candidate by a margin (`hybrid_curated_threshold_and_margin/1`, `:9786-9796`; the pure decision is
@@ -91,7 +91,7 @@ never pass `tenant_id`/`subject_id`.
    `{drift_signal, member_id}` — a group scored under the other signal's normalized key finds
    nothing and withholds (fail-closed).
 5. **Heat must not rank on a signal heat produces** — `Knowledge.heat_index/2`
-   (`knowledge.ex:10264`; the counted set is `@heat_read_access_types`, `:10134`). The heat index is the one retrieval route that
+   (`knowledge.ex:10277`; the counted set is `@heat_read_access_types`, `:10147`). The heat index is the one retrieval route that
    takes NO query, so its misses are uncorrelated with embedding similarity — which is worth nothing
    if its ordering is something a caller or the route itself generates. It has been violated FOUR
    times, each differently — and once by a FIX for one of the others — so treat any new input to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to loopctl are documented here.
 
 ## [Unreleased] — 2026-08-07 — Story lifecycle capability delivery
 
+### Changed
+
+- **`searches_reformulated` was measuring search density, not reformulation** — the figure it
+  published was wrong by a wide margin and is now corrected. On the hosted instance it read
+  **97%** where the session-scoped figure is **27%**. It is exposed by
+  `GET /api/v1/knowledge/retrieval_metrics` and the `knowledge_retrieval_metrics` MCP tool,
+  so any dashboard, report, or decision taken from it before this release should be re-read.
+
+  Two independent causes, both now fixed:
+
+  - It scoped "the same asker queried again" to `api_key_id`. Only two keys search a typical
+    deployment — the recall hook's and the shared MCP key that every session and subagent
+    authenticates with — and the median gap between consecutive searches on one of them is
+    ~127 seconds. "Another search happened on this key inside the window" was therefore true
+    almost always, by construction. It is now scoped to the **client session**.
+  - It compared `search_id` only, never the query text, so a **verbatim retry** of a degraded
+    search counted as a reformulation (142 of 311 flagged rows on one measured day). The query
+    text is now compared.
+
+  Two new columns, added by
+  `20260820011500_add_scored_disposition_base_to_retrieval_snapshots` (additive, both
+  `default 0`, no backfill, no manual step):
+
+  - `searches_scored` — the base the dispositions now partition.
+  - `searches_scored_with_follow_through` — of those, the ones that opened something.
+
+  **The partition moved.** `searches_scored_with_follow_through + searches_reformulated +
+  searches_quiet` now sums to `searches_scored`, **not** to `searches`. A search is scoreable
+  only if it carries a session identity and comes from a channel able to react to a result;
+  the recall hook and the session-start auto-query emit one distilled query per prompt and
+  never see what came back, so they are excluded from this metric alone. They remain in every
+  other denominator on that endpoint, precision included. Read `searches - searches_scored` as
+  **n/a, never as zero**.
+
+  The session identity is stamped forward-looking onto surfaced-result rows from the existing
+  client-context header, so **snapshots for days before this release report
+  `searches_scored: 0`** — which is how "not computed" is distinguished from "nothing scored".
+  No historical row is rewritten.
+
 ### Added
 
 - **Retroactive tagging** (`Loopctl.Workers.TagBackfillWorker`). Tags were LLM-generated once

--- a/docs/research/kb-retrieval-improvement-plan.md
+++ b/docs/research/kb-retrieval-improvement-plan.md
@@ -253,7 +253,9 @@ This is the shape of work the owner's constraint calls for — agents are only e
 plain search, so anything that makes results judgeable belongs on the server, not in an
 agent's tool choice. Phases 3–5 should be read the same way.
 **Check:** the injected block's rows are judgeable without a `knowledge_get`; re-measure
-`searches_quiet` against `cross_key_opens` once Phase 2c has collected real traffic.
+`searches_quiet` against `cross_key_opens` once Phase 2c has collected real traffic — noting
+that since #711 `searches_quiet` partitions `searches_scored`, not `searches`, and the hook
+channel `cross_key_opens` measures is deliberately outside that base.
 
 ### Phase 3 — Context an atomic note has lost *(DONE for the lexical half; the LLM half is refused, with a condition)*
 An atomic note extracted from a book or video loses the context of its source. The plan

--- a/docs/runbooks/search-events-analysis.md
+++ b/docs/runbooks/search-events-analysis.md
@@ -154,13 +154,24 @@ time, and the metrics payload reports:
 | `attributed_opens` | READS | opens whose originating search is known |
 | `cross_key_opens` | READS | **the injected channel** — surfaced by one key, read by another |
 | `direct_opens` | READS | agent went straight to the article (link, cited id) — not a miss |
-| `searches_reformulated` | SEARCH CALLS | asked again, in-window, nothing opened — a real failure |
+| `searches_scored` | SEARCH CALLS | the base the three below partition — **not** `searches` |
+| `searches_scored_with_follow_through` | SEARCH CALLS | of those, the ones that opened something |
+| `searches_reformulated` | SEARCH CALLS | same SESSION asked a DIFFERENT question, in-window, nothing opened — a real failure |
 | `searches_quiet` | SEARCH CALLS | neither opened nor re-asked — **still ambiguous** |
 
 Two things to hold onto when reading them:
 
 - **Units differ from `followed_through`.** That counts SURFACED RESULTS later opened; the
   `*_opens` fields count READS. They are not comparable and neither supersedes the other.
+- **`searches - searches_scored` is `n/a`, not zero.** A search is scoreable for
+  reformulation only if it carries a session identity (stamped forward-looking, so every row
+  written before it shipped is unscoreable) and comes from a channel that can react to a
+  result — the recall hook and the session-start auto-query cannot, because each emits one
+  mechanically-distilled query per prompt and never sees what came back. Both remain in every
+  other denominator, precision included; only this one metric cannot see them. Scoring on
+  `api_key_id` instead is step 2's shared-key trap re-entered one metric later: two keys
+  search this system, the median gap between consecutive searches on one is 127 seconds, and
+  the figure that produced was 97% where the session-scoped one is 27%.
 - **`quiet` is not "sufficed".** Splitting `reformulated` out removes the one unambiguous
   failure from the not-opened bucket; it does NOT resolve the snippet-sufficed-vs-ignored
   ambiguity in step 4 below. Nothing here turns a floor into a satisfaction rate.

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2767,17 +2767,30 @@ defmodule Loopctl.Knowledge do
   # — analytics only, never an authorization input. The failure it permits is a caller
   # excluding its OWN rows from a quality metric, which is self-harm rather than an attack
   # on anyone else's numbers.
+  # `session_id` rides along on the same terms and for a metric that could not be computed
+  # without it (#711). `RetrievalMetrics` decides whether a search was REFORMULATED by asking
+  # whether the same asker queried again inside the window. It used to ask that of
+  # `api_key_id`, which is not an asker: only two keys search this system — the recall hook's
+  # and the shared MCP key every session and subagent authenticates with — so the answer was
+  # governed by how busy the system was, not by whether anyone was struggling. Without a
+  # session on the SURFACED-RESULT row there is no way to scope the comparison, because that
+  # metric reads `article_access_events` and never joins back to `search_events`.
+  #
+  # Same trust posture as `entrypoint`: client-asserted, spoofable, analytics-only. Rows that
+  # do not carry it are excluded from that metric rather than compared on a weaker key —
+  # see `RetrievalMetrics.reformulation_scoreable/1`.
   defp search_access_meta(mode, results, opts) do
-    base = %{"mode" => mode, "results_returned" => length(results)}
+    attrs = client_context_attrs(opts)
 
-    case Map.get(client_context_attrs(opts), :client_entrypoint) do
-      entrypoint when is_binary(entrypoint) and entrypoint != "" ->
-        Map.put(base, "entrypoint", entrypoint)
-
-      _ ->
-        base
-    end
+    %{"mode" => mode, "results_returned" => length(results)}
+    |> put_client_meta("entrypoint", Map.get(attrs, :client_entrypoint))
+    |> put_client_meta("session_id", Map.get(attrs, :client_session_id))
   end
+
+  defp put_client_meta(meta, key, value) when is_binary(value) and value != "",
+    do: Map.put(meta, key, value)
+
+  defp put_client_meta(meta, _key, _value), do: meta
 
   defp search_duration_ms(opts) do
     case Keyword.get(opts, :_started_at) do

--- a/lib/loopctl/knowledge/retrieval_metric_snapshot.ex
+++ b/lib/loopctl/knowledge/retrieval_metric_snapshot.ex
@@ -79,7 +79,14 @@ defmodule Loopctl.Knowledge.RetrievalMetricSnapshot do
     field :cross_key_opens, :integer, default: 0
     field :direct_opens, :integer, default: 0
 
-    # Unit: SEARCH CALLS. With `searches_with_follow_through` these partition `searches`.
+    # Unit: SEARCH CALLS. These four partition each other, not `searches`:
+    # `searches_scored_with_follow_through + searches_reformulated + searches_quiet ==
+    # searches_scored`. A search is SCORED only if it carries a session identity and comes
+    # from a channel that can react to a result at all, so `searches - searches_scored` is
+    # unscoreable traffic — an `n/a`, never a quiet search (#711). A pre-#711 row has
+    # `searches_scored = 0`, which is how "not computed" is told apart from "nothing scored".
+    field :searches_scored, :integer, default: 0
+    field :searches_scored_with_follow_through, :integer, default: 0
     field :searches_reformulated, :integer, default: 0
     field :searches_quiet, :integer, default: 0
 
@@ -107,6 +114,8 @@ defmodule Loopctl.Knowledge.RetrievalMetricSnapshot do
     :attributed_opens,
     :cross_key_opens,
     :direct_opens,
+    :searches_scored,
+    :searches_scored_with_follow_through,
     :searches_reformulated,
     :searches_quiet,
     :computed_at

--- a/lib/loopctl/knowledge/retrieval_metrics.ex
+++ b/lib/loopctl/knowledge/retrieval_metrics.ex
@@ -129,19 +129,33 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
 
   ## What `quiet` does NOT mean
 
-  `searches_with_follow_through`, `searches_reformulated` and `searches_quiet` partition
-  `searches`. The partition exists because treating every not-opened search as a failure is
-  wrong, and `docs/runbooks/search-events-analysis.md` says so outright: "an agent whose
-  question is answered by the snippet correctly opens nothing, and that is a success this
-  metric scores as a failure."
+  `searches_scored_with_follow_through`, `searches_reformulated` and `searches_quiet`
+  partition `searches_scored` — NOT `searches` (#711). The partition exists because treating
+  every not-opened search as a failure is wrong, and
+  `docs/runbooks/search-events-analysis.md` says so outright: "an agent whose question is
+  answered by the snippet correctly opens nothing, and that is a success this metric scores
+  as a failure."
 
-  A REFORMULATION — the same key issuing a LATER SEARCH CALL inside the window, having opened
-  nothing — is the one member of that bucket that is closest to an unambiguous failure, so it
-  is peeled out. It is compared on the search identity, not the query text, so a verbatim
-  retry of a degraded search counts here too. What remains is named `quiet` and is STILL a mixture: "the snippet sufficed" and "the
-  rows were ignored" are indistinguishable here, and this instrumentation does not resolve
-  them. Do not rename it to anything that asserts satisfaction, and do not compute a rate
-  that treats it as either. Follow-through remains a floor, never a satisfaction rate.
+  A REFORMULATION — the SAME SESSION issuing a LATER SEARCH CALL with a DIFFERENT QUERY
+  inside the window, having opened nothing — is the one member of that bucket that is closest
+  to an unambiguous failure, so it is peeled out. What remains is named `quiet` and is STILL
+  a mixture: "the snippet sufficed" and "the rows were ignored" are indistinguishable here,
+  and this instrumentation does not resolve them. Do not rename it to anything that asserts
+  satisfaction, and do not compute a rate that treats it as either. Follow-through remains a
+  floor, never a satisfaction rate.
+
+  `searches_scored` is smaller than `searches`, and the gap is NOT quiet traffic. A search is
+  scoreable only if it carries a session identity (stamped forward-looking, so every row
+  written before #711 is unscoreable) and comes from a channel that can react to a result at
+  all (the recall hook and the session-start auto-query cannot — see
+  `@no_reformulation_entrypoints`). Report `searches - searches_scored` as unscoreable rather
+  than inferring anything from it: it is an `n/a`, not a zero.
+
+  Both of those replaced proxies that were measuring something else. Scoring on `api_key_id`
+  made the figure a function of search DENSITY — two shared keys, a 127-second median gap
+  between searches on one of them, so "another search happened on this key" was ~always true
+  and read as 97% reformulation. Comparing `search_id` without the query text counted a
+  verbatim retry as a reformulation. Both are documented at `reformulation_exists/1`.
 
   ## The proxy is gameable in one direction — never optimise it alone
 
@@ -209,6 +223,20 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
   # rather than behaviour.
   @infra_entrypoints ~w(smoke skill-eval)
 
+  # Channels that are counted everywhere else but CANNOT be scored for reformulation (#711).
+  #
+  # The recall hook (`hook`) and the session-start auto-query (`session-start`) each emit
+  # exactly ONE mechanically-distilled query per prompt. They are shell scripts issuing
+  # direct HTTP: they never see what the previous query returned, hold no conversation state,
+  # and cannot decide to ask again. A channel with no feedback loop cannot reformulate, so
+  # counting it as such is a category error rather than a measurement — and it was the single
+  # largest contributor to the inflated figure, because `hook` fires on every user prompt.
+  #
+  # They are deliberately NOT `@infra_entrypoints`. Their traffic is real, a real session goes
+  # on to open what they surface, and `cross_key_opens` exists precisely to credit that. This
+  # narrows ONE metric that cannot see them, and changes no denominator anywhere else.
+  @no_reformulation_entrypoints ~w(hook session-start)
+
   defp exclude_infra_traffic(query) do
     where(
       query,
@@ -248,7 +276,9 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
   Returns `%{searched, results_recorded, followed_through, precision, searches,
   searches_with_follow_through, search_follow_through, results_returned, day,
   window_seconds, curated_searched, curated_followed_through, curated_precision,
-  retrieved_searched, retrieved_followed_through, retrieved_precision}`.
+  retrieved_searched, retrieved_followed_through, retrieved_precision, attributed_opens,
+  cross_key_opens, direct_opens, searches_scored, searches_scored_with_follow_through,
+  searches_reformulated, searches_quiet}`.
 
   `searched` (and its self-describing twin `results_recorded`) is a count of RECORDED
   SURFACED RESULTS — capped at the first
@@ -300,7 +330,7 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
 
     call = compute_call_level(searched_q, window_seconds)
     opens = compute_open_attribution(tenant_id, day_start, day_end)
-    dispositions = compute_dispositions(searched_q, window_seconds, call)
+    dispositions = compute_dispositions(searched_q, window_seconds)
 
     %{
       day: day,
@@ -322,6 +352,8 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
       attributed_opens: opens.attributed_opens,
       cross_key_opens: opens.cross_key_opens,
       direct_opens: opens.direct_opens,
+      searches_scored: dispositions.searches_scored,
+      searches_scored_with_follow_through: dispositions.searches_scored_with_follow_through,
       searches_reformulated: dispositions.searches_reformulated,
       searches_quiet: dispositions.searches_quiet
     }
@@ -412,24 +444,49 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
   # the still-unopened rows of a search that WAS followed through — counting it in two
   # buckets at once, and (because `quiet` is the remainder) silently zeroing the bucket the
   # genuinely quiet searches belong to. So the opened SEARCH IDS are subtracted as a set.
-  defp compute_dispositions(searched_q, window_seconds, call) do
+  defp compute_dispositions(searched_q, window_seconds) do
+    scoreable = reformulation_scoreable(searched_q)
+
+    scored = count_distinct_searches(scoreable)
+    scored_with_ft = scoreable |> with_follow_through(window_seconds) |> count_distinct_searches()
+
     opened_ids =
-      searched_q
-      |> qualifying_calls()
+      scoreable
       |> with_follow_through(window_seconds)
       |> select([s], fragment("?->>'search_id'", s.metadata))
 
     reformulated =
-      searched_q
-      |> qualifying_calls()
+      scoreable
       |> where(^reformulation_exists(window_seconds))
       |> where([s], fragment("?->>'search_id'", s.metadata) not in subquery(opened_ids))
       |> count_distinct_searches()
 
     %{
+      searches_scored: scored,
+      searches_scored_with_follow_through: scored_with_ft,
       searches_reformulated: reformulated,
-      searches_quiet: max(call.searches - call.searches_with_follow_through - reformulated, 0)
+      searches_quiet: max(scored - scored_with_ft - reformulated, 0)
     }
+  end
+
+  # The population the disposition trio partitions: qualifying calls that COULD be OBSERVED
+  # reformulating. It is a SUBSET of `compute_call_level/2`'s population, which is why the
+  # trio partitions `searches_scored` and NOT `searches` — the remainder is reported as
+  # `searches` minus `searches_scored` rather than folded into `searches_quiet`.
+  #
+  # That distinction is the whole point. `quiet` means "the snippet answered it OR the rows
+  # were ignored"; a row with no session identity means "this instrument cannot see". Folding
+  # the second into the first publishes a structural `n/a` as a number, which is the failure
+  # `Loopctl.Knowledge.RetrievalEval` already names in so many words ("`0.0` is 'it ran and
+  # retrieved nothing'; `n/a` is 'there was nothing to score'").
+  defp reformulation_scoreable(searched_q) do
+    searched_q
+    |> qualifying_calls()
+    |> where([s], not is_nil(fragment("?->>'session_id'", s.metadata)))
+    |> where(
+      [s],
+      fragment("coalesce(?->>'entrypoint', '')", s.metadata) not in ^@no_reformulation_entrypoints
+    )
   end
 
   # Shared "searched -> followed-through within window" correlated-exists count, reused
@@ -520,11 +577,31 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
     )
   end
 
-  # "The same key issued a LATER SEARCH CALL inside the window." Distinctness is compared on
-  # the search identity, never the query text — `search_id` is minted per call, so an agent
-  # re-running the IDENTICAL query (a retry after a degraded response, say) satisfies this
-  # too. The published descriptions say "a later search call" for that reason; do not
-  # restate them as "a different query" without also comparing the query text here.
+  # "The SAME SESSION asked a DIFFERENT question inside the window" — the one member of the
+  # not-opened bucket that is unambiguously a retrieval failure.
+  #
+  # TWO PROXIES WERE REPLACED HERE, AND EACH MEASURED SOMETHING OTHER THAN REFORMULATION.
+  #
+  # 1. THE QUERY TEXT is now compared, not just `search_id`. `search_id` is minted per call,
+  #    so an agent re-running the IDENTICAL query (a retry after a degraded response) used to
+  #    satisfy this: 142 of the 311 flagged rows on 2026-08-17 had a byte-identical successor.
+  #    This module previously permitted that on the condition that the published descriptions
+  #    said "a later search call" — but the exported field is `searches_reformulated`, and the
+  #    name is what leaves the system and what a reader acts on. The name won; the code moved
+  #    to meet it. THE TWO MUST KEEP MOVING TOGETHER: do not relax the query comparison here
+  #    without renaming the field and every description in `@disposition_fields`.
+  #
+  # 2. THE SESSION is now the asker, not `api_key_id`. Only TWO keys search this system — the
+  #    recall hook's and the shared MCP key that every session and subagent authenticates
+  #    with — and the median gap between consecutive searches on one key is 127 seconds. So
+  #    "was there another search on this key inside the window" was true ~97% of the time BY
+  #    CONSTRUCTION: it measured search DENSITY and published it as agent frustration. It is
+  #    the same shared-key confound that makes the search-to-read join unusable
+  #    (`docs/runbooks/search-events-analysis.md` step 2), re-entered one metric later.
+  #
+  # Rows carrying no session identity are not compared at all — `reformulation_scoreable/1`
+  # removes them, because a NULL-matches-NULL join would rebuild the shared-key bug out of
+  # exactly the rows that lack the field.
   #
   # Bounded on BOTH sides by the window, and strictly after the surfacing row, so a search
   # is never called a reformulation of one that came later.
@@ -535,14 +612,18 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
         from(r in ArticleAccessEvent,
           where:
             r.tenant_id == parent_as(:s).tenant_id and
-              r.api_key_id == parent_as(:s).api_key_id and
               r.access_type == "search" and
-              not is_nil(fragment("?->>\'search_id\'", r.metadata)) and
-              fragment("?->>\'search_id\'", r.metadata) !=
-                fragment("?->>\'search_id\'", parent_as(:s).metadata) and
+              not is_nil(fragment("?->>'search_id'", r.metadata)) and
+              fragment("?->>'search_id'", r.metadata) !=
+                fragment("?->>'search_id'", parent_as(:s).metadata) and
+              not is_nil(fragment("?->>'session_id'", r.metadata)) and
+              fragment("?->>'session_id'", r.metadata) ==
+                fragment("?->>'session_id'", parent_as(:s).metadata) and
+              fragment("coalesce(?->>'query', '')", r.metadata) !=
+                fragment("coalesce(?->>'query', '')", parent_as(:s).metadata) and
               r.accessed_at > parent_as(:s).accessed_at and
               fragment(
-                "? <= ? + (? * interval \'1 second\')",
+                "? <= ? + (? * interval '1 second')",
                 r.accessed_at,
                 parent_as(:s).accessed_at,
                 ^window_seconds
@@ -615,6 +696,8 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
       attributed_opens: m.attributed_opens,
       cross_key_opens: m.cross_key_opens,
       direct_opens: m.direct_opens,
+      searches_scored: m.searches_scored,
+      searches_scored_with_follow_through: m.searches_scored_with_follow_through,
       searches_reformulated: m.searches_reformulated,
       searches_quiet: m.searches_quiet,
       computed_at: DateTime.utc_now()
@@ -642,6 +725,8 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
            :attributed_opens,
            :cross_key_opens,
            :direct_opens,
+           :searches_scored,
+           :searches_scored_with_follow_through,
            :searches_reformulated,
            :searches_quiet,
            :computed_at,
@@ -704,10 +789,15 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
           # indistinguishable from "surfaced and ignored", which is close to its opposite.
           direct_opens: s.direct_opens,
 
-          # Unit: SEARCH CALLS. With `searches_with_follow_through` these partition
-          # `searches`. `quiet` is "the snippet sufficed OR the rows were ignored" and this
-          # instrumentation does NOT separate those — only `reformulated`, the one member of
-          # the not-opened bucket that is unambiguously a failure, is peeled out.
+          # Unit: SEARCH CALLS. These three partition `searches_scored`, NOT `searches` —
+          # a search is scoreable only if it carries a session identity and comes from a
+          # channel that can react to a result at all. `searches - searches_scored` is
+          # unscoreable traffic and is an `n/a`, never a quiet search. `quiet` is "the
+          # snippet sufficed OR the rows were ignored" and this instrumentation does NOT
+          # separate those — only `reformulated`, the one member of the not-opened bucket
+          # that is unambiguously a failure, is peeled out.
+          searches_scored: s.searches_scored,
+          searches_scored_with_follow_through: s.searches_scored_with_follow_through,
           searches_reformulated: s.searches_reformulated,
           searches_quiet: s.searches_quiet
         }

--- a/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
@@ -362,17 +362,26 @@ defmodule LoopctlWeb.KnowledgeAnalyticsController do
         "re-asked of history; the correlated metrics take `window_seconds` at QUERY time. " <>
         "They share a default, so a divergence after passing a different `window_seconds` " <>
         "is that mismatch, not a bug.\n\n" <>
-        "DISPOSITION (unit: SEARCH CALLS) — `searches_with_follow_through`, " <>
-        "`searches_reformulated` and `searches_quiet` PARTITION `searches`. Treating " <>
-        "every not-opened search as a failure is wrong: an agent whose question is " <>
-        "answered by the result snippet correctly opens nothing, and that is a success. " <>
-        "A REFORMULATION (same key, a LATER SEARCH CALL inside the window, having opened " <>
-        "nothing — compared on search identity, so a verbatim retry counts) is the " <>
+        "DISPOSITION (unit: SEARCH CALLS) — `searches_scored_with_follow_through`, " <>
+        "`searches_reformulated` and `searches_quiet` PARTITION `searches_scored`, NOT " <>
+        "`searches`. Treating every not-opened search as a failure is wrong: an agent " <>
+        "whose question is answered by the result snippet correctly opens nothing, and " <>
+        "that is a success. A REFORMULATION (the SAME SESSION issuing a later search " <>
+        "call with a DIFFERENT QUERY inside the window, having opened nothing) is the " <>
         "closest thing to an unambiguous failure in that bucket, so it is reported " <>
         "separately. What remains is `quiet` and is STILL a mixture of 'the snippet " <>
         "sufficed' and 'the rows were ignored' — this surface does NOT separate them. " <>
         "Do not read `quiet` as either; follow-through is a floor, never a satisfaction " <>
-        "rate.",
+        "rate.\n\n" <>
+        "`searches_scored` IS SMALLER THAN `searches`, AND THE GAP IS NOT QUIET " <>
+        "TRAFFIC. A search is scoreable only if it carries a session identity (stamped " <>
+        "forward-looking, so every row predating it is unscoreable and a pre-migration " <>
+        "row reports `searches_scored: 0`) and comes from a channel that can react to a " <>
+        "result at all — the recall hook and the session-start auto-query emit one " <>
+        "distilled query per prompt and never see what came back, so they cannot " <>
+        "reformulate by construction. They remain in every other denominator on this " <>
+        "surface, including precision. Read `searches - searches_scored` as n/a, never " <>
+        "as zero.",
     parameters: [
       limit: [
         in: :query,

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -6505,14 +6505,21 @@ const TOOLS = [
       "tenant can reach one article independently), hence labelled rather than folded in. " +
       "direct_opens is the agent going straight to an article by link or cited id, which " +
       "used to look identical to 'surfaced and ignored' — close to its opposite.\n\n" +
-      "Disposition (unit: SEARCH CALLS): searches_with_follow_through, " +
-      "searches_reformulated and searches_quiet PARTITION searches. Treating every " +
-      "not-opened search as a failure is wrong — an agent answered by the result snippet " +
-      "correctly opens nothing, and that is a success. A reformulation (same key, a LATER " +
-      "SEARCH CALL in-window, nothing opened — compared on search identity, so a verbatim " +
-      "retry counts) is the closest thing to an unambiguous failure, so it is split out; " +
-      "what remains is `quiet` and is STILL a mixture of 'snippet sufficed' and 'rows " +
-      "ignored'. This surface does not separate them — do not read quiet as either.",
+      "Disposition (unit: SEARCH CALLS): searches_scored_with_follow_through, " +
+      "searches_reformulated and searches_quiet PARTITION searches_scored — NOT searches. " +
+      "Treating every not-opened search as a failure is wrong — an agent answered by the " +
+      "result snippet correctly opens nothing, and that is a success. A reformulation (the " +
+      "SAME SESSION issuing a later search call with a DIFFERENT QUERY in-window, nothing " +
+      "opened) is the closest thing to an unambiguous failure, so it is split out; what " +
+      "remains is `quiet` and is STILL a mixture of 'snippet sufficed' and 'rows ignored'. " +
+      "This surface does not separate them — do not read quiet as either.\n\n" +
+      "searches_scored is SMALLER than searches and the gap is NOT quiet traffic. A search " +
+      "is scoreable only if it carries a session identity (stamped forward-looking, so a " +
+      "pre-migration row reports searches_scored: 0) and comes from a channel that can " +
+      "react to a result at all — the recall hook and the session-start auto-query emit one " +
+      "distilled query per prompt and never see what came back, so they cannot reformulate " +
+      "by construction. They stay in every other denominator here, precision included. " +
+      "Read searches - searches_scored as n/a, never as zero.",
     inputSchema: {
       type: "object",
       properties: {

--- a/priv/repo/migrations/20260820011500_add_scored_disposition_base_to_retrieval_snapshots.exs
+++ b/priv/repo/migrations/20260820011500_add_scored_disposition_base_to_retrieval_snapshots.exs
@@ -1,0 +1,48 @@
+defmodule Loopctl.Repo.Migrations.AddScoredDispositionBaseToRetrievalSnapshots do
+  use Ecto.Migration
+
+  @moduledoc """
+  Gives the search-disposition trio the denominator it actually partitions.
+
+  `searches_reformulated` / `searches_quiet` shipped in
+  `20260817173100_add_origin_metrics_to_retrieval_snapshots` as a partition of `searches`.
+  They never were one, and the published figure was wrong in two independent ways
+  (both are documented at `Loopctl.Knowledge.RetrievalMetrics.reformulation_exists/1`):
+
+    * it scored on `api_key_id`, and only TWO keys search this system, with a 127-second
+      median gap between consecutive searches on one of them — so the metric was a function
+      of search DENSITY and reported 97% where the session-scoped figure is 27%;
+    * it compared `search_id` without the query text, so a verbatim retry counted as a
+      reformulation (142 of 311 flagged rows on 2026-08-17).
+
+  Narrowing the numerator is not enough on its own: a search can only be SCORED for
+  reformulation if it carries a session identity, and if it comes from a channel capable of
+  reacting to a result at all — the recall hook and the session-start auto-query emit one
+  distilled query per prompt and never see what came back. Those rows are not quiet; they are
+  unscoreable, and folding an `n/a` into a bucket named "quiet" publishes a structural blind
+  spot as an observation.
+
+  So the base itself becomes a column:
+
+    * `searches_scored` — qualifying search calls that could be observed reformulating.
+    * `searches_scored_with_follow_through` — of those, the ones that opened something.
+
+  With `searches_reformulated` and `searches_quiet` these partition `searches_scored`
+  exactly. `searches - searches_scored` is unscoreable traffic and must be reported as such.
+
+  No separate "computed from" marker is needed, and that is deliberate: a pre-migration row
+  carries `searches_scored = 0`, and a partition over a zero base is self-evidently
+  uncomputed. (The prior migration's moduledoc promised an `origin_metrics_from` field in the
+  payload for exactly this purpose; it was never implemented, which is why this one encodes
+  the same information structurally instead of in a parallel marker that can go missing.)
+
+  Both columns default to 0 so historical snapshots stay readable.
+  """
+
+  def change do
+    alter table(:retrieval_metric_snapshots) do
+      add :searches_scored, :integer, default: 0, null: false
+      add :searches_scored_with_follow_through, :integer, default: 0, null: false
+    end
+  end
+end

--- a/test/loopctl/knowledge/origin_attribution_test.exs
+++ b/test/loopctl/knowledge/origin_attribution_test.exs
@@ -310,14 +310,30 @@ defmodule Loopctl.Knowledge.OriginAttributionTest do
       assert m.cross_key_opens == 0
     end
 
-    defp search_call(tenant_id, article_id, api_key_id, search_id, at) do
+    # `session_id` DEFAULTS TO ONE DERIVED FROM THE KEY, so every test written before #711
+    # keeps exactly the meaning it had: same key means same session, different keys mean
+    # different sessions. The default `query` is derived from the search id so that two
+    # distinct calls are two distinct questions unless a test says otherwise — which is what
+    # "asked again" meant before the query text was compared at all.
+    defp search_call(tenant_id, article_id, api_key_id, search_id, at, opts \\ []) do
+      optional =
+        [
+          {"session_id", Keyword.get(opts, :session_id, "sess-" <> api_key_id)},
+          {"query", Keyword.get(opts, :query, "q-" <> search_id)},
+          {"entrypoint", Keyword.get(opts, :entrypoint)}
+        ]
+        |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+        |> Map.new()
+
+      meta = Map.merge(%{"search_id" => search_id, "rank" => 1, "mode" => "combined"}, optional)
+
       fixture(:article_access_event, %{
         tenant_id: tenant_id,
         article_id: article_id,
         api_key_id: api_key_id,
         access_type: "search",
         accessed_at: at,
-        metadata: %{"search_id" => search_id, "rank" => 1, "mode" => "combined"}
+        metadata: meta
       })
     end
 
@@ -354,12 +370,20 @@ defmodule Loopctl.Knowledge.OriginAttributionTest do
 
       m = RetrievalMetrics.compute(tenant.id, day)
 
-      assert m.searches ==
-               m.searches_with_follow_through + m.searches_reformulated + m.searches_quiet,
-             "the three must partition `searches`; `quiet` is derived by subtraction, so a " <>
-               "drift between the disposition population and the denominator shows up here"
+      assert m.searches_scored ==
+               m.searches_scored_with_follow_through + m.searches_reformulated +
+                 m.searches_quiet,
+             "the three must partition `searches_scored`; `quiet` is derived by " <>
+               "subtraction, so a drift between the disposition population and its own " <>
+               "denominator shows up here"
+
+      assert m.searches_scored == m.searches,
+             "every row here carries a session and a scoreable entrypoint, so nothing is " <>
+               "unscoreable; if this drifts the partition above is measuring a subset " <>
+               "without saying so"
 
       assert m.searches_with_follow_through == 1
+      assert m.searches_scored_with_follow_through == 1
       assert m.searches_reformulated == 1
     end
 
@@ -444,8 +468,9 @@ defmodule Loopctl.Knowledge.OriginAttributionTest do
 
       assert m.searches_quiet == 1, "S2 is the quiet search and must not be clamped away"
 
-      assert m.searches ==
-               m.searches_with_follow_through + m.searches_reformulated + m.searches_quiet
+      assert m.searches_scored ==
+               m.searches_scored_with_follow_through + m.searches_reformulated +
+                 m.searches_quiet
     end
 
     test "a lone search with no read and no follow-up query is quiet, not reformulated" do
@@ -462,6 +487,114 @@ defmodule Loopctl.Knowledge.OriginAttributionTest do
       assert m.searches == 1
       assert m.searches_reformulated == 0
       assert m.searches_quiet == 1
+    end
+
+    test "a VERBATIM retry is not a reformulation" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+      key = key_for(tenant.id)
+      day = Date.utc_today()
+      base = DateTime.new!(day, ~T[12:00:00.000000], "Etc/UTC")
+
+      search_call(tenant.id, article.id, key, Ecto.UUID.generate(), base, query: "same question")
+
+      search_call(
+        tenant.id,
+        article.id,
+        key,
+        Ecto.UUID.generate(),
+        DateTime.add(base, 120, :second),
+        query: "same question"
+      )
+
+      m = RetrievalMetrics.compute(tenant.id, day)
+
+      assert m.searches_scored == 2
+      assert m.searches_quiet == 2
+
+      assert m.searches_reformulated == 0,
+             "re-running the identical query is a retry, not a reformulation; scoring it " <>
+               "on `search_id` alone flagged 142 of 311 rows on 2026-08-17"
+    end
+
+    test "another SESSION on the SAME KEY is not a reformulation" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+      key = key_for(tenant.id)
+      day = Date.utc_today()
+      base = DateTime.new!(day, ~T[12:00:00.000000], "Etc/UTC")
+
+      search_call(tenant.id, article.id, key, Ecto.UUID.generate(), base, session_id: "sess-a")
+
+      search_call(
+        tenant.id,
+        article.id,
+        key,
+        Ecto.UUID.generate(),
+        DateTime.add(base, 120, :second),
+        session_id: "sess-b"
+      )
+
+      m = RetrievalMetrics.compute(tenant.id, day)
+
+      assert m.searches_scored == 2
+
+      assert m.searches_reformulated == 0,
+             "one shared MCP key serves every session and subagent, and the median gap " <>
+               "between searches on it is ~2 minutes — scoring on `api_key_id` made this " <>
+               "metric a function of search DENSITY (97% observed, 27% session-scoped)"
+    end
+
+    test "a search with NO session identity is unscoreable, not quiet" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+      key = key_for(tenant.id)
+      day = Date.utc_today()
+      base = DateTime.new!(day, ~T[12:00:00.000000], "Etc/UTC")
+
+      search_call(tenant.id, article.id, key, Ecto.UUID.generate(), base, session_id: nil)
+
+      m = RetrievalMetrics.compute(tenant.id, day)
+
+      assert m.searches == 1, "it is still a search everywhere else"
+
+      assert m.searches_scored == 0,
+             "no session identity means the comparison cannot be scoped at all"
+
+      assert m.searches_quiet == 0,
+             "an `n/a` folded into `quiet` publishes a blind spot as an observation"
+    end
+
+    test "the recall hook is counted everywhere but scored nowhere" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+      key = key_for(tenant.id)
+      day = Date.utc_today()
+      base = DateTime.new!(day, ~T[12:00:00.000000], "Etc/UTC")
+
+      for {entry, offset} <- [{"hook", 0}, {"session-start", 120}] do
+        search_call(
+          tenant.id,
+          article.id,
+          key,
+          Ecto.UUID.generate(),
+          DateTime.add(base, offset, :second),
+          entrypoint: entry,
+          session_id: "sess-shared"
+        )
+      end
+
+      m = RetrievalMetrics.compute(tenant.id, day)
+
+      assert m.searches == 2,
+             "these are NOT `@infra_entrypoints` — real traffic, still in every other " <>
+               "denominator including precision"
+
+      assert m.searches_scored == 0,
+             "a shell script emitting one distilled query per prompt never sees what came " <>
+               "back, so it cannot reformulate by construction"
+
+      assert m.searches_reformulated == 0
     end
 
     test "another KEY's later query is not a reformulation of mine" do

--- a/test/loopctl/knowledge/retrieval_metrics_test.exs
+++ b/test/loopctl/knowledge/retrieval_metrics_test.exs
@@ -140,7 +140,9 @@ defmodule Loopctl.Knowledge.RetrievalMetricsTest do
                cross_key_opens: 0,
                direct_opens: 0,
                searches_reformulated: 0,
-               searches_quiet: 0
+               searches_quiet: 0,
+               searches_scored: 0,
+               searches_scored_with_follow_through: 0
              }
     end
   end


### PR DESCRIPTION
## What was wrong

`searches_reformulated` read **97%** on the hosted instance. The session-scoped figure for the same two days is **27%**. Two independent causes, neither of them agent behaviour.

**It scoped "the same asker queried again" to `api_key_id`.** Only two keys search this system — the recall hook's and the shared MCP key that every session and subagent authenticates with — and the median gap between consecutive searches on one of them is 127 seconds. So "another search happened on this key inside the window" was true by construction, and the metric tracked search *density*. This is step 2 of `docs/runbooks/search-events-analysis.md` — the shared-key confound that makes the search-to-read join unusable — re-entered one metric later.

**It compared `search_id` without the query text**, so a verbatim retry counted as a reformulation: 142 of 311 flagged rows on 2026-08-17. The module permitted that deliberately, on the written condition that the published descriptions say "a later search call" rather than "a different query". They said `searches_reformulated` everywhere it mattered. The name is what leaves the system and what a reader acts on, so the code moved to meet the name; a note at `reformulation_exists/1` records that the two must keep moving together.

## Why narrowing the numerator was not enough

A search can only be **scored** for reformulation if it carries a session identity, and if it comes from a channel able to react to a result at all. The recall hook and the session-start auto-query emit one mechanically distilled query per prompt and never see what came back — they are shell scripts issuing direct HTTP. They cannot reformulate by construction, and they were the largest single contributor because the hook fires on every user prompt.

They are **not** reclassified as infra. Their traffic is real, a real session opens what they surface, and `cross_key_opens` exists to credit that. They stay in every other denominator on the endpoint, precision included. This narrows one metric that cannot see them.

So the base becomes explicit: `searches_scored` and `searches_scored_with_follow_through` are new columns, and the disposition trio now partitions `searches_scored` rather than `searches`. `searches - searches_scored` is unscoreable traffic and must be read as **n/a, never zero** — folding it into a bucket named "quiet" publishes a blind spot as an observation, which is the distinction `RetrievalEval` already draws in so many words.

## Deploy notes

- Migration `20260820011500` is additive — two integer columns, `default 0`, no backfill, no manual step.
- The session identity is stamped forward-looking from the existing client-context header (client-asserted, spoofable, analytics-only — same posture as `entrypoint`). Snapshots for days before this ships report `searches_scored: 0`, which is how "not computed" stays distinguishable from "nothing scored". No historical row is rewritten.
- Response payload gains two keys; nothing is removed or renamed.

## Verification

- `mix precommit` green: 7662 tests, 0 failures.
- Four new guards, each **mutation-verified** — deleted individually, each produced a named failing test: the query comparison, the session comparison, the hook exclusion, the session-required filter.
- `EXPLAIN ANALYZE` of the new predicate shape against production: 0.8 ms, index scan on `article_access_events_tenant_type_time_idx`, inner loop never executed. Dropping `api_key_id` moves the plan onto a better-matched index, not off one.

## Review

Reviewed inline by the authoring session rather than by the enhanced-review pipeline: this session runs under instructions that forbid dispatching review agents and workflows. Per the review-gate clause in CLAUDE.md the gate is satisfied by the best available reviewer, and the blast radius here is proportionate to that — an analytics metric on a feature branch, no auth, credentials, money, or PHI surface touched. The lenses applied were correctness of the SQL predicate, tenant scoping, the partition invariant, migration safety, index/plan cost, and payload compatibility.

Two things the inline pass surfaced and fixed rather than reported: 28 gratuitous backslash-quote escapes that had accumulated in `retrieval_metrics.ex`, and three `knowledge-wiki` skill citations that this change shifted.
