### PR TITLE
Stop ranking knowledge by where it came from

### DIFF
--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -182,6 +182,45 @@ never pass `tenant_id`/`subject_id`.
    depth, not authority. The server-guaranteed key is the `articles.idempotency_key` column with
    its per-tenant unique index — prefer it, and do not treat a tag as proof of capture identity.
 
+## Ranking must never key on HOW a document got in (owner decision, 2026-08-21)
+
+`Loopctl.Knowledge.RankingPriors` carried two PROVENANCE priors — a `source_type` table
+("human/reviewed provenance over raw automated ingests") and a first-party/third-party split
+keyed on the sourcers' capture tags (`book-`/`url-`/`yt-`/`doc-` and the bare kind tags).
+**Both are removed.** Mark's reasoning, which outlives the measurement: *"if we heavily favor
+the internally produced knowledge, we would never learn anything new and unexpectedly
+useful... agents improve and I don't want less intelligent agents to decide what to pick for
+more intelligent future agents. I want the decision of what knowledge to use and how to
+combine it to be done on the receiving side."*
+
+The prior's own evidence did not survive checking. It cited a 26.7x reads-per-article gap —
+a statistic whose denominator is the harvest's own volume (~96% of the corpus), so it falls
+~1/N mechanically. The measure that actually answers "is this material worse?" is
+**surfaced-to-opened conversion**, and rank-stratified on the live corpus it converged by
+rank 3 and INVERTED by rank 4 (first-party 1.95% vs third-party 1.96% at rank 4; 1.57% vs
+1.74% at rank 5). Its discriminator-verification claim (98.5%/0.4%) had also gone stale.
+
+**What is still allowed**, so this is a rule and not a mood: relevance itself (RRF — that IS
+the retrieval); DELIBERATE EDITORIAL ACTS (`verdict-kill`, `:superseded`, curation); FORM
+rather than origin (the MOC-hub demotion — a navigation stub is not an answer whoever wrote
+it); and `@category_authority`, KEPT by explicit owner decision on the same date because a
+category is an editorial classification, not an ingestion method.
+
+**What is forbidden** is a weight keyed on a document's sourcer, capture tag, `source_type`,
+or ingestion batch. Two failure modes no measurement catches: a provenance prior is a CLOSED
+LOOP (demote unread material → it stays unread → cite the ratio as proof) and a RATCHET (a
+weight shipped once by one model constrains every future receiver). Guarded by
+`test/loopctl/knowledge/ranking_priors_test.exs` — "provenance priors are GONE".
+
+**The golden-question eval below cannot catch a reintroduction.** Measured 2026-08-21: 1 of
+124 docs in `priv/retrieval_eval/golden.jsonl` carries a harvest marker and NONE carry a
+`source_type`, so removing both priors moved every metric by exactly `+0.000`. That green is
+near-vacuous for this class of change — the unit guard is the real one.
+
+**What would overturn this:** the owner saying so, or a conversion measurement that is
+rank-stratified, uses a discriminator verified against the CURRENT corpus, and still shows a
+durable gap. Reads-per-article is not that measurement.
+
 ## Ranking changes are gated by the golden-question eval (#469)
 
 Any change to `search_combined/3` ranking (weights, fusion, recency/authority) must ship with a

--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -115,7 +115,7 @@ never pass `tenant_id`/`subject_id`.
    `{drift_signal, member_id}` — a group scored under the other signal's normalized key finds
    nothing and withholds (fail-closed).
 5. **Heat must not rank on a signal heat produces** — `Knowledge.heat_index/2`
-   (`knowledge.ex:10875`; the counted set is `@heat_read_access_types`, `:10745`). The heat index is the one retrieval route that
+   (`knowledge.ex:10884`; the counted set is `@heat_read_access_types`, `:10754`). The heat index is the one retrieval route that
    takes NO query, so its misses are uncorrelated with embedding similarity — which is worth nothing
    if its ordering is something a caller or the route itself generates. It has been violated FOUR
    times, each differently — and once by a FIX for one of the others — so treat any new input to

--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -115,7 +115,7 @@ never pass `tenant_id`/`subject_id`.
    `{drift_signal, member_id}` — a group scored under the other signal's normalized key finds
    nothing and withholds (fail-closed).
 5. **Heat must not rank on a signal heat produces** — `Knowledge.heat_index/2`
-   (`knowledge.ex:10871`; the counted set is `@heat_read_access_types`, `:10741`). The heat index is the one retrieval route that
+   (`knowledge.ex:10875`; the counted set is `@heat_read_access_types`, `:10745`). The heat index is the one retrieval route that
    takes NO query, so its misses are uncorrelated with embedding similarity — which is worth nothing
    if its ordering is something a caller or the route itself generates. It has been violated FOUR
    times, each differently — and once by a FIX for one of the others — so treat any new input to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to loopctl are documented here.
 
 ## [Unreleased] — 2026-08-21 — The provenance harvest runs on a cadence
 
+### Changed
+
+- **Search ranking no longer keys on a document's provenance.** `Loopctl.Knowledge.RankingPriors`
+  carried two priors keyed on where a document came from — a `source_type` authority table and a
+  first-party/third-party split keyed on the sourcers' capture tags (`book-`/`url-`/`yt-`/`doc-`
+  plus `web-article`/`newsletter`/`inbox-harvest`/`youtube`/`document`/`book`). Both are removed.
+  `authority_factor/4` now reads `:category` alone; `provenance_authority/1` is gone.
+
+  **Operator impact:** results may reorder on NEAR-TIES only. Both priors were bounded
+  tie-breakers at the default strength 0.05 (a ~2.5% edge on an otherwise-equal pair, unable to
+  flip a cross-lane consensus winner), so no strong-relevance ordering changes. On the hosted
+  corpus 82,851 of 86,413 articles sat on the third-party side and now rank neutrally against the
+  other 3,562. `mix loopctl.retrieval.eval` reports `+0.000` on every golden question — but that
+  green is near-vacuous here, because only 1 of 124 golden docs carries a harvest marker and none
+  carry a `source_type`. **No baseline change, no migration, no configuration change.**
+  `:knowledge_authority_prior_enabled` and `:knowledge_hub_demotion_enabled` are unaffected.
+
+  Why: the prior rested on a 26.7x reads-per-article gap whose denominator is the harvest's own
+  volume, so it falls ~1/N mechanically. Rank-stratified surfaced-to-opened conversion converged
+  by rank 3 and inverted by rank 4. Dead-doctrine demotion (`verdict-kill`, `:superseded`), the
+  MOC-hub demotion, recency decay and category authority are all unchanged.
+
 ### Added
 
 - **`POST /api/v1/knowledge/conflicts` — assert a conflict pair the system never flagged

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -575,6 +575,14 @@ semantic/keyword **retrieval** result, on one uniform shape carrying
 - **#305/#306 are the same feature** (this epic implements both) — recommend
   closing one as a duplicate of the other rather than tracking them separately.
 
