### PR TITLE
Delete six provenance fields that could never have reported anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to loopctl are documented here.
 
 ## [Unreleased] — 2026-08-07 — Story lifecycle capability delivery
 
+### Removed
+
+- **The six `curated_*` / `retrieved_*` provenance fields** are gone from
+  `GET /api/v1/knowledge/retrieval_metrics`, the `knowledge_retrieval_metrics` MCP tool, and
+  the `retrieval_metric_snapshots` table (migration `20260820020000`, which drops six
+  columns). Any consumer reading those keys must stop; nothing else on the payload changed.
+
+  They could never report anything, and published a confident `0` instead of an absence:
+
+  - **Nothing has ever been curated.** A source counts as curated only if its article has
+    `curated_at` set, and that was NULL on all 85,325 production articles — the shipped
+    `scope: :system` canonicals included. Every provenance decision therefore resolves
+    `retrieved` over an empty candidate set.
+  - **The buckets read a tag namespace the default path does not write.** They filtered
+    `mode` for `hybrid_curated` / `hybrid_retrieved`, which only `knowledge_hybrid_search`
+    produces, while the default search path has tagged the same decision `combined_curated` /
+    `combined_retrieved` since the hybrid resolver moved onto it. At removal that was 8,090
+    rows the metric could not see against 252 it could — roughly 97% of the traffic its own
+    documentation claimed it made observable.
+
+  No data is lost that could not be recomputed: every value derived from
+  `article_access_events`, which is not pruned. Reintroducing the breakdown requires BOTH
+  that something actually sets `curated_at` and that the filter match the `combined_*` tags.
+
+- **`knowledge_hybrid_search` now says the curated branch is unreachable.** Its tool
+  description told agents that a `curated` verdict means a canonical article answered and to
+  trust it. That outcome cannot occur while no article is marked curated, so the description
+  now says so and tells agents to read `retrieved` as the normal case rather than as evidence
+  that a curated answer was considered and rejected. The line comes out when curation exists.
+
 ### Changed
 
 - **`searches_reformulated` was measuring search density, not reformulation** — the figure it

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -9595,9 +9595,12 @@ defmodule Loopctl.Knowledge do
   `mode: "hybrid_curated"` or `mode: "hybrid_retrieved"` in the `ArticleAccessEvent`
   metadata — an additive extension of the existing mode tags (`"keyword"`,
   `"semantic"`, `"combined"`). This rides the existing
-  `Loopctl.Knowledge.RetrievalMetrics` / `article_access_events` pipeline (see its
-  `curated_searched`/`retrieved_searched` breakdown), so "prefer-curated silently
-  hiding better retrieval" is observable per tenant without a new table. That DB-backed
+  `Loopctl.Knowledge.RetrievalMetrics` / `article_access_events` pipeline. NOTE: the
+  named `curated_*`/`retrieved_*` breakdown this used to point at was removed in #712 —
+  it read only these `hybrid_*` tags while the default path writes `combined_*`, so it
+  saw ~3% of the decisions. "Prefer-curated silently hiding better retrieval" is
+  observable per tenant by querying the mode tag directly, until a breakdown that reads
+  BOTH namespaces earns its way back. That DB-backed
   recording still requires a non-empty page + `:api_key_id` (an inherited constraint of
   `article_access_events`, whose `article_id`/`api_key_id` are NOT NULL); a MISS
   (empty page) or a keyless call additionally emits a bare

--- a/lib/loopctl/knowledge/retrieval_metric_snapshot.ex
+++ b/lib/loopctl/knowledge/retrieval_metric_snapshot.ex
@@ -36,15 +36,11 @@ defmodule Loopctl.Knowledge.RetrievalMetricSnapshot do
   (UP). Full derivation, those biases, and the two structural exclusions (zero-result and
   keyless searches) are in `Loopctl.Knowledge.RetrievalMetrics`.
 
