### PR TITLE
Give the knowledge graph a dimension a cosine score did not produce (US-42.1)

### DIFF
--- a/docs/user_stories/epic_42_recorded_structure/README.md
+++ b/docs/user_stories/epic_42_recorded_structure/README.md
@@ -1,6 +1,6 @@
 # Epic 42 — Recorded Structure
 
-**Status: PARTLY DELIVERED — US-42.2 is in PR #718; US-42.1 is specified and not implemented.** Per-story state and its merge PR live in the Stories table
+**Status: BOTH STORIES IMPLEMENTED.** US-42.2 merged in #718. US-42.1's harvester is built and tested; nothing schedules it yet, which is a deliberate separate decision recorded in that story. Per-story state and its merge PR live in the Stories table
 below — that table is the single source of truth for what is done, and this header is
 the only place that summarises it. Prose below is the epic's DESIGN record, written
 against master 2026-08-20; read its present tense as "at design time".
@@ -66,7 +66,7 @@ entire custody chain to `verified` with nothing that could have been verified.
 
 | Story | Title | Status | PR |
 |-------|-------|--------|----|
-| US-42.1 | Per-source hub articles and `derived_from` star edges | **not implemented** — spec corrected against measurement, see its technical notes | — |
+| US-42.1 | Per-source hub articles and `derived_from` star edges | **implemented** — scheduling deliberately separate, see its technical notes | — |
 | US-42.2 | A declared schema for work-breakdown imports, enforced instead of described | **merged-pending** | #718 |
 
 Neither story depends on the other; they can land in either order.

--- a/docs/user_stories/epic_42_recorded_structure/us_42.1.json
+++ b/docs/user_stories/epic_42_recorded_structure/us_42.1.json
@@ -18,47 +18,47 @@
     {
       "id": "AC-42.1.1",
       "description": "A source hub is an ordinary article (no new table) with category 'reference', title 'Source: <human-readable source name>', and metadata.hub_kind = 'source'. It is identified by a deterministic idempotency_key derived from (tenant_id, source_type, source_id) so a re-run resolves the existing hub rather than creating a second one.",
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": "AC-42.1.2",
       "description": "CORRECTED 2026-08-20 BY MEASUREMENT. Resolve each article's source from its SOURCE-FAMILY TAG (book-, doc-, repo-, yt- prefixes) FIRST, with the source_type/source_id COLUMNS as the fallback - the inverse of this story's original assumption. knowledge_get on a book-extracted article (360cd5a5, tagged book-9baec82a16b7) returns source_type: null and source_id: null, so the columns are largely unpopulated and a column-first harvest would find almost nothing. Loopctl.Knowledge.StructuralLinks.harvest/2 then creates, for each article with a resolvable source, exactly one derived_from edge from that article to its source hub. Direction is article -> hub. No sibling-to-sibling edge is ever written.",
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": "AC-42.1.3",
       "description": "The harvest is idempotent: running it twice over an unchanged corpus creates zero additional edges and zero additional hubs. It relies on the existing composite unique index on (tenant_id, source_article_id, target_article_id, relationship_type) rather than on a pre-read.",
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": "AC-42.1.4",
       "description": "A source below a configurable :structural_hub_min_siblings floor (default 3) gets NO hub and NO edges. A two-article source produces a hub with less information than the two articles already carry, and 210 book sources plus every one-off document would otherwise flood the corpus with near-empty reference articles.",
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": "AC-42.1.5",
       "description": "VERIFIED ALREADY TRUE, so this reduces to a regression test. LinkPruning filters on relationship_type = 'relates_to' (link_pruning.ex:265,285), so derived_from is exempt BY CONSTRUCTION and no code change is needed. Add the test asserting a derived_from edge survives a prune run which removes relates_to edges on the same article, so a future widening of the prune predicate cannot silently start evicting structural edges.",
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": "AC-42.1.6",
       "description": "Hub articles are excluded from the novelty gate's duplicate detection when created by the harvester (they are structurally near-identical to each other by construction), and are excluded from knowledge_heat_index ranking so a hub cannot displace real articles in an index designed to be pasted into a cached prefix (#567/#569).",
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": "AC-42.1.7",
-      "description": "OPEN DESIGN DECISION, deliberately not settled in the story. The harvest is a corpus-wide sweep and the repo choice is a capacity and isolation decision, not a detail: AdminRepo's 3-connection pool (config/runtime.exs:190) is load-bearing for every authenticated request and the recorded KB finding is to keep heavy reads off it - yet the existing system link-writers (ArticleLinkingWorker, promote_conflicts) insert via AdminRepo directly. The likely shape is Loopctl.HeavyRead for the scan plus a tenant-scoped RLS write, but settle it against tenancy-rls/SKILL.md before writing code. Whatever is chosen, the harvest must be tenant-scoped and a tenant-isolation test must assert that one tenant's harvest can neither read nor link another tenant's articles.",
-      "status": "pending"
+      "description": "SETTLED AND IMPLEMENTED against tenancy-rls/SKILL.md: the SCAN goes through Loopctl.HeavyRead (whose guard!/2 raises unless every base-table source carries a conjunctive tenant_id predicate, making isolation structural) with on_overload: :tag so a shed is propagated rather than bound as a list; the BOUNDED writes go to AdminRepo like the other system link-writers, with tenant_id set programmatically. Original note follows. The harvest is a corpus-wide sweep and the repo choice is a capacity and isolation decision, not a detail: AdminRepo's 3-connection pool (config/runtime.exs:190) is load-bearing for every authenticated request and the recorded KB finding is to keep heavy reads off it - yet the existing system link-writers (ArticleLinkingWorker, promote_conflicts) insert via AdminRepo directly. The likely shape is Loopctl.HeavyRead for the scan plus a tenant-scoped RLS write, but settle it against tenancy-rls/SKILL.md before writing code. Whatever is chosen, the harvest must be tenant-scoped and a tenant-isolation test must assert that one tenant's harvest can neither read nor link another tenant's articles.",
+      "status": "complete"
     },
     {
       "id": "AC-42.1.8",
       "description": "knowledge_get on an article with a hub returns the hub in outgoing_links, and knowledge_get on the hub returns its siblings in incoming_links, subject to the existing 25-per-direction cap with links_total reporting the true count.",
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": "AC-42.1.9",
       "description": "The harvester reports, per run: hubs created, hubs resolved, edges created, sources skipped below the floor, and articles with no resolvable source. A run that creates nothing logs that fact rather than exiting silently.",
-      "status": "pending"
+      "status": "complete"
     }
   ],
   "test_cases": [
@@ -77,7 +77,7 @@
         "exactly 6 derived_from edges exist",
         "zero edges exist between two non-hub articles"
       ],
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": "TC-42.1.2",
@@ -94,7 +94,7 @@
         "edge count unchanged",
         "the run reports 1 hub resolved and 0 created"
       ],
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": "TC-42.1.3",
@@ -111,7 +111,7 @@
         "no derived_from edge references those two articles",
         "the run reports 1 source skipped below the floor"
       ],
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": "TC-42.1.4",
@@ -127,7 +127,7 @@
         "relates_to edges are reduced to top-K",
         "the derived_from edge is still present"
       ],
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": "TC-42.1.5",
@@ -144,7 +144,7 @@
         "tenant B gains no hub and no edges",
         "no edge crosses tenants"
       ],
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": "TC-42.1.6",
@@ -160,7 +160,7 @@
         "the hub does not appear in the ranked stubs",
         "non-hub articles rank unchanged"
       ],
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": "TC-42.1.7",
@@ -175,7 +175,7 @@
       "expected_results": [
         "TC-42.1.3 fails"
       ],
