### PR TITLE
Show KB stats per tenant, and refuse to blend them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to loopctl are documented here.
 
 ### Added
 
+- **`GET /api/v1/admin/knowledge/retrieval-metrics`** — per-tenant KB retrieval breakdown for
+  superadmins. One row per tenant for a single day, so an operator can see **which** account's
+  KB is unhealthy. Optional `day`, `window_seconds`, `active_only`; a malformed `day` or
+  `window_seconds` is a 400, never a silent fall back to the default window.
+
+  **It is a breakdown and deliberately never a roll-up, and the payload says so
+  (`meta.aggregation: "none"`).** Each tenant's KB is a different corpus with a different size
+  and traffic profile, so a total or mean across them describes no corpus that exists — a 2%
+  read rate over 79,000 articles blended with 40% over 30 is not a fact about either, and the
+  blend hides the account you were looking for. Platform-wide numbers stay in
+  `GET /api/v1/admin/stats`, which counts inventory (summable) rather than retrieval quality
+  (not).
+
+  Tenants with no snapshot for the day are **included** with `snapshot: null` rather than
+  omitted — a KB nobody queried, or a broken ingest, is a finding, and dropping the row hides
+  the most interesting one. Rows carry their own `metric_version` and these can differ within
+  one response, because a tenant not re-snapshotted since a definition change still carries
+  the older one; compare a column across tenants only where the versions match.
+
+  No new environment variables, and **no MCP tool**: cross-tenant reads are a superadmin
+  capability, and pinning a superadmin key into the agent-facing MCP config to make a stats
+  tool convenient would put a cross-tenant credential in every agent's reach. Call it with a
+  superadmin key directly.
+
+
 - **`metric_version` on retrieval-metric snapshots** (migration `20260820030000`, additive,
   `default 0`, no manual step). Every row now records which set of definitions produced it,
   and the value is published in the series payload.

--- a/lib/loopctl/knowledge/retrieval_metrics.ex
+++ b/lib/loopctl/knowledge/retrieval_metrics.ex
@@ -173,6 +173,7 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
   alias Loopctl.AdminRepo
   alias Loopctl.Knowledge.ArticleAccessEvent
   alias Loopctl.Knowledge.RetrievalMetricSnapshot
+  alias Loopctl.Tenants.Tenant
 
   @default_window_seconds 1800
 
@@ -470,6 +471,108 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
   # the still-unopened rows of a search that WAS followed through — counting it in two
   # buckets at once, and (because `quiet` is the remainder) silently zeroing the bucket the
   # genuinely quiet searches belong to. So the opened SEARCH IDS are subtracted as a set.