-  The `curated_*`/`retrieved_*` columns (US-31.2, AC-31.2.5) are the SAME searched /
-  followed_through / precision breakdown, restricted to `article_access_events` whose
-  `metadata->>'mode'` is `"hybrid_curated"` / `"hybrid_retrieved"` respectively — so an
-  operator can tell whether the hybrid resolver's `:curated` answers are actually
-  followed through on as often as `:retrieved` ones (a "prefer-curated silently hides
-  better retrieval" regression would show up as `curated_precision` trending well below
-  `retrieved_precision`). Rows written before US-31.2 (or by non-hybrid searches) simply
-  carry `0`/`0.0` in these columns — same "additive, never breaking" convention as the
-  rest of this schema.
+  The `curated_*`/`retrieved_*` columns were dropped in #712. They could never report
+  anything: nothing has ever set `curated_at`, and the buckets filtered a `mode` tag
+  namespace (`hybrid_*`) that the default search path does not write (`combined_*`). See
+  `Loopctl.Knowledge.RetrievalMetrics` for the full reasoning and the two conditions that
+  would have to hold before reintroducing them.
 
   `tenant_id` is set programmatically, never cast.
   """
@@ -65,12 +61,6 @@ defmodule Loopctl.Knowledge.RetrievalMetricSnapshot do
     field :searches_with_follow_through, :integer, default: 0
     field :search_follow_through, :float, default: 0.0
     field :results_returned, :integer, default: 0
-    field :curated_searched, :integer, default: 0
-    field :curated_followed_through, :integer, default: 0
-    field :curated_precision, :float, default: 0.0
-    field :retrieved_searched, :integer, default: 0
-    field :retrieved_followed_through, :integer, default: 0
-    field :retrieved_precision, :float, default: 0.0
 
     # Unit: READS (get/context/drill rows), NOT surfaced results and NOT search calls.
     # `followed_through` above counts SURFACED RESULTS that were later opened, so it is not
@@ -105,12 +95,6 @@ defmodule Loopctl.Knowledge.RetrievalMetricSnapshot do
     :searches_with_follow_through,
     :search_follow_through,
     :results_returned,
-    :curated_searched,
-    :curated_followed_through,
-    :curated_precision,
-    :retrieved_searched,
-    :retrieved_followed_through,
-    :retrieved_precision,
     :attributed_opens,
     :cross_key_opens,
     :direct_opens,
@@ -136,12 +120,6 @@ defmodule Loopctl.Knowledge.RetrievalMetricSnapshot do
       :searches_with_follow_through,
       :search_follow_through,
       :results_returned,
-      :curated_searched,
-      :curated_followed_through,
-      :curated_precision,
-      :retrieved_searched,
-      :retrieved_followed_through,
-      :retrieved_precision,
       :computed_at
     ])
     |> unique_constraint([:tenant_id, :day, :window_seconds],

--- a/lib/loopctl/knowledge/retrieval_metrics.ex
+++ b/lib/loopctl/knowledge/retrieval_metrics.ex
@@ -275,8 +275,7 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
 
   Returns `%{searched, results_recorded, followed_through, precision, searches,
   searches_with_follow_through, search_follow_through, results_returned, day,
-  window_seconds, curated_searched, curated_followed_through, curated_precision,
-  retrieved_searched, retrieved_followed_through, retrieved_precision, attributed_opens,
+  window_seconds, attributed_opens,
   cross_key_opens, direct_opens, searches_scored, searches_scored_with_follow_through,
   searches_reformulated, searches_quiet}`.
 
@@ -289,14 +288,26 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
   are reported, for the cap's opposite-signed effects on `search_follow_through`, and for
   why neither ratio may be optimised alone.
 
-  The `curated_*`/`retrieved_*` fields (US-31.2, AC-31.2.5) are the SAME
-  searched/followed_through/precision computation, restricted to `"search"` events
-  whose `metadata->>'mode'` is `"hybrid_curated"` / `"hybrid_retrieved"` (set by
-  `Loopctl.Knowledge.hybrid_search/3`) — so the hybrid resolver's provenance decision
-  is observable through this NAMED surface, not just via ad-hoc raw
-  `article_access_events` queries on the mode tag. Non-hybrid search events (`"keyword"`,
-  `"semantic"`, `"combined"`, etc.) contribute to the top-level `searched`/
-  `followed_through`/`precision` only, never to either provenance bucket.
+  There is deliberately NO `curated_*`/`retrieved_*` provenance breakdown here any more
+  (US-31.2 / AC-31.2.5, removed #712). It was structurally incapable of reporting anything,
+  for two independent reasons, and published a confident `0` for both:
+
+    * NOTHING HAS EVER BEEN CURATED. `list_curated_sources` requires `curated_at IS NOT
+      NULL` (`Knowledge.curated_sources_base_query/2`); production held 0 such articles out
+      of 85,325 at removal, the shipped `scope: :system` canonicals included. Every
+      provenance decision therefore resolves `:retrieved` over an empty candidate set, so
+      `curated_searched` was a constant `0` that looked like a measurement.
+    * IT READ THE WRONG TAG NAMESPACE. The buckets filtered `mode` for `"hybrid_curated"` /
+      `"hybrid_retrieved"`, which only `hybrid_search/3` writes. Since #670 the DEFAULT
+      search path makes the same provenance decision and tags it `"combined_curated"` /
+      `"combined_retrieved"` (`Knowledge.combined_search_mode/1`). At removal that was 8,090
+      rows the metric could not see against 252 it could — so it ignored ~97% of the very
+      traffic its own docstring claimed made the decision "observable through this NAMED
+      surface".
+
+  If the provenance question is worth answering again, BOTH must be true first: something
+  must actually set `curated_at`, and the filter must match the `combined_*` tags. Restoring
+  the fields without the second is restoring a metric that reads a namespace nothing writes.
   """
   @spec compute(Ecto.UUID.t(), Date.t(), pos_integer()) :: map()
   def compute(tenant_id, %Date{} = day, window_seconds \\ @default_window_seconds) do
