### PR TITLE
A title collision is a different source, not this one's hub

### DIFF
--- a/lib/loopctl/knowledge/structural_links.ex
+++ b/lib/loopctl/knowledge/structural_links.ex
@@ -374,17 +374,53 @@ defmodule Loopctl.Knowledge.StructuralLinks do
       {:ok, %Article{} = hub} ->
         {:ok, hub, :created}
 
-      # A title collision means a hub for this source already exists under a different
-      # idempotency_key — treat it as resolved, never as a failure, so a re-run converges
-      # instead of logging the same error every night.
-      {:error, :duplicate_title, %Article{} = hub} ->
-        {:ok, hub, :resolved}
+      # A title collision is NOT this source's hub. It is a DIFFERENT source that happened
+      # to compute the same name, and returning it here merged them: measured on the live
+      # corpus, one "Source: synology netbackup" node ended up serving 85 distinct sources
+      # and 6,471 members, at which point a derived_from edge no longer means "derived from
+      # this source" but "derived from something that shared a name" — which is exactly the
+      # precision the whole feature exists to add.
+      #
+      # Names are not unique and were never going to be: the naming rule picks a tag every
+      # member shares, and a collection tag like `synology-netbackup` is universal across
+      # every document in that share. So disambiguate with the digest, which IS unique, and
+      # keep the readable name in front of it.
+      {:error, :duplicate_title, _other_sources_hub} ->
+        create_hub_disambiguated(tenant_id, source, key, member_count)
 
       {:error, reason} ->
         {:error, reason}
 
       other ->
         {:error, other}
+    end
+  end
+
+  defp create_hub_disambiguated(tenant_id, source, key, member_count) do
+    name = hub_title(tenant_id, source, member_count)
+    digest = digest_title(source)
+
+    title =
+      if name == digest, do: "Source: #{digest}", else: "Source: #{name} (#{digest})"
+
+    attrs = %{
+      title: title,
+      body: hub_body(source),
+      category: "reference",
+      status: :published,
+      tags: [source, "hub", "source-hub"],
+      idempotency_key: key,
+      metadata: %{
+        "hub_kind" => "source",
+        "source_key" => source,
+        "hub_title_generated" => title
+      }
+    }
+
+    case Knowledge.create_article(tenant_id, attrs) do
+      {:ok, %Article{} = hub} -> {:ok, hub, :created}
+      {:error, reason} -> {:error, reason}
+      other -> {:error, other}
     end
   end
 

--- a/test/loopctl/knowledge/structural_links_test.exs
+++ b/test/loopctl/knowledge/structural_links_test.exs
@@ -309,6 +309,51 @@ defmodule Loopctl.Knowledge.StructuralLinksTest do
       assert again.title == "Source: the better name"
     end
 
+    test "two sources that compute the SAME name get two hubs, never one" do
+      tenant = fixture(:tenant)
+
+      # The real case: every document in a Synology share carries `synology-netbackup`,
+      # so it is universal for each of them separately. Returning the first source's hub
+      # for the second merged 85 sources onto one node and 6,471 members with it.
+      for _ <- 1..5, do: article(tenant, ["doc-aaa111", "synology-netbackup"])
+      for _ <- 1..5, do: article(tenant, ["doc-bbb222", "synology-netbackup"])
+
+      assert {:ok, report} = StructuralLinks.harvest(tenant.id)
+
+      assert report.hubs_created == 2, "each source gets its OWN hub"
+      hub_ids = hubs(tenant.id) |> Enum.map(& &1.id) |> Enum.uniq()
+      assert length(hub_ids) == 2
+
+      # And no hub may serve members drawn from more than one source.
+      edges = links(tenant.id, :derived_from)
+
+      for hub_id <- hub_ids do
+        sources =
+          edges
+          |> Enum.filter(&(&1.target == hub_id))
+          |> Enum.map(fn e ->
+            AdminRepo.get!(Article, e.source).tags
+            |> Enum.find(&String.starts_with?(&1, "doc-"))
+          end)
+          |> Enum.uniq()
+
+        assert length(sources) == 1, "a hub must serve exactly one source"
+      end
+    end
+
+    test "the disambiguated title keeps the readable name and adds the digest" do
+      tenant = fixture(:tenant)
+      for _ <- 1..5, do: article(tenant, ["doc-ccc333", "shared-collection"])
+      for _ <- 1..5, do: article(tenant, ["doc-ddd444", "shared-collection"])
+
+      assert {:ok, _} = StructuralLinks.harvest(tenant.id)
+
+      titles = hubs(tenant.id) |> Enum.map(& &1.title) |> Enum.sort()
+      assert length(Enum.uniq(titles)) == 2, "titles must be distinct"
+      assert Enum.any?(titles, &(&1 == "Source: shared collection"))
+      assert Enum.any?(titles, &String.contains?(&1, "shared collection ("))
+    end
+
     test "a title that is not ours is never overwritten" do
       tenant = fixture(:tenant)
       for _ <- 1..5, do: article(tenant, ["book-handnamed", "an-author"])


### PR DESCRIPTION
Found while stepping the backfill down to floor 25 and reconciling the counters — 312 sources had produced only 146 hubs.

## The defect

#720 mapped `create_article`'s `{:error, :duplicate_title, existing}` to `{:ok, hub, :resolved}`, reasoning that a collision meant *this* source already had a hub under a different key. Wrong. It meant a **different source** computed the same name — and the second source then silently adopted the first one's hub.

Measured on the live corpus:

| hub | distinct sources | members |
|---|---|---|
| `Source: synology netbackup` | **85** | 6,471 |
| `Source: synology docs` | 65 | 4,830 |
| `Source: gdrive` | 7 | 778 |
| `Source: chris pine` | 4 | 786 |

At that point a `derived_from` edge no longer means *derived from this source*; it means *derived from something that shared a name*. That is worse than having no edge, because it still looks exact — and exactness was the entire justification for the feature over the existing similarity edges.

## Why it was inevitable

Names were never going to be unique. The naming rule (#722) picks a tag every member of a source shares — and a collection tag like `synology-netbackup` is universal across *every document in that share*, so dozens of unrelated sources legitimately compute the same name. The **digest is** unique. So a collision now mints a distinct hub titled with the readable name followed by the digest: `Source: synology netbackup (doc a8d8cf71c5df)`. No source is ever handed another source's hub.

## Verification

Mutation-verified: restoring the merge behaviour fails both new tests — one asserting each source gets its own hub, one asserting no hub serves members drawn from more than one source. 33 tests in the module file; full gate green (**7722 tests, 0 failures**); `credo --strict` clean.

## Data repair is separate

The ~38,900 edges already written under the old behaviour are wrong and a code change doesn't touch them. They need deleting and re-harvesting, which I'll do against production after this deploys.

## What I'd take from this

The unit tests were green through all of #719–#722 and the defect only appeared when I reconciled two independently-derived counts (sources qualified vs. hubs existing) against real data. Neither number alone looked wrong. That reconciliation is worth building into the harvest's own reporting rather than leaving it to whoever happens to notice.