### PR TITLE
Count reads, not what the ranker surfaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to loopctl are documented here.
 
 ## [Unreleased] — 2026-08-07 — Story lifecycle capability delivery
 
+### Changed
+
+- **The KB analytics surfaces now count READS, not impressions — and several payload keys are
+  renamed.** `article_access_events` holds two populations distinguished only by
+  `access_type`: reads (`get`/`context`/`drill`, a body actually delivered) and impressions
+  (`search`/`index`, one row per result the ranker surfaced). Impressions outrun reads roughly
+  50:1, and four surfaces headlined an unfiltered count of both under names that promised
+  reads. **Any dashboard reading these will report different — much smaller, and correct —
+  numbers after this release.**
+
+  Behaviour changes:
+
+  - `knowledge_analytics_top` / `GET .../analytics/top-articles` — `access_type` now defaults
+    to reads instead of every event. Pass `access_type=all` for the previous behaviour; single
+    types are unchanged. It was ranking ranker output while documented as "which articles
+    agents actually read".
+  - `knowledge_unused_articles` — "unused" now means **not read**, where it previously meant
+    "no event of any type". On the old definition an article the ranker surfaced constantly
+    and nobody ever opened counted as *used*, so the dead-weight detector was blind to the
+    largest class of dead weight.
+  - `knowledge_agent_usage` — `total_reads` now counts reads. It counted every event, so the
+    recall hook's key reported thousands of "reads" for a shell script that has deliberately
+    read one article ever. `total_events` is added for the old figure.
+
+  Renamed payload keys:
+
+  | surface | was | now |
+  |---|---|---|
+  | `knowledge_article_stats` | `total_accesses` | `total_events` (plus a new `total_reads`) |
+  | `knowledge_article_stats` | `unique_agents` | `unique_keys` |
+  | `knowledge_analytics_top` rows | `unique_agents` | `unique_keys` |
+
+  `unique_agents` was `count(DISTINCT api_key_id)`. That is not an agent count — the v2
+  dispatch pattern mints one ephemeral key per dispatch, so one agent dispatched N times is N
+  keys. The per-project `unique_agents` figure is unchanged: it joins `api_keys` and counts
+  distinct `agent_id`, so it always meant what it said.
+
 ### Removed
 
 - **The six `curated_*` / `retrieved_*` provenance fields** are gone from

--- a/lib/loopctl/knowledge/analytics.ex
+++ b/lib/loopctl/knowledge/analytics.ex
@@ -52,6 +52,26 @@ defmodule Loopctl.Knowledge.Analytics do
   # `"drill"` exists and why the two allowlists move together (#569).
   @valid_access_types ~w(search get context index drill)
 
+  # A READ is a body actually delivered to an agent. `search` and `index` are IMPRESSIONS —
+  # rows the RANKER produced, one per surfaced result — and they outnumber reads ~50:1 here.
+  #
+  # The distinction is enforced at ONE seam (`maybe_filter_access_type/2`, whose `nil` clause
+  # means "reads", not "everything"), because the KB records the failure of assuming it at
+  # each query surface instead: "the recording is transparent — each access row looks
+  # identical whether from a direct get (user intent) or from a query result", so an aggregate
+  # `COUNT(*) by article_id` ranks ranker output while reading as usage. Every surface that
+  # exposes this data applies it, for the same reason a new exclusion has to be threaded
+  # through per-article, per-project, per-agent, stats AND unused rather than only the primary
+  # one — missing a single surface reintroduces the whole defect there. The three usage
+  # builders construct their own `top_articles` query without the `:event` alias, so they
+  # carry the predicate explicitly rather than through the seam.
+  #
+  # `drill` counts as a read: progressive disclosure delivers a body. It is deliberately
+  # EXCLUDED from the heat index (`Knowledge.@heat_read_access_types`), and that divergence is
+  # intended — heat asks "was this a deliberate vote", this asks "was a body delivered". Do
+  # not unify the two lists.
+  @read_access_types ~w(get context drill)
+
   # The access types that mean "a body was DELIVERED to the agent" — the ones worth
   # attributing back to a search. Deliberately the same three `RetrievalMetrics` counts as
   # follow-through, INCLUDING `drill`: #569 split drill out of the heat index so that index