-      "status": "pending"
+      "status": "complete"
     }
   ],
   "technical_notes": [
@@ -185,7 +185,8 @@
     "Run it as an Oban worker on the existing knowledge cadence rather than inline on write - the harvest is a whole-corpus sweep and must not sit in the ingestion request path. Idempotency (AC-42.1.3) is what makes an unattended repeat safe.",
     "This is stage 0.5 of #611, sitting between the shipped prune (stage 0) and the LLM relation typing (stage 1). It is deliberately cheap: no model call, no embedding, no judgment. Land it before stage 1 so the expensive pass has a set of known-true edges to calibrate against.",
     "Do NOT extend this to co-membership of a project_id or a shared topical tag. Those are set memberships, not relations, and harvesting them reintroduces the clique problem this story's star shape exists to avoid.",
-    "STATUS 2026-08-20: NOT IMPLEMENTED. Specified, and two acceptance criteria corrected against evidence gathered while starting it (AC-42.1.2 source resolution, AC-42.1.5 already-true-by-construction). AC-42.1.7 is a genuine open decision about repo and RLS that a session should settle deliberately rather than inherit. The measurement that shaped the whole story - 210 distinct book- sources, the largest over 1,500 articles, hence a star and never a clique - came from knowledge_facets(tag_prefix: 'book-') and is worth re-running before implementing, since the corpus grows."
+    "STATUS 2026-08-20: IMPLEMENTED. Loopctl.Knowledge.StructuralLinks plus 15 tests, all nine acceptance criteria met. Four guards verified NON-VACUOUS by mutation: disabling the sibling floor, flipping source resolution to column-first, turning the star into a clique, and removing the heat-index exclusion each fail a test. That last mutation initially failed to fail, and the diagnosis was a REAL defect rather than a weak test - create_article/3 defaults to :draft, so hubs were being created unpublished, invisible to search and the index and therefore never heat candidates at all. Hubs are now explicitly :published.",
+    "SCHEDULING IS DELIBERATELY A SEPARATE CHANGE. harvest/2 is callable and idempotent but nothing runs it on a cadence. An all-tenants nightly sweep is not a free addition here: the recorded KB finding is that self-signup permanently joins every all-tenants cron fan-out and per-IP caps do not bound that growth, so the fan-out shape wants deciding on its own rather than inheriting from whichever worker it is folded into. Enabling it should also start with the sibling floor deliberately high on the hosted corpus, since the first run creates one hub per qualifying source across every source family at once."
   ],
   "dependencies": [],
   "estimated_tokens": 120000

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -10508,6 +10508,14 @@ defmodule Loopctl.Knowledge do
     from(a in Article,
       where: a.tenant_id == ^tenant_id or a.scope == :system,
       where: a.status == :published,
+      # Machine-generated source hubs (US-42.1) are navigation, not knowledge, and are
+      # excluded from the heat ranking. A hub exists to be traversed — every article from
+      # its source points at it — so it accumulates readers as a FUNCTION of how many
+      # siblings the harvest gave it, not of whether anyone found it useful. Letting that
+      # rank would put the biggest imported book at the top of an index designed to be
+      # pasted into a cached prefix, which is the same failure #567/#569/#572 each fixed
+      # once: heat must not rank on a signal heat's own plumbing produces.
+      where: fragment("coalesce(? ->> 'hub_kind', '') <> 'source'", a.metadata),
       select: a.id
     )
     |> heat_filter_category(category)

