### PR TITLE
Scrub the four docs that still describe the removed provenance prior as live

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -997,20 +997,25 @@ config :loopctl, :knowledge_reranker, Loopctl.Knowledge.Reranker.Noop
 # truth Loopctl.Knowledge.RankingPriors.recency_decay/2 — applied as the BOUNDED factor
 # `1 - w + w*decay` on the fused score. Default weight 0.3 matches knowledge_context.
 config :loopctl, :knowledge_recency_weight, 0.3
-# Source-authority prior: toggle + magnitude. The factor is
-# `clamp(1 + strength * (category_weight + source_type_weight + provenance_weight), 0.9, 1.1)`.
-# The provenance term (#251) separates first-party knowledge from third-party HARVESTED
-# material by the structural capture tag a sourcer stamps (`book-`/`url-`/`yt-`/`doc-`
-# prefixes and the bare kind tags) — `source_type` cannot, because ~98% of the corpus
-# carries a NULL one. It earns its place: measured 2026-08-11, first-party articles are read
-# 26.7x more per article than harvested ones (389.7 vs 14.6 reads per 1k), and are 4% of the
-# corpus but 53% of the reads. The weight is deliberately far smaller than that ratio —
-# priors break near-ties here, they do not dominate relevance. Because every
-# category/source_type/provenance weight is >= 0 and strength is >= 0, `1 + strength*(sum)` is
-# always >= 1.0 — so the 0.9 floor is UNREACHABLE and the EFFECTIVE range is [1.0, 1.1].
+# Category-authority prior: toggle + magnitude. The factor is
+# `clamp(1 + strength * category_weight, 0.9, 1.1)`.
+#
+# It keys on `category` and NOTHING ELSE. Both PROVENANCE terms — the `source_type` table
+# and the first-party/third-party split keyed on the sourcers' capture tags (#251) — were
+# REMOVED on 2026-08-21 by owner decision: ranking must not key on how a document got in.
+# This comment used to re-argue that prior on its merits, citing a 26.7x reads-per-article
+# gap. Do not restore either the term or the argument — that statistic carries the harvest's
+# own volume in its denominator (~96% of the corpus), so it falls ~1/N mechanically, and
+# rank-stratified surfaced-to-opened conversion converged by rank 3 and INVERTED by rank 4.
+# The full reasoning, and what would have to be true to bring a provenance term back, is the
+# long note above `@kill_tag` in Loopctl.Knowledge.RankingPriors.
+#
+# Because every category weight is >= 0 and strength is >= 0, `1 + strength*cat` is always
+# >= 1.0 — so the 0.9 floor is UNREACHABLE and the EFFECTIVE range is
+# `[1.0, 1 + strength*max_cat]`, i.e. 1.05 at the default strength 0.05.
 # The band is one-sided BY DESIGN: authority only ever BOOSTS a higher-authority doc; it
 # never demotes a low-authority raw note below neutral (demotion comes solely from the
-# separate verdict-kill / :superseded 0.5 factor). The weight tables live in
+# separate verdict-kill / :superseded 0.5 factor). The weight table lives in
 # Loopctl.Knowledge.RankingPriors. Small and clamped so it only re-ranks near-ties (RRF
 # ties by construction) and can never flip a cross-lane-consensus winner (~2x a single-lane
 # hit). verdict-kill ideas and :superseded articles are demoted regardless of this toggle.

--- a/docs/runbooks/retrieval_eval.md
+++ b/docs/runbooks/retrieval_eval.md
@@ -371,7 +371,8 @@ re-baselining on pg16.
 
 ### #471 re-baseline: the priors are a like-for-like improvement (no accepted regression)
 
-The #471 ranking priors (recency + source/category authority) ship **default-on in every
+The #471 ranking priors (recency + category authority — the source_type/provenance half was
+removed on 2026-08-21 by owner decision) ship **default-on in every
 env** (`config/config.exs`: `knowledge_recency_weight` 0.3, `knowledge_authority_prior_enabled`
 true, `knowledge_authority_strength` 0.05 — no `test.exs` override). golden_v2 also adds one
 new question (`q-recency-fusion`) that exercises the recency prior directly.

--- a/lib/loopctl/knowledge/consolidation.ex
+++ b/lib/loopctl/knowledge/consolidation.ex
@@ -1252,7 +1252,9 @@ defmodule Loopctl.Knowledge.Consolidation do
   # The pass runs as the SYSTEM. It holds no agent identity, so it can never be the owner
   # that `Knowledge`'s read paths let through; "not visible to this caller" is total here,
   # not conditional. Same `COALESCE(..., 'shared')` spelling as those paths
-  # (`knowledge.ex:5902` and friends) so an article with no `visibility` key stays in scope.
+  # (`knowledge.ex:7293` and friends) so an article with no `visibility` key stays in scope.
+  # NOTE: `mix loopctl.check_skill_citations` scans docs, not `.ex` comments, so a cite like
+  # this one drifts silently — the previous anchor pointed at a bare `end`.
   defp shared_only(query), do: where(query, [a], shared_visibility(a.metadata))
 
   defp heavy_opts, do: HeavyRead.opts(@heavy_endpoint)

--- a/test/loopctl/knowledge_combined_priors_test.exs
+++ b/test/loopctl/knowledge_combined_priors_test.exs
@@ -1,5 +1,7 @@
 defmodule Loopctl.KnowledgeCombinedPriorsTest do
-  # #471 — recency + source-authority priors applied post-fusion in search_combined/3.
+  # #471 — recency + category-authority priors applied post-fusion in search_combined/3.
+  # The source_type/provenance half of the authority prior was removed 2026-08-21 (owner
+  # decision: ranking must not key on how a document got in).
   use Loopctl.DataCase, async: true
 
   setup :verify_on_exit!


### PR DESCRIPTION
Follow-up to #735, which removed both provenance ranking priors and scrubbed the prose inside its own write scope. These four sites sat outside it and still asserted the deleted terms. Found by that PR's review; owed as a follow-up rather than filed and forgotten.

**The one that matters is `config/config.exs`.** It is the file an operator reads when tuning `knowledge_authority_prior_enabled`, and it did not merely describe the old formula — it **re-argued the forbidden prior on its merits**, quoting the 26.7x reads-per-article gap as justification. A decision is only as durable as the places that could talk a later reader out of it, and that comment was the best remaining argument for undoing #735. It now states the category-only formula (`clamp(1 + strength * category_weight, 0.9, 1.1)`, effective range 1.05 at the default strength), says plainly that the argument was withdrawn and why, and points at the note above `@kill_tag` for what would have to be true to bring a provenance term back.

The other three are a line each:
- `docs/runbooks/retrieval_eval.md` and `test/loopctl/knowledge_combined_priors_test.exs` both still said "source authority".
- `lib/loopctl/knowledge/consolidation.ex` cited `knowledge.ex:5902` for a `COALESCE(..., 'shared')` fragment. **That anchor was never right** — on master before this work, line 5902 is a bare `end` — and `mix loopctl.check_skill_citations` only scans docs, so an `.ex` comment cite drifts with nothing to catch it. Repointed at `7293`, re-verified against master *after* #735 merged (the review's suggested anchor was computed pre-merge), and the comment now records that the checker does not cover this class.

Sequenced deliberately after #735: based on master, these comments would have claimed a removal that had not happened yet.

`mix precommit` green at commit. Documentation only — no behaviour change.