@@ -77,6 +97,25 @@ defmodule Loopctl.Knowledge.Analytics do
   """
   @spec valid_access_types() :: [String.t()]
   def valid_access_types, do: @valid_access_types
+
+  @doc """
+  The access types that count as a READ (a body delivered), as opposed to an impression.
+
+  Public so callers and tests can assert the set without reaching into the attribute.
+  """
+  @spec read_access_types() :: [String.t()]
+  def read_access_types, do: @read_access_types
+
+  @doc """
+  Access-type values a CALLER may select on an analytics query.
+
+  This is `valid_access_types/0` plus `"all"`, and the two lists are deliberately separate.
+  `@valid_access_types` validates the access_type of a RECORDED event (`record_access/6`),
+  so `"all"` must never appear there — it is a query selector, not a storable type, and
+  admitting it would let a caller persist an event whose type means "every type".
+  """
+  @spec selectable_access_types() :: [String.t()]
+  def selectable_access_types, do: ["all" | @valid_access_types]
 
   @doc """
   The access types whose rows get an `origin_search_id` resolved at write time.
@@ -308,8 +347,10 @@ defmodule Loopctl.Knowledge.Analytics do
 
   A map with:
 
-  - `:total_accesses` -- total event count
-  - `:unique_agents` -- distinct `api_key_id` count
+  - `:total_events` -- total event count, impressions included
+  - `:total_reads` -- events that delivered a body (`get`/`context`/`drill`)
+  - `:unique_keys` -- distinct `api_key_id` count. NOT an agent count: v2 mints one
+    ephemeral key per dispatch, so one agent dispatched N times is N keys
   - `:last_accessed_at` -- most recent `accessed_at` (or nil)
   - `:accesses_by_type` -- `%{"search" => N, "get" => N, ...}`
   - `:recent_accesses` -- last 10 events as plain maps
@@ -321,9 +362,13 @@ defmodule Loopctl.Knowledge.Analytics do
         where: e.tenant_id == ^tenant_id and e.article_id == ^article_id
       )
 
-    total = AdminRepo.aggregate(base, :count, :id)
+    total_events = AdminRepo.aggregate(base, :count, :id)
 
-    unique_agents =
+    total_reads =
+      from(e in base, where: e.access_type in @read_access_types)
+      |> AdminRepo.aggregate(:count, :id)
+
+    unique_keys =
       from(e in base, select: count(e.api_key_id, :distinct))
       |> AdminRepo.one()
       |> Kernel.||(0)
@@ -353,8 +398,9 @@ defmodule Loopctl.Knowledge.Analytics do
 
     %{
       article_id: article_id,
-      total_accesses: total,
-      unique_agents: unique_agents,
+      total_events: total_events,
+      total_reads: total_reads,
+      unique_keys: unique_keys,
       last_accessed_at: last_accessed_at,
       accesses_by_type: accesses_by_type,
       recent_accesses: recent_accesses
@@ -377,7 +423,11 @@ defmodule Loopctl.Knowledge.Analytics do
   - `:group_by` -- `:article` (default), `:project`, or `:agent`
 
   When `group_by` is `:article`, each row is:
-  `%{article_id, title, category, access_count, unique_agents}`.
+  `%{article_id, title, category, access_count, unique_keys}`.
+
+  `access_type` defaults to READS (`get`/`context`/`drill`), not to every event. Pass
+  `access_type: "all"` for the old impressions-included behaviour, or a single type to
+  select one. See `@read_access_types`.
 
   When `group_by` is `:project`, each row is:
   `%{project_id, project_name, access_count, unique_articles, unique_api_keys}`.
@@ -433,7 +483,7 @@ defmodule Loopctl.Knowledge.Analytics do
           title: a.title,
           category: a.category,
           access_count: count(e.id),
-          unique_agents: count(e.api_key_id, :distinct)
+          unique_keys: count(e.api_key_id, :distinct)
         }
       )
 
@@ -661,7 +711,11 @@ defmodule Loopctl.Knowledge.Analytics do
         where: e.accessed_at >= ^since
       )
 
