### PR TITLE
Stamp which definitions produced a snapshot row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to loopctl are documented here.
 
 ## [Unreleased] — 2026-08-07 — Story lifecycle capability delivery
 
+### Added
+
+- **`metric_version` on retrieval-metric snapshots** (migration `20260820030000`, additive,
+  `default 0`, no manual step). Every row now records which set of definitions produced it,
+  and the value is published in the series payload.
+
+  Three changes have already altered what a figure in this table *means*, each
+  forward-looking and each leaving no mark on the row: `searched` was redefined from search
+  calls to recorded surfaced results, infrastructure traffic began being excluded, and the
+  disposition trio was rescoped onto `searches_scored`. A reader comparing across one of those
+  boundaries was comparing definitions rather than days, with nothing in the data to reveal
+  it. That is the mechanism behind every "these numbers don't make sense" report this table
+  has produced.
+
+  **Compare rows only within a version.** Existing rows report `0` — "written before the
+  stamp, definitions unknown" — and are deliberately **not** backfilled to `1`, because
+  claiming they were computed under current definitions is the exact false confidence the
+  column exists to remove.
+
+  The bump is enforced as far as it mechanically can be: a test pins the current version
+  against the exact key set `compute/3` returns, so a field cannot be added, removed or
+  renamed without failing. A change of *meaning* that keeps the same keys is not detectable
+  that way, so the rule is written at the definition site: if a reader would draw a different
+  conclusion from the same number, bump the version and re-snapshot the affected days.
+
 ### Changed
 
 - **The KB analytics surfaces now count READS, not impressions — and several payload keys are

--- a/lib/loopctl/knowledge/retrieval_metric_snapshot.ex
+++ b/lib/loopctl/knowledge/retrieval_metric_snapshot.ex
@@ -80,6 +80,10 @@ defmodule Loopctl.Knowledge.RetrievalMetricSnapshot do
     field :searches_reformulated, :integer, default: 0
     field :searches_quiet, :integer, default: 0
 
+    # Which set of DEFINITIONS produced this row (see `RetrievalMetrics.@metric_version`).
+    # Rows are comparable only within a version. `0` predates the stamp.
+    field :metric_version, :integer, default: 0
+
     field :computed_at, :utc_datetime_usec
 
     timestamps(type: :utc_datetime_usec)
@@ -102,6 +106,7 @@ defmodule Loopctl.Knowledge.RetrievalMetricSnapshot do
     :searches_scored_with_follow_through,
     :searches_reformulated,
     :searches_quiet,
+    :metric_version,
     :computed_at
   ]
 

--- a/lib/loopctl/knowledge/retrieval_metrics.ex
+++ b/lib/loopctl/knowledge/retrieval_metrics.ex
@@ -176,6 +176,39 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
 
   @default_window_seconds 1800
 
+  # WHICH SET OF DEFINITIONS PRODUCED A ROW.
+  #
+  # Stamped on every snapshot and published in the series. Three changes have already altered
+  # what a figure here MEANS, each forward-looking, each leaving no mark on the row:
+  #
+  #   * #582 redefined `searched` from search CALLS to recorded surfaced RESULTS;
+  #   * #673 began excluding infrastructure traffic, so days either side are not comparable;
+  #   * #711 rescoped the disposition trio onto `searches_scored` and fixed a reformulation
+  #     predicate that had been measuring search density.
+  #
+  # A session comparing across one of those boundaries is comparing DEFINITIONS, not days, and
+  # nothing in the data let it notice. That is the machine that manufactures "numbers that
+  # don't make sense", and this column is the mark that stops it.
+  #
+  # BUMP THIS whenever you change what an existing figure means, add one, remove one, or
+  # rename one — then RE-SNAPSHOT the affected days, or accept that the series carries two
+  # definitions and say so. `retrieval_metrics_test.exs` pins the version against the exact
+  # key set `compute/3` returns, so a SHAPE change cannot land without a bump. A change of
+  # MEANING that keeps the same keys — #711 was exactly that — is not mechanically detectable,
+  # so it is on you: if a reader would draw a different conclusion from the same number, bump.
+  #
+  #   v0  rows predating this column. Definitions unknown; do not compare them with v1+.
+  #   v1  post-#711/#712/#713: disposition trio partitions `searches_scored`; no curated /
+  #       retrieved provenance breakdown; reads and impressions separated on the analytics
+  #       surfaces.
+  @metric_version 1
+
+  @doc """
+  The definition-set version stamped on snapshots written by this code. See `@metric_version`.
+  """
+  @spec metric_version() :: pos_integer()
+  def metric_version, do: @metric_version
+
   # `"search"` access rows are ALSO written by the query-less enumeration paths —
   # `Knowledge.list_filtered/2` (mode `"list"`) and `Knowledge.list_keyset/2` (mode
   # `"list_keyset"`). They belong in `searched` (they did surface results) but NOT in the
