### PR TITLE
Adopt the hub the extraction pipeline already made, instead of minting a rival

### DIFF
--- a/docs/user_stories/epic_42_recorded_structure/us_42.1.json
+++ b/docs/user_stories/epic_42_recorded_structure/us_42.1.json
@@ -17,7 +17,7 @@
   "acceptance_criteria": [
     {
       "id": "AC-42.1.1",
-      "description": "A source hub is an ordinary article (no new table) with category 'reference', title 'Source: <human-readable source name>', and metadata.hub_kind = 'source'. It is identified by a deterministic idempotency_key derived from (tenant_id, source_type, source_id) so a re-run resolves the existing hub rather than creating a second one.",
+      "description": "A source hub is an ordinary article (no new table) with category 'reference', title 'Source: <human-readable source name>', and metadata.hub_kind = 'source'. It is identified by a deterministic idempotency_key derived from (tenant_id, source_type, source_id) so a re-run resolves the existing hub rather than creating a second one. AMENDED 2026-08-20: minting is the FALLBACK, not the default. Most sources already have a hub - every extraction skill emits 'hub + atomic notes' and that article carries the source's real name (book-6a3020c2cd15 is 'Advanced Cypher Concepts') - so the harvester ADOPTS an existing published article carrying the source tag and the 'hub' tag, oldest-first for stability, and mints a synthetic hub only where none exists. Adopting also disposes of the naming problem: a minted hub can only be named from a digest, an adopted one already has the real title.",
       "status": "complete"
     },
     {

--- a/lib/loopctl/knowledge/structural_links.ex
+++ b/lib/loopctl/knowledge/structural_links.ex
@@ -174,27 +174,62 @@ defmodule Loopctl.Knowledge.StructuralLinks do
       {:ok, hub, :resolved} ->
         write_edges(tenant_id, hub, members, %{acc | hubs_resolved: acc.hubs_resolved + 1})
 
+      {:ok, hub, :adopted} ->
+        write_edges(tenant_id, hub, members, %{acc | hubs_adopted: acc.hubs_adopted + 1})
+
       {:error, reason} ->
         Logger.warning("structural_links: hub failed for #{source}: #{inspect(reason)}")
         %{acc | hub_failures: acc.hub_failures + 1}
     end
   end
 
+  # Three steps, in this order, and the middle one is the point.
+  #
+  # Most sources ALREADY HAVE A HUB. Every extraction skill produces one — `book-`,
+  # `doc-`, `yt-` and `repo-` captures each emit "hub + atomic notes" — and that hub
+  # carries the source's REAL name ("Advanced Cypher Concepts", not
+  # "book-6a3020c2cd15"). Minting our own beside it would put a digest-named rival next
+  # to a well-named article that is already there, and doing that weekly across every
+  # tenant would quietly double the hub population. So: adopt what exists, mint only
+  # where nothing does.
+  #
+  # Adoption keys off the `hub` TAG, and tags are agent-writable via knowledge_update —
+  # which is exactly why `KnowledgeMocWorker` keys its own hubs off an idempotency_key
+  # instead. The weaker signal is acceptable HERE and not there: the choice is only ever
+  # between articles inside one tenant's own source group, the effect is which sibling
+  # becomes the centre of a navigational star, and nothing is destroyed either way.
+  # Selection is oldest-first so a re-run is stable rather than racing ties.
   defp resolve_or_create_hub(tenant_id, source) do
     key = hub_idempotency_key(source)
 
-    case AdminRepo.one(
-           from(a in Article,
-             where: a.tenant_id == ^tenant_id and a.idempotency_key == ^key,
-             select: a
-           )
-         ) do
-      %Article{} = hub ->
-        {:ok, hub, :resolved}
-
-      nil ->
-        create_hub(tenant_id, source, key)
+    cond do
+      hub = minted_hub(tenant_id, key) -> {:ok, hub, :resolved}
+      hub = existing_source_hub(tenant_id, source) -> {:ok, hub, :adopted}
+      true -> create_hub(tenant_id, source, key)
     end
+  end
+
+  defp minted_hub(tenant_id, key) do
+    AdminRepo.one(
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id and a.idempotency_key == ^key,
+        select: a
+      )
+    )
+  end
+
+  defp existing_source_hub(tenant_id, source) do
+    AdminRepo.one(
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id,
+        where: a.status == :published,
+        where: ^source in a.tags,
+        where: "hub" in a.tags,
+        order_by: [asc: a.inserted_at, asc: a.id],
+        limit: 1,
+        select: a
+      )
+    )
   end
 
   defp create_hub(tenant_id, source, key) do