+## Ranking must never key on HOW a document got in (owner decision, 2026-08-21)
+
+`Loopctl.Knowledge.RankingPriors` no longer carries any PROVENANCE prior. The `source_type` authority table and the first-party/third-party split keyed on the sourcers' capture tags (`book-`/`url-`/`yt-`/`doc-` and the bare kind tags) were both removed. Mark: *"if we heavily favor the internally produced knowledge, we would never learn anything new and unexpectedly useful... agents improve and I don't want less intelligent agents to decide what to pick for more intelligent future agents. I want the decision of what knowledge to use and how to combine it to be done on the receiving side."*
+
+The prior rested on a 26.7x reads-per-article gap, which carries the harvest's own volume in its denominator (~96% of the corpus) and so falls ~1/N mechanically. Rank-stratified surfaced-to-opened conversion — the measure that actually answers the question — converged by rank 3 and inverted by rank 4 on the live corpus.
+
+STILL ALLOWED: relevance (RRF), deliberate editorial acts (`verdict-kill`, `:superseded`, curation), FORM rather than origin (the MOC-hub demotion), and `@category_authority` (kept by explicit owner decision — a category is an editorial classification, not an ingestion method). FORBIDDEN: any weight keyed on a document's sourcer, capture tag, `source_type`, or ingestion batch. Note that the golden-question eval cannot catch a reintroduction (1 of 124 golden docs carries a harvest marker, none carry a `source_type`) — the guard is `test/loopctl/knowledge/ranking_priors_test.exs`. Full reasoning and what would overturn it: the note above `@kill_tag` in `ranking_priors.ex` and the `knowledge-wiki` skill.
+
 ## Elixir / Phoenix guidelines
 
 These are the stock `phx.new` rules, condensed. Each line is a hard rule.

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2175,13 +2175,15 @@ defmodule Loopctl.Knowledge do
               category: a.category,
               status: a.status,
               tags: a.tags,
-              # Projected for the response shape, not for ranking: the source-type
-              # authority prior was removed on 2026-08-21 (RankingPriors, note above
-              # `@kill_tag`). `category` is what the surviving authority prior reads.
+              # Retained for LANE-SHAPE SYMMETRY only — every lane projects the same keys
+              # so fusion compares like with like. It feeds no ranking prior (the
+              # source-type authority prior was removed on 2026-08-21; RankingPriors, note
+              # above `@kill_tag`) and no search renderer emits it.
               source_type: a.source_type,
-              # idempotency_key is the MOC-hub signal (#654 follow-up). Projected for the
-              # SAME reason as source_type: RankingPriors fails open on a missing field,
-              # so a lane that omits it silently stops demoting hubs on that lane only.
+              # idempotency_key is the MOC-hub signal (#654 follow-up) and, UNLIKE
+              # source_type above, it is a live ranking input: RankingPriors fails open on
+              # a missing field, so a lane that omits it silently stops demoting hubs on
+              # that lane only.
               idempotency_key: a.idempotency_key,
               inserted_at: a.inserted_at,
               updated_at: a.updated_at,
@@ -8973,10 +8975,12 @@ defmodule Loopctl.Knowledge do
         category: c.category,
         status: c.status,
         tags: c.tags,
-        # Response shape only — no longer a ranking input (see the keyword select). The
-        # inner pool_select(:semantic) must project it for this outer select to read it.
+        # Lane-shape symmetry only — no longer a ranking input, and no search renderer
+        # emits it (see the keyword select). The inner pool_select(:semantic) must project
+        # it for this outer select to read it.
         source_type: c.source_type,
-        # Same contract for the MOC-hub demotion signal: inner projects it, outer reads it.
+        # Same projection contract for the MOC-hub demotion signal, which unlike
+        # source_type IS still ranked on: inner projects it, outer reads it.
         idempotency_key: c.idempotency_key,
         inserted_at: c.inserted_at,
         updated_at: c.updated_at,
@@ -9125,7 +9129,7 @@ defmodule Loopctl.Knowledge do
     - `:recency_weight` -- per-call override for the bounded recency prior weight
       (#471; default `:knowledge_recency_weight`, 0.3), clamped to `[0.0, 1.0]`. A
       weight of 0 makes recency a no-op. See `Loopctl.Knowledge.RankingPriors`.
-    - `:authority_prior` -- per-call boolean toggle for the source/category authority
+    - `:authority_prior` -- per-call boolean toggle for the CATEGORY authority
       prior (default `:knowledge_authority_prior_enabled`, true). The dead-doctrine
       demotion (`verdict-kill`/`:superseded`) applies regardless of this toggle.
     - `:authority_strength` -- per-call override for the authority prior strength
@@ -9663,7 +9667,7 @@ defmodule Loopctl.Knowledge do
     Keyword.get(opts, :rrf_k, Application.get_env(:loopctl, :knowledge_rrf_k, 60))
   end
 
-  # --- Recency + source-authority priors (#471) -------------------------------
+  # --- Recency + category-authority priors (#471) -----------------------------
   #
   # Post-fusion re-ranking applied on `search_combined/3`'s fused candidate list (and,
   # via apply_ranking_priors_fallback/2, on the degraded keyword_only path). PURE re-rank:
@@ -10004,11 +10008,11 @@ defmodule Loopctl.Knowledge do
           project_id: a.project_id,
           title: a.title,
           category: a.category,
-          # Projected for symmetry with the keyword lane and the semantic pool, and
-          # surfaced to callers by ArticleJSON. It NO LONGER feeds any ranking prior —
-          # the source-type authority prior was removed on 2026-08-21 (provenance must
-          # not move ranking; see the note above `@kill_tag` in RankingPriors). Kept as
-          # a projected FIELD, not as a ranking input.
+          # Projected for symmetry with the keyword lane and the semantic pool, and for
+          # nothing else: it feeds no ranking prior (the source-type authority prior was
+          # removed on 2026-08-21 — provenance must not move ranking; see the note above
+          # `@kill_tag` in RankingPriors) and no search renderer emits it. ArticleJSON
+          # surfaces the column on the article CRUD path, never on this one.
           source_type: a.source_type,
           status: a.status,
           tags: a.tags,

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -8773,6 +8773,10 @@ defmodule Loopctl.Knowledge do
           category: a.category,
           status: a.status,
           tags: a.tags,
+          # The MOC-hub demotion signal, on the side-table path exactly as on
+          # pool_select(:semantic): RankingPriors fails open without it, so omitting it here
+          # made the WHOLE semantic lane hub-blind once side-table reads are on.
+          idempotency_key: a.idempotency_key,
           inserted_at: a.inserted_at,
           updated_at: a.updated_at
         }
