### PR TITLE
Stop the curated route index drifting from the router

### DIFF
--- a/lib/loopctl_web/controllers/route_discovery_controller.ex
+++ b/lib/loopctl_web/controllers/route_discovery_controller.ex
@@ -12,7 +12,29 @@ defmodule LoopctlWeb.RouteDiscoveryController do
   use LoopctlWeb, :controller
 
   def index(conn, _params) do
-    routes = [
+    routes = curated_routes()
+
+    json(conn, %{
+      routes: routes,
+      count: length(routes),
+      openapi: "/api/v1/openapi",
+      note:
+        "Curated index of common routes — the authoritative full API surface is the OpenAPI spec at /api/v1/openapi."
+    })
+  end
+
+  @doc """
+  The hand-curated route index.
+
+  Public so tests can check it against `LoopctlWeb.Router.__routes__/0` in BOTH directions:
+  no phantom entry for a route the router does not serve, and no `/api/v1/admin` GET route
+  missing from it. Omission is legal in general — this is a "common routes" index, not the
+  API surface, which is the OpenAPI spec — but admin is a small closed set whose whole
+  audience discovers routes here, so a superadmin endpoint absent from it is invisible.
+  """
+  @spec curated_routes() :: [%{method: String.t(), path: String.t(), description: String.t()}]
+  def curated_routes do
+    [
       # Route discovery
       %{method: "GET", path: "/api/v1/routes", description: "This endpoint — list all routes"},
 
@@ -612,13 +634,18 @@ defmodule LoopctlWeb.RouteDiscoveryController do
         method: "GET",
         path: "/api/v1/knowledge/analytics/top-articles",
         description:
-          "Top accessed articles for the tenant. " <>
+          "Top READ articles for the tenant (bodies actually delivered). access_type " <>
+            "DEFAULTS TO READS, not every event — search/index rows are ranker impressions " <>
+            "and outnumber reads ~50:1; pass access_type=all for the old behaviour. " <>
             "Params: limit, since_days, access_type. Role: orchestrator+."
       },
       %{
         method: "GET",
         path: "/api/v1/knowledge/articles/:id/stats",
-        description: "Per-article usage stats (counts, unique agents, recent events)"
+        description:
+          "Per-article usage stats: total_events (impressions included), total_reads, " <>
+            "unique_keys (distinct API KEYS, not agents — one key is minted per dispatch), " <>
+            "by-type breakdown, recent events."
       },
       %{
         method: "GET",
@@ -630,7 +657,9 @@ defmodule LoopctlWeb.RouteDiscoveryController do
         method: "GET",
         path: "/api/v1/knowledge/analytics/unused-articles",
         description:
-          "Published articles with zero accesses. Params: days_unused, limit. Role: orchestrator+."
+          "Published articles never READ in the window (no get/context/drill). NOT " <>
+            "\"no event\" — an article the ranker surfaces constantly and nobody opens is " <>
+            "dead weight, not usage. Params: days_unused, limit. Role: orchestrator+."
       },
       %{
         method: "GET",
@@ -732,15 +761,23 @@ defmodule LoopctlWeb.RouteDiscoveryController do
         method: "GET",
         path: "/api/v1/admin/audit",
         description: "Cross-tenant audit log (superadmin only)"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/admin/violators",
+        description:
+          "Pre-existing chain-of-custody violations awaiting triage (superadmin only). " <>
+            "Resolve or ignore via POST /api/v1/admin/violators/:id/{resolve,ignore}."
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/admin/knowledge/retrieval-metrics",
+        description:
+          "Per-tenant KB retrieval BREAKDOWN (superadmin only) — one row per tenant, and " <>
+            "deliberately no cross-tenant total: each tenant's KB is a different corpus, so " <>
+            "a blended rate describes none of them and hides the account you are looking " <>
+            "for. Params: day, window_seconds, active_only."
       }
     ]
-
-    json(conn, %{
-      routes: routes,
-      count: length(routes),
-      openapi: "/api/v1/openapi",
-      note:
-        "Curated index of common routes — the authoritative full API surface is the OpenAPI spec at /api/v1/openapi."
-    })
   end
 end

