### PR TITLE
Name a source hub from a tag its members universally share, or abstain

### DIFF
--- a/lib/loopctl/knowledge/structural_links.ex
+++ b/lib/loopctl/knowledge/structural_links.ex
@@ -59,6 +59,7 @@ defmodule Loopctl.Knowledge.StructuralLinks do
 
   import Ecto.Query
 
+  alias Ecto.Adapters.SQL
   alias Loopctl.AdminRepo
   alias Loopctl.HeavyRead
   alias Loopctl.Knowledge
@@ -70,6 +71,14 @@ defmodule Loopctl.Knowledge.StructuralLinks do
   @source_tag_prefixes ~w(book- doc- repo- yt-)
 
   @default_min_siblings 3
+
+  # A tag must cover at least this fraction of a source's members to name its hub. High on
+  # purpose: the point is to abstain rather than to guess (see hub_title/3).
+  @hub_name_coverage 0.9
+
+  # Format and structure tags: true of the source but not a NAME for it.
+  @hub_name_stoplist ~w(book books document documents reference hub moc source-hub actionable
+                        pdf epub md txt html code external youtube video article audible)
 
   # Keyset page size for the corpus scan. Bounds PEAK MEMORY, not total work — every
   # article is still visited, just never all at once. See collect_sources/2.
@@ -220,7 +229,7 @@ defmodule Loopctl.Knowledge.StructuralLinks do
   # ------------------------------------------------------------------
 
   defp harvest_one_source(tenant_id, source, member_ids, acc) do
-    case resolve_or_create_hub(tenant_id, source) do
+    case resolve_or_create_hub(tenant_id, source, length(member_ids)) do
       {:ok, hub, :created} ->
         write_edges(tenant_id, hub, member_ids, %{acc | hubs_created: acc.hubs_created + 1})
 
@@ -252,13 +261,34 @@ defmodule Loopctl.Knowledge.StructuralLinks do
   # between articles inside one tenant's own source group, the effect is which sibling
   # becomes the centre of a navigational star, and nothing is destroyed either way.
   # Selection is oldest-first so a re-run is stable rather than racing ties.
-  defp resolve_or_create_hub(tenant_id, source) do
+  defp resolve_or_create_hub(tenant_id, source, member_count) do
     key = hub_idempotency_key(source)
 
     cond do
-      hub = minted_hub(tenant_id, key) -> {:ok, hub, :resolved}
-      hub = existing_source_hub(tenant_id, source) -> {:ok, hub, :adopted}
-      true -> create_hub(tenant_id, source, key)
+      hub = minted_hub(tenant_id, key) ->
+        {:ok, maybe_retitle(tenant_id, hub, source, member_count), :resolved}
+
+      hub = existing_source_hub(tenant_id, source) ->
+        {:ok, hub, :adopted}
+
+      true ->
+        create_hub(tenant_id, source, key, member_count)
+    end
+  end
+
+  # A hub minted before a name was derivable keeps its digest title forever otherwise.
+  # Retitle ONLY when the stored title is still exactly the digest form we generated: that
+  # way a name a human (or a later, better rule) put there is never overwritten by this.
+  defp maybe_retitle(tenant_id, hub, source, member_count) do
+    desired = "Source: " <> hub_title(tenant_id, source, member_count)
+
+    if hub.title == "Source: " <> digest_title(source) and hub.title != desired do
+      case Knowledge.update_article(tenant_id, hub.id, %{title: desired}) do
+        {:ok, updated} -> updated
+        _ -> hub
+      end
+    else
+      hub
     end
   end
 
@@ -285,9 +315,9 @@ defmodule Loopctl.Knowledge.StructuralLinks do
     )
   end
 