@@ -10014,6 +10018,11 @@ defmodule Loopctl.Knowledge do
           # `@kill_tag` in RankingPriors) and no search renderer emits it. ArticleJSON
           # surfaces the column on the article CRUD path, never on this one.
           source_type: a.source_type,
+          # UNLIKE source_type, this one IS a live ranking input: RankingPriors fails open
+          # on a missing field, so a lane that omits it silently stops demoting MOC hubs on
+          # that lane only — and a hub links to every member, so it is the likeliest
+          # graph-ONLY candidate there is (#654 follow-up).
+          idempotency_key: a.idempotency_key,
           status: a.status,
           tags: a.tags,
           inserted_at: a.inserted_at,

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2175,9 +2175,9 @@ defmodule Loopctl.Knowledge do
               category: a.category,
               status: a.status,
               tags: a.tags,
-              # source_type feeds the #471 authority prior (it is NOT projected by
-              # default elsewhere); carried on the keyword lane so the priors apply on the
-              # degraded keyword_only fallback too (AC-5).
+              # Projected for the response shape, not for ranking: the source-type
+              # authority prior was removed on 2026-08-21 (RankingPriors, note above
+              # `@kill_tag`). `category` is what the surviving authority prior reads.
               source_type: a.source_type,
               # idempotency_key is the MOC-hub signal (#654 follow-up). Projected for the
               # SAME reason as source_type: RankingPriors fails open on a missing field,
@@ -8973,8 +8973,8 @@ defmodule Loopctl.Knowledge do
         category: c.category,
         status: c.status,
         tags: c.tags,
-        # source_type feeds the #471 authority prior (see the keyword select). The inner
-        # pool_select(:semantic) must project it for this outer select to read it.
+        # Response shape only — no longer a ranking input (see the keyword select). The
+        # inner pool_select(:semantic) must project it for this outer select to read it.
         source_type: c.source_type,
         # Same contract for the MOC-hub demotion signal: inner projects it, outer reads it.
         idempotency_key: c.idempotency_key,
@@ -9502,9 +9502,10 @@ defmodule Loopctl.Knowledge do
             opts
           )
       end
-      # #471: re-rank the fused list by the recency + source-authority priors BEFORE the
-      # top-k cut. Pure (no DB) — the result maps already carry updated_at/category/
-      # source_type/tags/status, so merge_results/5 stays a DB-free fusion function.
+      # #471: re-rank the fused list by the recency + CATEGORY-authority priors (plus the
+      # dead-doctrine and MOC-hub demotions) BEFORE the top-k cut. Pure (no DB) — the
+      # result maps already carry updated_at/category/tags/status, so merge_results/5 stays
+      # a DB-free fusion function. Provenance priors were removed 2026-08-21.
       |> apply_ranking_priors_fused(opts)
 
     # #31 follow-up: the curated-vs-retrieved decision runs HERE, on the default path,
@@ -10003,12 +10004,11 @@ defmodule Loopctl.Knowledge do
           project_id: a.project_id,
           title: a.title,
           category: a.category,
-          # source_type is projected here for symmetry with the keyword lane
-          # (knowledge.ex ~1870) and the semantic pool (vector_search.ex ~499) so
-          # RankingPriors.authority_factor reads the SAME source-authority prior no
-          # matter which lane first surfaced a doc. Without it a graph-lane-only doc
-          # would fall back to source_authority(nil) (the 0.0 neutral floor) and get a
-          # category-only authority factor — asymmetric with kw/sem (#471 review).
+          # Projected for symmetry with the keyword lane and the semantic pool, and
+          # surfaced to callers by ArticleJSON. It NO LONGER feeds any ranking prior —
+          # the source-type authority prior was removed on 2026-08-21 (provenance must
+          # not move ranking; see the note above `@kill_tag` in RankingPriors). Kept as
+          # a projected FIELD, not as a ranking input.
           source_type: a.source_type,
           status: a.status,
           tags: a.tags,

--- a/lib/loopctl/knowledge/ranking_priors.ex
+++ b/lib/loopctl/knowledge/ranking_priors.ex
@@ -43,8 +43,9 @@ defmodule Loopctl.Knowledge.RankingPriors do
   Post-#470 the fused `:final_score` is `Σ_lane weight/(k + rank)`. Two docs that each top
   a single lane tie EXACTLY; a doc with cross-lane consensus scores ~2x a single-lane hit.
   The authority factor clamps to `[0.9, 1.1]`, but the band is ONE-SIDED in practice: every
-  category/source weight is >= 0 and `strength` >= 0, so `1 + strength*(cat+src)` is always
-  >= 1.0 and the 0.9 floor is unreachable — the EFFECTIVE range is `[1.0, 1.1]`. Authority
+  category weight is >= 0 and `strength` >= 0, so `1 + strength*cat` is always >= 1.0 and
+  the 0.9 floor is unreachable — the EFFECTIVE range is `[1.0, 1 + strength*max_cat]`,
+  which at the default strength 0.05 tops out at 1.05, short of the 1.1 ceiling. Authority
   therefore only ever BOOSTS a higher-authority doc; it never demotes a low-authority raw
   note below neutral (that demotion is the SEPARATE `demotion_factor/1` job). Even so it can
   flip an exact/near tie but can NEVER flip a 2x-stronger consensus winner — precisely the