-    total_reads = AdminRepo.aggregate(base, :count, :id)
+    total_events = AdminRepo.aggregate(base, :count, :id)
+
+    total_reads =
+      from(e in base, where: e.access_type in @read_access_types)
+      |> AdminRepo.aggregate(:count, :id)
 
     unique_articles =
       from(e in base, select: count(e.article_id, :distinct))
@@ -680,6 +734,7 @@ defmodule Loopctl.Knowledge.Analytics do
         where: e.tenant_id == ^tenant_id,
         where: e.api_key_id == ^api_key_id,
         where: e.accessed_at >= ^since,
+        where: e.access_type in @read_access_types,
         group_by: [a.id, a.title, a.category],
         order_by: [desc: count(e.id)],
         limit: ^limit,
@@ -696,6 +751,7 @@ defmodule Loopctl.Knowledge.Analytics do
     %{
       resolved_as: :api_key,
       api_key_id: api_key_id,
+      total_events: total_events,
       total_reads: total_reads,
       unique_articles: unique_articles,
       access_by_type: access_by_type,
@@ -739,7 +795,11 @@ defmodule Loopctl.Knowledge.Analytics do
         where: e.accessed_at >= ^since
       )
 
-    total_reads = AdminRepo.aggregate(base, :count, :id)
+    total_events = AdminRepo.aggregate(base, :count, :id)
+
+    total_reads =
+      from(e in base, where: e.access_type in @read_access_types)
+      |> AdminRepo.aggregate(:count, :id)
 
     unique_articles =
       from(e in base, select: count(e.article_id, :distinct))
@@ -765,6 +825,7 @@ defmodule Loopctl.Knowledge.Analytics do
         where: e.tenant_id == ^tenant_id,
         where: e.api_key_id in subquery(live_keys),
         where: e.accessed_at >= ^since,
+        where: e.access_type in @read_access_types,
         group_by: [a.id, a.title, a.category],
         order_by: [desc: count(e.id)],
         limit: ^limit,
@@ -784,6 +845,7 @@ defmodule Loopctl.Knowledge.Analytics do
       agent_name: agent && agent.name,
       agent_type: agent && agent.agent_type && Atom.to_string(agent.agent_type),
       api_key_count: api_key_count,
+      total_events: total_events,
       total_reads: total_reads,
       unique_articles: unique_articles,
       access_by_type: access_by_type,
@@ -845,7 +907,11 @@ defmodule Loopctl.Knowledge.Analytics do
         where: e.accessed_at >= ^since
       )
 
-    total_reads = AdminRepo.aggregate(base, :count, :id)
+    total_events = AdminRepo.aggregate(base, :count, :id)
+
+    total_reads =
+      from(e in base, where: e.access_type in @read_access_types)
+      |> AdminRepo.aggregate(:count, :id)
 
     unique_articles =
       from(e in base, select: count(e.article_id, :distinct))
@@ -879,6 +945,7 @@ defmodule Loopctl.Knowledge.Analytics do
         where: e.tenant_id == ^tenant_id,
         where: e.project_id == ^project.id,
         where: e.accessed_at >= ^since,
+        where: e.access_type in @read_access_types,
         group_by: [a.id, a.title, a.category],
         order_by: [desc: count(e.id)],
         limit: ^limit,
@@ -897,6 +964,7 @@ defmodule Loopctl.Knowledge.Analytics do
     %{
       project_id: project.id,
       project_name: project.name,
+      total_events: total_events,
       total_reads: total_reads,
       unique_articles: unique_articles,
       unique_api_keys: unique_api_keys,
@@ -987,6 +1055,10 @@ defmodule Loopctl.Knowledge.Analytics do
               where: e.tenant_id == ^tenant_id,
               where: e.accessed_at >= ^cutoff,
               where: e.article_id == parent_as(:article).id,
+              # READS only. On "any event at all", an article the ranker surfaces constantly
+              # and nobody ever opens counted as USED — leaving the dead-weight detector
+              # blind to the largest class of dead weight there is.
+              where: e.access_type in @read_access_types,
               select: 1
             )
           ),
@@ -1462,7 +1534,15 @@ defmodule Loopctl.Knowledge.Analytics do
   defp maybe_put_query(map, query) when is_binary(query), do: Map.put(map, "query", query)
   defp maybe_put_query(map, _), do: map
 