--- a/test/loopctl_web/controllers/route_discovery_controller_test.exs
+++ b/test/loopctl_web/controllers/route_discovery_controller_test.exs
@@ -11,6 +11,50 @@ defmodule LoopctlWeb.RouteDiscoveryControllerTest do
     put_req_header(conn, "authorization", "Bearer #{raw_key}")
   end
 
+  describe "curated index vs the router" do
+    # The index is HAND-CURATED and says so ("common routes"), which makes omission legal in
+    # general — but not for /admin. That is a small closed set, every other member is listed,
+    # and a superadmin route missing from the index is invisible to the one audience that
+    # goes looking for it. This caught exactly that: the per-tenant KB breakdown shipped and
+    # the index still listed only stats and audit.
+    test "every /api/v1/admin GET route in the router appears in the curated index" do
+      router_admin_gets =
+        LoopctlWeb.Router.__routes__()
+        |> Enum.filter(&(&1.verb == :get and String.starts_with?(&1.path, "/api/v1/admin")))
+        |> Enum.map(& &1.path)
+        |> MapSet.new()
+
+      indexed =
+        LoopctlWeb.RouteDiscoveryController.curated_routes()
+        |> Enum.filter(&(&1.method == "GET"))
+        |> Enum.map(& &1.path)
+        |> MapSet.new()
+
+      missing = MapSet.difference(router_admin_gets, indexed)
+
+      assert MapSet.size(router_admin_gets) > 0,
+             "the filter matched nothing — it has drifted from the router's shape and this " <>
+               "test is now vacuous"
+
+      assert MapSet.equal?(missing, MapSet.new()),
+             "admin GET routes missing from the curated /routes index: " <>
+               inspect(MapSet.to_list(missing))
+    end
+
+    test "every path in the curated index actually exists in the router" do
+      router_paths =
+        LoopctlWeb.Router.__routes__() |> Enum.map(& &1.path) |> MapSet.new()
+
+      phantom =
+        LoopctlWeb.RouteDiscoveryController.curated_routes()
+        |> Enum.map(& &1.path)
+        |> Enum.reject(&MapSet.member?(router_paths, &1))
+
+      assert phantom == [],
+             "the index advertises routes the router does not serve: " <> inspect(phantom)
+    end
+  end
+
   describe "GET /api/v1/routes" do
     test "returns list of routes with method, path, description", %{conn: conn} do
       tenant = fixture(:tenant)


### PR DESCRIPTION
Follow-on from #713/#715 — found while verifying the new endpoint was reachable.

## Three drifts in the hand-maintained `/api/v1/routes` index

- **#715's per-tenant KB breakdown was not listed.**
- **`/api/v1/admin/violators` had never been listed at all** — a pre-existing omission the new guard caught on its first run.
- **Three knowledge-analytics descriptions still described pre-#713 behaviour**: top-articles as "top accessed", article stats as reporting "unique agents", unused-articles as "zero accesses".

That last one matters more than a stale string: an index saying "top accessed" points an operator at the number that counts ranker impressions, which is precisely the reading #713 removed from the product. The docs were re-teaching the defect one layer out.

## The guard

Omission is legal here in general, and the payload note says so — this is an index of *common* routes, and the OpenAPI spec is the authoritative surface. It is **not** legal for `/api/v1/admin`: a small closed set whose entire audience discovers routes through this endpoint, so a superadmin route missing from it is invisible to the only people who would call it.

The list moves out of the controller action into a public `curated_routes/0`, and two tests check it against `Router.__routes__/0` in both directions:

1. every `/api/v1/admin` GET route in the router appears in the index;
2. no entry advertises a path the router does not serve.

Test 1 also asserts the router filter matched something, so a future change to route shapes cannot quietly turn it into a test of nothing.

## Verification

Gate green: 7675 tests, 0 failures. Both guards **mutation-verified** — removing the new admin route from the index fails the coverage test; adding an entry for a nonexistent path fails the phantom test.