--- a/lib/loopctl/knowledge/structural_links.ex
+++ b/lib/loopctl/knowledge/structural_links.ex
@@ -1,0 +1,330 @@
+defmodule Loopctl.Knowledge.StructuralLinks do
+  @moduledoc """
+  Harvests `derived_from` edges from provenance the corpus already carries (US-42.1, #611
+  stage 0.5).
+
+  ## Why this exists
+
+  Measured on the hosted corpus for #611: every one of ~1.4M `relates_to` edges is a cosine
+  threshold artifact — zero structural, zero hand-made — with 59% sitting in the 0.60-0.70
+  band just above the floor, and `precision@20 = 0.038`. The issue's own diagnosis is that
+  the graph "has exactly one dimension, sliced into thirds and given three names". Stage 0
+  (`Loopctl.Knowledge.LinkPruning`) bounded that graph's density, but pruning a
+  single-dimensional graph leaves it single-dimensional.
+
+  `ArticleLink` has always declared a `derived_from` type that NOTHING produced: it is read
+  by the OKF exporter and written by no code path. Meanwhile articles extracted from one
+  source share a source-family tag. This module is the missing producer, and the edges it
+  writes are the first class in the corpus that is TRUE rather than probable.
+
+  ## A star, never a clique
+
+  The obvious harvest — link every article to its siblings — is catastrophic at this
+  corpus's shape. Measured 2026-08-20 via `knowledge_facets(tag_prefix: "book-")`: 210
+  distinct book sources, the largest contributing 1,523 articles. Sibling-to-sibling over
+  that ONE book is ~1.16M edges, more than the entire pre-pruning graph stage 0 was filed
+  to reduce.
+
+  Routing siblings through one hub costs N edges instead of N²/2, keeps two-hop
+  reachability meaningful, and produces a node with a NAME an agent can read — which
+  sibling-to-sibling edges never do.
+
+  ## Where the source signal actually lives
+
+  The `source_type` / `source_id` COLUMNS are largely unpopulated: `knowledge_get` on a
+  book-extracted article (tagged `book-9baec82a16b7`) returns `null` for both. The real
+  signal is the source-family TAG (`book-`, `doc-`, `repo-`, `yt-`), so resolution is
+  tag-first with the columns as a fallback. A column-first harvest would have found almost
+  nothing. Per the recorded finding on #137, `source_id` is deliberately NOT per-article
+  unique — a shared source across siblings is the signal this module consumes, not a defect.
+
+  ## Repo topology (the decision AC-42.1.7 left open, settled against `tenancy-rls`)
+
+  * The SCAN is a heavy enumeration over the whole corpus, so it goes through
+    `Loopctl.HeavyRead` — never `AdminRepo`, whose 3-connection pool is load-bearing for
+    every authenticated request. `HeavyRead`'s `guard!/2` additionally RAISES unless every
+    base-table source carries a conjunctive `tenant_id` predicate bound to the passed
+    tenant, which is what makes the isolation structural rather than a promise.
+  * A heavy read can be SHED. `scan/2` asks for `on_overload: :tag` and the caller
+    propagates `{:error, :heavy_read_overloaded}` — binding a shed result as a list would
+    crash exactly under the load the gate exists for.
+  * The WRITES are bounded (one hub plus N edges per qualifying source) and follow the
+    other system link-writers onto `AdminRepo`. RLS does nothing there, so the explicit
+    `tenant_id` is the only isolation and it is set programmatically, never cast.
+  """
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.HeavyRead
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ArticleLink
+
+  require Logger
+
+  @source_tag_prefixes ~w(book- doc- repo- yt-)
+
+  @default_min_siblings 3
+
+  @doc """
+  Harvests source hubs and their `derived_from` star edges for one tenant.
+
+  Idempotent: a second run over an unchanged corpus creates no hub and no edge. Hubs are
+  resolved by a deterministic `idempotency_key`, and edges rely on the composite unique
+  index on `(tenant_id, source_article_id, target_article_id, relationship_type)`.
+
+  Returns `{:ok, report}` or `{:error, :heavy_read_overloaded}`.
+  """
+  @spec harvest(binary(), keyword()) ::
+          {:ok, map()} | {:error, :heavy_read_overloaded}
+  def harvest(tenant_id, opts \\ []) when is_binary(tenant_id) do
+    floor = Keyword.get(opts, :min_siblings, min_siblings())
+
+    case scan(tenant_id, opts) do
+      {:error, :heavy_read_overloaded} = shed ->
+        shed
+
+      articles ->
+        {qualifying, skipped} =
+          articles
+          |> group_by_source()
+          |> Enum.split_with(fn {_source, members} -> length(members) >= floor end)
+
+        report =
+          Enum.reduce(qualifying, blank_report(skipped, articles, floor), fn {source, members},
+                                                                             acc ->
+            harvest_one_source(tenant_id, source, members, acc)
+          end)
+
+        log_report(tenant_id, report)
+        {:ok, report}
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # Scan
+  # ------------------------------------------------------------------
+
+  defp scan(tenant_id, opts) do
+    query =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id,
+        where: a.status == :published,
+        where: is_nil(a.metadata["hub_kind"]),
+        select: %{id: a.id, tags: a.tags, source_type: a.source_type, source_id: a.source_id}
+      )
+
+    HeavyRead.all(tenant_id, query, Keyword.merge([on_overload: :tag], opts))
+  end
+
+  # ------------------------------------------------------------------
+  # Source resolution — tag first, columns as the fallback
+  # ------------------------------------------------------------------
+
+  @doc """
+  Resolves an article's source key, or `nil` when it carries none.
+
+  Public so the resolution rule can be unit-tested directly rather than only through a
+  whole harvest — the tag-vs-column precedence is the part measurement corrected, and it
+  is worth pinning on its own.
+  """
+  @spec source_key(map()) :: String.t() | nil
+  def source_key(%{} = article) do
+    case source_tag(article[:tags] || []) do
+      nil -> column_source(article)
+      tag -> tag
+    end
+  end
+
+  defp source_tag(tags) when is_list(tags) do
+    Enum.find(tags, fn tag ->
+      is_binary(tag) and Enum.any?(@source_tag_prefixes, &String.starts_with?(tag, &1))
+    end)
+  end
+
+  defp source_tag(_tags), do: nil
+
+  defp column_source(%{source_type: type, source_id: id})
+       when is_binary(type) and is_binary(id),
+       do: "#{type}-#{id}"
+
+  defp column_source(_article), do: nil
+
+  defp group_by_source(articles) do
+    articles
+    |> Enum.reduce(%{}, fn article, acc ->
+      case source_key(article) do
+        nil -> acc
+        key -> Map.update(acc, key, [article], &[article | &1])
+      end
+    end)
+    |> Enum.sort_by(fn {key, _members} -> key end)
+  end
+
+  # ------------------------------------------------------------------
+  # Hub + edges
+  # ------------------------------------------------------------------
+
+  defp harvest_one_source(tenant_id, source, members, acc) do
+    case resolve_or_create_hub(tenant_id, source) do
+      {:ok, hub, :created} ->
+        write_edges(tenant_id, hub, members, %{acc | hubs_created: acc.hubs_created + 1})
+
+      {:ok, hub, :resolved} ->
+        write_edges(tenant_id, hub, members, %{acc | hubs_resolved: acc.hubs_resolved + 1})
+
+      {:error, reason} ->
+        Logger.warning("structural_links: hub failed for #{source}: #{inspect(reason)}")
+        %{acc | hub_failures: acc.hub_failures + 1}
+    end
+  end
+
+  defp resolve_or_create_hub(tenant_id, source) do
+    key = hub_idempotency_key(source)
+
+    case AdminRepo.one(
+           from(a in Article,
+             where: a.tenant_id == ^tenant_id and a.idempotency_key == ^key,
+             select: a
+           )
+         ) do
+      %Article{} = hub ->
+        {:ok, hub, :resolved}
+
+      nil ->
+        create_hub(tenant_id, source, key)
+    end
+  end
+
+  defp create_hub(tenant_id, source, key) do
+    attrs = %{
+      title: "Source: #{hub_title(source)}",
+      # Never invent a source's human name. A hub named by its digest is still a
+      # navigational win over no hub; a hub named by a hallucinated book title is worse
+      # than nothing, because it reads as a fact.
+      body: hub_body(source),
+      category: "reference",
+      # PUBLISHED explicitly. `create_article/3` defaults to :draft (the "publishes by
+      # default" behaviour belongs to the proposal path, not this one), and a draft hub is
+      # invisible to search, the index and the heat candidate set — which makes it not
+      # navigation at all, defeating the entire point of the star. Caught by mutation
+      # testing: the heat-exclusion guard passed vacuously because the hub was never a
+      # heat candidate in the first place.
+      status: :published,
+      tags: [source, "hub", "source-hub"],
+      idempotency_key: key,
+      metadata: %{"hub_kind" => "source", "source_key" => source}
+    }
+
+    # The novelty gate lives in `propose_article/3`, NOT here: `create_article/3` is the
+    # direct, ungated path. That matters for this writer rather than being trivia — hubs
+    # are structurally near-identical to one another by construction, so a gated create
+    # would stage every one after the first as a draft and the harvest would silently
+    # produce unpublished hubs. Using the ungated path is the deliberate choice; do not
+    # "improve" this by routing it through propose_article.
+    case Knowledge.create_article(tenant_id, attrs) do
+      {:ok, %Article{} = hub} ->
+        {:ok, hub, :created}
+
+      # A title collision means a hub for this source already exists under a different
+      # idempotency_key — treat it as resolved, never as a failure, so a re-run converges
+      # instead of logging the same error every night.
+      {:error, :duplicate_title, %Article{} = hub} ->
+        {:ok, hub, :resolved}
+
+      {:error, reason} ->
+        {:error, reason}
+
+      other ->
+        {:error, other}
+    end
+  end
+
+  defp write_edges(tenant_id, hub, members, acc) do
+    # ArticleLink.inserted_at is :utc_datetime_usec — truncating to :second makes Ecto
+    # raise on dump. It also has no updated_at (links are immutable), so only one stamp.
+    now = DateTime.utc_now()
+
+    rows =
+      members
+      |> Enum.reject(&(&1.id == hub.id))
+      |> Enum.map(
+        &%{
+          id: Ecto.UUID.generate(),
+          tenant_id: tenant_id,
+          source_article_id: &1.id,
+          target_article_id: hub.id,
+          relationship_type: :derived_from,
+          metadata: %{"origin" => "structural_links"},
+          inserted_at: now
+        }
+      )
+
+    {inserted, _} =
+      AdminRepo.insert_all(ArticleLink, rows,
+        on_conflict: :nothing,
+        conflict_target: [
+          :tenant_id,
+          :source_article_id,
+          :target_article_id,
+          :relationship_type
+        ]
+      )
+
+    %{acc | edges_created: acc.edges_created + inserted}
+  end
+
+  # ------------------------------------------------------------------
+  # Naming, config, reporting
+  # ------------------------------------------------------------------
+
+  defp hub_idempotency_key(source), do: "structural-hub-" <> source
+
+  # The tag IS the name we have. Strip the family prefix for readability and leave the
+  # digest — see the comment in create_hub/3 about never inventing a title.
+  defp hub_title(source) do
+    Enum.reduce(@source_tag_prefixes, source, fn prefix, acc ->
+      String.replace_prefix(acc, prefix, String.trim_trailing(prefix, "-") <> " ")
+    end)
+  end
+
+  defp hub_body(source) do
+    """
+    Navigational hub for everything extracted from the source `#{source}`.
+
+    Every article derived from this source carries a `derived_from` edge to this node, so
+    its siblings are one hop away. Created mechanically by
+    `Loopctl.Knowledge.StructuralLinks` from provenance the corpus already carried — this
+    node asserts co-origin, which is exact, and asserts nothing about similarity.
+    """
+  end
+
+  defp min_siblings do
+    Application.get_env(:loopctl, :structural_hub_min_siblings, @default_min_siblings)
+  end
+
+  defp blank_report(skipped, articles, floor) do
+    %{
+      hubs_created: 0,
+      hubs_resolved: 0,
+      hub_failures: 0,
+      edges_created: 0,
+      sources_below_floor: length(skipped),
+      articles_without_source: Enum.count(articles, &is_nil(source_key(&1))),
+      min_siblings: floor
+    }
+  end
+
+  # A run that creates nothing says so, rather than exiting silently (AC-42.1.9): "no new
+  # edges" and "the sweep never ran" are the two readings that must not look alike.
+  defp log_report(tenant_id, report) do
+    Logger.info(
+      "structural_links: tenant=#{tenant_id} hubs_created=#{report.hubs_created} " <>
+        "hubs_resolved=#{report.hubs_resolved} edges_created=#{report.edges_created} " <>
+        "sources_below_floor=#{report.sources_below_floor} " <>
+        "articles_without_source=#{report.articles_without_source} " <>
+        "hub_failures=#{report.hub_failures}"
+    )
+  end
+end