-  defp maybe_filter_access_type(query, nil), do: query
+  # Unspecified means READS, never "every row". The previous default mixed impressions into
+  # every figure whose name promised reads, and impressions outnumber reads ~50:1, so the
+  # default answer was ranker output wearing a usage label.
+  defp maybe_filter_access_type(query, nil) do
+    from([event: e] in query, where: e.access_type in @read_access_types)
+  end
+
+  # The explicit escape hatch for "I really do want impressions counted too".
+  defp maybe_filter_access_type(query, "all"), do: query
 
   defp maybe_filter_access_type(query, type) when type in @valid_access_types do
     from([event: e] in query, where: e.access_type == ^type)

--- a/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
@@ -39,6 +39,11 @@ defmodule LoopctlWeb.KnowledgeAnalyticsController do
   # from the enforced one either.
   @valid_access_types Analytics.valid_access_types()
 
+  # What a CALLER may ask for, which is the stored types PLUS `"all"`. Kept separate from
+  # `@valid_access_types` on purpose: that list validates the type of a RECORDED event, and
+  # `"all"` is a query selector rather than a storable type.
+  @selectable_access_types Analytics.selectable_access_types()
+
   # Same discipline as the line above: the published cap is READ from the module that
   # enforces it (`Knowledge.maybe_record_search_access/5` takes exactly this many), so
   # raising the cap cannot leave the API description stating the old number.
@@ -74,7 +79,12 @@ defmodule LoopctlWeb.KnowledgeAnalyticsController do
         in: :query,
         type: :string,
         description:
-          "Restrict to a single access type (#{Enum.join(@valid_access_types, ", ")}). " <>
+          "Restrict to a single access type (#{Enum.join(@valid_access_types, ", ")}), or " <>
+            "\"all\" for every event type. DEFAULTS TO READS " <>
+            "(#{Enum.join(Analytics.read_access_types(), ", ")}) rather than to every event: " <>
+            "`search` and `index` are IMPRESSIONS the ranker produced, they outnumber reads " <>
+            "roughly 50:1, and counting them made this endpoint rank ranker output under a " <>
+            "name that promises usage. Pass \"all\" for the pre-#713 behaviour. " <>
             "An unrecognised value is a 400, never a silently unfiltered result.",
         required: false
       ],
@@ -531,11 +541,11 @@ defmodule LoopctlWeb.KnowledgeAnalyticsController do
   # filter had applied. A caller cannot tell that from a real answer.
   defp validate_access_type(nil), do: :ok
   defp validate_access_type(""), do: :ok
-  defp validate_access_type(value) when value in @valid_access_types, do: :ok
+  defp validate_access_type(value) when value in @selectable_access_types, do: :ok
 
   defp validate_access_type(value) when is_binary(value) do
     {:error, :bad_request,
-     "Invalid access_type #{inspect(value)}. Valid values: #{Enum.join(@valid_access_types, ", ")}"}
+     "Invalid access_type #{inspect(value)}. Valid values: #{Enum.join(@selectable_access_types, ", ")}"}
   end
 
   defp validate_access_type(_value),

--- a/lib/loopctl_web/controllers/knowledge_analytics_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_analytics_json.ex
@@ -44,8 +44,9 @@ defmodule LoopctlWeb.KnowledgeAnalyticsJSON do
         category: to_string(article.category),
         status: to_string(article.status),
         tags: article.tags || [],
-        total_accesses: stats.total_accesses,
-        unique_agents: stats.unique_agents,
+        total_events: stats.total_events,
+        total_reads: stats.total_reads,
+        unique_keys: stats.unique_keys,
         last_accessed_at: encode_dt(stats.last_accessed_at),
         accesses_by_type: stats.accesses_by_type,
         recent_accesses: Enum.map(stats.recent_accesses, &render_recent/1)
@@ -139,7 +140,7 @@ defmodule LoopctlWeb.KnowledgeAnalyticsJSON do
       title: row.title,
       category: row.category,
       access_count: row.access_count,
