### PR TITLE
Publish the MCP server, and fail a PR that ships index.js without a bump

### DIFF
--- a/.github/workflows/mcp-server-ci.yml
+++ b/.github/workflows/mcp-server-ci.yml
@@ -42,6 +42,59 @@ jobs:
               - 'mcp-server/**'
               - '.github/workflows/mcp-server-ci.yml'
 
+  # A published-file change with no version bump never reaches npm. mcp-autopublish.yml
+  # fires on `mcp-server/package.json` changing, so editing index.js alone is silently a
+  # no-op for every agent: the server deploys, the client keeps the OLD tool descriptions,
+  # and the two then disagree about what the payload contains. That happened across six PRs
+  # (#689, #708, #711-#714) before this guard existed — the last four had removed and
+  # renamed payload fields the published descriptions still advertised.
+  #
+  # Same failure the autopublish workflow was itself written for, one layer up: that one
+  # fixed "the bump happened but no tag was pushed", this fixes "the code changed but no
+  # bump happened".
+  #
+  # Scoped to what npm actually SHIPS (package.json `files`), so test-only, smoke-test and
+  # workflow edits do not demand a bump.
+  version-bump:
+    name: Published files require a version bump
+    needs: changes
+    if: needs.changes.outputs.mcp == 'true' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fail if a shipped file changed without a version bump
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          changed=$(git diff --name-only "$BASE" "$HEAD" -- \
+            'mcp-server/index.js' 'mcp-server/lib/**' 'mcp-server/README.md')
+
+          if [ -z "$changed" ]; then
+            echo "No published mcp-server file changed; no bump required."
+            exit 0
+          fi
+
+          echo "Published files changed in this PR:"
+          echo "$changed"
+
+          base_version=$(git show "$BASE:mcp-server/package.json" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
+          head_version=$(node -p "require('./mcp-server/package.json').version")
+
+          echo "version: base=$base_version head=$head_version"
+
+          if [ "$base_version" = "$head_version" ]; then
+            echo "::error::mcp-server published files changed but the version is still $head_version. Nothing publishes to npm without a version bump, so agents keep the OLD tool descriptions while the server serves the new payload. Bump mcp-server/package.json."
+            exit 1
+          fi
+
+          echo "Version bumped $base_version -> $head_version."
+
   test:
     name: Node unit tests
     needs: changes
@@ -74,17 +127,24 @@ jobs:
   # blew up — fails the gate. Note the deliberate asymmetry: a SKIPPED test is
   # only benign because `changes` proved there was nothing to test, so the gate
   # checks the probe's result too rather than trusting the skip on its own.
+  # The single required check. It must depend on EVERY job whose failure should block a
+  # merge — a job branch protection does not key on can go red without stopping anything,
+  # which is the quietest way to have a guard that does not guard.
   mcp-gate:
     name: MCP Server Gate
-    needs: [changes, test]
+    needs: [changes, test, version-bump]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Assert the unit suite did not fail
+      - name: Assert the unit suite and the version-bump guard did not fail
         run: |
           probe='${{ needs.changes.result }}'
           suite='${{ needs.test.result }}'
-          echo "changes=$probe test=$suite"
+          # Bracket syntax is REQUIRED for a hyphenated job id: `needs.version-bump.result`
+          # parses as a subtraction (`needs.version` minus `bump.result`) and silently
+          # evaluates to empty, which the case below would then treat as a failure.
+          bump='${{ needs['version-bump'].result }}'
+          echo "changes=$probe test=$suite version-bump=$bump"
           if [ "$probe" != success ]; then
             echo "The path probe did not succeed — refusing to pass the gate blind."
             exit 1
@@ -93,4 +153,11 @@ jobs:
             success) echo "mcp-server unit suite green." ;;
             skipped) echo "No mcp-server change in this PR — nothing to test." ;;
             *)       echo "mcp-server unit suite is $suite."; exit 1 ;;
+          esac
+          # `skipped` is legitimate here and only here: the guard is PR-only (it needs a base
+          # SHA to diff against), so a push to master skips it by design.
+          case "$bump" in
+            success) echo "version-bump guard green." ;;
+            skipped) echo "version-bump guard not applicable (push, or no mcp-server change)." ;;
+            *)       echo "version-bump guard is $bump."; exit 1 ;;
           esac

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.74.0",
+  "version": "2.75.0",
   "description": "MCP server for loopctl \u2014 structural trust for AI development loops",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
## npm has been behind since 2026-08-17

Six PRs have edited `mcp-server/index.js` since the last version bump — #689 and #708 on Aug 17, then **#711–#714 tonight**. None bumped the version. `mcp-autopublish.yml` fires only when `mcp-server/package.json` changes, so npm still serves **2.74.0** tool descriptions against a server that no longer matches them.

The last four make this a **live disagreement**, not stale prose:

| tool | published description says | server now does |
|---|---|---|
| `knowledge_article_stats` | `total_accesses`, `unique_agents` | returns `total_events`, `total_reads`, `unique_keys` — the advertised fields **do not exist** |
| `knowledge_analytics_top` | unfiltered "top accessed" | defaults to reads; `access_type=all` restores the old view |
| `knowledge_retrieval_metrics` | trio partitions `searches`; six curated/retrieved fields | partitions `searches_scored`; those fields deleted; `metric_version` added |
| `knowledge_hybrid_search` | a `curated` verdict means a canonical answered — trust it | unreachable here; no article is curated |

An agent following the published description for `knowledge_article_stats` reads fields that aren't in the payload.

Bumping to **2.75.0** publishes all of it. The autopublish workflow gates on the node unit suite, green at **369 tests**.

## The structural half

A CI job fails a PR that touches a file npm actually ships (per `package.json` `files`) without a version change. Test-only, smoke-test and workflow edits don't demand a bump.

This is the same failure `mcp-autopublish.yml` was itself written for, one layer up — that one fixed *"the bump happened but no tag was pushed"*; this fixes *"the code changed but no bump happened"*.

**The gate job now depends on it.** A job the required check doesn't depend on can go red without blocking anything, which is the quietest way to own a guard that doesn't guard.

## Verification

This PR bumps the version *without* touching `index.js`, so it cannot exercise its own guard. Verified against real history instead:

| range | result |
|---|---|
| #711, #712, #713 | **fires** — index.js changed, version stuck at 2.74.0 |
| #716 (no mcp-server file) | passes |
| bump-only (this PR) | passes |
| synthetic: index.js changed **and** bumped | passes |

One subtlety, commented in the workflow: `needs.version-bump.result` parses as a *subtraction* in a GitHub Actions expression because the job id is hyphenated — it evaluates to empty and the case statement would read that as failure. The bracket form is required.

Gate green: 7675 tests, 0 failures.

## Review

Reviewed inline by the authoring session; this session runs under instructions that forbid dispatching review agents. Blast radius is proportionate — a version bump and a CI guard. The publish itself is test-gated by the existing workflow and I confirmed that suite passes locally before bumping.