--- a/test/loopctl/knowledge/structural_links_test.exs
+++ b/test/loopctl/knowledge/structural_links_test.exs
@@ -1,0 +1,279 @@
+defmodule Loopctl.Knowledge.StructuralLinksTest do
+  @moduledoc """
+  US-42.1 — `derived_from` star edges harvested from source provenance.
+
+  The load-bearing assertion in this file is TC-42.1.1's "zero edges between two non-hub
+  articles". A sibling-to-sibling harvest is the obvious implementation and it is
+  catastrophic at this corpus's shape: one 1,523-article book source would produce ~1.16M
+  edges on its own, more than the entire pre-pruning graph #611 stage 0 exists to reduce.
+  The star shape is the whole design, so it is asserted directly rather than inferred from
+  an edge count.
+  """
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ArticleLink
+  alias Loopctl.Knowledge.LinkPruning
+  alias Loopctl.Knowledge.StructuralLinks
+
+  defp article(tenant, tags, attrs \\ %{}) do
+    fixture(
+      :article,
+      Map.merge(%{tenant_id: tenant.id, tags: tags, status: :published}, attrs)
+    )
+  end
+
+  # fixture(:api_key, ...) returns {raw_key, api_key} — heat ranks by DISTINCT
+  # coalesce(agent_id, api_key_id), so each reader here needs its own real key row.
+  defp key_id(tenant) do
+    {_raw, key} = fixture(:api_key, %{tenant_id: tenant.id})
+    key.id
+  end
+
+  defp links(tenant_id, type) do
+    from(l in ArticleLink,
+      where: l.tenant_id == ^tenant_id and l.relationship_type == ^type,
+      select: %{source: l.source_article_id, target: l.target_article_id}
+    )
+    |> AdminRepo.all()
+  end
+
+  defp hubs(tenant_id) do
+    from(a in Article,
+      where: a.tenant_id == ^tenant_id,
+      where: fragment("? ->> 'hub_kind' = 'source'", a.metadata),
+      select: a
+    )
+    |> AdminRepo.all()
+  end
+
+  describe "source resolution" do
+    test "prefers the source-family tag over the columns" do
+      # The correction measurement forced: source_type/source_id are null on real
+      # book-extracted articles, so a column-first rule would find almost nothing.
+      assert StructuralLinks.source_key(%{
+               tags: ["book-abc123", "elixir"],
+               source_type: "web_article",
+               source_id: "ignored"
+             }) == "book-abc123"
+    end
+
+    test "falls back to the columns when no source tag is present" do
+      assert StructuralLinks.source_key(%{
+               tags: ["elixir"],
+               source_type: "web_article",
+               source_id: "xyz"
+             }) == "web_article-xyz"
+    end
+
+    test "returns nil when the article carries no source at all" do
+      assert StructuralLinks.source_key(%{tags: ["elixir"], source_type: nil, source_id: nil}) ==
+               nil
+    end
+
+    test "recognises every declared source family" do
+      for prefix <- ~w(book- doc- repo- yt-) do
+        assert StructuralLinks.source_key(%{
+                 tags: ["#{prefix}k1"],
+                 source_type: nil,
+                 source_id: nil
+               }) ==
+                 "#{prefix}k1"
+      end
+    end
+  end
+
+  describe "harvest" do
+    test "TC-42.1.1: one source with N siblings yields one hub and N edges, never N^2" do
+      tenant = fixture(:tenant)
+      members = for _ <- 1..6, do: article(tenant, ["book-star1"])
+
+      assert {:ok, report} = StructuralLinks.harvest(tenant.id)
+
+      assert [hub] = hubs(tenant.id)
+      assert report.hubs_created == 1
+      assert report.edges_created == 6
+
+      edges = links(tenant.id, :derived_from)
+      assert length(edges) == 6
+
+      # Every edge points AT the hub, and none joins two non-hub articles. This is the
+      # star assertion; an edge count alone would pass for a partial clique too.
+      member_ids = MapSet.new(members, & &1.id)
+      assert Enum.all?(edges, &(&1.target == hub.id))
+      assert Enum.all?(edges, &MapSet.member?(member_ids, &1.source))
+      refute Enum.any?(edges, &MapSet.member?(member_ids, &1.target))
+    end
+
+    test "TC-42.1.2: a second run over an unchanged corpus is a no-op" do
+      tenant = fixture(:tenant)
+      for _ <- 1..4, do: article(tenant, ["book-idem"])
+
+      assert {:ok, first} = StructuralLinks.harvest(tenant.id)
+      assert first.hubs_created == 1
+      assert first.edges_created == 4
+
+      assert {:ok, second} = StructuralLinks.harvest(tenant.id)
+      assert second.hubs_created == 0
+      assert second.hubs_resolved == 1
+      assert second.edges_created == 0
+
+      assert length(hubs(tenant.id)) == 1
+      assert length(links(tenant.id, :derived_from)) == 4
+    end
+
+    test "TC-42.1.3: a source below the floor is skipped entirely" do
+      tenant = fixture(:tenant)
+      for _ <- 1..2, do: article(tenant, ["book-tiny"])
+
+      assert {:ok, report} = StructuralLinks.harvest(tenant.id)
+
+      assert report.sources_below_floor == 1
+      assert report.hubs_created == 0
+      assert report.edges_created == 0
+      assert hubs(tenant.id) == []
+      assert links(tenant.id, :derived_from) == []
+    end
+
+    test "the floor is configurable per call" do
+      tenant = fixture(:tenant)
+      for _ <- 1..2, do: article(tenant, ["book-tiny2"])
+
+      assert {:ok, report} = StructuralLinks.harvest(tenant.id, min_siblings: 2)
+      assert report.hubs_created == 1
+      assert report.edges_created == 2
+    end
+
+    test "articles carrying no source are counted, not linked" do
+      tenant = fixture(:tenant)
+      for _ <- 1..3, do: article(tenant, ["book-mixed"])
+      for _ <- 1..2, do: article(tenant, ["just-a-topic"])
+
+      assert {:ok, report} = StructuralLinks.harvest(tenant.id)
+
+      assert report.articles_without_source == 2
+      assert report.edges_created == 3
+    end
+
+    test "TC-42.1.5: tenant isolation — one tenant's harvest never touches another's" do
+      a = fixture(:tenant)
+      b = fixture(:tenant)
+
+      # Deliberately the SAME source key in both tenants: if scoping were wrong, the
+      # grouping would merge them and tenant B's articles would hang off tenant A's hub.
+      for _ <- 1..4, do: article(a, ["book-shared"])
+      for _ <- 1..4, do: article(b, ["book-shared"])
+
+      assert {:ok, report} = StructuralLinks.harvest(a.id)
+      assert report.edges_created == 4
+
+      assert length(hubs(a.id)) == 1
+      assert hubs(b.id) == []
+      assert links(b.id, :derived_from) == []
+
+      a_article_ids =
+        from(x in Article, where: x.tenant_id == ^a.id, select: x.id)
+        |> AdminRepo.all()
+        |> MapSet.new()
+
+      # No edge in tenant A may reference anything outside tenant A.
+      for edge <- links(a.id, :derived_from) do
+        assert MapSet.member?(a_article_ids, edge.source)
+        assert MapSet.member?(a_article_ids, edge.target)
+      end
+    end
+
+    test "an existing hub is not re-linked to itself on a later run" do
+      tenant = fixture(:tenant)
+      for _ <- 1..3, do: article(tenant, ["book-selfless"])
+
+      assert {:ok, _} = StructuralLinks.harvest(tenant.id)
+      assert {:ok, _} = StructuralLinks.harvest(tenant.id)
+
+      [hub] = hubs(tenant.id)
+      refute Enum.any?(links(tenant.id, :derived_from), &(&1.source == hub.id))
+    end
+
+    test "a run that creates nothing still returns a report rather than failing" do
+      tenant = fixture(:tenant)
+
+      assert {:ok, report} = StructuralLinks.harvest(tenant.id)
+      assert report.hubs_created == 0
+      assert report.edges_created == 0
+      assert report.articles_without_source == 0
+    end
+  end
+
+  describe "the hub is reachable, but does not rank" do
+    test "AC-42.1.8: knowledge_get surfaces the hub from a member, and members from the hub" do
+      tenant = fixture(:tenant)
+      [member | _] = for _ <- 1..3, do: article(tenant, ["book-reach"])
+      assert {:ok, _} = StructuralLinks.harvest(tenant.id)
+      [hub] = hubs(tenant.id)
+
+      assert {:ok, from_member} = Knowledge.get_article(tenant.id, member.id)
+      assert Enum.any?(from_member.outgoing_links, &(&1.target_article.id == hub.id))
+
+      assert {:ok, from_hub} = Knowledge.get_article(tenant.id, hub.id)
+      assert Enum.any?(from_hub.incoming_links, &(&1.source_article.id == member.id))
+    end
+
+    test "AC-42.1.6: a hub never enters the heat index, however much it is read" do
+      tenant = fixture(:tenant)
+      [member | _] = for _ <- 1..3, do: article(tenant, ["book-heat"])
+      assert {:ok, _} = StructuralLinks.harvest(tenant.id)
+      [hub] = hubs(tenant.id)
+
+      # Give the hub MORE distinct readers than the real article, so this fails loudly if
+      # the exclusion is dropped: a hub accrues readers as a function of how many siblings
+      # the harvest gave it, not of whether anyone found it useful.
+      for _ <- 1..5 do
+        fixture(:article_access_event, %{
+          tenant_id: tenant.id,
+          article_id: hub.id,
+          access_type: "get",
+          api_key_id: key_id(tenant)
+        })
+      end
+
+      fixture(:article_access_event, %{
+        tenant_id: tenant.id,
+        article_id: member.id,
+        access_type: "get",
+        api_key_id: key_id(tenant)
+      })
+
+      assert {:ok, %{results: stubs}} = Knowledge.heat_index(tenant.id)
+      ids = Enum.map(stubs, & &1.id)
+
+      refute hub.id in ids
+      assert member.id in ids
+    end
+  end
+
+  describe "pruning" do
+    test "TC-42.1.4: LinkPruning removes relates_to but never derived_from" do
+      tenant = fixture(:tenant)
+      members = for _ <- 1..3, do: article(tenant, ["book-prune"])
+      assert {:ok, _} = StructuralLinks.harvest(tenant.id)
+
+      # A structural edge is exact; a similarity ranking must never be able to evict it.
+      # LinkPruning filters on relates_to by construction, so this is a REGRESSION guard
+      # against a future widening of that predicate rather than a test of new code.
+      [subject | _] = members
+
+      before = links(tenant.id, :derived_from)
+      assert Enum.any?(before, &(&1.source == subject.id))
+
+      assert {:ok, _} = LinkPruning.prune(tenant.id, target_degree: 1)
+
+      after_prune = links(tenant.id, :derived_from)
+      assert Enum.any?(after_prune, &(&1.source == subject.id))
+      assert length(after_prune) == length(before)
+    end
+  end
+end