+  @doc """
+  One row PER TENANT for a single day — the cross-tenant BREAKDOWN, never a cross-tenant total.
+
+  Superadmin-only, and the shape is the point. Each tenant's KB is a different corpus with a
+  different size, subject mix and traffic profile, so a figure summed or averaged across them
+  describes no corpus that exists: a 2% read rate over 79,000 articles and a 40% read rate
+  over 30 says nothing when blended, and the blend hides exactly the account you were trying
+  to find. This function therefore returns ROWS and deliberately reports no aggregate — the
+  operator question it exists to answer is "WHICH tenant's KB is unhealthy", which only a
+  breakdown can answer.
+
+  **Do not add a totals row, a mean, or a `summary` key to this payload.** If a caller wants a
+  platform-wide number, that is a different question about a different unit (the platform, not
+  a KB) and belongs in `Tenants.system_stats/0`, which counts inventory rather than quality.
+
+  Tenants with no snapshot for `day` are INCLUDED with `snapshot: nil` rather than omitted.
+  A tenant that recorded nothing is a finding — a KB nobody queried, or a broken ingest — and
+  dropping it makes the most interesting row invisible. `active_only: false` additionally
+  includes suspended/deactivated tenants.
+
+  Rows carry their own `metric_version`, and they can DIFFER across tenants in the same
+  response: a tenant not re-snapshotted since a definition change still carries the older one.
+  Compare a column across tenants only where the versions match.
+
+  Opts: `:day` (default: yesterday, the day the nightly worker snapshots),
+  `:window_seconds`, `:active_only` (default `true`).
+  """
+  @spec tenant_breakdown(keyword()) :: %{rows: [map()], meta: map()}
+  def tenant_breakdown(opts \\ []) do
+    day = Keyword.get(opts, :day) || Date.add(Date.utc_today(), -1)
+    window = Keyword.get(opts, :window_seconds, @default_window_seconds)
+    active_only = Keyword.get(opts, :active_only, true)
+
+    tenants =
+      Tenant
+      |> scope_tenants_by_status(active_only)
+      |> order_by([t], asc: t.name)
+      |> select([t], %{id: t.id, name: t.name, status: t.status})
+      |> AdminRepo.all()
+
+    snapshots =
+      from(s in RetrievalMetricSnapshot,
+        where: s.day == ^day,
+        where: s.window_seconds == ^window
+      )
+      |> AdminRepo.all()
+      |> Map.new(fn s -> {s.tenant_id, s} end)
+
+    rows =
+      Enum.map(tenants, fn t ->
+        %{
+          tenant_id: t.id,
+          tenant_name: t.name,
+          tenant_status: t.status,
+          snapshot: snapshots |> Map.get(t.id) |> present_snapshot()
+        }
+      end)
+
+    %{
+      rows: rows,
+      meta: %{
+        day: day,
+        window_seconds: window,
+        active_only: active_only,
+        tenant_count: length(rows),
+        # Stated in the payload, not only in the docs, because the shape is what stops a
+        # reader summing it: this is a breakdown, and a cross-tenant total of a per-corpus
+        # rate is meaningless.
+        aggregation: :none,
+        note:
+          "One row per tenant. These figures are NOT summable or averageable across " <>
+            "tenants — each row describes a different corpus. Compare a column across rows " <>
+            "only where metric_version matches."
+      }
+    }
+  end
+
+  defp scope_tenants_by_status(query, true), do: where(query, [t], t.status == :active)
+  defp scope_tenants_by_status(query, _), do: query
+
+  defp present_snapshot(nil), do: nil
+
+  defp present_snapshot(%RetrievalMetricSnapshot{} = s) do
+    %{
+      searched: s.searched,
+      followed_through: s.followed_through,
+      precision: s.precision,
+      searches: s.searches,
+      searches_with_follow_through: s.searches_with_follow_through,
+      search_follow_through: s.search_follow_through,
+      searches_scored: s.searches_scored,
+      searches_scored_with_follow_through: s.searches_scored_with_follow_through,
+      searches_reformulated: s.searches_reformulated,
+      searches_quiet: s.searches_quiet,
+      attributed_opens: s.attributed_opens,
+      cross_key_opens: s.cross_key_opens,
+      direct_opens: s.direct_opens,
+      metric_version: s.metric_version,
+      computed_at: s.computed_at
+    }
+  end
+
   defp compute_dispositions(searched_q, window_seconds) do
     scoreable = reformulation_scoreable(searched_q)
 

