### PR TITLE
Stop the corpus scan holding the whole corpus (it OOM-killed prod)

### DIFF
--- a/lib/loopctl/knowledge/structural_links.ex
+++ b/lib/loopctl/knowledge/structural_links.ex
@@ -45,9 +45,13 @@ defmodule Loopctl.Knowledge.StructuralLinks do
     every authenticated request. `HeavyRead`'s `guard!/2` additionally RAISES unless every
     base-table source carries a conjunctive `tenant_id` predicate bound to the passed
     tenant, which is what makes the isolation structural rather than a promise.
-  * A heavy read can be SHED. `scan/2` asks for `on_overload: :tag` and the caller
+  * The scan is KEYSET-BATCHED and reduces each page to `source => [id]` before reading
+    the next. Loading the whole corpus at once OOM-killed the production BEAM on the first
+    real run; the `tags` array was the weight, not the row count. See `collect_sources/2`.
+  * A heavy read can be SHED. Each page asks for `on_overload: :tag` and the caller
     propagates `{:error, :heavy_read_overloaded}` — binding a shed result as a list would
-    crash exactly under the load the gate exists for.
+    crash exactly under the load the gate exists for, and a partially-grouped corpus is
+    not a usable answer anyway.
   * The WRITES are bounded (one hub plus N edges per qualifying source) and follow the
     other system link-writers onto `AdminRepo`. RLS does nothing there, so the explicit
     `tenant_id` is the only isolation and it is set programmatically, never cast.
@@ -67,6 +71,10 @@ defmodule Loopctl.Knowledge.StructuralLinks do
 
   @default_min_siblings 3
 