@@ -316,18 +327,6 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
     followed = compute_followed_through(searched_q, window_seconds)
     precision = safe_precision(followed, searched)
 
-    curated_q = where(searched_q, [s], fragment("?->>'mode' = ?", s.metadata, "hybrid_curated"))
-    curated_searched = AdminRepo.aggregate(curated_q, :count, :id)
-    curated_followed = compute_followed_through(curated_q, window_seconds)
-    curated_precision = safe_precision(curated_followed, curated_searched)
-
-    retrieved_q =
-      where(searched_q, [s], fragment("?->>'mode' = ?", s.metadata, "hybrid_retrieved"))
-
-    retrieved_searched = AdminRepo.aggregate(retrieved_q, :count, :id)
-    retrieved_followed = compute_followed_through(retrieved_q, window_seconds)
-    retrieved_precision = safe_precision(retrieved_followed, retrieved_searched)
-
     call = compute_call_level(searched_q, window_seconds)
     opens = compute_open_attribution(tenant_id, day_start, day_end)
     dispositions = compute_dispositions(searched_q, window_seconds)
@@ -343,12 +342,6 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
       searches_with_follow_through: call.searches_with_follow_through,
       search_follow_through: call.search_follow_through,
       results_returned: call.results_returned,
-      curated_searched: curated_searched,
-      curated_followed_through: curated_followed,
-      curated_precision: curated_precision,
-      retrieved_searched: retrieved_searched,
-      retrieved_followed_through: retrieved_followed,
-      retrieved_precision: retrieved_precision,
       attributed_opens: opens.attributed_opens,
       cross_key_opens: opens.cross_key_opens,
       direct_opens: opens.direct_opens,
@@ -687,12 +680,6 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
       searches_with_follow_through: m.searches_with_follow_through,
       search_follow_through: m.search_follow_through,
       results_returned: m.results_returned,
-      curated_searched: m.curated_searched,
-      curated_followed_through: m.curated_followed_through,
-      curated_precision: m.curated_precision,
-      retrieved_searched: m.retrieved_searched,
-      retrieved_followed_through: m.retrieved_followed_through,
-      retrieved_precision: m.retrieved_precision,
       attributed_opens: m.attributed_opens,
       cross_key_opens: m.cross_key_opens,
       direct_opens: m.direct_opens,