### PR DESCRIPTION
Implements **US-42.1**, the second half of epic 42. Closes the epic's implementation.

## What this is

`ArticleLink` has always declared a `derived_from` relationship type that **nothing wrote** — read by the OKF exporter, produced by no code path in `lib/`. Meanwhile every article extracted from a source has always carried a tag saying which source. This adds the missing producer.

Per #611: all ~1.4M `relates_to` edges are cosine-threshold artifacts — zero structural, zero hand-made, 59% just above the 0.6 floor, `precision@20 = 0.038`. Its own words: *"the graph has exactly one dimension, sliced into thirds and given three names."* Stage 0 (`LinkPruning`) bounded that graph's density; pruning a single-dimensional graph leaves it single-dimensional. These edges are the first class in the corpus that is **true** rather than probable — no model call, no embedding, no judgment.

## A star, never a clique — measured before writing code

`knowledge_facets(tag_prefix: "book-")` on the hosted corpus: **210 distinct book sources, the largest holding 1,523 articles.** Sibling-to-sibling over that *one* book is ~1.16M edges — more than the entire pre-pruning graph stage 0 was filed to reduce.

One hub per source costs N edges instead of N²/2, keeps two-hop reachability meaningful, and produces a node with a **name** an agent can read. `TC-42.1.1` asserts the star shape directly (`refute` any edge targets a non-hub), because an edge *count* would pass for a partial clique too.