--- a/lib/loopctl/knowledge/ranking_priors.ex
+++ b/lib/loopctl/knowledge/ranking_priors.ex
@@ -19,8 +19,8 @@ defmodule Loopctl.Knowledge.RankingPriors do
       > decay as the single source of truth), but #471 now surfaces it on the PRIMARY search
       > path. If you run a mass re-embed, expect ranking to shift until authored-age drift
       > re-accumulates; there is no separate authored/source timestamp to fall back to.
-    * **Source authority** — a bounded prior derived from `category` / `source_type` /
-      `tags`, centered on 1.0 and clamped to a narrow band, so it re-ranks NEAR-TIES
+    * **Category authority** — a bounded prior derived from `category` ALONE, centered on
+      1.0 and clamped to a narrow band, so it re-ranks NEAR-TIES
       (which post-#470 Reciprocal Rank Fusion produces by construction) rather than
       overriding strong relevance. `verdict-kill` ideas and `:superseded` articles are
       demoted regardless of the authority toggle, so dead doctrine stops outranking live
@@ -94,65 +94,66 @@ defmodule Loopctl.Knowledge.RankingPriors do
   # `idea`, per the issue's "decision/playbook/finding > idea > raw atomic note".
   @default_category_authority 0.0
 
-  # Source-type authority (data-driven). Human/reviewed provenance over raw automated
-  # ingests. Keys mirror Loopctl.Knowledge.Article.known_source_types/0; an unknown or
-  # nil source_type is neutral (0.0).
-  @source_authority %{
-    "review_finding" => 1.0,
-    "manual" => 0.8,
-    "skill" => 0.6,
-    "channel_graduation" => 0.5,
-    "session_log" => 0.2,
-    "agent" => 0.2,
-    "newsletter" => 0.1,
-    "web_article" => 0.1,
-    "ingestion" => 0.0
-  }
-  @default_source_authority 0.0
-
-  # Provenance authority (#251). The single strongest measured signal in this table, and
-  # the one the category/source_type weights above could not see.
+  # PROVENANCE PRIORS REMOVED (2026-08-21, owner decision).
   #
-  # Measured on the live corpus 2026-08-11, over 30 days of reads:
+  # This module carried two priors keyed on WHERE A DOCUMENT CAME FROM: a source_type
+  # table ("human/reviewed provenance over raw automated ingests") and a first-party /
+  # third-party split keyed on the sourcers' capture tags (`book-`/`url-`/`yt-`/`doc-`).
+  # Both are gone, and the reason they must not come back is worth more than the code was.
   #
-  #   first-party              3,164 articles   389.7 reads/1k   18.30% ever read
-  #   third-party (harvested) 75,768 articles    14.6 reads/1k    1.09% ever read
+  # THE EVIDENCE THEY RESTED ON DID NOT HOLD. The provenance prior cited a 26.7x
+  # per-article read rate. That statistic carries the harvest's own volume in its
+  # denominator — third-party was ~96% of the corpus — so with a roughly fixed query rate
+  # it falls ~1/N mechanically, whatever the material is worth. The number that actually
+  # answers "is this material worse?" is SURFACED-TO-OPENED CONVERSION, and nobody had
+  # taken it. Measured 2026-08-21 over the whole history of `article_access_events`, using
+  # this module's own discriminator and stratified by rank to remove position bias:
   #
-  # A 26.7x per-article read rate: first-party is 4% of the corpus and 53% of the reads.
-  # The June 2026 bulk harvest added 76k third-party articles, and every query since has
-  # had to pull the ~3k articles anyone actually opens out of that pool.
+  #   rank | first-party (+0.5) | third-party (0.0)
+  #      1 |  8.30% (6,144)     |  4.48% (3,304)
+  #      2 |  3.91% (5,390)     |  2.75% (3,927)
+  #      3 |  2.57% (5,167)     |  2.41% (4,019)
+  #      4 |  1.95% (4,916)     |  1.96% (3,477)
+  #      5 |  1.57% (4,774)     |  1.74% (3,455)
   #
-  # Why TAGS and not `source_type`: 83,487 of 85,157 articles carry a NULL `source_type`,
-  # the whole harvest included, so `@source_authority` returns its 0.0 default for
-  # essentially the entire corpus and cannot separate these cohorts at all. The sourcers
-  # DO stamp a structural capture tag (`book-<id>`, `url-<id>`, `yt-<id>`, `doc-<id>`, plus
-  # the bare kind tags below). Verified as a discriminator before being relied on: it marks
-  # 98.5% of the June harvest and 0.4% of the pre-June curated set.
+  # Converged by rank 3 and INVERTED by rank 4. Controlling for position, provenance
+  # carried almost no signal — and the residual top-of-list gap is partly the prior marking
+  # its own homework, since it lifted first-party into the positions where conversion is
+  # highest and that conversion then read as evidence for the prior.
   #
-  # THIRD-PARTY IS THE POSITIVE TEST, and first-party is the absence of a marker — never the
-  # reverse. A first-party allowlist would have to enumerate every repo/topic tag Mark will
-  # ever use, and each one it missed would silently demote genuinely first-party knowledge.
-  # A missed marker here fails the other way: an unmarked harvest article is merely treated
-  # as neutral, which is exactly today's behaviour.
+  # The discriminator's own verification had also gone stale: it was justified as marking
+  # "98.5% of the June harvest and 0.4% of the pre-June curated set". On the live corpus in
+  # August the split was 82,851 / 3,562 and no longer separated the cohorts that cleanly.
   #
-  # The weight is deliberately SMALLER than the measured effect. Priors here break near-ties
-  # (RRF ties by construction), they do not dominate relevance — a 26.7x weight would let
-  # provenance outrank the query. At the default strength 0.05 this is a ~2.5% edge on an
-  # otherwise-equal pair, and it can never flip a cross-lane consensus winner (~2x a
-  # single-lane hit).
-  # SCOPE: these markers are the SOURCERS' own convention (the harvest skills stamp them at
-  # knowledge_create time), not user-authored freeform tags, which is what makes them a
-  # reliable signal. They are nonetheless GLOBAL, like `@category_authority` above, so a
-  # future tenant that uses `book-`/`document` to mean something else would inherit this
-  # prior. The failure is bounded and one-directional — a misread tag costs an article its
-  # 0.5 boost, dropping it to the neutral 0.0 every article gets today — so it can never
-  # demote anything below current behaviour. Revisit if a second real tenant appears; the
-  # right fix then is config-driven weight tables for the whole module, not a special case
-  # for this one term.
-  @harvest_marker_prefixes ~w(book- url- yt- doc-)
-  @harvest_marker_tags ~w(web-article newsletter inbox-harvest youtube document book)
-  @first_party_authority 0.5
-  @third_party_authority 0.0
+  # THE OWNER'S REASONING, which outlives the measurement (Mark, 2026-08-21):
+  #
+  #   "If we heavily favor the internally produced knowledge, we would never learn anything
+  #    new and unexpectedly useful. Besides, agents improve and I don't want less
+  #    intelligent agents to decide what to pick for more intelligent future agents. I want
+  #    the decision of what knowledge to use and how to combine it to be done on the
+  #    receiving side."
+  #
+  # Two failure modes that argument names, neither of which a measurement would catch:
+  # a provenance prior is a CLOSED LOOP (demote unread material, it stays unread, cite the
+  # ratio as proof), and it is a RATCHET (a weight shipped once by one model constrains
+  # every future receiver regardless of how much more capable that receiver is).
+  #
+  # WHAT IS STILL ALLOWED HERE, so this is a rule and not a mood:
+  #   * relevance itself (RRF over the lanes) — that IS the retrieval, not a prior;
+  #   * DELIBERATE EDITORIAL ACTS — `verdict-kill`, `:superseded`, curation. Someone judged
+  #     the content on its merits;
+  #   * FORM, not origin — the MOC-hub demotion below. A navigation stub is not an answer
+  #     whoever generated it;
+  #   * `@category_authority` above, KEPT by explicit owner decision on the same date: it
+  #     keys on an editorial classification, not on how a document was ingested.
+  #
+  # What is forbidden is a weight keyed on HOW A DOCUMENT GOT IN — its sourcer, its capture
+  # tag, its source_type, its ingestion batch. If a future measurement seems to justify one,
+  # re-read the table above first: that is what the last one looked like.
+  #
+  # WHAT WOULD OVERTURN THIS: the owner saying so, or a conversion measurement that is
+  # rank-stratified, uses a discriminator verified against the CURRENT corpus, and still
+  # shows a durable gap. Reads-per-article is not that measurement and never was.
 
   # A verdict-killed idea and a superseded article are demoted hard regardless of the
   # authority toggle — they are dead doctrine that must not outrank live doctrine.
@@ -236,11 +237,15 @@ defmodule Loopctl.Knowledge.RankingPriors do
 
   @doc """
   The bounded authority FACTOR for a result map, centered on 1.0 and clamped to
-  `[floor, ceiling]`. `strength` scales the combined category + source_type prior; a
+  `[floor, ceiling]`. `strength` scales the CATEGORY prior — the only one left; a
   `strength` of 0 makes authority a no-op (factor 1.0).
 
-  NOTE the band is effectively ONE-SIDED: every category/source weight is >= 0 and
-  `strength` >= 0, so `1 + strength*(cat+src)` is always >= 1.0 and the `floor` (0.9 in
+  It keys on `:category` and nothing else. The `source_type` and capture-tag provenance
+  priors were removed on 2026-08-21 — see the long note above `@kill_tag` for why, and for
+  what would have to be true to bring one back.
+
+  NOTE the band is effectively ONE-SIDED: every category weight is >= 0 and
+  `strength` >= 0, so `1 + strength*cat` is always >= 1.0 and the `floor` (0.9 in
   the default config) is never hit — the reachable range is `[1.0, ceiling]`. This factor
   only ever BOOSTS; demoting dead doctrine below neutral is `demotion_factor/1`'s job.
   """
@@ -249,43 +254,11 @@ defmodule Loopctl.Knowledge.RankingPriors do
 
   def authority_factor(result, strength, floor, ceiling) do
     cat = category_authority(Map.get(result, :category))
-    src = source_authority(Map.get(result, :source_type))
-    prov = provenance_authority(Map.get(result, :tags))
 
-    (1.0 + strength * (cat + src + prov))
+    (1.0 + strength * cat)
     |> max(floor)
     |> min(ceiling)
   end
-
-  @doc """
-  The provenance weight for a result's `tags`: `#{@first_party_authority}` for first-party
-  knowledge, `#{@third_party_authority}` for third-party harvested material (#251).
-
-  Third-party is the POSITIVE test — a structural capture tag stamped by a sourcer
-  (`book-`/`url-`/`yt-`/`doc-` prefixes, or a bare kind tag). First-party is the absence of
-  one, so a marker this function does not know leaves the article neutral rather than
-  demoting real first-party knowledge. `nil` tags are first-party (an article no sourcer
-  stamped).
-  """
-  @spec provenance_authority([String.t()] | nil) :: float()
-  def provenance_authority(nil), do: @first_party_authority
-
-  def provenance_authority(tags) when is_list(tags) do
-    if Enum.any?(tags, &harvest_marker?/1) do
-      @third_party_authority
-    else
-      @first_party_authority
-    end
-  end
-
-  def provenance_authority(_), do: @first_party_authority
-
-  defp harvest_marker?(tag) when is_binary(tag) do
-    tag in @harvest_marker_tags or
-      Enum.any?(@harvest_marker_prefixes, &String.starts_with?(tag, &1))
-  end
-
-  defp harvest_marker?(_), do: false
 
   @doc """
   The demotion FACTOR for a result that should not win a question: `#{@demote_factor}`
@@ -382,11 +355,5 @@ defmodule Loopctl.Knowledge.RankingPriors do
 
   defp category_authority(category) do
     Map.get(@category_authority, to_string(category), @default_category_authority)
-  end
-
-  defp source_authority(nil), do: @default_source_authority
-
-  defp source_authority(source_type) do
-    Map.get(@source_authority, to_string(source_type), @default_source_authority)
   end
 end

--- a/lib/loopctl/knowledge/vector_search.ex
+++ b/lib/loopctl/knowledge/vector_search.ex
@@ -288,7 +288,7 @@ defmodule Loopctl.Knowledge.VectorSearch do
         # the two reads would let the query BUILD (side table, pool*4 over-fetch) and the
         # ef_search DECISION disagree — build side-table but not raise ef_search → transient
         # under-recall. This is the same "resolve once and thread" invariant candidate_pool_query
-        # documents (vector_search.ex:447-452) and suggest_links honors (knowledge.ex:4711).
+        # documents (vector_search.ex:447-452) and suggest_links honors (knowledge.ex:4713).
         opts =
           Keyword.put_new_lazy(opts, :reads_side_table, &Embeddings.side_table_reads_enabled?/0)
 

--- a/lib/loopctl/knowledge/vector_search.ex
+++ b/lib/loopctl/knowledge/vector_search.ex
@@ -945,7 +945,8 @@ defmodule Loopctl.Knowledge.VectorSearch do
       category: a.category,
       status: a.status,
       tags: a.tags,
-      # source_type feeds the #471 authority prior in Loopctl.Knowledge.search_combined/3.
+      # source_type is projected for the response shape, NOT for ranking: the source-type
+      # authority prior was removed on 2026-08-21 (see RankingPriors, note above @kill_tag).
       source_type: a.source_type,
       # idempotency_key feeds the MOC-hub demotion in the same place (#654 follow-up).
       idempotency_key: a.idempotency_key,

--- a/lib/loopctl/knowledge/vector_search.ex
+++ b/lib/loopctl/knowledge/vector_search.ex
@@ -945,8 +945,9 @@ defmodule Loopctl.Knowledge.VectorSearch do
       category: a.category,
       status: a.status,
       tags: a.tags,
-      # source_type is projected for the response shape, NOT for ranking: the source-type
-      # authority prior was removed on 2026-08-21 (see RankingPriors, note above @kill_tag).
+      # source_type is projected for lane-shape symmetry, NOT for ranking and not for any
+      # search response: the source-type authority prior was removed on 2026-08-21 (see
+      # RankingPriors, note above @kill_tag).
       source_type: a.source_type,
       # idempotency_key feeds the MOC-hub demotion in the same place (#654 follow-up).
       idempotency_key: a.idempotency_key,

--- a/test/loopctl/knowledge/ranking_priors_test.exs
+++ b/test/loopctl/knowledge/ranking_priors_test.exs
@@ -76,7 +76,7 @@ defmodule Loopctl.Knowledge.RankingPriorsTest do
     end
   end
 
-  describe "authority_factor/4 (data-driven from category + source_type, bounded)" do
+  describe "authority_factor/4 (data-driven from category, bounded)" do
     test "a zero strength makes authority a no-op" do
       assert RankingPriors.authority_factor(%{category: :decision}, 0.0, @floor, @ceiling) == 1.0
     end
@@ -119,15 +119,17 @@ defmodule Loopctl.Knowledge.RankingPriorsTest do
                RankingPriors.authority_factor(%{category: nil}, 0.05, @floor, @ceiling)
     end
 
-    test "source_type lifts an otherwise identical article" do
+    test "source_type does NOT lift an article — that prior was removed (2026-08-21)" do
+      # It was the same provenance question as the capture-tag prior, keyed on a column
+      # instead of a tag: "human/reviewed provenance over raw automated ingests". Both are
+      # gone; see the note above `@kill_tag` in RankingPriors.
       reviewed = %{category: :finding, source_type: "review_finding"}
       raw_ingest = %{category: :finding, source_type: "ingestion"}
       none = %{category: :finding, source_type: nil}
 
-      assert RankingPriors.authority_factor(reviewed, 0.05, @floor, @ceiling) >
+      assert RankingPriors.authority_factor(reviewed, 0.05, @floor, @ceiling) ==
                RankingPriors.authority_factor(raw_ingest, 0.05, @floor, @ceiling)
 
-      # ingestion is weighted 0.0, so it ties the nil (unknown) source.
       assert RankingPriors.authority_factor(raw_ingest, 0.05, @floor, @ceiling) ==
                RankingPriors.authority_factor(none, 0.05, @floor, @ceiling)
     end
@@ -289,102 +291,104 @@ defmodule Loopctl.Knowledge.RankingPriorsTest do
       do: %{category: :reference, updated_at: @now, tags: ["deployment"], status: :published}
   end
 
-  describe "#251 provenance prior: first-party outranks harvested material on a near-tie" do
+  describe "provenance priors are GONE — ranking must not key on how a document got in" do
     alias Loopctl.Knowledge.RankingPriors
 
-    test "an article with no sourcer capture tag is first-party" do
-      assert RankingPriors.provenance_authority([]) > 0.0
-      assert RankingPriors.provenance_authority(["elixir", "oban"]) > 0.0
-      assert RankingPriors.provenance_authority(nil) > 0.0
-    end
+    # Owner decision, 2026-08-21: "if we heavily favor the internally produced knowledge,
+    # we would never learn anything new and unexpectedly useful... I want the decision of
+    # what knowledge to use and how to combine it to be done on the receiving side."
+    #
+    # The evidence that justified the removed prior was a 26.7x reads-per-article gap,
+    # which carries the harvest's own volume in its denominator. Rank-stratified conversion
+    # — the measure that actually answers "is this worse?" — converged by rank 3 and
+    # inverted by rank 4. These tests are what stops it coming back by accident.
 
-    test "each structural capture PREFIX marks third-party" do
-      for tag <- ["book-0be008289fe8", "url-d046e10f48b3", "yt-eCx3SSCcISo", "doc-3941363c04b3"] do
-        assert RankingPriors.provenance_authority([tag]) == 0.0,
-               "expected #{tag} to mark the article as harvested"
+    test "a harvested doc and a first-party doc rank IDENTICALLY when all else is equal" do
+      for marker <- [
+            "book-0be008289fe8",
+            "url-d046e10f48b3",
+            "yt-eCx3SSCcISo",
+            "doc-3941363c04b3",
+            "web-article",
+            "newsletter",
+            "inbox-harvest",
+            "youtube",
+            "document",
+            "book"
+          ] do
+        harvested = %{category: :finding, updated_at: @now, tags: [marker], status: :published}
+
+        first_party = %{
+          category: :finding,
+          updated_at: @now,
+          tags: ["elixir"],
+          status: :published
+        }
+
+        assert mult(harvested, []) == mult(first_party, []),
+               "#{marker} still changes the ranking — a provenance prior has come back"
       end
     end
 
-    test "each bare kind tag marks third-party" do
-      for tag <- ~w(web-article newsletter inbox-harvest youtube document book) do
-        assert RankingPriors.provenance_authority([tag]) == 0.0,
-               "expected #{tag} to mark the article as harvested"
-      end
-    end
-
-    test "one marker among many first-party tags is enough" do
-      assert RankingPriors.provenance_authority(["elixir", "oban", "yt-abc123", "patterns"]) ==
-               0.0
-    end
-
-    test "a prefix must be a PREFIX — a tag merely containing it stays first-party" do
-      # "notebook-lm" contains "book-" but does not start with it; "handbook" likewise.
-      assert RankingPriors.provenance_authority(["notebook-lm"]) > 0.0
-      assert RankingPriors.provenance_authority(["handbook"]) > 0.0
-    end
-
-    test "a first-party doc outranks an otherwise-IDENTICAL harvested doc" do
-      first_party = %{category: :finding, updated_at: @now, tags: ["elixir"], status: :published}
-
-      harvested = %{
+    test "source_type does not move the ranking either" do
+      # The other provenance prior: "human/reviewed provenance over raw automated ingests".
+      # It keyed on `source_type`, which is the same question wearing a different column.
+      reviewed = %{
         category: :finding,
         updated_at: @now,
-        tags: ["web-article"],
-        status: :published
+        tags: [],
+        status: :published,
+        source_type: "review_finding"
       }
 
-      assert mult(first_party, []) > mult(harvested, [])
+      ingested = %{
+        category: :finding,
+        updated_at: @now,
+        tags: [],
+        status: :published,
+        source_type: "ingestion"
+      }
+
+      assert mult(reviewed, []) == mult(ingested, [])
     end
 
-    test "the prior BREAKS ties but never dominates relevance or category" do
-      # A harvested `decision` must still outrank a first-party `idea`: provenance is a
-      # tiebreaker, not an override of the far larger category spread.
-      harvested_decision = %{
+    test "authority now keys on CATEGORY and nothing else" do
+      # Kept by explicit owner decision on the same date: a category is an editorial
+      # classification, not a statement about how the document was ingested.
+      decision = %{
         category: :decision,
         updated_at: @now,
         tags: ["web-article"],
         status: :published
       }
 
-      first_party_idea = %{category: :idea, updated_at: @now, tags: [], status: :published}
+      raw = %{category: nil, updated_at: @now, tags: [], status: :published}
 
-      assert mult(harvested_decision, []) > mult(first_party_idea, [])
+      assert mult(decision, []) > mult(raw, []),
+             "category authority was removed too — only the PROVENANCE priors should be gone"
     end
 
-    test "it stays inside the bounded band — no saturation at the common shape" do
-      # source_type is NULL for ~98% of the corpus, so the realistic maximum is
-      # category(1.0) + provenance(0.5) = 1.5, well under the 2.0 the ceiling needs.
-      best = %{category: :decision, updated_at: @now, tags: [], status: :published}
+    test "deliberate editorial acts still demote — this is not a ban on all re-ranking" do
+      # Dead doctrine and navigation stubs are judged on their merits and their FORM, not
+      # on where they came from, so they are untouched by the provenance decision.
+      live = %{category: :finding, updated_at: @now, tags: [], status: :published}
+      killed = %{category: :finding, updated_at: @now, tags: ["verdict-kill"], status: :published}
 
-      factor = RankingPriors.authority_factor(best, 0.05, 0.9, 1.1)
-
-      assert factor < 1.1, "expected headroom below the ceiling, got #{factor}"
-      assert factor > 1.0
-    end
-
-    test "a verdict-kill first-party doc is still demoted below a clean harvested one" do
-      killed_first_party = %{
-        category: :decision,
+      hub = %{
+        category: :reference,
         updated_at: @now,
-        tags: ["verdict-kill"],
-        status: :published
+        tags: [],
+        status: :published,
+        idempotency_key: "moc:deployment"
       }
 
-      clean_harvested = %{
-        category: :decision,
-        updated_at: @now,
-        tags: ["web-article"],
-        status: :published
-      }
-
-      assert mult(clean_harvested, []) > mult(killed_first_party, [])
+      assert mult(killed, []) < mult(live, [])
+      assert mult(hub, []) < mult(live, [])
     end
 
-    test "provenance is gated by the authority toggle like the rest of the prior" do
-      first_party = %{category: :finding, updated_at: @now, tags: [], status: :published}
-      harvested = %{category: :finding, updated_at: @now, tags: ["book-abc"], status: :published}
-
-      assert mult(first_party, authority?: false) == mult(harvested, authority?: false)
+    test "the removed functions are gone, not merely unused" do
+      refute function_exported?(RankingPriors, :provenance_authority, 1),
+             "provenance_authority/1 is back — the prior it computes is the one that was removed"
     end
   end
 end

--- a/test/loopctl/knowledge/ranking_priors_test.exs
+++ b/test/loopctl/knowledge/ranking_priors_test.exs
@@ -387,7 +387,17 @@ defmodule Loopctl.Knowledge.RankingPriorsTest do
     end
 
     test "the removed functions are gone, not merely unused" do
-      refute function_exported?(RankingPriors, :provenance_authority, 1),
+      # NEVER use function_exported?/3 here: it answers false for an UNLOADED module, so it
+      # passes vacuously whenever this test runs before anything else touches RankingPriors
+      # (a line-filtered run, or an unlucky within-module shuffle). Load first, read the
+      # export list, and keep the positive control so the guard cannot go silently inert.
+      Code.ensure_loaded!(RankingPriors)
+      exports = RankingPriors.__info__(:functions)
+
+      assert {:authority_factor, 4} in exports,
+             "positive control failed — this guard is not reading a real export list"
+
+      refute {:provenance_authority, 1} in exports,
              "provenance_authority/1 is back — the prior it computes is the one that was removed"
     end
   end

--- a/test/loopctl/knowledge/ranking_priors_test.exs
+++ b/test/loopctl/knowledge/ranking_priors_test.exs
@@ -401,4 +401,48 @@ defmodule Loopctl.Knowledge.RankingPriorsTest do
              "provenance_authority/1 is back — the prior it computes is the one that was removed"
     end
   end
+
+  describe "#654 the hub demotion needs its signal on EVERY ranking-fed lane" do
+    # `moc_hub?/1` fails OPEN on a missing `:idempotency_key`, so a lane whose select omits
+    # it stops demoting hubs on that lane ALONE — invisibly, because fusion unions the lane
+    # maps and a hub some OTHER lane also returned keeps the key. Only lane-ONLY candidates
+    # lose the demotion, which is exactly the set each lane exists to add (a MOC hub links
+    # to every member, so it is the likeliest graph-only candidate there is). No behavioural
+    # test can see that, so anchor to the SELECT SOURCE of every lane feeding
+    # `apply_ranking_priors_fused/2`.
+    @ranking_lanes [
+      {"lib/loopctl/knowledge.ex", "def search_keyword(tenant_id, query_string, opts) do"},
+      {"lib/loopctl/knowledge.ex",
+       "defp hydrate_semantic_pool(tenant_id, pool_rows, status, opts, limit, offset) do"},
+      {"lib/loopctl/knowledge.ex",
+       "def semantic_results_query(tenant_id, query_embedding, opts) do"},
+      {"lib/loopctl/knowledge.ex",
+       "defp fetch_graph_lane_articles(tenant_id, ranked_ids, status) do"},
+      {"lib/loopctl/knowledge/vector_search.ex",
+       "defp dimension_pool_select(query, :semantic) do"},
+      {"lib/loopctl/knowledge/vector_search.ex", "defp pool_select(base, :semantic, target) do"}
+    ]
+
+    test "every lane select projects idempotency_key" do
+      for {path, head} <- @ranking_lanes do
+        source = File.read!(path)
+
+        # Positive control: a renamed or moved lane fails LOUDLY here instead of passing
+        # vacuously on a substring that no longer exists.
+        assert String.contains?(source, head),
+               "#{path}: lane head moved, re-anchor this guard -- #{head}"
+
+        body =
+          source
+          |> String.split(head, parts: 2)
+          |> List.last()
+          |> String.split(~r/\n  end\n/, parts: 2)
+          |> hd()
+
+        assert String.contains?(body, "idempotency_key:"),
+               "#{path}: #{head} does not project idempotency_key -- RankingPriors fails " <>
+                 "open, so a MOC hub seen ONLY on this lane keeps its full fused score"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Owner decision, 2026-08-21. **Ranking must not key on how a document got in.**

`Loopctl.Knowledge.RankingPriors` carried two provenance priors:

- **`@source_authority`** — a `source_type` table, "human/reviewed provenance over raw automated ingests".
- **`@first_party_authority` / `@third_party_authority`** (#251) — a first-party/third-party split keyed on the sourcers' capture tags (`book-`/`url-`/`yt-`/`doc-` plus `web-article`/`newsletter`/`inbox-harvest`/`youtube`/`document`/`book`), described in its own comment as "the single strongest measured signal in this table."

Both are removed. `authority_factor/4` now reads `:category` alone; `provenance_authority/1` is gone.

## Why

Mark's reasoning, which outlives any measurement:

> If we heavily favor the internally produced knowledge, we would never learn anything new and unexpectedly useful. Besides, agents improve and I don't want less intelligent agents to decide what to pick for more intelligent future agents. I want the decision of what knowledge to use and how to combine it to be done on the receiving side.

Two failure modes that argument names and no measurement catches: a provenance prior is a **closed loop** (demote unread material → it stays unread → cite the ratio as proof) and a **ratchet** (a weight shipped once by one model constrains every future receiver regardless of how much more capable it is).

The prior's own evidence also failed on checking. It cited a **26.7x per-article read rate** — a statistic whose denominator is the harvest's own volume (~96% of the corpus), so it falls ~1/N mechanically whatever the material is worth. The measure that actually answers *"is this material worse?"* is surfaced-to-opened conversion, and nobody had taken it. Measured over the whole history of `article_access_events`, using the prior's **own** discriminator, stratified by rank to remove position bias:

| rank | first-party (+0.5) | third-party (0.0) |
|---|---|---|
| 1 | 8.30% (6,144) | 4.48% (3,304) |
| 2 | 3.91% (5,390) | 2.75% (3,927) |
| 3 | 2.57% (5,167) | 2.41% (4,019) |
| 4 | 1.95% (4,916) | **1.96%** (3,477) |
| 5 | 1.57% (4,774) | **1.74%** (3,455) |

Converged by rank 3, inverted by rank 4. The residual top-of-list gap is partly the prior marking its own homework: it lifted first-party into the positions where conversion is highest, and that conversion then read as evidence for the prior. The discriminator's verification had gone stale too — justified as marking "98.5% of the June harvest and 0.4% of the pre-June curated set", it was 82,851 / 3,562 in August.

## Kept deliberately, so this is a rule and not a mood

- **Relevance itself** (RRF over the lanes) — that *is* the retrieval, not a prior.
- **Deliberate editorial acts** — `verdict-kill`, `:superseded`, curation. Someone judged the content on its merits.
- **Form, not origin** — the MOC-hub demotion. A navigation stub is not an answer whoever generated it.
- **`@category_authority`** — kept by explicit owner decision on the same date: a category is an editorial classification, not an ingestion method.

## Read this before trusting the eval

`mix loopctl.retrieval.eval` reports **`+0.000` on every golden question**, status OK, no winners, no losers — and that green is **near-vacuous for this change**. Only **1 of 124** docs in `priv/retrieval_eval/golden.jsonl` carries a harvest marker, and **none** carry a `source_type`, so the gate had almost nothing to see. No baseline change was needed and none was made (avoiding the re-baseline anti-pattern entirely).

The real guard is `test/loopctl/knowledge/ranking_priors_test.exs` — "provenance priors are GONE" — and it is **mutation-verified**: sneaking a provenance term back into `authority_factor/4` fails it, while removing `@category_authority` or the dead-doctrine demotion fails different tests, so the guard is specific rather than blanket.

## Where the decision is recorded

Previously it lived only in `claude-config`'s `CLAUDE.md` — not where anyone editing `RankingPriors` would look. Now: a long note above `@kill_tag` in `ranking_priors.ex`, this repo's `CLAUDE.md`, and the `knowledge-wiki` skill. Each states **what would overturn it**: the owner saying so, or a conversion measurement that is rank-stratified, uses a discriminator verified against the *current* corpus, and still shows a durable gap. Reads-per-article is not that measurement.

Stale comments in `knowledge.ex` and `vector_search.ex` that pointed at the removed prior are corrected; `source_type` stays projected because `ArticleJSON` surfaces it, but it is no longer a ranking input.

**Operator impact:** results may reorder on near-ties only — both priors were bounded tie-breakers at strength 0.05 (~2.5% edge, unable to flip a cross-lane consensus winner). No migration, no configuration change, no baseline change.

`mix precommit` green at commit: 7784 tests, 0 failures.