-      unique_agents: Map.get(row, :unique_agents)
+      unique_keys: Map.get(row, :unique_keys)
     }
     |> compact()
   end

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -6546,8 +6546,15 @@ const TOOLS = [
   {
     name: "knowledge_analytics_top",
     description:
-      "Return the top accessed knowledge articles for the tenant. " +
-      "Use to identify which articles agents actually read. Requires orchestrator role.",
+      "Return the top READ knowledge articles for the tenant — articles whose body was " +
+      "actually delivered (get/context/drill). Requires orchestrator role.\n\n" +
+      "access_type DEFAULTS TO READS, not to every event. `search` and `index` rows are " +
+      "IMPRESSIONS the ranker produced — one per surfaced result — and they outnumber reads " +
+      "roughly 50:1, so the old unfiltered default ranked ranker output while claiming to " +
+      "show what agents read. Pass access_type:'all' if you genuinely want impressions " +
+      "counted, or a single type to select one. unique_keys counts distinct API KEYS, not " +
+      "agents: v2 mints one ephemeral key per dispatch, so one agent dispatched N times is " +
+      "N keys.",
     inputSchema: {
       type: "object",
       properties: {
@@ -6580,8 +6587,12 @@ const TOOLS = [
   {
     name: "knowledge_article_stats",
     description:
-      "Return per-article usage statistics: total accesses, unique agents, " +
-      "by-type breakdown, and the 10 most recent events. Requires orchestrator role.",
+      "Return per-article usage statistics: total_events (impressions included), " +
+      "total_reads (bodies actually delivered — get/context/drill), unique_keys, a by-type " +
+      "breakdown, and the 10 most recent events. Requires orchestrator role.\n\n" +
+      "Read total_reads, not total_events, when you want usage: impressions outnumber reads " +
+      "roughly 50:1. unique_keys counts distinct API KEYS rather than agents — v2 mints one " +
+      "ephemeral key per dispatch.",
     inputSchema: {
       type: "object",
       properties: {
@@ -6596,7 +6607,8 @@ const TOOLS = [
   {
     name: "knowledge_agent_usage",
     description:
-      "Return knowledge usage for an agent: total reads, unique articles, top read articles. " +
+      "Return knowledge usage for an agent: total_reads (bodies actually delivered), " +
+      "total_events (impressions included), unique articles, top read articles. " +
       "Pass api_key_id (api_keys.id credential) OR agent_id (agents.id logical identity) — not both. " +
       "Requires orchestrator role.",
     inputSchema: {
@@ -6631,8 +6643,11 @@ const TOOLS = [
   {
     name: "knowledge_unused_articles",
     description:
-      "Return published articles that have not been accessed in the configured " +
-      "time window. Use to identify dead-weight knowledge. Requires orchestrator role.",
+      "Return published articles that have not been READ in the configured time window. " +
+      "Use to identify dead-weight knowledge. Requires orchestrator role.\n\n" +
+      "\"Not read\" means no get/context/drill. It deliberately does NOT mean \"no event\": " +
+      "on that definition an article the ranker surfaces constantly and nobody ever opens " +
+      "counted as USED, which made this blind to the largest class of dead weight there is.",
     inputSchema: {
       type: "object",
       properties: {

--- a/test/loopctl/knowledge_analytics_test.exs
+++ b/test/loopctl/knowledge_analytics_test.exs
@@ -199,8 +199,9 @@ defmodule Loopctl.KnowledgeAnalyticsTest do
       stats = Knowledge.get_article_stats(tenant.id, article.id)
 
       assert stats.article_id == article.id
-      assert stats.total_accesses == 3
-      assert stats.unique_agents == 2
+      assert stats.total_events == 3, "impressions included"
+      assert stats.total_reads == 2, "get + context; the `search` impression is not a read"
+      assert stats.unique_keys == 2
       assert stats.accesses_by_type == %{"get" => 1, "search" => 1, "context" => 1}
       assert is_struct(stats.last_accessed_at, DateTime)
       assert length(stats.recent_accesses) == 3
@@ -212,8 +213,9 @@ defmodule Loopctl.KnowledgeAnalyticsTest do
 
       stats = Knowledge.get_article_stats(tenant.id, article.id)
 
-      assert stats.total_accesses == 0
-      assert stats.unique_agents == 0
+      assert stats.total_events == 0
+      assert stats.total_reads == 0
+      assert stats.unique_keys == 0
       assert stats.accesses_by_type == %{}
       assert stats.last_accessed_at == nil
       assert stats.recent_accesses == []
@@ -237,7 +239,7 @@ defmodule Loopctl.KnowledgeAnalyticsTest do
       rows = Knowledge.list_top_articles(tenant.id, since: hours_ago(1))
 
       assert [%{title: "Hot", access_count: 3} = top | _] = rows
-      assert top.unique_agents == 1
+      assert top.unique_keys == 1
       titles = Enum.map(rows, & &1.title)
       assert "Cold" in titles
     end
@@ -271,6 +273,32 @@ defmodule Loopctl.KnowledgeAnalyticsTest do
       assert "Canon" in titles, "a system canonical's reads were dropped by the article join"
       assert "Own" in titles
       assert Enum.find(rows, &(&1.title == "Canon")).access_count == 2
+    end
+
+    test "defaults to READS, not to every event" do
+      tenant = fixture(:tenant)
+      {_raw, agent} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      read_me = fixture(:article, %{tenant_id: tenant.id, title: "Read", status: :published})
+      surfaced = fixture(:article, %{tenant_id: tenant.id, title: "Surfaced", status: :published})
+
+      Knowledge.record_access(tenant.id, read_me.id, agent.id, "get")
+
+      # Surfaced five times by the ranker and never once opened.
+      for _ <- 1..5 do
+        Knowledge.record_access(tenant.id, surfaced.id, agent.id, "search")
+      end
+
+      rows = Knowledge.list_top_articles(tenant.id, since: hours_ago(1))
+      titles = Enum.map(rows, & &1.title)
+
+      assert titles == ["Read"],
+             "impressions outnumber reads ~50:1 in production, so an unfiltered default " <>
+               "ranks ranker output under a name that promises reads"
+
+      # The escape hatch still returns the old view, and the ordering flips — which is
+      # exactly how badly the default was misreporting.
+      all_rows = Knowledge.list_top_articles(tenant.id, since: hours_ago(1), access_type: "all")
+      assert Enum.map(all_rows, & &1.title) == ["Surfaced", "Read"]
     end
 
     test "filters by access_type" do
@@ -321,7 +349,13 @@ defmodule Loopctl.KnowledgeAnalyticsTest do
 
       assert usage.resolved_as == :api_key
       assert usage.api_key_id == agent_a.id
-      assert usage.total_reads == 3
+      assert usage.total_events == 3, "every event on this key"
+
+      assert usage.total_reads == 2,
+             "get + context. `total_reads` counted the `search` impression too, so the " <>
+               "recall hook's key reported thousands of reads for a shell script that has " <>
+               "deliberately read one article ever"
+
       assert usage.unique_articles == 2
       assert usage.access_by_type == %{"get" => 1, "search" => 1, "context" => 1}
       assert length(usage.top_articles) == 2
@@ -329,6 +363,22 @@ defmodule Loopctl.KnowledgeAnalyticsTest do
   end
 
   describe "list_unused_articles/2" do
+    test "an article surfaced constantly but never read counts as UNUSED" do
+      tenant = fixture(:tenant)
+      {_raw, agent} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      article = fixture(:article, %{tenant_id: tenant.id, title: "Ghost", status: :published})
+
+      for _ <- 1..10 do
+        Knowledge.record_access(tenant.id, article.id, agent.id, "search")
+      end
+
+      rows = Knowledge.list_unused_articles(tenant.id, days_unused: 7)
+
+      assert Enum.map(rows, & &1.title) == ["Ghost"],
+             "on 'no event of any type' the dead-weight detector was blind to the largest " <>
+               "class of dead weight: surfaced constantly, opened never"
+    end
+
     test "returns published articles with zero accesses in the window" do
       tenant = fixture(:tenant)
       {_raw, agent} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
@@ -416,7 +466,7 @@ defmodule Loopctl.KnowledgeAnalyticsTest do
       Knowledge.record_access(tenant_b.id, article_b.id, agent_b.id, "get")
 
       stats_a_from_b = Knowledge.get_article_stats(tenant_b.id, article_a.id)
-      assert stats_a_from_b.total_accesses == 0
+      assert stats_a_from_b.total_events == 0
 
       top_a = Knowledge.list_top_articles(tenant_a.id, since: hours_ago(1))
       assert Enum.all?(top_a, &(&1.article_id == article_a.id))

--- a/test/loopctl_web/controllers/knowledge_analytics_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_analytics_controller_test.exs
@@ -85,7 +85,7 @@ defmodule LoopctlWeb.KnowledgeAnalyticsControllerTest do
       [first | _] = body["data"]
       assert first["title"] == "Hot"
       assert first["access_count"] == 3
-      assert first["unique_agents"] == 1
+      assert first["unique_keys"] == 1
       assert is_map(body["meta"])
     end
 
@@ -156,8 +156,9 @@ defmodule LoopctlWeb.KnowledgeAnalyticsControllerTest do
       data = json_response(conn, 200)["data"]
       assert data["article_id"] == article.id
       assert data["title"] == article.title
-      assert data["total_accesses"] == 2
-      assert data["unique_agents"] == 1
+      assert data["total_events"] == 2, "impressions included"
+      assert data["total_reads"] == 1, "the `search` row is an impression, not a read"
+      assert data["unique_keys"] == 1
       assert data["accesses_by_type"] == %{"get" => 1, "search" => 1}
       assert is_list(data["recent_accesses"])
     end


### PR DESCRIPTION
Tranche 1 of the Fable 5 audit's recommendations — the top-ranked cause of "numbers that don't make sense".

## The defect

`article_access_events` holds two populations distinguished only by `access_type`: **reads** (`get`/`context`/`drill` — a body delivered) and **impressions** (`search`/`index` — one row per result the ranker surfaced). Impressions outrun reads roughly **50:1**. Four surfaces headlined an unfiltered count of both, under names that promised reads.

| surface | what it claimed | what it did |
|---|---|---|
| `knowledge_analytics_top` | "which articles agents actually read" | no `access_type` filter — ranked ranker output |
| `list_unused_articles` | dead weight | "no event of any type", so surfaced-constantly-never-opened counted as **used** |
| `agent_usage.total_reads` | reads | every event — the recall hook's key reported thousands of "reads" for a shell script that has deliberately read one article ever |
| `unique_agents` (2 sites) | agent count | `count(DISTINCT api_key_id)`; the dispatch pattern mints one key per dispatch, so one agent dispatched N times is N keys |

## The shape of the fix

Enforced at **one seam** — `maybe_filter_access_type/2`'s `nil` clause now means *reads*, not *everything* — so per-article, per-project and per-agent inherit it. The three usage builders construct their own `top_articles` query without the `:event` alias, so they carry the predicate explicitly.

That shape is deliberate and comes from two KB findings: the diagnosis that "each access row looks identical whether from a direct get or from a query result", and the pattern that a new exclusion must be threaded through *every* surface exposing the data, because missing one reintroduces the whole defect there.

`drill` counts as a read here and stays **excluded** from the heat index. The divergence is intended and noted at both definitions: heat asks "was this a deliberate vote", this asks "was a body delivered".

## Breaking changes

Any dashboard on these will report different — much smaller, and correct — numbers.

- `access_type` defaults to reads. Pass `access_type=all` for the old behaviour.
- `total_accesses` → `total_events`, plus a new real `total_reads`.
- `unique_agents` → `unique_keys` on article-stats and top-article rows. The **per-project** `unique_agents` is untouched: it joins `api_keys` and counts distinct `agent_id`, so it always meant what it said.

`"all"` is validated against a **separate selectable list**, not added to the stored-type enum — that enum validates the `access_type` of a *recorded* event, and admitting `"all"` there would let a caller persist an event whose own type means "every type".

## Verification

`mix precommit` green: 7662 tests, 0 failures, credo clean. Three guards **mutation-verified** — each deleted individually, each produced a named failing test: the seam default, the unused-articles predicate, and the `total_reads` split.

## Review

Reviewed inline by the authoring session; this session runs under instructions that forbid dispatching review agents. Per the review-gate clause in CLAUDE.md the gate is satisfied by the best available reviewer, and the blast radius is proportionate — analytics payloads on a feature branch, no auth, credentials, money or PHI surface. The findings originated from an independent Fable 5 audit and were re-verified against production first.