@@ -716,12 +703,6 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
            :searches_with_follow_through,
            :search_follow_through,
            :results_returned,
-           :curated_searched,
-           :curated_followed_through,
-           :curated_precision,
-           :retrieved_searched,
-           :retrieved_followed_through,
-           :retrieved_precision,
            :attributed_opens,
            :cross_key_opens,
            :direct_opens,
@@ -770,12 +751,6 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
           searches_with_follow_through: s.searches_with_follow_through,
           search_follow_through: s.search_follow_through,
           results_returned: s.results_returned,
-          curated_searched: s.curated_searched,
-          curated_followed_through: s.curated_followed_through,
-          curated_precision: s.curated_precision,
-          retrieved_searched: s.retrieved_searched,
-          retrieved_followed_through: s.retrieved_followed_through,
-          retrieved_precision: s.retrieved_precision,
 
           # Unit: READS. NOT comparable with `followed_through`, which counts surfaced
           # RESULTS that were later opened. `cross_key_opens` is the injected recall hook's

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -4665,7 +4665,12 @@ const TOOLS = [
       "trustworthy answer plus its provenance rather than a ranked list to triage yourself; " +
       "use knowledge_search when you want to browse/enumerate matches. Additive — existing " +
       "knowledge tools are unchanged. If semantic ranking is unavailable it degrades to " +
-      "keyword-only (meta.fallback/fallback_reason), same as knowledge_search.",
+      "keyword-only (meta.fallback/fallback_reason), same as knowledge_search.\n\n" +
+      "TODAY THE CURATED BRANCH IS UNREACHABLE ON THIS DEPLOYMENT: a source counts as " +
+      "curated only if its article has curated_at set, and no article does — so every " +
+      "call returns provenance 'retrieved' and a null curated_article_id. Read a " +
+      "'retrieved' verdict as the normal case, not as evidence that a curated answer " +
+      "was considered and rejected. This line comes out when something actually curates.",
     inputSchema: {
       type: "object",
       properties: {

--- a/priv/repo/migrations/20260820020000_drop_dead_provenance_columns_from_retrieval_snapshots.exs
+++ b/priv/repo/migrations/20260820020000_drop_dead_provenance_columns_from_retrieval_snapshots.exs
@@ -1,0 +1,47 @@
+defmodule Loopctl.Repo.Migrations.DropDeadProvenanceColumnsFromRetrievalSnapshots do
+  use Ecto.Migration
+
+  @moduledoc """
+  Drops the six `curated_*` / `retrieved_*` columns (US-31.2, AC-31.2.5).
+
+  They were structurally incapable of reporting anything, and published a confident `0`
+  rather than an absence:
+
+    * Nothing has ever been curated. `curated_at` was NULL on all 85,325 production
+      articles at removal, so every provenance decision resolves `:retrieved` over an
+      empty candidate set and `curated_searched` was a constant `0`.
+    * The buckets filtered `mode` for `hybrid_curated` / `hybrid_retrieved`, which only
+      `hybrid_search/3` writes, while the DEFAULT search path has tagged the same decision
+      `combined_curated` / `combined_retrieved` since #670 — 8,090 rows the metric could
+      not see against 252 it could.
+
+  No data is lost that could not be recomputed: every value is derived from
+  `article_access_events`, which is not pruned, so a future breakdown that reads both tag
+  namespaces can backfill any day still covered by that table.
+
+  Irreversible by construction — `down/0` restores the columns (so a rollback boots), but
+  their historical values are NOT restored. They were `0` and `0.0` on every row anyway.
+  """
+
+  def up do
+    alter table(:retrieval_metric_snapshots) do
+      remove :curated_searched
+      remove :curated_followed_through
+      remove :curated_precision
+      remove :retrieved_searched
+      remove :retrieved_followed_through
+      remove :retrieved_precision
+    end
+  end
+
+  def down do
+    alter table(:retrieval_metric_snapshots) do
+      add :curated_searched, :integer, default: 0, null: false
+      add :curated_followed_through, :integer, default: 0, null: false
+      add :curated_precision, :float, default: 0.0, null: false
+      add :retrieved_searched, :integer, default: 0, null: false
+      add :retrieved_followed_through, :integer, default: 0, null: false
+      add :retrieved_precision, :float, default: 0.0, null: false
+    end
+  end
+end

--- a/test/loopctl/knowledge/retrieval_metrics_test.exs
+++ b/test/loopctl/knowledge/retrieval_metrics_test.exs
@@ -130,12 +130,6 @@ defmodule Loopctl.Knowledge.RetrievalMetricsTest do
                searches_with_follow_through: 0,
                search_follow_through: 0.0,
                results_returned: 0,
-               curated_searched: 0,
-               curated_followed_through: 0,
-               curated_precision: 0.0,
-               retrieved_searched: 0,
-               retrieved_followed_through: 0,
-               retrieved_precision: 0.0,
                attributed_opens: 0,
                cross_key_opens: 0,
                direct_opens: 0,
@@ -402,59 +396,6 @@ defmodule Loopctl.Knowledge.RetrievalMetricsTest do
     end
   end
 
-  describe "compute/3 - provenance breakdown (US-31.2, AC-31.2.5)" do
-    test "curated and retrieved hybrid-search events are broken out from each other and from non-hybrid events",
-         ctx do
-      %{tenant: t, key: k, x: x, y: y} = ctx
-      z = fixture(:article, %{tenant_id: t.id, status: :published})
-
-      # A hybrid :curated search, opened within the window -> curated follow-through.
-      fixture(:article_access_event, %{
-        tenant_id: t.id,
-        api_key_id: k.id,
-        article_id: x.id,
-        access_type: "search",
-        metadata: %{"mode" => "hybrid_curated"},
-        accessed_at: at(~T[12:00:00])
-      })
-
-      event(t.id, k.id, x.id, "get", ~T[12:05:00])
-
-      # A hybrid :retrieved search, never opened -> retrieved miss.
-      fixture(:article_access_event, %{
-        tenant_id: t.id,
-        api_key_id: k.id,
-        article_id: y.id,
-        access_type: "search",
-        metadata: %{"mode" => "hybrid_retrieved"},
-        accessed_at: at(~T[12:00:00])
-      })
-
-      # A plain (non-hybrid) combined search -> counts toward the aggregate only.
-      fixture(:article_access_event, %{
-        tenant_id: t.id,
-        api_key_id: k.id,
-        article_id: z.id,
-        access_type: "search",
-        metadata: %{"mode" => "combined"},
-        accessed_at: at(~T[12:00:00])
-      })
-
-      m = RetrievalMetrics.compute(t.id, @day, 1800)
-
-      assert m.searched == 3
-      assert m.followed_through == 1
-
-      assert m.curated_searched == 1
-      assert m.curated_followed_through == 1
-      assert m.curated_precision == 1.0
-
-      assert m.retrieved_searched == 1
-      assert m.retrieved_followed_through == 0
-      assert m.retrieved_precision == 0.0
-    end
-  end
-
   describe "snapshot/3 + list_snapshots/2" do
     test "records a snapshot and is idempotent per tenant/day/window", ctx do
       %{tenant: t, key: k, x: x} = ctx
@@ -480,47 +421,6 @@ defmodule Loopctl.Knowledge.RetrievalMetricsTest do
       {:ok, _} = RetrievalMetrics.snapshot(t.id, @day, 1800)
 
       assert %{meta: %{total_count: 0}} = RetrievalMetrics.list_snapshots(other.id)
-    end
-
-    test "persists and lists the curated/retrieved provenance breakdown (US-31.2, AC-31.2.5)",
-         ctx do
-      %{tenant: t, key: k, x: x, y: y} = ctx
-
-      fixture(:article_access_event, %{
-        tenant_id: t.id,
-        api_key_id: k.id,
-        article_id: x.id,
-        access_type: "search",
-        metadata: %{"mode" => "hybrid_curated"},
-        accessed_at: at(~T[12:00:00])
-      })
-
-      event(t.id, k.id, x.id, "get", ~T[12:05:00])
-
-      fixture(:article_access_event, %{
-        tenant_id: t.id,
-        api_key_id: k.id,
-        article_id: y.id,
-        access_type: "search",
-        metadata: %{"mode" => "hybrid_retrieved"},
-        accessed_at: at(~T[12:00:00])
-      })
-
-      assert {:ok, snap} = RetrievalMetrics.snapshot(t.id, @day, 1800)
-      assert snap.curated_searched == 1
-      assert snap.curated_followed_through == 1
-      assert snap.curated_precision == 1.0
-      assert snap.retrieved_searched == 1
-      assert snap.retrieved_followed_through == 0
-      assert snap.retrieved_precision == 0.0
-
-      %{data: [row]} = RetrievalMetrics.list_snapshots(t.id)
-      assert row.curated_searched == 1
-      assert row.curated_followed_through == 1
-      assert row.curated_precision == 1.0
-      assert row.retrieved_searched == 1
-      assert row.retrieved_followed_through == 0
-      assert row.retrieved_precision == 0.0
     end
 
     test "persists, upserts and lists the call-level fields (#582)", ctx do


### PR DESCRIPTION
Owner-approved removal, following the Fable 5 holistic audit of the retrieval measurement surface.

## Why these six fields could never work

`curated_searched` has been `0` for the entire life of the series. That is a certainty, not a measurement — two independent causes, either one sufficient on its own.

**Nothing has ever been curated.** A source counts as curated only if its article has `curated_at` set. Production: **0 of 85,325 articles**, the shipped `scope: :system` canonicals included. Every provenance decision resolves `:retrieved` over an empty candidate set.

**The buckets read a tag namespace the default path does not write.** They filtered `mode` for `hybrid_curated`/`hybrid_retrieved`, which only `knowledge_hybrid_search` produces. Since #670 the *default* search path makes the same provenance decision and tags it `combined_curated`/`combined_retrieved`. Production 30-day mode mix:

| tag | rows | visible to the metric |
|---|---|---|
| `combined` | 21,325 | no (pre-tagging) |
| `combined_retrieved` | 8,090 | **no — wrong namespace** |
| `keyword` | 1,032 | no |
| `hybrid_retrieved` | 252 | yes |
| `combined_fallback` | 46 | no |
| `combined_curated` / `hybrid_curated` | 0 | never produced |

The docstring claimed the resolver's decision was "observable through this NAMED surface". It was blind to ~97% of the decisions.

## Why the fix is deletion rather than a wider filter

A curated-vs-retrieved split is only worth computing once something is actually curated. Widening the filter alone would produce a "retrieved" bucket that duplicates `searched`. Both conditions for reintroduction are recorded at the removal site, so a future reader gets the test rather than the conclusion.

## Deploy notes

- Migration `20260820020000` **drops six columns**. No data is lost that could not be recomputed — every value derives from `article_access_events`, which is not pruned, so a future breakdown can backfill any day that table still covers. `down/0` restores the columns so a rollback boots, but not their values, which were `0`/`0.0` on every row.
- **Breaking for any consumer reading those six payload keys.** Nothing else on the payload changed.

## Also in here

`knowledge_hybrid_search`'s tool description told agents that a `curated` verdict means a canonical article answered and to trust it. That outcome cannot occur on this deployment, so an agent seeing `retrieved` was invited to infer that a curated answer had been considered and rejected. It now states the branch is unreachable and why, and that the line comes out when curation exists.

## Verification

`mix precommit` green: 7660 tests, 0 failures. The two tests that exercised the provenance breakdown are deleted rather than weakened — they asserted behaviour that no longer exists.

## Review

Reviewed inline by the authoring session; this session runs under instructions that forbid dispatching review agents. Per the review-gate clause in CLAUDE.md the gate is satisfied by the best available reviewer, and the blast radius is proportionate — an analytics payload on a feature branch, no auth, credentials, money or PHI surface. The finding itself originated from an independent Fable 5 audit and was re-verified against production before this change was written.