@@ -687,6 +720,7 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
       searches_scored_with_follow_through: m.searches_scored_with_follow_through,
       searches_reformulated: m.searches_reformulated,
       searches_quiet: m.searches_quiet,
+      metric_version: @metric_version,
       computed_at: DateTime.utc_now()
     }
 
@@ -710,6 +744,7 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
            :searches_scored_with_follow_through,
            :searches_reformulated,
            :searches_quiet,
+           :metric_version,
            :computed_at,
            :updated_at
          ]},
@@ -774,7 +809,12 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
           searches_scored: s.searches_scored,
           searches_scored_with_follow_through: s.searches_scored_with_follow_through,
           searches_reformulated: s.searches_reformulated,
-          searches_quiet: s.searches_quiet
+          searches_quiet: s.searches_quiet,
+
+          # Which set of definitions produced this row. Rows are comparable only WITHIN a
+          # version: a change here means a figure's meaning changed, not that the world did.
+          # `0` predates the stamp and its definitions are unknown.
+          metric_version: s.metric_version
         }
       )
       |> AdminRepo.all()

--- a/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
@@ -391,7 +391,14 @@ defmodule LoopctlWeb.KnowledgeAnalyticsController do
         "distilled query per prompt and never see what came back, so they cannot " <>
         "reformulate by construction. They remain in every other denominator on this " <>
         "surface, including precision. Read `searches - searches_scored` as n/a, never " <>