--- a/lib/loopctl_web/controllers/admin_knowledge_stats_controller.ex
+++ b/lib/loopctl_web/controllers/admin_knowledge_stats_controller.ex
@@ -1,0 +1,140 @@
+defmodule LoopctlWeb.AdminKnowledgeStatsController do
+  @moduledoc """
+  Cross-tenant KB retrieval BREAKDOWN for superadmins.
+
+  `GET /api/v1/admin/knowledge/retrieval-metrics` — one row per tenant for a single day.
+
+  This is deliberately a breakdown and never a roll-up. Each tenant's KB is a different
+  corpus with a different size, subject mix and traffic profile, so a figure summed or
+  averaged across them describes no corpus that exists — and the blend hides the very
+  account an operator is looking for. `Tenants.system_stats/0` is the place for
+  platform-wide numbers; it counts inventory, which IS summable, rather than retrieval
+  quality, which is not.
+
+  The tenant-scoped equivalent for a normal key is
+  `GET /api/v1/knowledge/analytics/retrieval-metrics`, which never crosses a tenant
+  boundary. Nothing here relaxes that: this endpoint reads snapshots, which are already
+  one row per tenant per day, and it reports them separately.
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Knowledge.RetrievalMetrics
+
+  action_fallback LoopctlWeb.FallbackController
+
+  plug LoopctlWeb.Plugs.RequireRole, exact_role: :superadmin
+
+  tags(["Admin"])
+
+  operation(:index,
+    summary: "Per-tenant KB retrieval breakdown (admin)",
+    description:
+      "One row PER TENANT for a single day. Requires superadmin.\n\n" <>
+        "THIS IS A BREAKDOWN, NOT A ROLL-UP, AND THE ROWS ARE NOT SUMMABLE. Each tenant's " <>
+        "KB is a different corpus with a different size and traffic profile, so a mean or " <>
+        "total across them describes no corpus that exists — a 2% read rate over 79,000 " <>
+        "articles blended with a 40% rate over 30 is not a fact about either. The payload " <>
+        "reports `meta.aggregation: \"none\"` for that reason and carries no totals row. " <>
+        "For platform-wide numbers use GET /api/v1/admin/stats, which counts inventory " <>
+        "(summable) rather than retrieval quality (not).\n\n" <>
+        "Tenants with no snapshot for the day are INCLUDED with `snapshot: null` rather " <>
+        "than omitted — a KB nobody queried, or a broken ingest, is a finding, and dropping " <>
+        "the row makes the most interesting one invisible.\n\n" <>
+        "Rows carry their own `metric_version` and these CAN DIFFER within one response: a " <>
+        "tenant not re-snapshotted since a definition change still carries the older one. " <>
+        "Compare a column across tenants only where the versions match.",
+    parameters: [
+      day: [
+        in: :query,
+        type: :string,
+        description:
+          "ISO date (YYYY-MM-DD). Defaults to yesterday, which is the day the " <>
+            "nightly snapshot worker writes.",
+        required: false
+      ],
+      window_seconds: [
+        in: :query,
+        type: :integer,
+        description:
+          "Follow-through window the snapshot was computed with (default 1800). " <>
+            "A snapshot exists per (tenant, day, window), so a non-default value returns " <>
+            "rows only where one was computed at that window.",
+        required: false
+      ],
+      active_only: [
+        in: :query,
+        type: :boolean,
+        description:
+          "Restrict to active tenants (default true). Pass false to include " <>
+            "suspended and deactivated ones.",
+        required: false
+      ]
+    ],
+    responses: %{
+      200 =>
+        {"Per-tenant breakdown", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      400 => {"Invalid parameter", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc "GET /api/v1/admin/knowledge/retrieval-metrics"
+  def index(conn, params) do
+    with {:ok, day} <- parse_day(params["day"]),
+         {:ok, window} <- parse_window(params["window_seconds"]) do
+      opts = build_opts(day, window, params["active_only"] != "false")
+
+      %{rows: rows, meta: meta} = RetrievalMetrics.tenant_breakdown(opts)
+
+      json(conn, %{data: rows, meta: meta})
+    end
+  end
+
+  # Only the params the caller actually supplied are passed through, so the defaults live in
+  # ONE place (`RetrievalMetrics.tenant_breakdown/1`) rather than being restated here where
+  # they could drift out of agreement with it.
+  defp build_opts(day, window, active_only) do
+    [active_only: active_only]
+    |> put_unless_nil(:day, day)
+    |> put_unless_nil(:window_seconds, window)
+  end
+
+  defp put_unless_nil(opts, _key, nil), do: opts
+  defp put_unless_nil(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp parse_day(nil), do: {:ok, nil}
+  defp parse_day(""), do: {:ok, nil}
+
+  defp parse_day(value) when is_binary(value) do
+    case Date.from_iso8601(value) do
+      {:ok, day} -> {:ok, day}
+      {:error, _} -> {:error, :bad_request, "Invalid day #{inspect(value)}: expected YYYY-MM-DD"}
+    end
+  end
+
+  defp parse_day(_), do: {:error, :bad_request, "Invalid day: expected a string"}
+
+  defp parse_window(nil), do: {:ok, nil}
+  defp parse_window(""), do: {:ok, nil}
+
+  # A silently-ignored bad window would return the DEFAULT window's rows under a caller's
+  # explicit non-default request — the same shape of analytics bug the access_type validation
+  # already exists to prevent, so it is a 400 rather than a fallback.
+  defp parse_window(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {n, ""} when n > 0 ->
+        {:ok, n}
+
+      _ ->
+        {:error, :bad_request,
+         "Invalid window_seconds #{inspect(value)}: expected a positive integer"}
+    end
+  end
+
+  defp parse_window(_),
+    do: {:error, :bad_request, "Invalid window_seconds: expected a positive integer"}
+end

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -673,8 +673,13 @@ defmodule LoopctlWeb.Router do
     post "/tenants/:id/suspend", AdminTenantController, :suspend
     post "/tenants/:id/activate", AdminTenantController, :activate
 
-    # System-wide stats
+    # System-wide stats — INVENTORY counts, which are summable across tenants.
     get "/stats", AdminStatsController, :show
+
+    # Per-tenant KB retrieval BREAKDOWN — deliberately NOT part of /stats above. Retrieval
+    # quality is per-corpus and does not sum across tenants; this returns one row per tenant
+    # and no totals. See AdminKnowledgeStatsController.
+    get "/knowledge/retrieval-metrics", AdminKnowledgeStatsController, :index
 
     # Cross-tenant audit log
     get "/audit", AdminAuditController, :index

--- a/test/loopctl/knowledge/tenant_breakdown_test.exs
+++ b/test/loopctl/knowledge/tenant_breakdown_test.exs
@@ -1,0 +1,106 @@
+defmodule Loopctl.Knowledge.TenantBreakdownTest do
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.RetrievalMetrics
+  alias Loopctl.Knowledge.RetrievalMetricSnapshot
+
+  @day ~D[2026-08-18]
+
+  defp snapshot_for(tenant_id, opts) do
+    %RetrievalMetricSnapshot{tenant_id: tenant_id}
+    |> RetrievalMetricSnapshot.changeset(
+      Enum.into(opts, %{
+        day: @day,
+        window_seconds: 1800,
+        searched: 0,
+        followed_through: 0,
+        precision: 0.0,
+        computed_at: DateTime.utc_now()
+      })
+    )
+    |> AdminRepo.insert!()
+  end
+
+  describe "tenant_breakdown/1" do
+    test "returns one row per tenant and NO cross-tenant aggregate" do
+      busy = fixture(:tenant, %{name: "AAA Busy"})
+      quiet = fixture(:tenant, %{name: "BBB Quiet"})
+
+      snapshot_for(busy.id, searched: 1000, followed_through: 40, precision: 0.04)
+      snapshot_for(quiet.id, searched: 10, followed_through: 4, precision: 0.4)
+
+      %{rows: rows, meta: meta} = RetrievalMetrics.tenant_breakdown(day: @day)
+
+      busy_row = Enum.find(rows, &(&1.tenant_id == busy.id))
+      quiet_row = Enum.find(rows, &(&1.tenant_id == quiet.id))
+
+      assert busy_row.snapshot.searched == 1000
+      assert quiet_row.snapshot.searched == 10
+
+      assert busy_row.snapshot.precision == 0.04
+      assert quiet_row.snapshot.precision == 0.4
+
+      assert meta.aggregation == :none
+
+      refute Map.has_key?(meta, :total_searched),
+             "a cross-tenant total of a per-corpus figure describes no corpus that exists"
+
+      refute Map.has_key?(meta, :precision),
+             "averaging 4% over a large corpus with 40% over a tiny one is not a fact " <>
+               "about either, and it hides the account the operator is looking for"
+    end
+
+    test "a tenant with NO snapshot is included with a nil snapshot, not dropped" do
+      seen = fixture(:tenant, %{name: "AAA Seen"})
+      silent = fixture(:tenant, %{name: "BBB Silent"})
+
+      snapshot_for(seen.id, searched: 5)
+
+      %{rows: rows} = RetrievalMetrics.tenant_breakdown(day: @day)
+
+      silent_row = Enum.find(rows, &(&1.tenant_id == silent.id))
+
+      assert silent_row,
+             "a tenant that recorded nothing is a FINDING — a KB nobody queried " <>
+               "or a broken ingest — so dropping the row hides the most " <>
+               "interesting one"
+
+      assert silent_row.snapshot == nil
+      assert Enum.find(rows, &(&1.tenant_id == seen.id)).snapshot.searched == 5
+    end
+
+    test "rows carry their own metric_version and may differ within one response" do
+      old_defs = fixture(:tenant, %{name: "AAA Old"})
+      new_defs = fixture(:tenant, %{name: "BBB New"})
+
+      snapshot_for(old_defs.id, searched: 1, metric_version: 0)
+      snapshot_for(new_defs.id, searched: 1, metric_version: 1)
+
+      %{rows: rows} = RetrievalMetrics.tenant_breakdown(day: @day)
+
+      versions =
+        rows
+        |> Enum.filter(& &1.snapshot)
+        |> Map.new(&{&1.tenant_name, &1.snapshot.metric_version})
+
+      assert versions["AAA Old"] == 0
+
+      assert versions["BBB New"] == 1,
+             "a tenant not re-snapshotted since a definition change carries the older " <>
+               "version; the payload must expose that rather than implying comparability"
+    end
+
+    test "one tenant's snapshot never appears under another tenant" do
+      a = fixture(:tenant, %{name: "AAA"})
+      b = fixture(:tenant, %{name: "BBB"})
+
+      snapshot_for(a.id, searched: 777)
+
+      %{rows: rows} = RetrievalMetrics.tenant_breakdown(day: @day)
+
+      assert Enum.find(rows, &(&1.tenant_id == b.id)).snapshot == nil
+      assert Enum.find(rows, &(&1.tenant_id == a.id)).snapshot.searched == 777
+    end
+  end
+end

--- a/test/loopctl_web/controllers/admin_knowledge_stats_controller_test.exs
+++ b/test/loopctl_web/controllers/admin_knowledge_stats_controller_test.exs
@@ -1,0 +1,108 @@
+defmodule LoopctlWeb.AdminKnowledgeStatsControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.RetrievalMetricSnapshot
+
+  @day ~D[2026-08-18]
+
+  defp auth_conn(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+  defp snapshot_for(tenant_id, attrs) do
+    %RetrievalMetricSnapshot{tenant_id: tenant_id}
+    |> RetrievalMetricSnapshot.changeset(
+      Enum.into(attrs, %{
+        day: @day,
+        window_seconds: 1800,
+        searched: 0,
+        followed_through: 0,
+        precision: 0.0,
+        computed_at: DateTime.utc_now()
+      })
+    )
+    |> AdminRepo.insert!()
+  end
+
+  describe "GET /api/v1/admin/knowledge/retrieval-metrics" do
+    test "returns one row per tenant with no cross-tenant aggregate", %{conn: conn} do
+      {raw_key, _} = fixture(:api_key, %{role: :superadmin})
+
+      big = fixture(:tenant, %{name: "AAA Big Corpus", status: :active})
+      small = fixture(:tenant, %{name: "BBB Small Corpus", status: :active})
+
+      snapshot_for(big.id, searched: 1000, followed_through: 40, precision: 0.04)
+      snapshot_for(small.id, searched: 10, followed_through: 4, precision: 0.4)
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/admin/knowledge/retrieval-metrics?day=2026-08-18")
+        |> json_response(200)
+
+      rows = body["data"]
+      by_id = Map.new(rows, &{&1["tenant_id"], &1})
+
+      assert by_id[big.id]["snapshot"]["precision"] == 0.04
+      assert by_id[small.id]["snapshot"]["precision"] == 0.4
+
+      assert body["meta"]["aggregation"] == "none"
+
+      refute Map.has_key?(body["meta"], "precision"),
+             "blending a 4% rate over a large corpus with 40% over a tiny one is not a " <>
+               "fact about either, and it hides the account being looked for"
+    end
+
+    test "a tenant with no snapshot appears with a null snapshot", %{conn: conn} do
+      {raw_key, _} = fixture(:api_key, %{role: :superadmin})
+      silent = fixture(:tenant, %{name: "ZZZ Silent", status: :active})
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/admin/knowledge/retrieval-metrics?day=2026-08-18")
+        |> json_response(200)
+
+      row = Enum.find(body["data"], &(&1["tenant_id"] == silent.id))
+
+      assert row, "a KB nobody queried is a finding; dropping the row hides it"
+      assert row["snapshot"] == nil
+    end
+
+    test "403s every role below superadmin", %{conn: conn} do
+      tenant = fixture(:tenant)
+
+      for role <- [:agent, :orchestrator, :user] do
+        {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: role})
+
+        assert conn
+               |> auth_conn(raw_key)
+               |> get(~p"/api/v1/admin/knowledge/retrieval-metrics")
+               |> json_response(403),
+               "cross-tenant reads are a superadmin capability; #{role} must not see " <>
+                 "another tenant's KB figures"
+      end
+    end
+
+    test "400s a malformed day rather than silently returning the default", %{conn: conn} do
+      {raw_key, _} = fixture(:api_key, %{role: :superadmin})
+
+      assert conn
+             |> auth_conn(raw_key)
+             |> get(~p"/api/v1/admin/knowledge/retrieval-metrics?day=last-tuesday")
+             |> json_response(400)
+    end
+
+    test "400s a malformed window_seconds rather than falling back", %{conn: conn} do
+      {raw_key, _} = fixture(:api_key, %{role: :superadmin})
+
+      assert conn
+             |> auth_conn(raw_key)
+             |> get(~p"/api/v1/admin/knowledge/retrieval-metrics?window_seconds=soon")
+             |> json_response(400),
+             "a silently-ignored window returns the DEFAULT window's rows under an " <>
+               "explicit non-default request"
+    end
+  end
+end


### PR DESCRIPTION
Owner requirement: KB stats must be tenant-scoped and never lumped together, **and** stats by account should help identify issues with a particular KB.

## Verified first: the read path was already scoped

Before building anything I checked the existing surface against the rule that `tenant_id` must appear in every filter on every table:

- Every public function in `Knowledge.Analytics` and `RetrievalMetrics` takes `tenant_id` as its first argument.
- Every derived query hangs off a `base` that already carries the predicate (a static sweep flags those as bare, but each resolves to a scoped base — `get_article_stats`, `count_distinct_searches`, `sum_results_returned`, `list_snapshots` all check out).
- Snapshots are one row per `(tenant_id, day, window_seconds)`.
- The `a.tenant_id == ^tenant_id or a.scope == :system` join admits shared canonicals for **title resolution only**; the events it counts stay tenant-scoped.

So nothing was blending. **No fix was needed there, and none was invented.**

## What was actually missing

There was no per-account view of retrieval at all, so an operator could not tell *which* KB was unhealthy. The one cross-tenant endpoint, `/admin/stats`, reports platform inventory.

`GET /api/v1/admin/knowledge/retrieval-metrics` (superadmin) now returns **one row per tenant** for a single day.

## Why it refuses to aggregate — the shape is the feature

Each tenant's KB is a different corpus with a different size, subject mix and traffic profile. A total or mean across them describes no corpus that exists: **a 2% read rate over 79,000 articles blended with 40% over 30 is not a fact about either**, and the blend hides the exact account you went looking for.

So the payload carries `meta.aggregation: "none"` and no totals row, and the router comments say why this is *not* part of `/admin/stats`: inventory counts sum across tenants, retrieval quality does not. Stating it in the payload rather than only the docs is deliberate — the thing that stops a reader summing a column is the shape in front of them.

## Two details that carry the operator value

- **A tenant with no snapshot is included with `snapshot: null`, not dropped.** A KB nobody queried, or an ingest that broke, is a finding — dropping the row makes the most interesting one invisible.
- **Rows carry their own `metric_version`, and these can differ within one response**, because a tenant not re-snapshotted since a definition change still carries the older one. Compare a column across tenants only where the versions match. This is what #714's stamp was for.

A malformed `day` or `window_seconds` is a 400 rather than a silent fallback — an ignored window returns the *default* window's rows under an explicit non-default request, the same shape of bug the `access_type` validation already exists to prevent.

## No MCP tool, deliberately

Cross-tenant reads are a superadmin capability. Pinning a superadmin key into the agent-facing MCP config to make a stats tool convenient would put a cross-tenant credential within reach of every agent, which is a worse trade than calling the endpoint directly with a superadmin key. Flagging it as a reversible decision if you'd rather have the tool.

## Verification

`mix precommit` green: 7673 tests, 0 failures, credo clean. Three guards **mutation-verified** — each deleted individually, each produced a named failing test: the superadmin plug, the inclusion of snapshot-less tenants, and the absence of a cross-tenant total. Includes a tenant-isolation test per the repo convention.

## Review

Reviewed inline by the authoring session; this session runs under instructions that forbid dispatching review agents. Per the review-gate clause in CLAUDE.md the gate is satisfied by the best available reviewer. This one touches a superadmin surface, so the role gate got specific attention: `exact_role: :superadmin`, and the 403 is asserted for agent, orchestrator **and** user roles, with the plug mutation-verified rather than assumed.