-  defp create_hub(tenant_id, source, key) do
+  defp create_hub(tenant_id, source, key, member_count) do
     attrs = %{
-      title: "Source: #{hub_title(source)}",
+      title: "Source: #{hub_title(tenant_id, source, member_count)}",
       # Never invent a source's human name. A hub named by its digest is still a
       # navigational win over no hub; a hub named by a hallucinated book title is worse
       # than nothing, because it reads as a fact.
@@ -373,11 +403,73 @@ defmodule Loopctl.Knowledge.StructuralLinks do
 
   # The tag IS the name we have. Strip the family prefix for readability and leave the
   # digest — see the comment in create_hub/3 about never inventing a title.
-  defp hub_title(source) do
+  # Name the hub from a tag its members UNIVERSALLY share, or abstain to the digest.
+  #
+  # The digest names the first 17 hubs produced ("Source: doc a8d8cf71c5df") and they are
+  # poor articles: published, searchable, and telling a reader nothing about what the
+  # source is. The corpus can usually do better, because the extraction skills tag every
+  # member of a source with something identifying — measured 2026-08-20:
+  #
+  #   book-9baec82a16b7  -> chris-mccord-bruce-tate-jos-valim   813/813 members
+  #   doc-d690c97f3116   -> iota                                416/416
+  #   doc-a8d8cf71c5df   -> synology-netbackup                 1404/1404
+  #   book-aca9eec5858f  -> nothing universal (top real tag `scalability` covers 19/338)
+  #
+  # That last row is why the rule is UNIVERSALITY and not popularity. "Most common tag"
+  # would have titled a 338-article source "scalability" on 6% coverage — a confident,
+  # wrong name, which is worse than a digest because it reads as a fact. So a candidate
+  # must cover at least @hub_name_coverage of the members, structural and format tags are
+  # excluded, and when nothing qualifies the digest stands. Never invent a name.
+  defp hub_title(tenant_id, source, member_count) do
+    case universal_tag(tenant_id, source, member_count) do
+      nil -> digest_title(source)
+      tag -> humanize_tag(tag)
+    end
+  end
+
+  defp digest_title(source) do
     Enum.reduce(@source_tag_prefixes, source, fn prefix, acc ->
       String.replace_prefix(acc, prefix, String.trim_trailing(prefix, "-") <> " ")
     end)
   end
+
+  defp humanize_tag(tag), do: tag |> String.replace("-", " ") |> String.trim()
+
+  # Raw SQL rather than Ecto here for one reason: this aggregates over `unnest(tags)`, and
+  # the Postgres adapter cannot select from a fragment join. Every value is a bound
+  # parameter — nothing is interpolated — and the result is a single row.
+  defp universal_tag(tenant_id, source, member_count) when member_count > 0 do
+    threshold = ceil(member_count * @hub_name_coverage)
+
+    sql = """
+    SELECT t
+    FROM articles a, unnest(a.tags) AS t
+    WHERE a.tenant_id = $1
+      AND a.status = 'published'
+      AND (a.metadata->>'hub_kind') IS NULL
+      AND $2 = ANY(a.tags)
+      AND NOT (t = ANY($3))
+      AND t NOT LIKE 'book-%'
+      AND t NOT LIKE 'doc-%'
+      AND t NOT LIKE 'repo-%'
+      AND t NOT LIKE 'yt-%'
+      AND t NOT LIKE 'pp-%'
+    GROUP BY t
+    HAVING count(*) >= $4
+    ORDER BY count(*) DESC, length(t) DESC, t ASC
+    LIMIT 1
+    """
+
+    with {:ok, tid} <- Ecto.UUID.dump(tenant_id),
+         %{rows: [[tag]]} <-
+           SQL.query!(AdminRepo, sql, [tid, source, @hub_name_stoplist, threshold]) do
+      tag
+    else
+      _ -> nil
+    end
+  end
+
+  defp universal_tag(_tenant_id, _source, _member_count), do: nil
 
   defp hub_body(source) do
     """

--- a/test/loopctl/knowledge/structural_links_test.exs
+++ b/test/loopctl/knowledge/structural_links_test.exs
@@ -208,6 +208,85 @@ defmodule Loopctl.Knowledge.StructuralLinksTest do
     end
   end
 
+  describe "naming a minted hub" do
+    test "a tag every member shares names the hub" do
+      tenant = fixture(:tenant)
+      for _ <- 1..5, do: article(tenant, ["book-named", "chris-mccord-bruce-tate-jos-valim"])
+
+      assert {:ok, _} = StructuralLinks.harvest(tenant.id)
+
+      [hub] = hubs(tenant.id)
+      assert hub.title == "Source: chris mccord bruce tate jos valim"
+    end
+
+    test "a POPULAR but not universal tag is refused, and the digest stands" do
+      tenant = fixture(:tenant)
+      # 2 of 6 carry it. Naming the source "scalability" off 33% would be a confident
+      # wrong answer — the real case was a 338-article book whose top real tag covered 19.
+      for _ <- 1..2, do: article(tenant, ["book-partial", "scalability"])
+      for _ <- 1..4, do: article(tenant, ["book-partial"])
+
+      assert {:ok, _} = StructuralLinks.harvest(tenant.id)
+
+      [hub] = hubs(tenant.id)
+      assert hub.title == "Source: book partial"
+      refute hub.title =~ "scalability"
+    end
+
+    test "format and structure tags never name a hub" do
+      tenant = fixture(:tenant)
+      # Universal, but they describe the FORMAT, not the source.
+      for _ <- 1..5, do: article(tenant, ["book-formatty", "book", "reference", "pdf"])
+
+      assert {:ok, _} = StructuralLinks.harvest(tenant.id)
+
+      [hub] = hubs(tenant.id)
+      assert hub.title == "Source: book formatty"
+    end
+
+    test "another source's tag never names this hub" do
+      tenant = fixture(:tenant)
+      for _ <- 1..5, do: article(tenant, ["book-a1b2c3", "doc-deadbeef"])
+
+      assert {:ok, _} = StructuralLinks.harvest(tenant.id)
+
+      titles = Enum.map(hubs(tenant.id), & &1.title)
+      # Both source tags are universal here; neither may be used as the other's NAME.
+      assert Enum.all?(titles, &(&1 in ["Source: book a1b2c3", "Source: doc deadbeef"]))
+    end
+
+    test "a hub minted with a digest title is retitled once a name becomes derivable" do
+      tenant = fixture(:tenant)
+      for _ <- 1..4, do: article(tenant, ["book-latename"])
+
+      assert {:ok, _} = StructuralLinks.harvest(tenant.id)
+      [first] = hubs(tenant.id)
+      assert first.title == "Source: book latename"
+
+      # The corpus grows a universal identifying tag (a re-tag pass, a later import).
+      for _ <- 1..40, do: article(tenant, ["book-latename", "some-real-author"])
+
+      assert {:ok, _} = StructuralLinks.harvest(tenant.id)
+      [again] = hubs(tenant.id)
+
+      assert again.id == first.id, "retitle must not mint a second hub"
+      assert again.title == "Source: some real author"
+    end
+
+    test "a title that is not ours is never overwritten" do
+      tenant = fixture(:tenant)
+      for _ <- 1..5, do: article(tenant, ["book-handnamed", "an-author"])
+      assert {:ok, _} = StructuralLinks.harvest(tenant.id)
+      [hub] = hubs(tenant.id)
+
+      {:ok, _} = Knowledge.update_article(tenant.id, hub.id, %{title: "A Human Chose This"})
+
+      assert {:ok, _} = StructuralLinks.harvest(tenant.id)
+      [after_run] = hubs(tenant.id)
+      assert after_run.title == "A Human Chose This"
+    end
+  end
+
   describe "the corpus scan is paged, and paging must not change the answer" do
     test "a source spanning many pages is grouped whole" do
       tenant = fixture(:tenant)


### PR DESCRIPTION
Prompted by looking at the 17 hubs the floor-300 backfill actually produced. They are **poor articles**: `Source: doc a8d8cf71c5df`, a templated body, published and searchable, telling a reader nothing about the source. At floor 25 that would be 241 of them; at floor 3, over two thousand.

## The corpus can usually do better

The extraction skills tag every member of a source with something identifying. Measured on the live corpus today:

| source | universal tag | coverage |
|---|---|---|
| `book-9baec82a16b7` | `chris-mccord-bruce-tate-jos-valim` | 813 / 813 |
| `doc-d690c97f3116` | `iota` | 416 / 416 |
| `doc-a8d8cf71c5df` | `synology-netbackup` | 1404 / 1404 |
| `book-aca9eec5858f` | — none — | top real tag covers 19 / 338 |

**That last row is the entire design.** A "most common tag" rule would have titled a 338-article book *scalability* on 6% coverage — a confident wrong answer, and worse than a digest because it reads as a fact rather than as a placeholder.

## The rule

Universality, not popularity: a candidate must cover **≥90%** of the source's members; format/structure words (`book`, `pdf`, `reference`, `hub`, …) are excluded; other sources' tags are excluded; and **when nothing qualifies the digest stands**. It abstains rather than guesses — the same principle the module already stated and did not yet implement.

Hubs already minted under a digest are retitled once a name becomes derivable, but **only while the stored title is still exactly the digest form this module generated**, so a title a human set is never overwritten.

## Verification

Two guards mutation-verified: dropping the coverage threshold to 0 fails the popularity test; emptying the stoplist fails another. 29 tests in the module's file, 1062 across `knowledge/`, full gate green via pre-commit (**7718 tests, 0 failures**), `credo --strict` clean.

Raw SQL for the single aggregate, because the Postgres adapter cannot select from a fragment join over `unnest(tags)`. Every value is a bound parameter; nothing is interpolated.

## Honest limit

`synology-netbackup` names the *collection a document came from*, not the document. It is true of the source and better than a digest, but it is not a title — several documents from that share will now carry the same hub name. Distinguishing them needs a real source-name record, which loopctl does not have: the digest is generated client-side by the harvest skills and nothing maps it back to a filename. Worth knowing before reading the floor-25 results.

Reviewed inline by the authoring session, as with #718–#721.