### PR TITLE
Attribute the MOC hub mint to the worker, like its own update already was

### DIFF
--- a/lib/loopctl/workers/knowledge_moc_worker.ex
+++ b/lib/loopctl/workers/knowledge_moc_worker.ex
@@ -49,6 +49,12 @@ defmodule Loopctl.Workers.KnowledgeMocWorker do
   alias Loopctl.Oban.FairShare
   alias Loopctl.Tenants.Tenant
 
+  # These writes are made by a scheduled worker holding no key. Attribute BOTH of them —
+  # `Knowledge` defaults `actor_type` to "api_key" with a nil id, so an unattended write
+  # that omits this records itself in the immutable audit log against an API key that does
+  # not exist. One attribute, so the create and the update cannot drift apart again.
+  @actor [actor_type: "system", actor_label: "worker:knowledge_moc"]
+
   @default_min_tag_count 25
   @default_max_tags 50
   @max_members 300
@@ -185,13 +191,7 @@ defmodule Loopctl.Workers.KnowledgeMocWorker do
     # already-published article is a no-op the changeset rejects.
     with {:ok, id} <- ensure_hub(tenant_id, attrs),
          {:ok, _} <-
-           Knowledge.update_article(
-             tenant_id,
-             id,
-             %{body: body, tags: moc_tags},
-             actor_type: "system",
-             actor_label: "worker:knowledge_moc"
-           ) do
+           Knowledge.update_article(tenant_id, id, %{body: body, tags: moc_tags}, @actor) do
       :ok
     else
       other ->
@@ -204,7 +204,7 @@ defmodule Loopctl.Workers.KnowledgeMocWorker do
   # `{:ok, :deduplicated, article}` (or another reason tuple) when the
   # idempotency_key already exists — normalize both to the hub id.
   defp ensure_hub(tenant_id, attrs) do
-    case Knowledge.create_article(tenant_id, attrs) do
+    case Knowledge.create_article(tenant_id, attrs, @actor) do
       {:ok, %{id: id}} -> {:ok, id}
       {:ok, _reason, %{id: id}} -> {:ok, id}
       other -> other

--- a/test/loopctl/workers/knowledge_moc_worker_test.exs
+++ b/test/loopctl/workers/knowledge_moc_worker_test.exs
@@ -7,6 +7,7 @@ defmodule Loopctl.Workers.KnowledgeMocWorkerTest do
   import Ecto.Query
 
   alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
   alias Loopctl.Knowledge.Article
   alias Loopctl.Workers.KnowledgeMocWorker
 
@@ -176,6 +177,51 @@ defmodule Loopctl.Workers.KnowledgeMocWorkerTest do
       refute moc_hub(tenant.id, "idem-book-7ebe1ca33431")
       refute moc_hub(tenant.id, "url-7ebe1ca33431")
       assert moc_hub(tenant.id, "otp")
+    end
+  end
+
+  describe "audit attribution" do
+    # Both writes this worker makes are unattended — it holds no key. `Knowledge` defaults
+    # `actor_type` to "api_key" with a nil id, so an omitted actor records a hub mint in
+    # the immutable audit log against an API key that does not exist, in a product whose
+    # premise is attributable custody. The UPDATE carried the system actor from the start
+    # and the CREATE beside it did not, which is the drift these two tests pin.
+    test "the first mint of a MOC hub is audited as the system worker" do
+      tenant = fixture(:tenant)
+      published(tenant.id, "One", ["attributed"])
+      published(tenant.id, "Two", ["attributed"])
+
+      assert :ok = run(tenant.id)
+      hub = moc_hub(tenant.id, "attributed")
+
+      entry =
+        from(e in AuditLog,
+          where: e.tenant_id == ^tenant.id,
+          where: e.action == "article.created" and e.entity_id == ^hub.id
+        )
+        |> AdminRepo.one()
+
+      assert entry.actor_type == "system"
+      assert entry.actor_label == "worker:knowledge_moc"
+    end
+
+    test "the weekly body refresh is audited as the system worker too" do
+      tenant = fixture(:tenant)
+      published(tenant.id, "One", ["refreshed"])
+      published(tenant.id, "Two", ["refreshed"])
+
+      assert :ok = run(tenant.id)
+      hub = moc_hub(tenant.id, "refreshed")
+
+      entry =
+        from(e in AuditLog,
+          where: e.tenant_id == ^tenant.id,
+          where: e.action == "article.updated" and e.entity_id == ^hub.id
+        )
+        |> AdminRepo.one()
+
+      assert entry.actor_type == "system"
+      assert entry.actor_label == "worker:knowledge_moc"
     end
   end
 


### PR DESCRIPTION
The one out-of-scope finding from the [#726](https://github.com/mkreyman/loopctl/pull/726) review, fixed on its own branch as the review protocol requires — real work, wrong branch, not a deferral.

`KnowledgeMocWorker.upsert_moc/3` makes two writes. The update passes `actor_type: "system", actor_label: "worker:knowledge_moc"`; the `ensure_hub/2` create beside it passed nothing. `Knowledge.create_article/3` defaults `actor_type` to `"api_key"` with a nil `actor_id`, so **every first mint of a MOC hub per (tenant, tag) has been recorded in the immutable audit log against an API key that does not exist** — in a product whose premise is attributable custody.

The two writes now share one `@actor` attribute instead of one carrying an inline keyword list that the other could be written without, which is exactly how they drifted. Both directions are pinned by a test; deleting the actor from the create fails one of them (mutation-verified).

Gate run stage by stage (`core.hooksPath` is unset in this clone, so the pre-commit hook does not fire): format, `--warnings-as-errors`, credo --strict, dialyzer, full suite 7,745 tests 0 failures.