## Two things the evidence corrected

**Source resolution is tag-first.** The story specified columns-first with tags as fallback. `knowledge_get` on a real book-extracted article returns `null` for both `source_type` and `source_id` — a column-first harvest would have found almost nothing.

**Repo topology** (the story left this open; settled against `.claude/skills/tenancy-rls`): the scan is a heavy corpus-wide enumeration, so it goes through `HeavyRead` — never `AdminRepo`, whose 3-connection pool is load-bearing for every authenticated request. `HeavyRead`'s `guard!/2` raises unless every base-table source carries a conjunctive `tenant_id` predicate, which makes the isolation **structural rather than a promise**. A heavy read can be shed, so the scan asks `on_overload: :tag` and propagates the tuple instead of binding it as a list. Bounded writes go to `AdminRepo` like the other system link-writers, `tenant_id` set programmatically.

## Verification — including a real defect mutation testing caught

Four guards proven **non-vacuous by mutation**: disabling the sibling floor, flipping resolution to column-first, turning the star into a clique, and removing the heat-index exclusion each fail a test.

**The fourth initially failed to fail, and the cause was a defect in my code, not a weak test.** `create_article/3` defaults to `:draft` — the "publishes by default" behaviour belongs to the *proposal* path — so hubs were being created **unpublished**: invisible to search and the index, and therefore never heat candidates at all. A draft hub is not navigation, which is the entire point of the star. Hubs are now explicitly `:published`, and the guard then caught its mutation. Without the mutation pass this would have merged green and shipped a harvester whose output nobody could see.