@@ -308,6 +343,7 @@ defmodule Loopctl.Knowledge.StructuralLinks do
     %{
       hubs_created: 0,
       hubs_resolved: 0,
+      hubs_adopted: 0,
       hub_failures: 0,
       edges_created: 0,
       sources_below_floor: length(skipped),
@@ -321,6 +357,7 @@ defmodule Loopctl.Knowledge.StructuralLinks do
   defp log_report(tenant_id, report) do
     Logger.info(
       "structural_links: tenant=#{tenant_id} hubs_created=#{report.hubs_created} " <>
+        "hubs_adopted=#{report.hubs_adopted} " <>
         "hubs_resolved=#{report.hubs_resolved} edges_created=#{report.edges_created} " <>
         "sources_below_floor=#{report.sources_below_floor} " <>
         "articles_without_source=#{report.articles_without_source} " <>

--- a/test/loopctl/knowledge/structural_links_test.exs
+++ b/test/loopctl/knowledge/structural_links_test.exs
@@ -208,6 +208,80 @@ defmodule Loopctl.Knowledge.StructuralLinksTest do
     end
   end
 
+  describe "adopting the hub the extraction pipeline already made" do
+    test "an existing hub-tagged sibling becomes the star centre, and nothing is minted" do
+      tenant = fixture(:tenant)
+
+      # This is the real corpus shape: every extraction skill emits "hub + atomic notes",
+      # so the source already has a hub carrying its actual NAME. Minting beside it would
+      # put "Source: book 6a3020c2cd15" next to "Advanced Cypher Concepts".
+      existing =
+        article(tenant, ["book-adopt", "hub"], %{title: "Advanced Cypher Concepts"})
+
+      members = for _ <- 1..3, do: article(tenant, ["book-adopt"])
+
+      assert {:ok, report} = StructuralLinks.harvest(tenant.id)
+
+      assert report.hubs_adopted == 1
+      assert report.hubs_created == 0
+      assert hubs(tenant.id) == [], "no synthetic hub_kind article should exist"
+
+      edges = links(tenant.id, :derived_from)
+      assert Enum.all?(edges, &(&1.target == existing.id))
+      assert length(edges) == 3
+      assert MapSet.new(edges, & &1.source) == MapSet.new(members, & &1.id)
+    end
+
+    test "the adopted hub is never linked to itself" do
+      tenant = fixture(:tenant)
+      existing = article(tenant, ["book-adopt2", "hub"], %{title: "Real Title"})
+      for _ <- 1..3, do: article(tenant, ["book-adopt2"])
+
+      assert {:ok, _} = StructuralLinks.harvest(tenant.id)
+
+      refute Enum.any?(links(tenant.id, :derived_from), &(&1.source == existing.id))
+    end
+
+    test "adoption is idempotent and picks the same hub on a re-run" do
+      tenant = fixture(:tenant)
+      existing = article(tenant, ["book-adopt3", "hub"], %{title: "Stable"})
+      for _ <- 1..3, do: article(tenant, ["book-adopt3"])
+
+      assert {:ok, first} = StructuralLinks.harvest(tenant.id)
+      assert {:ok, second} = StructuralLinks.harvest(tenant.id)
+
+      assert first.edges_created == 3
+      assert second.edges_created == 0
+      assert second.hubs_adopted == 1
+
+      assert Enum.all?(links(tenant.id, :derived_from), &(&1.target == existing.id))
+    end
+
+    test "a source with no existing hub still mints one" do
+      tenant = fixture(:tenant)
+      for _ <- 1..3, do: article(tenant, ["book-nohub"])
+
+      assert {:ok, report} = StructuralLinks.harvest(tenant.id)
+
+      assert report.hubs_created == 1
+      assert report.hubs_adopted == 0
+      assert [_minted] = hubs(tenant.id)
+    end
+
+    test "a hub tag belonging to a DIFFERENT source is not adopted" do
+      tenant = fixture(:tenant)
+      # A hub for another book must not become this book's centre just by carrying "hub".
+      article(tenant, ["book-other", "hub"], %{title: "Someone Else's Book"})
+      for _ <- 1..3, do: article(tenant, ["book-mine"])
+
+      assert {:ok, report} = StructuralLinks.harvest(tenant.id)
+
+      assert report.hubs_created == 1, "book-mine had no hub of its own, so one is minted"
+      [minted] = hubs(tenant.id)
+      assert Enum.all?(links(tenant.id, :derived_from), &(&1.target == minted.id))
+    end
+  end
+
   describe "the hub is reachable, but does not rank" do
     test "AC-42.1.8: knowledge_get surfaces the hub from a member, and members from the hub" do
       tenant = fixture(:tenant)


### PR DESCRIPTION
Follow-on correction to #719, found while working out what a cron entry for the harvest would look like.

## The defect

US-42.1 assumed a source has no hub until `StructuralLinks` makes one. **That is false for most of the corpus.** Every extraction skill emits "hub + atomic notes" — `book-knowledge-extract`, `youtube-knowledge-extract`, `document-knowledge-extract` all say so in their own descriptions — and the resulting hub carries the source's **real name**:

- `book-6a3020c2cd15` → *Advanced Cypher Concepts*
- `book-1769a883a212` → *Cypher Query Tuning*
- `book-29fffea87cd4` → *Javascript Introduction*

Minting beside those puts `Source: book 6a3020c2cd15` next to a well-named article that is already there. Weekly across every tenant, that quietly doubles the hub population — so this had to be fixed *before* anything schedules the harvest, not after.

## The fix

Resolution is now three steps: a hub we minted earlier → an existing published article carrying both the source tag and `hub` (oldest-first, so a re-run is stable rather than racing ties) → minting as the **fallback**.

The report counts `hubs_adopted` separately from `hubs_created`. That is also the measurement worth reading before this ever goes on a cron: **if minting dominates in production, the premise here is wrong** and the adoption rule needs revisiting rather than the schedule.

This also disposes of the hub-naming concern raised in #719's own review section. A minted hub can only be named from a digest; an adopted one already has the title a human wrote.

## One judgement worth checking

Adoption keys off the `hub` **tag**, and tags are agent-writable via `knowledge_update` — which is precisely why `KnowledgeMocWorker` keys its own hubs off an `idempotency_key` instead. I think the weaker signal is acceptable here and not there: the choice is only ever between articles inside one tenant's own source group, the effect is which sibling becomes the centre of a navigational star, and nothing is destroyed either way. If you'd rather it were unspoofable, the alternative is requiring `metadata.hub_kind` on the extraction side, which is a change to four skills in another repo.

## Verification

Guard proven **non-vacuous by mutation**: removing the adoption step fails three tests. Full gate green via pre-commit — **7709 tests, 0 failures**, `credo --strict` clean, format and compile-with-warnings-as-errors clean. 20 tests in the module's own file.

Reviewed inline by the authoring session, same as #718/#719 and for the same reason.