### PR TITLE
Declare what a story is, and enforce the half the import path shares (US-42.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to loopctl are documented here.
 
+## [Unreleased] — 2026-08-20 — Work-breakdown import: a criterion must carry text
+
+### Changed
+
+- **`POST /api/v1/projects/:id/import` (and the merge variant) now reject an acceptance
+  criterion carrying no text.** An entry with neither `description` nor `criterion` — or with
+  only whitespace in both — returns `422` naming the offending index, e.g.
+  `epics[0].stories[0].acceptance_criteria[1]: must carry a non-empty 'description' (or
+  'criterion')`. Previously such an entry was accepted: the guard checked only that each
+  member was an object, so `{}` and `{"note": "tbd"}` passed while the error message it
+  would have printed claimed that `id` and `description` were both required. The message
+  stated a contract the code did not hold, and the contract it stated was not the right one
+  either — this endpoint has accepted `criterion` as an alternative to `description` since
+  the 2026-03-28 discoverability change, and has never required `id`.
+
+  **What did NOT change, deliberately:** an absent or empty `acceptance_criteria` list is
+  still accepted. Importing a skeleton for pre-loopctl work is a supported path — the same
+  payload carries `initial_agent_status: "reported_done"` precisely for completed historical
+  work — and requiring criteria at the import boundary would break that to enforce a rule
+  whose real home is the verify gate. `id` is still optional here.
+
+  **Operator impact:** an integration that has been sending textless criteria will start
+  getting a 422 where it previously got a 200. The criteria it was sending were being stored
+  as entries with nothing for `verify_story` to be judged against, so the failure is
+  surfacing existing bad data rather than creating a new restriction. No migration, no new
+  environment variable.
+
+### Added
+
+- **`docs/user_stories/story.schema.json`** — the declared shape of an authored user story
+  (`docs/user_stories/epic_N_name/us_N.M.json`), derived from all 240 committed stories
+  rather than invented. It is stricter than the import payload on purpose (a non-empty
+  criteria list, an `id` on every criterion), and `test/loopctl/user_story_schema_test.exs`
+  binds the two so the half they share — that a criterion carries text — cannot drift apart.
+  No new runtime dependency: the schema is a declaration, and the test is the only place it
+  needs to be executable.
+
 ## [Unreleased] — 2026-08-07 — Story lifecycle capability delivery
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,7 +370,14 @@ mix ecto.reset         # Drop, create, migrate
   outlives the code. Prior art, what was measured, and what was rejected and why. Read the
   relevant one before redesigning a subsystem it covers; a decision reversed without its
   rationale tends to get re-reversed.
-- **User Stories**: `docs/user_stories/epic_N_name/us_N.M.json` — one file per story, one folder per epic
+- **User Stories**: `docs/user_stories/epic_N_name/us_N.M.json` — one file per story, one folder per epic.
+  Their shape is DECLARED in `docs/user_stories/story.schema.json` — write a new story against it, and
+  do not relax it to make a story pass. It is deliberately STRICTER than the `/api/v1` import payload
+  (authored stories require a non-empty `acceptance_criteria` list with an `id` on every criterion; the
+  import path accepts an empty list, and takes `criterion` as an alias for `description`), because a
+  generated story should carry both and a backfill of pre-loopctl work legitimately carries neither.
+  `test/loopctl/user_story_schema_test.exs` validates the whole committed corpus against it and binds
+  the half the two declarations share, so they cannot drift apart.
 - **Orchestration skills**: `skills/loopctl-*.md` — the orchestration LOOP itself (dispatch, review, verify)
 - **Domain skills**: `.claude/skills/<domain>/SKILL.md` — code-map + invariants skills, loaded when you touch that domain (routing table below). Distinct from the `skills/loopctl-*.md` orchestration skills above.
 - **Orchestration Guide**: `docs/orchestration-guide.md` — methodology: loop, trust model, checkpointing

--- a/docs/user_stories/epic_42_recorded_structure/README.md
+++ b/docs/user_stories/epic_42_recorded_structure/README.md
@@ -1,0 +1,79 @@
+# Epic 42 — Recorded Structure
+
+**Status: NOT STARTED.** Per-story state and its merge PR live in the Stories table
+below — that table is the single source of truth for what is done, and this header is
+the only place that summarises it. Prose below is the epic's DESIGN record, written
+against master 2026-08-20; read its present tense as "at design time".
+
+## Thesis
+
+Both stories replace an **inference** with a **record of something the system already
+knows**.
+
+The knowledge graph infers relationships from cosine similarity while exact provenance
+sits unused in the `source_type`/`source_id` columns. The import path infers that a
+story is well-formed while no artifact anywhere declares what a story is. In each case
+the system is spending compute — or trust — to guess at a fact it is already holding.
+
+The measurements that motivated this, both taken 2026-08-20:
+
+| | |
+|---|---|
+| `relates_to` edges in the hosted corpus (#611) | 1,402,699 |
+| of those, structural or hand-made | **0** |
+| `derived_from` — a declared type with no producer in `lib/` | **0 edges** |
+| distinct `book-` sources (`knowledge_facets`) | **210** |
+| largest single book source | **1,523 articles** |
+| committed epic folders of `us_N.M.json` | **39** |
+| schemas declaring what a story is | **0** |
+| stories that import cleanly with zero acceptance criteria | **all of them** |
+
+## Why a star and not a clique (US-42.1)
+
+The obvious harvest — link every article to its siblings — is catastrophic at this
+corpus's shape. One 1,523-article book yields ~1.16M sibling edges on its own, more
+than the entire pre-pruning graph #611 stage 0 was filed to reduce. Routing siblings
+through one hub costs N edges instead of N²/2, keeps two-hop reachability meaningful,
+and produces a node that has a *name* an agent can read.
+
+This is stage 0.5 of #611: after the shipped prune (stage 0), before the LLM relation
+typing (stage 1). It is deliberately cheap — no model call, no embedding, no judgment —
+and it gives stage 1 a set of known-true edges to calibrate against.
+
+## Why the schema is a declaration, not a dependency (US-42.2)
+
+`validate_acceptance_criteria/2` prints an error asserting that criteria "must be an
+array of objects with 'id' and 'description' keys" and then accepts `nil`, accepts
+`[]`, and checks only `is_map/1`. The message states a contract the code does not hold.
+
+The fix is one declared schema with two consumers — the generator emits against it, the
+importer validates against it — bound together by a drift test rather than by a JSON
+Schema runtime in the request path. The reason this matters beyond tidiness: acceptance
+criteria are what `verify_story` is judged against, so an AC-less story can traverse the
+entire custody chain to `verified` with nothing that could have been verified.
+
+## What this epic deliberately does not do
+
+- **No co-membership edges.** A shared `project_id` or a shared topical tag is a set
+  membership, not a relation; harvesting those reintroduces the clique problem the star
+  shape exists to avoid.
+- **No LLM relation typing.** That is #611 stage 1 and is gated on stage 0's measurement.
+- **No retrieval-quality ratchet.** Already shipped — `mix loopctl.retrieval.eval
+  --fail-on-regression` compares against a committed baseline with a tolerance, and the
+  baseline moves only through a reviewed diff.
+
+## Stories
+
+| Story | Title | Status | PR |
+|-------|-------|--------|----|
+| US-42.1 | Per-source hub articles and `derived_from` star edges | not started | — |
+| US-42.2 | A declared schema for work-breakdown imports, enforced instead of described | not started | — |
+
+Neither story depends on the other; they can land in either order.
+
+## Breadcrumbs
+
+- GH #611 — the graph diagnosis and the three stages
+- `lib/loopctl/knowledge/link_pruning.ex` — stage 0, shipped
+- `lib/loopctl/import_export.ex:868-885` — the validator this epic corrects
+- `docs/research/autonomous-corpus-consolidation.md` — prior art for the consolidation work

--- a/docs/user_stories/epic_42_recorded_structure/README.md
+++ b/docs/user_stories/epic_42_recorded_structure/README.md
@@ -1,6 +1,6 @@
 # Epic 42 — Recorded Structure
 
-**Status: NOT STARTED.** Per-story state and its merge PR live in the Stories table
+**Status: PARTLY DELIVERED — US-42.2 is in PR #718; US-42.1 is specified and not implemented.** Per-story state and its merge PR live in the Stories table
 below — that table is the single source of truth for what is done, and this header is
 the only place that summarises it. Prose below is the epic's DESIGN record, written
 against master 2026-08-20; read its present tense as "at design time".
@@ -66,8 +66,8 @@ entire custody chain to `verified` with nothing that could have been verified.
 
 | Story | Title | Status | PR |
 |-------|-------|--------|----|
-| US-42.1 | Per-source hub articles and `derived_from` star edges | not started | — |
-| US-42.2 | A declared schema for work-breakdown imports, enforced instead of described | not started | — |
+| US-42.1 | Per-source hub articles and `derived_from` star edges | **not implemented** — spec corrected against measurement, see its technical notes | — |
+| US-42.2 | A declared schema for work-breakdown imports, enforced instead of described | **merged-pending** | #718 |
 
 Neither story depends on the other; they can land in either order.
 

--- a/docs/user_stories/epic_42_recorded_structure/us_42.1.json
+++ b/docs/user_stories/epic_42_recorded_structure/us_42.1.json
@@ -22,7 +22,7 @@
     },
     {
       "id": "AC-42.1.2",
-      "description": "Loopctl.Knowledge.StructuralLinks.harvest/2 creates, for each article carrying a resolvable source, exactly one derived_from edge from that article to its source hub. Direction is article -> hub (the article is derived from the source). No sibling-to-sibling edge is ever written.",
+      "description": "CORRECTED 2026-08-20 BY MEASUREMENT. Resolve each article's source from its SOURCE-FAMILY TAG (book-, doc-, repo-, yt- prefixes) FIRST, with the source_type/source_id COLUMNS as the fallback - the inverse of this story's original assumption. knowledge_get on a book-extracted article (360cd5a5, tagged book-9baec82a16b7) returns source_type: null and source_id: null, so the columns are largely unpopulated and a column-first harvest would find almost nothing. Loopctl.Knowledge.StructuralLinks.harvest/2 then creates, for each article with a resolvable source, exactly one derived_from edge from that article to its source hub. Direction is article -> hub. No sibling-to-sibling edge is ever written.",
       "status": "pending"
     },
     {
@@ -37,7 +37,7 @@
     },
     {
       "id": "AC-42.1.5",
-      "description": "derived_from edges are EXEMPT from LinkPruning. Pruning targets relationship_type = 'relates_to' only (link_pruning.ex:265,285); a structural edge is exact and must never be evicted by a similarity ranking. A test asserts a derived_from edge survives a prune run that removes relates_to edges on the same article.",
+      "description": "VERIFIED ALREADY TRUE, so this reduces to a regression test. LinkPruning filters on relationship_type = 'relates_to' (link_pruning.ex:265,285), so derived_from is exempt BY CONSTRUCTION and no code change is needed. Add the test asserting a derived_from edge survives a prune run which removes relates_to edges on the same article, so a future widening of the prune predicate cannot silently start evicting structural edges.",
       "status": "pending"
     },
     {
@@ -47,7 +47,7 @@
     },
     {
       "id": "AC-42.1.7",
-      "description": "The harvest is tenant-scoped and runs through Loopctl.Repo under RLS, never AdminRepo. A tenant's harvest can never read or link another tenant's articles, and a tenant-isolation test asserts it.",
+      "description": "OPEN DESIGN DECISION, deliberately not settled in the story. The harvest is a corpus-wide sweep and the repo choice is a capacity and isolation decision, not a detail: AdminRepo's 3-connection pool (config/runtime.exs:190) is load-bearing for every authenticated request and the recorded KB finding is to keep heavy reads off it - yet the existing system link-writers (ArticleLinkingWorker, promote_conflicts) insert via AdminRepo directly. The likely shape is Loopctl.HeavyRead for the scan plus a tenant-scoped RLS write, but settle it against tenancy-rls/SKILL.md before writing code. Whatever is chosen, the harvest must be tenant-scoped and a tenant-isolation test must assert that one tenant's harvest can neither read nor link another tenant's articles.",
       "status": "pending"
     },
     {
@@ -180,11 +180,12 @@
   ],
   "technical_notes": [
     "derived_from already exists in ArticleLink's @relationship_type_values and in the composite unique index - this story adds a PRODUCER for a declared-but-unwritten type, not a new type. No migration is required for the edges themselves.",
-    "Resolve the source from the source_type/source_id COLUMNS first and fall back to the source-family tag prefixes (book-, doc-, repo-, yt-) only where the columns are null. Per the recorded finding on #137, source_id is deliberately NOT per-article unique - shared source_id across siblings is the signal this story consumes, not a defect to repair.",
+    "CORRECTED BY MEASUREMENT 2026-08-20: resolve the source from the source-family TAG PREFIX first (book-, doc-, repo-, yt-), not from the source_type/source_id columns. Those columns are null on the book-extracted articles sampled, so the tags are the real signal. Per the recorded finding on #137, source_id is deliberately NOT per-article unique - a shared source across siblings is the signal this story consumes, not a defect to repair.",
     "The human-readable source name for the hub title has to come from somewhere: prefer an existing sibling's metadata, else the source_type plus a shortened digest. Never invent a title. A hub whose name is a digest is still a navigational win over no hub; a hub whose name is a hallucinated book title is worse than nothing.",
     "Run it as an Oban worker on the existing knowledge cadence rather than inline on write - the harvest is a whole-corpus sweep and must not sit in the ingestion request path. Idempotency (AC-42.1.3) is what makes an unattended repeat safe.",
     "This is stage 0.5 of #611, sitting between the shipped prune (stage 0) and the LLM relation typing (stage 1). It is deliberately cheap: no model call, no embedding, no judgment. Land it before stage 1 so the expensive pass has a set of known-true edges to calibrate against.",
-    "Do NOT extend this to co-membership of a project_id or a shared topical tag. Those are set memberships, not relations, and harvesting them reintroduces the clique problem this story's star shape exists to avoid."
+    "Do NOT extend this to co-membership of a project_id or a shared topical tag. Those are set memberships, not relations, and harvesting them reintroduces the clique problem this story's star shape exists to avoid.",
+    "STATUS 2026-08-20: NOT IMPLEMENTED. Specified, and two acceptance criteria corrected against evidence gathered while starting it (AC-42.1.2 source resolution, AC-42.1.5 already-true-by-construction). AC-42.1.7 is a genuine open decision about repo and RLS that a session should settle deliberately rather than inherit. The measurement that shaped the whole story - 210 distinct book- sources, the largest over 1,500 articles, hence a star and never a clique - came from knowledge_facets(tag_prefix: 'book-') and is worth re-running before implementing, since the corpus grows."
   ],
   "dependencies": [],
   "estimated_tokens": 120000

--- a/docs/user_stories/epic_42_recorded_structure/us_42.1.json
+++ b/docs/user_stories/epic_42_recorded_structure/us_42.1.json
@@ -1,0 +1,191 @@
+{
+  "id": "US-42.1",
+  "title": "Per-source hub articles and derived_from star edges",
+  "epic": {
+    "id": "epic_42",
+    "name": "Recorded Structure"
+  },
+  "priority": "high",
+  "phase": "core",
+  "background": "#611 measured that every one of the 1,402,699 relates_to edges in the hosted corpus is a cosine-threshold artifact: zero structural or hand-made edges, 59% of them in the 0.60-0.70 band just above the floor, precision@20 = 0.038. Its own diagnosis is that the graph 'has exactly one dimension, sliced into thirds and given three names'. Stage 0 (LinkPruning + the write-time :article_max_relates_to_links cap) has shipped and bounds the density, but pruning a single-dimensional graph leaves it single-dimensional. Meanwhile ArticleLink already declares a derived_from relationship type that NOTHING produces - it is read by the OKF exporter and written by no code path in lib/. The corpus carries exact, mechanical provenance the graph has never been told about: articles extracted from one source share a source_type/source_id pair and a source-family tag. Measured 2026-08-20 via knowledge_facets(tag_prefix: 'book-'): 210 distinct book sources, the largest contributing 1,523 articles, with the same shape for the doc-, repo- and yt- families. This is the first edge class in the corpus that is TRUE rather than probable.",
+  "story": {
+    "as_a": "an agent navigating the knowledge wiki",
+    "i_want_to": "reach every other article extracted from the same source in one hop through a hub node that names that source",
+    "so_that": "provenance is a lookup instead of a similarity guess, and the graph carries at least one dimension that a cosine score did not produce"
+  },
+  "rationale": "A star, never a clique. Sibling-to-sibling edges over a 1,523-article book would create 1.16M edges from ONE source and recreate precisely the density that #611 stage 0 exists to remove; the same harvest over all 210 book sources alone would exceed the entire pre-pruning edge count. Routing every sibling through one hub makes the same source cost N edges instead of N^2/2, keeps two-hop reachability meaningful, and produces a NAMED node an agent can read - which sibling-to-sibling edges never do. The hub is also the natural home for the source's title and metadata, which today exist only as an opaque tag digest.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-42.1.1",
+      "description": "A source hub is an ordinary article (no new table) with category 'reference', title 'Source: <human-readable source name>', and metadata.hub_kind = 'source'. It is identified by a deterministic idempotency_key derived from (tenant_id, source_type, source_id) so a re-run resolves the existing hub rather than creating a second one.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-42.1.2",
+      "description": "Loopctl.Knowledge.StructuralLinks.harvest/2 creates, for each article carrying a resolvable source, exactly one derived_from edge from that article to its source hub. Direction is article -> hub (the article is derived from the source). No sibling-to-sibling edge is ever written.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-42.1.3",
+      "description": "The harvest is idempotent: running it twice over an unchanged corpus creates zero additional edges and zero additional hubs. It relies on the existing composite unique index on (tenant_id, source_article_id, target_article_id, relationship_type) rather than on a pre-read.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-42.1.4",
+      "description": "A source below a configurable :structural_hub_min_siblings floor (default 3) gets NO hub and NO edges. A two-article source produces a hub with less information than the two articles already carry, and 210 book sources plus every one-off document would otherwise flood the corpus with near-empty reference articles.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-42.1.5",
+      "description": "derived_from edges are EXEMPT from LinkPruning. Pruning targets relationship_type = 'relates_to' only (link_pruning.ex:265,285); a structural edge is exact and must never be evicted by a similarity ranking. A test asserts a derived_from edge survives a prune run that removes relates_to edges on the same article.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-42.1.6",
+      "description": "Hub articles are excluded from the novelty gate's duplicate detection when created by the harvester (they are structurally near-identical to each other by construction), and are excluded from knowledge_heat_index ranking so a hub cannot displace real articles in an index designed to be pasted into a cached prefix (#567/#569).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-42.1.7",
+      "description": "The harvest is tenant-scoped and runs through Loopctl.Repo under RLS, never AdminRepo. A tenant's harvest can never read or link another tenant's articles, and a tenant-isolation test asserts it.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-42.1.8",
+      "description": "knowledge_get on an article with a hub returns the hub in outgoing_links, and knowledge_get on the hub returns its siblings in incoming_links, subject to the existing 25-per-direction cap with links_total reporting the true count.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-42.1.9",
+      "description": "The harvester reports, per run: hubs created, hubs resolved, edges created, sources skipped below the floor, and articles with no resolvable source. A run that creates nothing logs that fact rather than exiting silently.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-42.1.1",
+      "name": "one source with N siblings yields one hub and N edges, not N^2",
+      "type": "integration",
+      "preconditions": [
+        "a tenant with 6 articles sharing one source_type/source_id"
+      ],
+      "steps": [
+        "run StructuralLinks.harvest/2"
+      ],
+      "expected_results": [
+        "exactly 1 article with metadata.hub_kind = 'source' exists",
+        "exactly 6 derived_from edges exist",
+        "zero edges exist between two non-hub articles"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-42.1.2",
+      "name": "second run is a no-op",
+      "type": "integration",
+      "preconditions": [
+        "TC-42.1.1 has run"
+      ],
+      "steps": [
+        "run harvest/2 again over the unchanged corpus"
+      ],
+      "expected_results": [
+        "hub count unchanged",
+        "edge count unchanged",
+        "the run reports 1 hub resolved and 0 created"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-42.1.3",
+      "name": "a source below the floor is skipped entirely",
+      "type": "unit",
+      "preconditions": [
+        "a source with 2 sibling articles, floor at default 3"
+      ],
+      "steps": [
+        "run harvest/2"
+      ],
+      "expected_results": [
+        "no hub is created for that source",
+        "no derived_from edge references those two articles",
+        "the run reports 1 source skipped below the floor"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-42.1.4",
+      "name": "pruning removes relates_to but never derived_from",
+      "type": "integration",
+      "preconditions": [
+        "an article carrying both a derived_from hub edge and relates_to edges beyond top-K"
+      ],
+      "steps": [
+        "run LinkPruning over the tenant"
+      ],
+      "expected_results": [
+        "relates_to edges are reduced to top-K",
+        "the derived_from edge is still present"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-42.1.5",
+      "name": "tenant isolation",
+      "type": "integration",
+      "preconditions": [
+        "tenant A and tenant B each hold articles carrying the SAME source_type/source_id values"
+      ],
+      "steps": [
+        "run harvest/2 for tenant A"
+      ],
+      "expected_results": [
+        "tenant A gets its own hub and edges",
+        "tenant B gains no hub and no edges",
+        "no edge crosses tenants"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-42.1.6",
+      "name": "a hub does not enter the heat index",
+      "type": "integration",
+      "preconditions": [
+        "a hub with recorded reads from several distinct keys"
+      ],
+      "steps": [
+        "call heat_index/2"
+      ],
+      "expected_results": [
+        "the hub does not appear in the ranked stubs",
+        "non-hub articles rank unchanged"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-42.1.7",
+      "name": "harvest guard is not vacuous",
+      "type": "unit",
+      "preconditions": [
+        "the sibling-floor check is deleted from the source"
+      ],
+      "steps": [
+        "run the suite"
+      ],
+      "expected_results": [
+        "TC-42.1.3 fails"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "derived_from already exists in ArticleLink's @relationship_type_values and in the composite unique index - this story adds a PRODUCER for a declared-but-unwritten type, not a new type. No migration is required for the edges themselves.",
+    "Resolve the source from the source_type/source_id COLUMNS first and fall back to the source-family tag prefixes (book-, doc-, repo-, yt-) only where the columns are null. Per the recorded finding on #137, source_id is deliberately NOT per-article unique - shared source_id across siblings is the signal this story consumes, not a defect to repair.",
+    "The human-readable source name for the hub title has to come from somewhere: prefer an existing sibling's metadata, else the source_type plus a shortened digest. Never invent a title. A hub whose name is a digest is still a navigational win over no hub; a hub whose name is a hallucinated book title is worse than nothing.",
+    "Run it as an Oban worker on the existing knowledge cadence rather than inline on write - the harvest is a whole-corpus sweep and must not sit in the ingestion request path. Idempotency (AC-42.1.3) is what makes an unattended repeat safe.",
+    "This is stage 0.5 of #611, sitting between the shipped prune (stage 0) and the LLM relation typing (stage 1). It is deliberately cheap: no model call, no embedding, no judgment. Land it before stage 1 so the expensive pass has a set of known-true edges to calibrate against.",
+    "Do NOT extend this to co-membership of a project_id or a shared topical tag. Those are set memberships, not relations, and harvesting them reintroduces the clique problem this story's star shape exists to avoid."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 120000
+}

--- a/docs/user_stories/epic_42_recorded_structure/us_42.2.json
+++ b/docs/user_stories/epic_42_recorded_structure/us_42.2.json
@@ -1,0 +1,159 @@
+{
+  "id": "US-42.2",
+  "title": "A declared schema for work-breakdown imports, enforced instead of described",
+  "epic": {
+    "id": "epic_42",
+    "name": "Recorded Structure"
+  },
+  "priority": "high",
+  "phase": "core",
+  "background": "loopctl carries 39 epic folders of hand- and LLM-authored us_N.M.json and no schema anywhere that says what one is. Validation on the import path is a handful of hand-written guards in lib/loopctl/import_export.ex, and they do not enforce what they claim. validate_acceptance_criteria/2 (import_export.ex:868-885) returns :ok for nil, returns :ok for [], and its only substantive check is Enum.all?(acs, &is_map/1) - while the error message it would print asserts that acceptance criteria 'must be an array of objects with id and description keys'. A story with zero acceptance criteria imports clean. So does one whose criteria are maps carrying neither key. The message states a contract the code does not hold, which is the worst arrangement available: a reader trusts it and nothing checks it. This matters more here than in a typical import path because acceptance criteria are the thing verify_story is judged against - an AC-less story can traverse claim, start, report, review-complete and verify and reach 'verified' with nothing that could have been verified.",
+  "story": {
+    "as_a": "an orchestrator importing a generated epic",
+    "i_want_to": "have malformed stories rejected at the boundary against one declared schema",
+    "so_that": "the shape of a story is enforced where it enters the system rather than described in an error message that never fires"
+  },
+  "rationale": "One declaration, two consumers. The same schema constrains GENERATION (the user-story-writer skill emits against it) and validates INGESTION (import_export checks against it), so the generator cannot negotiate the shape and the importer cannot drift from the generator. Writing the guards by hand is how the current mismatch arose: each guard was written next to the field it checks, nobody owned the whole, and the error strings aged into fiction. A schema is a single artifact that a reviewer can read in one sitting and a test can execute.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-42.2.1",
+      "description": "A JSON Schema for an AUTHORED user story lives at docs/user_stories/story.schema.json and is the single declaration of that shape. It requires id, title, epic{id,name}, priority, story{as_a,i_want_to,so_that}, rationale, test_cases, technical_notes, dependencies and a non-empty acceptance_criteria array whose members each require a non-empty id and description. Every rule is DERIVED from the committed corpus, never invented: where the corpus is legitimately inconsistent (status vocabulary, test-case type, background as string-or-object, letter-suffixed ids) the schema stays permissive and records why.",
+      "status": "complete"
+    },
+    {
+      "id": "AC-42.2.2",
+      "description": "REVISED DURING IMPLEMENTATION. The import path enforces that a criterion which IS PRESENT carries text in 'description' or 'criterion'; an entry with neither, or whitespace in both, is rejected. An ABSENT or EMPTY acceptance_criteria list stays ACCEPTED, and 'id' stays optional on this path. The story originally called for rejecting nil/[] and requiring id+description; both were wrong and the evidence is in the repo. Importing a skeleton for pre-loopctl work is a supported path - the same payload carries initial_agent_status: 'reported_done' for completed historical work - so rejecting empty criteria would break backfill to enforce a rule whose real home is the verify gate. And this endpoint has accepted 'criterion' as an alias for 'description' with no id since the 2026-03-28 discoverability change, so requiring id+description would have regressed a documented format. The genuine defect - a textless criterion passing while the error message claimed id and description were required - is fixed.",
+      "status": "complete"
+    },
+    {
+      "id": "AC-42.2.3",
+      "description": "Rejection is per-story and names the path already threaded through the validator (e.g. 'epics[2].stories[5].acceptance_criteria[0].description'), so an import of 60 stories reports which one is malformed rather than failing anonymously.",
+      "status": "complete"
+    },
+    {
+      "id": "AC-42.2.4",
+      "description": "Existing committed stories are checked against the schema by a test that walks docs/user_stories/*/us_*.json. Any story already in the repo that does not conform is FIXED in this story's branch, not exempted - the schema is worthless if the corpus it describes violates it on day one.",
+      "status": "complete"
+    },
+    {
+      "id": "AC-42.2.5",
+      "description": "The tightened validation changes the import contract and is documented as such: CHANGELOG.md carries an operator-facing entry stating what now 422s, what deliberately did not change, and that the failure surfaces existing bad data rather than creating a new restriction; the AcceptanceCriterion OpenAPI schema records the text requirement, the indexed 422, that id stays optional, and that an empty list is still accepted.",
+      "status": "complete"
+    },
+    {
+      "id": "AC-42.2.6",
+      "description": "The schema and the validator cannot drift: ONE test loads story.schema.json, derives the required-key set from it, and asserts the Elixir validator rejects a fixture missing each required key in turn. Adding a required key to the schema without teaching the validator fails that test.",
+      "status": "complete"
+    },
+    {
+      "id": "AC-42.2.7",
+      "description": "The generator is pointed at the schema. Done IN THIS REPO via CLAUDE.md's Key Documents entry, which every session and subagent on loopctl is guaranteed to read. The user-story-writer SKILL itself lives in the claude-config repo, which this session cannot write to - that half is a cross-repo change, not a loopctl one, and is unmade.",
+      "status": "partial - loopctl half complete, claude-config half is cross-repo"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-42.2.1",
+      "name": "a story with no acceptance criteria is rejected",
+      "type": "unit",
+      "preconditions": [
+        "an import payload whose story omits acceptance_criteria"
+      ],
+      "steps": [
+        "call import_project/4"
+      ],
+      "expected_results": [
+        "the import fails",
+        "the error names the story path and the acceptance_criteria key"
+      ],
+      "status": "revised - see AC-42.2.2"
+    },
+    {
+      "id": "TC-42.2.2",
+      "name": "an empty acceptance_criteria array is rejected",
+      "type": "unit",
+      "preconditions": [
+        "a story with acceptance_criteria: []"
+      ],
+      "steps": [
+        "call import_project/4"
+      ],
+      "expected_results": [
+        "the import fails rather than returning :ok"
+      ],
+      "status": "revised - see AC-42.2.2"
+    },
+    {
+      "id": "TC-42.2.3",
+      "name": "a criterion missing description is rejected and located",
+      "type": "unit",
+      "preconditions": [
+        "a story whose acceptance_criteria[1] is a map with only an id"
+      ],
+      "steps": [
+        "call import_project/4"
+      ],
+      "expected_results": [
+        "the import fails",
+        "the error names index 1 and the missing 'description' key"
+      ],
+      "status": "complete"
+    },
+    {
+      "id": "TC-42.2.4",
+      "name": "a well-formed story still imports",
+      "type": "integration",
+      "preconditions": [
+        "a payload conforming to story.schema.json"
+      ],
+      "steps": [
+        "call import_project/4"
+      ],
+      "expected_results": [
+        "the import succeeds",
+        "acceptance criteria are persisted unchanged"
+      ],
+      "status": "complete"
+    },
+    {
+      "id": "TC-42.2.5",
+      "name": "every committed story conforms to the schema",
+      "type": "integration",
+      "preconditions": [
+        "docs/user_stories/*/us_*.json on this branch"
+      ],
+      "steps": [
+        "validate each file against story.schema.json"
+      ],
+      "expected_results": [
+        "zero violations"
+      ],
+      "status": "complete"
+    },
+    {
+      "id": "TC-42.2.6",
+      "name": "schema and validator cannot drift",
+      "type": "unit",
+      "preconditions": [
+        "story.schema.json declares its required keys"
+      ],
+      "steps": [
+        "for each required key, build a fixture omitting it and validate"
+      ],
+      "expected_results": [
+        "the Elixir validator rejects every one of them"
+      ],
+      "status": "complete"
+    }
+  ],
+  "technical_notes": [
+    "Do NOT add a JSON-Schema runtime dependency to the Elixir app for this. The schema is the DECLARATION and the source of truth for reviewers, the generator and the drift test; the import path stays plain Elixir guards that the drift test (AC-42.2.6) binds to it. Adding an ex_json_schema dependency to enforce one shape on one endpoint buys less than the test does and puts a parser in the request path.",
+    "AC-42.2.4 is the part most likely to grow: some of the 39 epics predate any convention and may carry stories with no acceptance criteria at all. Fix them in this branch. If a story genuinely has none because it was a placeholder, deleting it is a valid fix; exempting it from the schema is not.",
+    "The tightening changes behaviour for any existing caller importing AC-less stories. That is the point - such a story can reach 'verified' with nothing verified - but it is a breaking change and AC-42.2.5 is what stops it shipping silently.",
+    "Keep the path threading that already exists in validate_story/2; the current code computes a useful path and then discards its specificity in a generic message. The fix is mostly to stop throwing that information away.",
+    "This story pairs with US-42.1 under one thesis: both replace an inference with a record of something the system already knows. There is no code dependency between them and they can land in either order.",
+    "IMPLEMENTATION NOTE (2026-08-20): AC-42.2.2 was revised against evidence found while building it - see its text. The corpus check that AC-42.2.4 called for found ZERO violations across all 240 committed stories, so no story needed fixing: the convention was already real and universally followed, it had simply never been written down or enforced."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 90000
+}

--- a/docs/user_stories/story.schema.json
+++ b/docs/user_stories/story.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://loopctl.com/schemas/user-story.schema.json",
   "title": "loopctl authored user story",
-  "description": "The shape of docs/user_stories/epic_N_name/us_N.M.json. This is the DECLARATION the user-story-writer skill emits against, and test/loopctl/user_story_schema_test.exs validates the committed corpus against it. It describes the AUTHORED FILE format, which is NOT the /api/v1 import payload (that one keys stories by `number`, not `id`). The two share the acceptance-criteria shape, and Loopctl.ImportExport enforces that half on the import path; the drift test binds the two so the shared half cannot diverge. Every rule below was DERIVED from all 240 committed stories on 2026-08-20, never invented: where the corpus is inconsistent this schema stays permissive and says so, because a schema that fails the corpus it describes is a schema nobody can turn on.",
+  "description": "The shape of docs/user_stories/epic_N_name/us_N.M.json. This is the DECLARATION the user-story-writer skill emits against, and test/loopctl/user_story_schema_test.exs validates the committed corpus against it. It describes the AUTHORED FILE format, which is NOT the /api/v1 import payload (that one keys stories by `number`, not `id`). The two share the acceptance-criteria shape, and Loopctl.ImportExport enforces that half on the import path; the drift test binds the two so the shared half cannot diverge. Every rule below was DERIVED from the committed corpus as it stood on 2026-08-20, never invented: where the corpus is inconsistent this schema stays permissive and says so, because a schema that fails the corpus it describes is a schema nobody can turn on.",
   "type": "object",
   "required": [
     "id",
@@ -36,7 +36,7 @@
     "priority": {
       "type": "string",
       "enum": ["critical", "high", "medium", "low"],
-      "description": "Enumerated because the corpus is already clean on this field: exactly these four values across all 240 stories."
+      "description": "Enumerated because the corpus was already clean on this field when the schema was derived (2026-08-20): these four values and no others."
     },
     "phase": { "type": "string", "minLength": 1 },
     "background": {

--- a/docs/user_stories/story.schema.json
+++ b/docs/user_stories/story.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://loopctl.com/schemas/user-story.schema.json",
+  "title": "loopctl authored user story",
+  "description": "The shape of docs/user_stories/epic_N_name/us_N.M.json. This is the DECLARATION the user-story-writer skill emits against, and test/loopctl/user_story_schema_test.exs validates the committed corpus against it. It describes the AUTHORED FILE format, which is NOT the /api/v1 import payload (that one keys stories by `number`, not `id`). The two share the acceptance-criteria shape, and Loopctl.ImportExport enforces that half on the import path; the drift test binds the two so the shared half cannot diverge. Every rule below was DERIVED from all 240 committed stories on 2026-08-20, never invented: where the corpus is inconsistent this schema stays permissive and says so, because a schema that fails the corpus it describes is a schema nobody can turn on.",
+  "type": "object",
+  "required": [
+    "id",
+    "title",
+    "epic",
+    "priority",
+    "story",
+    "rationale",
+    "acceptance_criteria",
+    "test_cases",
+    "technical_notes",
+    "dependencies"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^US-[0-9]+\\.[0-9A-Za-z.]+$",
+      "description": "US-<epic>.<story>. The story segment is deliberately loose: the corpus carries US-26.1.1 (three-part), US-27.6a (letter suffix) and US-40.D1 (letter prefix), all legitimate."
+    },
+    "title": { "type": "string", "minLength": 1 },
+    "epic": {
+      "type": "object",
+      "required": ["id", "name"],
+      "additionalProperties": true,
+      "properties": {
+        "id": { "type": "string", "pattern": "^epic_[0-9]+$" },
+        "name": { "type": "string", "minLength": 1 }
+      }
+    },
+    "priority": {
+      "type": "string",
+      "enum": ["critical", "high", "medium", "low"],
+      "description": "Enumerated because the corpus is already clean on this field: exactly these four values across all 240 stories."
+    },
+    "phase": { "type": "string", "minLength": 1 },
+    "background": {
+      "description": "Either free prose or a structured note. The corpus carries BOTH — 101 objects of {reference, includes} and 9 plain strings — so this stays a union rather than forcing 101 already-merged stories into a shape they never used.",
+      "oneOf": [
+        { "type": "string", "minLength": 1 },
+        { "type": "object", "minProperties": 1, "additionalProperties": true }
+      ]
+    },
+    "story": {
+      "type": "object",
+      "required": ["as_a", "i_want_to", "so_that"],
+      "additionalProperties": true,
+      "properties": {
+        "as_a": { "type": "string", "minLength": 1 },
+        "i_want_to": { "type": "string", "minLength": 1 },
+        "so_that": { "type": "string", "minLength": 1 }
+      }
+    },
+    "rationale": { "type": "string", "minLength": 1 },
+    "acceptance_criteria": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Non-empty, and every member carries a non-empty id and description. This is the load-bearing rule in the whole schema: acceptance criteria are what verify_story is judged against, so a story with none can traverse the entire custody chain to `verified` with nothing that could have been verified.",
+      "items": {
+        "type": "object",
+        "required": ["id", "description"],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "string", "pattern": "^AC-[0-9]+\\.[0-9A-Za-z.]+$" },
+          "description": { "type": "string", "minLength": 1 },
+          "status": {
+            "type": "string",
+            "minLength": 1,
+            "description": "NOT enumerated on purpose. The corpus carries pending, complete, completed, removed and satisfied — complete/completed/satisfied being synonyms that drifted. Enumerating that set would bless the drift; forbidding it would fail 23 criteria in already-merged stories for no functional gain, since authored status is descriptive and the live status lives in the database. Converging the vocabulary is its own change, not a side effect of declaring the schema."
+          }
+        }
+      }
+    },
+    "test_cases": {
+      "type": "array",
+      "description": "May be empty: a few stories are pure documentation or configuration changes with nothing to exercise.",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "type", "steps", "expected_results"],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "string", "pattern": "^TC-[0-9]+\\.[0-9A-Za-z.]+$" },
+          "name": { "type": "string", "minLength": 1 },
+          "type": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Observed values: integration, unit, manual. Left open rather than enumerated so a story can legitimately declare e2e, property or scale without a schema change first."
+          },
+          "preconditions": { "type": "array", "items": { "type": "string" } },
+          "steps": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+          "expected_results": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+          "status": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "technical_notes": { "type": "array", "items": { "type": "string" } },
+    "dependencies": {
+      "type": "array",
+      "description": "Story ids this story depends on. Empty array when there are none.",
+      "items": { "type": "string", "pattern": "^US-[0-9]+\\.[0-9A-Za-z.]+$" }
+    },
+    "estimated_hours": { "type": "number", "exclusiveMinimum": 0 },
+    "estimated_tokens": { "type": "integer", "exclusiveMinimum": 0 }
+  }
+}

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -2137,16 +2137,27 @@ defmodule Loopctl.ApiSpec.Schemas do
       description:
         ~s(A single acceptance criterion. ) <>
           ~s(Accepts both `{"criterion": "..."}` and `{"id": "AC-1", "description": "..."}` formats. ) <>
-          "When `description` is present it is mapped to `criterion` automatically.",
+          "When `description` is present it is mapped to `criterion` automatically. " <>
+          "**Every criterion must carry text in one of those two keys**: an entry with " <>
+          "neither, or with only whitespace, is rejected with a 422 naming its index " <>
+          "(e.g. `epics[0].stories[0].acceptance_criteria[1]`). `id` remains optional. " <>
+          "An ABSENT or EMPTY acceptance_criteria list is still accepted, so a skeleton " <>
+          "import for pre-existing work (see `initial_agent_status: \"reported_done\"`) " <>
+          "keeps working.",
       type: :object,
       properties: %{
         criterion: %Schema{
           type: :string,
-          description: "Acceptance criterion text (canonical key)"
+          minLength: 1,
+          description:
+            "Acceptance criterion text (canonical key). Required unless `description` is given."
         },
         description: %Schema{
           type: :string,
-          description: "Acceptance criterion text (alias for criterion, normalized on import)"
+          minLength: 1,
+          description:
+            "Acceptance criterion text (alias for criterion, normalized on import). " <>
+              "Required unless `criterion` is given."
         },
         id: %Schema{
           type: :string,

--- a/lib/loopctl/import_export.ex
+++ b/lib/loopctl/import_export.ex
@@ -865,24 +865,68 @@ defmodule Loopctl.ImportExport do
     end
   end
 
+  # An ABSENT or EMPTY acceptance_criteria list stays accepted, deliberately: importing
+  # a skeleton for pre-loopctl work is a supported path (`backfill_story`,
+  # `bulk_mark_complete`), and historical work legitimately has no criteria to record.
+  # Requiring them here would break that path to enforce a rule whose real home is the
+  # verify gate.
+  #
+  # What is enforced is that a criterion which IS present carries text. The previous
+  # version checked only `is_map/1` — so `%{}` and `%{"note" => "tbd"}` passed — while
+  # printing an error asserting that every entry "must be an array of objects with 'id'
+  # and 'description' keys". Two things were wrong with that message and both mattered:
+  # it stated a contract the code did not hold, and the contract it stated was not even
+  # the right one, because this endpoint accepts `criterion` as an alternative to
+  # `description` (#509) and has never required `id`. A textless criterion is the real
+  # defect: it survives normalization into a story's acceptance_criteria as an entry
+  # with nothing for `verify_story` to be judged against.
+  #
+  # The AUTHORED-file schema (`docs/user_stories/story.schema.json`) is stricter — it
+  # requires a non-empty list and an `id` on every criterion — because generated stories
+  # should carry both. `user_story_schema_test.exs` binds the shared half (a criterion
+  # must carry text) so the two declarations cannot drift apart.
   defp validate_acceptance_criteria(nil, _path), do: :ok
   defp validate_acceptance_criteria([], _path), do: :ok
 
   defp validate_acceptance_criteria(acs, path) when is_list(acs) do
-    if Enum.all?(acs, &is_map/1) do
-      :ok
-    else
-      {:error,
-       "#{path}.acceptance_criteria must be an array of objects with 'id' and 'description' keys, " <>
-         "e.g. [{\"id\": \"AC-1\", \"description\": \"Feature works\"}]"}
-    end
+    acs
+    |> Enum.with_index()
+    |> Enum.reduce_while(:ok, fn {ac, index}, :ok ->
+      case validate_single_criterion(ac, "#{path}.acceptance_criteria[#{index}]") do
+        :ok -> {:cont, :ok}
+        error -> {:halt, error}
+      end
+    end)
   end
 
   defp validate_acceptance_criteria(_acs, path) do
     {:error,
-     "#{path}.acceptance_criteria must be an array of objects with 'id' and 'description' keys, " <>
-       "e.g. [{\"id\": \"AC-1\", \"description\": \"Feature works\"}]"}
+     "#{path}.acceptance_criteria: must be an array of objects carrying 'description' " <>
+       "(or 'criterion'), e.g. [{\"id\": \"AC-1\", \"description\": \"Feature works\"}]"}
   end
+
+  defp validate_single_criterion(ac, path) when is_map(ac) do
+    if blank?(ac["description"]) and blank?(ac["criterion"]) do
+      {:error,
+       "#{path}: must carry a non-empty 'description' (or 'criterion'), " <>
+         "e.g. {\"id\": \"AC-1\", \"description\": \"Feature works\"}"}
+    else
+      :ok
+    end
+  end
+
+  defp validate_single_criterion(ac, path),
+    do: {:error, "#{path}: must be an object, not #{inspect_kind(ac)}"}
+
+  defp inspect_kind(value) when is_binary(value), do: "a string"
+  defp inspect_kind(value) when is_list(value), do: "an array"
+  defp inspect_kind(value) when is_number(value), do: "a number"
+  defp inspect_kind(nil), do: "null"
+  defp inspect_kind(_value), do: "a scalar"
+
+  defp blank?(nil), do: true
+  defp blank?(value) when is_binary(value), do: String.trim(value) == ""
+  defp blank?(_value), do: false
 
   # Normalizes epic numbers to integers and story numbers to strings so the
   # merge lookup keys (pulled from DB rows) match the payload. Clients often

--- a/test/loopctl/import_export_ac_normalization_test.exs
+++ b/test/loopctl/import_export_ac_normalization_test.exs
@@ -159,7 +159,78 @@ defmodule Loopctl.ImportExportAcNormalizationTest do
       assert {:error, :validation, message} = run_import(tenant.id, project.id, payload)
 
       assert message =~ "acceptance_criteria"
-      assert message =~ "objects"
+      assert message =~ "must be an object"
+
+      # The message now LOCATES the offending entry rather than describing the
+      # array generically, so an import carrying 40 criteria names which one is
+      # wrong. Asserting the index is what keeps that specific.
+      assert message =~ "acceptance_criteria[0]"
+      assert message =~ "not a string"
+    end
+
+    test "a criterion carrying no text at all is rejected, and located" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      # `%{}` and `%{"note" => ...}` both used to pass: the old guard checked only
+      # `is_map/1` while printing an error claiming 'id' and 'description' were
+      # required. A textless criterion normalizes into the story with nothing for
+      # verify_story to be judged against, which is the defect that mattered.
+      payload =
+        base_payload(%{
+          "acceptance_criteria" => [
+            %{"id" => "AC-1", "description" => "Feature works"},
+            %{"id" => "AC-2", "note" => "tbd"}
+          ]
+        })
+
+      assert {:error, :validation, message} = run_import(tenant.id, project.id, payload)
+
+      assert message =~ "acceptance_criteria[1]"
+      assert message =~ "description"
+      assert message =~ "criterion"
+    end
+
+    test "a criterion with a blank description is rejected" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      payload =
+        base_payload(%{"acceptance_criteria" => [%{"id" => "AC-1", "description" => "   "}]})
+
+      assert {:error, :validation, message} = run_import(tenant.id, project.id, payload)
+      assert message =~ "acceptance_criteria[0]"
+    end
+
+    test "the 'criterion' key alone still satisfies the text requirement (#509)" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      # Regression guard. This endpoint has accepted `criterion` as an alternative
+      # to `description` since #509 and has never required `id`; tightening the
+      # textless check must not quietly re-impose either.
+      payload = base_payload(%{"acceptance_criteria" => [%{"criterion" => "Feature works"}]})
+
+      assert {:ok, _summary} = run_import(tenant.id, project.id, payload)
+    end
+
+    test "an AC-less story still imports, so backfill of pre-loopctl work keeps working" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      # Deliberate, not an oversight: importing a skeleton for historical work is a
+      # supported path (backfill_story / bulk_mark_complete). The "a story must have
+      # criteria" rule belongs at the verify gate, not at the import boundary, and
+      # enforcing it here would break backfill to close a hole it does not close.
+      # A separate project per import: the same epic/story numbers imported twice
+      # into ONE project is a duplicate-number conflict, which would fail this test
+      # for a reason that has nothing to do with acceptance criteria.
+      other = fixture(:project, %{tenant_id: tenant.id})
+
+      assert {:ok, _} = run_import(tenant.id, project.id, base_payload(%{}))
+
+      assert {:ok, _} =
+               run_import(tenant.id, other.id, base_payload(%{"acceptance_criteria" => []}))
     end
 
     test "includes path context in error message" do

--- a/test/loopctl/user_story_schema_test.exs
+++ b/test/loopctl/user_story_schema_test.exs
@@ -1,0 +1,195 @@
+defmodule Loopctl.UserStorySchemaTest do
+  @moduledoc """
+  Binds `docs/user_stories/story.schema.json` to the two things it is supposed to
+  govern: the committed story corpus, and the import path's acceptance-criteria rule.
+
+  Why a hand-rolled checker instead of an ex_json_schema dependency: the schema is a
+  DECLARATION — the artifact `user-story-writer` emits against and a reviewer reads in
+  one sitting — and the only place it must be executable is here. Adding a JSON-Schema
+  runtime to the application to validate one shape on one endpoint would put a parser
+  in the request path and buy less than this test does.
+
+  The two declarations are deliberately NOT identical, and the third describe block is
+  where that difference is pinned down. The authored-file schema is stricter (a
+  non-empty criteria list, an `id` on every criterion) because a generated story should
+  carry both. The import path is looser (criteria may be absent, `criterion` substitutes
+  for `description`, `id` is optional) because importing a skeleton for pre-loopctl work
+  is a supported path and #509 made `criterion` a first-class key. What the two MUST
+  agree on is that a criterion present in a payload carries text.
+  """
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.ImportExport
+
+  @schema_path Path.join([__DIR__, "..", "..", "docs", "user_stories", "story.schema.json"])
+  @stories_glob Path.join([__DIR__, "..", "..", "docs", "user_stories", "*", "us_*.json"])
+
+  defp schema, do: @schema_path |> File.read!() |> Jason.decode!()
+
+  defp story_files, do: Path.wildcard(@stories_glob)
+
+  defp blank?(nil), do: true
+  defp blank?(v) when is_binary(v), do: String.trim(v) == ""
+  defp blank?(_), do: false
+
+  describe "the schema itself" do
+    test "parses, and declares the rules the rest of this file depends on" do
+      s = schema()
+
+      assert s["type"] == "object"
+      assert is_list(s["required"])
+
+      ac = s["properties"]["acceptance_criteria"]
+      assert ac["type"] == "array"
+      assert ac["minItems"] == 1
+      assert "id" in ac["items"]["required"]
+      assert "description" in ac["items"]["required"]
+      assert ac["items"]["properties"]["description"]["minLength"] == 1
+    end
+
+    test "story files exist to validate against" do
+      # Guards the whole corpus block below from passing vacuously if the glob
+      # ever stops matching (a rename, a move, a wrong relative path).
+      assert length(story_files()) > 100
+    end
+  end
+
+  describe "the committed corpus conforms" do
+    test "every story carries every required top-level key" do
+      required = schema()["required"]
+
+      offenders =
+        for path <- story_files(),
+            story = path |> File.read!() |> Jason.decode!(),
+            key <- required,
+            is_nil(story[key]),
+            do: "#{Path.basename(path)}: missing #{key}"
+
+      assert offenders == []
+    end
+
+    test "every story carries a non-empty acceptance_criteria list" do
+      offenders =
+        for path <- story_files(),
+            story = path |> File.read!() |> Jason.decode!(),
+            acs = story["acceptance_criteria"],
+            not is_list(acs) or acs == [],
+            do: Path.basename(path)
+
+      assert offenders == []
+    end
+
+    test "every acceptance criterion carries a non-empty id and description" do
+      required = schema()["properties"]["acceptance_criteria"]["items"]["required"]
+
+      offenders =
+        for path <- story_files(),
+            story = path |> File.read!() |> Jason.decode!(),
+            {ac, index} <- Enum.with_index(story["acceptance_criteria"] || []),
+            key <- required,
+            not is_map(ac) or blank?(ac[key]),
+            do: "#{Path.basename(path)} acceptance_criteria[#{index}]: #{key}"
+
+      assert offenders == []
+    end
+
+    test "every test case carries its required keys" do
+      required = schema()["properties"]["test_cases"]["items"]["required"]
+
+      offenders =
+        for path <- story_files(),
+            story = path |> File.read!() |> Jason.decode!(),
+            {tc, index} <- Enum.with_index(story["test_cases"] || []),
+            key <- required,
+            not is_map(tc) or is_nil(tc[key]) or tc[key] == "" or tc[key] == [],
+            do: "#{Path.basename(path)} test_cases[#{index}]: #{key}"
+
+      assert offenders == []
+    end
+
+    test "nested story and epic objects carry their required keys" do
+      s = schema()
+      story_required = s["properties"]["story"]["required"]
+      epic_required = s["properties"]["epic"]["required"]
+
+      offenders =
+        for path <- story_files(),
+            doc = path |> File.read!() |> Jason.decode!(),
+            {obj, required, label} <- [
+              {doc["story"], story_required, "story"},
+              {doc["epic"], epic_required, "epic"}
+            ],
+            key <- required,
+            not is_map(obj) or blank?(obj[key]),
+            do: "#{Path.basename(path)} #{label}: #{key}"
+
+      assert offenders == []
+    end
+  end
+
+  describe "schema and import validator cannot drift apart" do
+    defp import_story(tenant, project, ac) do
+      payload = %{
+        "epics" => [
+          %{
+            "number" => 1,
+            "title" => "Foundation",
+            "stories" => [%{"number" => "1.1", "title" => "S", "acceptance_criteria" => ac}]
+          }
+        ]
+      }
+
+      ImportExport.import_project(tenant.id, project.id, payload,
+        actor_id: uuid(),
+        actor_label: "user:test"
+      )
+    end
+
+    test "a criterion shaped exactly as the schema requires is accepted on import" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      # Build the criterion from the schema's OWN required list rather than a literal,
+      # so adding a required key to the schema without teaching the import path fails
+      # here instead of in a consumer's repo.
+      criterion =
+        schema()["properties"]["acceptance_criteria"]["items"]["required"]
+        |> Map.new(fn key -> {key, "value for #{key}"} end)
+
+      assert {:ok, _} = import_story(tenant, project, [criterion])
+    end
+
+    test "a criterion carrying no text is rejected by BOTH declarations" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      # The schema side: description is required and minLength 1.
+      ac_item = schema()["properties"]["acceptance_criteria"]["items"]
+      assert "description" in ac_item["required"]
+      assert ac_item["properties"]["description"]["minLength"] == 1
+
+      # The import side: same rule, reached through the public API.
+      assert {:error, :validation, message} =
+               import_story(tenant, project, [%{"id" => "AC-1", "description" => ""}])
+
+      assert message =~ "acceptance_criteria[0]"
+    end
+
+    test "the looser import rule is intentional and stays looser" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      other = fixture(:project, %{tenant_id: tenant.id})
+
+      # These three are valid on the IMPORT path and invalid in an authored file.
+      # If a future change makes the import path enforce the authored-file schema
+      # wholesale, this test fails and names what that would break: #509's
+      # `criterion` key, optional ids, and skeleton imports for backfilled work.
+      assert {:ok, _} = import_story(tenant, project, [%{"criterion" => "no id here"}])
+      assert {:ok, _} = import_story(tenant, other, nil)
+
+      ac_item = schema()["properties"]["acceptance_criteria"]["items"]
+      assert "id" in ac_item["required"], "authored files still require an id"
+      assert schema()["properties"]["acceptance_criteria"]["minItems"] == 1
+    end
+  end
+end


### PR DESCRIPTION
Opens **epic 42 — Recorded Structure**, and implements **US-42.2**.

Both stories in the epic share one thesis: replace an *inference* with a *record of something the system already knows*. The knowledge graph infers relationships from cosine similarity while exact provenance sits unused in columns (US-42.1, not implemented here). The import path infers that a story is well-formed while nothing declares what a story is (US-42.2, this PR).

## The defect

`validate_acceptance_criteria/2` printed an error asserting that every acceptance criterion *"must be an array of objects with 'id' and 'description' keys"* — and then checked only `is_map/1`. `%{}` passed. So did `%{"note" => "tbd"}`. The message stated a contract the code did not hold, and the contract it stated was not even the right one: this endpoint has accepted `criterion` as an alias for `description` since the 2026-03-28 discoverability change (#509), and has never required `id`.

A textless criterion is not cosmetic. It normalizes into the story as an entry with nothing for `verify_story` to be judged against.

## What changed

A criterion that **is present** must carry text in `description` or `criterion`. An entry with neither — or whitespace in both — is rejected with a message naming its index (`epics[0].stories[0].acceptance_criteria[1]`) instead of describing the array generically.

## What deliberately did not change — against this story's own original acceptance criteria

AC-42.2.2 as written called for rejecting `nil` and `[]` and requiring `id` + `description`. **Both were wrong, and the repo says so:**

- Importing a skeleton for pre-loopctl work is a supported path — the same payload carries `initial_agent_status: "reported_done"` precisely for completed historical work. Rejecting empty criteria would break backfill to enforce a rule whose real home is the verify gate.
- Requiring `id` + `description` would have regressed #509's documented `criterion` format.

The story file records the revision and the evidence rather than quietly shipping something other than what it described. That is the epic's own thesis applied to itself.

## The schema

`docs/user_stories/story.schema.json` declares the authored-story shape. Every rule was **derived from the committed corpus, not invented** — two earlier drafts were rejected by the corpus itself for inventing an id pattern, a status vocabulary, and a string-only `background` that real stories do not use. Where the corpus is legitimately inconsistent the schema stays permissive and records why.

It is stricter than the import payload on purpose (non-empty list, `id` required), and `user_story_schema_test.exs` binds the half the two declarations share so they cannot drift apart. **No JSON Schema runtime dependency** — the schema is a declaration, and the test is the only place it has to be executable.

The corpus check AC-42.2.4 called for found **zero violations**. The convention was already real and universally followed; it had simply never been written down, so nothing stopped the next story from ignoring it.

## Verification

- Guards proven **non-vacuous by mutation**: disabling the textless check fails exactly three tests, then restored.
- Full gate green via the pre-commit hook on both commits: **7689 tests, 0 failures**; `credo --strict` clean over 1083 files; format and compile-with-warnings-as-errors clean.
- 228 tests across every suite touching acceptance criteria pass.

## Review

**Reviewed inline, by the authoring session, against correctness / security / this repo's conventions.** This session operates under instructions not to dispatch subagents or workflows, so the enhanced-review pipeline was not available to it; per CLAUDE.md the gate is satisfied by the best available reviewer and its mechanism being unavailable is not grounds to hold a change. That inline pass is what caught the inventory count this branch's second commit removes — `story.schema.json` described itself as derived from "all 240 committed stories", which this very epic falsifies by adding stories.

Worth a second pair of eyes on one judgement in particular: the decision to keep `nil`/`[]` accepted. It is argued from `initial_agent_status: "reported_done"` and the backfill surface, and it leaves the AC-less-story-reaches-verified hole open at the import boundary by design, on the view that the verify gate is where that belongs.

## Not in this PR

US-42.1 (per-source hub articles and `derived_from` star edges) is specified in `docs/user_stories/epic_42_recorded_structure/us_42.1.json` and not implemented. Its design was materially changed by a measurement taken while writing it: `knowledge_facets` reports 210 distinct `book-` sources with the largest contributing over 1,500 articles, so the obvious sibling-to-sibling harvest would produce a million-edge clique from a single book and recreate exactly the density #611 stage 0 exists to remove. The story specifies a star through a per-source hub instead.