+  # Keyset page size for the corpus scan. Bounds PEAK MEMORY, not total work — every
+  # article is still visited, just never all at once. See collect_sources/2.
+  @scan_batch 2000
+
   @doc """
   Harvests source hubs and their `derived_from` star edges for one tenant.
 
@@ -81,20 +89,20 @@ defmodule Loopctl.Knowledge.StructuralLinks do
   def harvest(tenant_id, opts \\ []) when is_binary(tenant_id) do
     floor = Keyword.get(opts, :min_siblings, min_siblings())
 
-    case scan(tenant_id, opts) do
+    case collect_sources(tenant_id, opts) do
       {:error, :heavy_read_overloaded} = shed ->
         shed
 
-      articles ->
+      {:ok, groups, without_source} ->
         {qualifying, skipped} =
-          articles
-          |> group_by_source()
-          |> Enum.split_with(fn {_source, members} -> length(members) >= floor end)
+          groups
+          |> Enum.sort_by(fn {source, _ids} -> source end)
+          |> Enum.split_with(fn {_source, ids} -> length(ids) >= floor end)
 
         report =
-          Enum.reduce(qualifying, blank_report(skipped, articles, floor), fn {source, members},
-                                                                             acc ->
-            harvest_one_source(tenant_id, source, members, acc)
+          Enum.reduce(qualifying, blank_report(skipped, without_source, floor), fn {source, ids},
+                                                                                   acc ->
+            harvest_one_source(tenant_id, source, ids, acc)
           end)
 
         log_report(tenant_id, report)
@@ -103,19 +111,75 @@ defmodule Loopctl.Knowledge.StructuralLinks do
   end
 
   # ------------------------------------------------------------------
-  # Scan
+  # Scan — KEYSET-BATCHED, and that is not a refinement
   # ------------------------------------------------------------------
 
-  defp scan(tenant_id, opts) do
+  # This used to be one `HeavyRead.all` selecting every published article of the tenant
+  # with its `tags` array, then grouping the whole list in memory.
+  #
+  # That OOM-killed the production BEAM on the first real run (2026-08-20, 512MB machine:
+  # "Out of memory: Killed process 647 (beam.smp)"). The row COUNT was not the problem —
+  # ~79k ids is about a megabyte. The `tags` ARRAY was: every row dragged a list of tag
+  # strings, and the whole decoded result set had to exist at once before a single group
+  # could be formed.
+  #
+  # So the fix is not a bigger machine or a smaller corpus. It is to never hold the corpus:
+  # read a bounded keyset page, reduce it IMMEDIATELY to `source => [id]` so the tags are
+  # discarded with the page, and carry only the id map forward. Peak memory becomes one
+  # page plus the ids, which is what the accumulation was always worth.
+  #
+  # A shed (`{:error, :heavy_read_overloaded}`) is propagated from any page — partial
+  # grouping is not a usable answer, because a source that straddles two pages would be
+  # counted short and could fall under the floor.
+  defp collect_sources(tenant_id, opts) do
+    batch = Keyword.get(opts, :scan_batch, @scan_batch)
+    collect_pages(tenant_id, opts, batch, nil, %{}, 0)
+  end
+
+  defp collect_pages(tenant_id, opts, batch, after_id, groups, without_source) do
+    case fetch_page(tenant_id, opts, batch, after_id) do
+      {:error, :heavy_read_overloaded} = shed ->
+        shed
+
+      [] ->
+        {:ok, groups, without_source}
+
+      rows ->
+        {groups, without_source} = reduce_page(rows, groups, without_source)
+        last = rows |> List.last() |> Map.fetch!(:id)
+        collect_pages(tenant_id, opts, batch, last, groups, without_source)
+    end
+  end
+
+  # Reducing the page HERE, not at the call site, is what discards the `tags` arrays with
+  # the page rather than carrying them to the end of the scan.
+  defp reduce_page(rows, groups, without_source) do
+    Enum.reduce(rows, {groups, without_source}, fn row, {acc, missing} ->
+      case source_key(row) do
+        nil -> {acc, missing + 1}
+        key -> {Map.update(acc, key, [row.id], &[row.id | &1]), missing}
+      end
+    end)
+  end
+
+  defp fetch_page(tenant_id, opts, batch, after_id) do
     query =
       from(a in Article,
         where: a.tenant_id == ^tenant_id,
         where: a.status == :published,
         where: is_nil(a.metadata["hub_kind"]),
+        order_by: [asc: a.id],
+        limit: ^batch,
         select: %{id: a.id, tags: a.tags, source_type: a.source_type, source_id: a.source_id}
       )
 
-    HeavyRead.all(tenant_id, query, Keyword.merge([on_overload: :tag], opts))
+    query = if after_id, do: where(query, [a], a.id > ^after_id), else: query
+
+    HeavyRead.all(
+      tenant_id,
+      query,
+      opts |> Keyword.drop([:scan_batch, :min_siblings]) |> Keyword.merge(on_overload: :tag)
+    )
   end
 
   # ------------------------------------------------------------------
@@ -151,31 +215,20 @@ defmodule Loopctl.Knowledge.StructuralLinks do
 
   defp column_source(_article), do: nil
 
-  defp group_by_source(articles) do
-    articles
-    |> Enum.reduce(%{}, fn article, acc ->
-      case source_key(article) do
-        nil -> acc
-        key -> Map.update(acc, key, [article], &[article | &1])
-      end
-    end)
-    |> Enum.sort_by(fn {key, _members} -> key end)
-  end
-
   # ------------------------------------------------------------------
   # Hub + edges
   # ------------------------------------------------------------------
 
-  defp harvest_one_source(tenant_id, source, members, acc) do
+  defp harvest_one_source(tenant_id, source, member_ids, acc) do
     case resolve_or_create_hub(tenant_id, source) do
       {:ok, hub, :created} ->
-        write_edges(tenant_id, hub, members, %{acc | hubs_created: acc.hubs_created + 1})
+        write_edges(tenant_id, hub, member_ids, %{acc | hubs_created: acc.hubs_created + 1})
 
       {:ok, hub, :resolved} ->
-        write_edges(tenant_id, hub, members, %{acc | hubs_resolved: acc.hubs_resolved + 1})
+        write_edges(tenant_id, hub, member_ids, %{acc | hubs_resolved: acc.hubs_resolved + 1})
 
       {:ok, hub, :adopted} ->
-        write_edges(tenant_id, hub, members, %{acc | hubs_adopted: acc.hubs_adopted + 1})
+        write_edges(tenant_id, hub, member_ids, %{acc | hubs_adopted: acc.hubs_adopted + 1})
 
       {:error, reason} ->
         Logger.warning("structural_links: hub failed for #{source}: #{inspect(reason)}")
@@ -276,19 +329,21 @@ defmodule Loopctl.Knowledge.StructuralLinks do
     end
   end
 
-  defp write_edges(tenant_id, hub, members, acc) do
+  defp write_edges(tenant_id, hub, member_ids, acc) do
     # ArticleLink.inserted_at is :utc_datetime_usec — truncating to :second makes Ecto
     # raise on dump. It also has no updated_at (links are immutable), so only one stamp.
     now = DateTime.utc_now()
 
+    # `member_ids` are bare ids, not rows: the batched scan discards everything except the
+    # id as each page is reduced, which is what keeps peak memory bounded.
     rows =
-      members
-      |> Enum.reject(&(&1.id == hub.id))
+      member_ids
+      |> Enum.reject(&(&1 == hub.id))
       |> Enum.map(
         &%{
           id: Ecto.UUID.generate(),
           tenant_id: tenant_id,
-          source_article_id: &1.id,
+          source_article_id: &1,
           target_article_id: hub.id,
           relationship_type: :derived_from,
           metadata: %{"origin" => "structural_links"},
@@ -339,7 +394,7 @@ defmodule Loopctl.Knowledge.StructuralLinks do
     Application.get_env(:loopctl, :structural_hub_min_siblings, @default_min_siblings)
   end
 
-  defp blank_report(skipped, articles, floor) do
+  defp blank_report(skipped, without_source, floor) do
     %{
       hubs_created: 0,
       hubs_resolved: 0,
@@ -347,7 +402,7 @@ defmodule Loopctl.Knowledge.StructuralLinks do
       hub_failures: 0,
       edges_created: 0,
       sources_below_floor: length(skipped),
-      articles_without_source: Enum.count(articles, &is_nil(source_key(&1))),
+      articles_without_source: without_source,
       min_siblings: floor
     }
   end

--- a/test/loopctl/knowledge/structural_links_test.exs
+++ b/test/loopctl/knowledge/structural_links_test.exs
@@ -208,6 +208,47 @@ defmodule Loopctl.Knowledge.StructuralLinksTest do
     end
   end
 
+  describe "the corpus scan is paged, and paging must not change the answer" do
+    test "a source spanning many pages is grouped whole" do
+      tenant = fixture(:tenant)
+      members = for _ <- 1..7, do: article(tenant, ["book-paged"])
+
+      # scan_batch: 2 forces four pages over seven rows. The regression this guards is
+      # silent UNDER-counting: a source split across pages that is grouped per-page would
+      # look smaller than it is and could fall under the floor, producing no hub at all.
+      assert {:ok, report} = StructuralLinks.harvest(tenant.id, scan_batch: 2)
+
+      assert report.edges_created == 7
+      [hub] = hubs(tenant.id)
+
+      edges = links(tenant.id, :derived_from)
+      assert MapSet.new(edges, & &1.source) == MapSet.new(members, & &1.id)
+      assert Enum.all?(edges, &(&1.target == hub.id))
+    end
+
+    test "paging does not change which sources clear the floor" do
+      tenant = fixture(:tenant)
+      for _ <- 1..5, do: article(tenant, ["book-justover"])
+      for _ <- 1..2, do: article(tenant, ["book-justunder"])
+
+      assert {:ok, paged} = StructuralLinks.harvest(tenant.id, scan_batch: 1, min_siblings: 5)
+
+      assert paged.hubs_created == 1, "the 5-article source clears a floor of 5"
+      assert paged.sources_below_floor == 1
+      assert paged.edges_created == 5
+    end
+
+    test "articles with no source are counted once, not once per page" do
+      tenant = fixture(:tenant)
+      for _ <- 1..3, do: article(tenant, ["book-counted"])
+      for _ <- 1..4, do: article(tenant, ["no-source-here"])
+
+      assert {:ok, report} = StructuralLinks.harvest(tenant.id, scan_batch: 2)
+
+      assert report.articles_without_source == 4
+    end
+  end
+
   describe "adopting the hub the extraction pipeline already made" do
     test "an existing hub-tagged sibling becomes the star centre, and nothing is minted" do
       tenant = fixture(:tenant)


### PR DESCRIPTION
Found by running the US-42.1 backfill against the real corpus for the first time. **The harvest OOM-killed the production BEAM.**

```
2026-08-20T18:20:36Z  Out of memory: Killed process 647 (beam.smp) total-vm:2077264kB
```

**Nothing was written** — `derived_from` stayed at 0, no hub was created — and the node came back on its own with all health checks passing (`oban`, `database`, `oban_orphans`, `scale_alerts`). But the harvest as merged could not run against a real corpus at all, and no unit test could have shown that: they exercise a handful of fixture rows.

## Cause

Not the row count — ~79k ids is about a megabyte. The **`tags` array on every row** was the weight. The scan selected `id, tags, source_type, source_id` for every published article in one `HeavyRead.all`, so the entire decoded result set had to exist at once before a single group could form, on a 512 MB machine already running the app.

## Fix

Read a bounded keyset page, reduce it **immediately** to `source => [id]` so the tag arrays are discarded along with the page, carry only the id map forward. Peak memory becomes one page plus the ids — all the accumulation was ever worth. Every article is still visited; only the peak changed.

A shed on any page aborts the whole scan rather than returning what it has. Partial grouping isn't a smaller answer, it's a **wrong** one: a source split across pages would be counted short and could drop under the floor, silently skipping a hub it should have made.

## Verification

Three new tests drive the pager with `scan_batch: 1` and `2` so pages genuinely split a source, covering whole-source grouping, floor decisions across pages, and no double-counting of source-less articles.

Guard proven **non-vacuous by mutation**: resetting the accumulator per page — precisely the silent under-count this is about — fails six tests.

Full gate green via pre-commit: **7712 tests, 0 failures**, `credo --strict` clean, format and compile-with-warnings-as-errors clean.

## What this says about the story

US-42.1's tests were all correct and all green, and the feature still could not run once. The gap was that nothing exercised it at corpus scale. Worth remembering before the cron in the epic's scheduling note is ever enabled — the same blind spot applies to any all-tenants sweep whose fixtures are five rows.

Reviewed inline by the authoring session, as with #718/#719/#720.