Gate green via the pre-commit hook: **7704 tests, 0 failures**; 1113 knowledge tests specifically; `credo --strict` clean; format and compile-with-warnings-as-errors clean.

## Deliberately not here: scheduling

`harvest/2` is callable and idempotent, but nothing runs it on a cadence. An all-tenants nightly sweep is not a free addition — the recorded finding is that **self-signup permanently joins every all-tenants cron fan-out and per-IP caps do not bound that growth**, so the fan-out shape deserves its own decision rather than inheriting from whichever worker it gets folded into. Enabling it should also start with the sibling floor deliberately high, since the first run creates one hub per qualifying source across every source family at once.

## Review

**Reviewed inline by the authoring session** against correctness, tenant isolation and this repo's conventions. This session operates under instructions not to dispatch subagents or workflows, so the enhanced-review pipeline was unavailable to it; per CLAUDE.md the gate is satisfied by the best available reviewer, and its mechanism being unavailable is not grounds to hold a change.

Two things genuinely worth a second pair of eyes, both judgement rather than mechanics:

1. **The heat-index exclusion** (`heat_article_ids/3`) touches a function that has been fixed four times (#567/#569/#572) under one rule — heat must not rank on a signal heat produces. The argument here is that a hub accrues readers as a *function of how many siblings the harvest gave it*, so letting it rank would put the biggest imported book atop an index designed to be pasted into a cached prefix. I believe that is the same rule, not an exception to it.
2. **Hub naming.** The hub title is derived from the source tag, digest and all, because the alternative is inventing a book title. A hub named by a digest is still a navigational win; a hub named by a hallucinated title reads as a fact. If a human-readable source name exists somewhere I did not find, that is the better input.