-        "as zero.",
+        "as zero.\n\n" <>
+        "COMPARE ROWS ONLY WITHIN A `metric_version`. Every row carries the version of the " <>
+        "definition set that produced it. Three changes have already altered what a figure " <>
+        "here MEANS — `searched` went from search calls to surfaced results, infrastructure " <>
+        "traffic began being excluded, and the disposition trio was rescoped — each " <>
+        "forward-looking and each previously leaving no mark on the row, so a series read " <>
+        "across one of those boundaries compares definitions rather than days. `0` means " <>
+        "the row predates the stamp and its definitions are unknown.",
     parameters: [
       limit: [
         in: :query,

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -6524,7 +6524,14 @@ const TOOLS = [
       "react to a result at all — the recall hook and the session-start auto-query emit one " +
       "distilled query per prompt and never see what came back, so they cannot reformulate " +
       "by construction. They stay in every other denominator here, precision included. " +
-      "Read searches - searches_scored as n/a, never as zero.",
+      "Read searches - searches_scored as n/a, never as zero.\n\n" +
+      "COMPARE ROWS ONLY WITHIN A metric_version. Every row carries the version of the " +
+      "definition set that produced it. Three changes have already altered what a figure here " +
+      "MEANS — searched went from search calls to surfaced results, infrastructure traffic " +
+      "began being excluded, and the disposition trio was rescoped — each forward-looking and " +
+      "each previously leaving no mark on the row, so a series read across one of those " +
+      "boundaries compares definitions rather than days. 0 means the row predates the stamp " +
+      "and its definitions are unknown.",
     inputSchema: {
       type: "object",
       properties: {

--- a/priv/repo/migrations/20260820030000_add_metric_version_to_retrieval_snapshots.exs
+++ b/priv/repo/migrations/20260820030000_add_metric_version_to_retrieval_snapshots.exs
@@ -1,0 +1,26 @@
+defmodule Loopctl.Repo.Migrations.AddMetricVersionToRetrievalSnapshots do
+  use Ecto.Migration
+
+  @moduledoc """
+  Records WHICH SET OF DEFINITIONS produced each retrieval-metric snapshot row.
+
+  Three changes have already altered what a figure in this table MEANS, each forward-looking,
+  each leaving no mark on the row: #582 redefined `searched` from search calls to recorded
+  surfaced results, #673 began excluding infrastructure traffic, and #711 rescoped the
+  disposition trio and fixed a reformulation predicate that had been measuring search density.
+
+  A reader comparing across one of those boundaries is comparing definitions rather than days,
+  and nothing in the data let them notice. That is the mechanism behind every "these numbers
+  don't make sense" report this table has produced, and it is what this column ends.
+
+  Defaults to `0`, meaning "written before the stamp existed, definitions unknown". Existing
+  rows are deliberately NOT backfilled to `1`: they were computed by older code and claiming
+  otherwise would be the exact false confidence this column exists to remove.
+  """
+
+  def change do
+    alter table(:retrieval_metric_snapshots) do
+      add :metric_version, :integer, default: 0, null: false
+    end
+  end
+end

--- a/test/loopctl/knowledge/retrieval_metrics_test.exs
+++ b/test/loopctl/knowledge/retrieval_metrics_test.exs
@@ -396,6 +396,59 @@ defmodule Loopctl.Knowledge.RetrievalMetricsTest do
     end
   end
 
+  describe "metric_version" do
+    # This is the mechanical half of the bump discipline. It CANNOT see a change of MEANING
+    # that keeps the same keys (#711 was exactly that, and is why the rule is written down at
+    # `@metric_version` rather than left to this test). It can and does see a field being
+    # added, removed or renamed — the shape changes that have historically shipped without any
+    # mark on the row, leaving a series where a value's meaning depends on when it was
+    # computed.
+    test "the published key set is pinned to the current version" do
+      keys =
+        RetrievalMetrics.compute(fixture(:tenant).id, @day, 1800)
+        |> Map.keys()
+        |> Enum.sort()
+
+      assert RetrievalMetrics.metric_version() == 1,
+             "the version changed — update the pinned key set below and RE-SNAPSHOT the " <>
+               "affected days, or the series silently carries two definitions"
+
+      assert keys == [
+               :attributed_opens,
+               :cross_key_opens,
+               :day,
+               :direct_opens,
+               :followed_through,
+               :precision,
+               :results_recorded,
+               :results_returned,
+               :search_follow_through,
+               :searched,
+               :searches,
+               :searches_quiet,
+               :searches_reformulated,
+               :searches_scored,
+               :searches_scored_with_follow_through,
+               :searches_with_follow_through,
+               :window_seconds
+             ],
+             "the shape of the published metric changed. That is a definition change: bump " <>
+               "`@metric_version`, update this list, and re-snapshot affected days."
+    end
+
+    test "a snapshot is stamped with the version that computed it" do
+      tenant = fixture(:tenant)
+
+      assert {:ok, snap} = RetrievalMetrics.snapshot(tenant.id, @day, 1800)
+      assert snap.metric_version == RetrievalMetrics.metric_version()
+
+      %{data: [row]} = RetrievalMetrics.list_snapshots(tenant.id)
+
+      assert row.metric_version == RetrievalMetrics.metric_version(),
+             "the version must reach the payload; a stamp nobody can read is not a stamp"
+    end
+  end
+
   describe "snapshot/3 + list_snapshots/2" do
     test "records a snapshot and is idempotent per tenant/day/window", ctx do
       %{tenant: t, key: k, x: x} = ctx


### PR DESCRIPTION
Tranche 2 of the Fable 5 audit's recommendations, and the one the audit ranked as the structural cause rather than a symptom.

## The problem it ends

Three changes have already altered what a figure in `retrieval_metric_snapshots` *means* — each forward-looking, each leaving no mark on the row:

| change | what it redefined |
|---|---|
| #582 | `searched` went from search CALLS to recorded surfaced RESULTS |
| #673 | infrastructure traffic began being excluded, so days either side are not comparable |
| #711 | the disposition trio was rescoped onto `searches_scored`, after its reformulation predicate turned out to be measuring search density |

A reader comparing across any of those boundaries was comparing definitions rather than days, with nothing in the data to reveal it. That is the mechanism behind every "these numbers don't make sense" report this table has produced — including the one that started this work.

## What lands

- `metric_version` on every snapshot, stamped at write time and **published in the series payload** — a stamp nobody can read is not a stamp.
- Existing rows report `0`: "written before the stamp, definitions unknown." Deliberately **not** backfilled to `1`, because asserting older rows were computed under current definitions is the exact false confidence this column exists to remove.
- The endpoint and MCP descriptions now say plainly: compare rows only within a version.

## The bump discipline, and its honest limit

A test pins the current version against the exact key set `compute/3` returns, so a field cannot be added, removed or renamed without a failure that tells you to bump and re-snapshot.

That cannot see a change of *meaning* which keeps the same keys — and #711 was exactly that shape. So the rule is written at the definition site rather than left to the test: **if a reader would draw a different conclusion from the same number, bump the version and re-snapshot the affected days.** The limitation is documented rather than papered over, because a guard trusted beyond its reach is worse than no guard.

## Deploy notes

Migration `20260820030000` is additive — one integer column, `default 0`, no backfill, no manual step.

## Verification

`mix precommit` green: 7664 tests, 0 failures, credo clean. (One earlier run showed a `DBConnection tcp recv: closed` in an unrelated LLM test — the known connection-exhaustion flake, not an assertion failure; it passed on retry and the full gate is green.)

Both guards **mutation-verified**: adding a field without bumping fails the pin; removing the stamp from the writer fails the round-trip test.

## Review

Reviewed inline by the authoring session; this session runs under instructions that forbid dispatching review agents. Per the review-gate clause in CLAUDE.md the gate is satisfied by the best available reviewer, and the blast radius is proportionate — one additive analytics column on a feature branch, no auth, credentials, money or PHI surface.
