### PR TITLE
Promote the two capture families the idempotency census missed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@ All notable changes to loopctl are documented here.
   newline, so `idem-url-<digest>\n` stored as well-formed and a bare `email-<digest>\n` would
   have been promoted into the reserved namespace with the newline embedded — after which
   `--drop-legacy` deletes the only readable copy. Both anchors are now `\z`. **Operator impact:**
-  a create/update carrying such a tag is now rejected 422 instead of stored.
+  a create/update carrying a RESERVED `idem-...` tag with a trailing newline is now rejected
+  422 instead of stored. A tag without that prefix is unchanged at write time — the article
+  tag-format check still admits it — and now stays put instead of promoting dirty, so any
+  whitespace-dirty tags already in the corpus still need a cleanup pass.
 
 - **Search ranking no longer keys on a document's provenance.** `Loopctl.Knowledge.RankingPriors`
   carried two priors keyed on where a document came from — a `source_type` authority table and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,21 @@ All notable changes to loopctl are documented here.
 ### Changed
 
 - **`mix loopctl.reserve_idempotency_tags` now promotes the `email-` and `corpus-` families
-  too (#733).** The #583 census counted four families and missed two: `email-<sha1(id)[:12]>`
-  (claude-config's inbox sourcer) and `corpus-<sha1(member ids)>` (the corpus synthesizer) are
-  per-capture ids exactly like `url-`/`doc-`, but were absent from the legacy allowlist, so the
-  backfill would have left them in the ambiguous namespace forever. Both halves of the shape
-  rule are unchanged, so only the digest-shaped tags promote — a topical `email-marketing` is
-  still left alone. **Operator impact:** re-run the task; it is idempotent, so rows promoted by
-  an earlier run are untouched and only the newly-eligible families are written.
+  too (#733).** The #583 census missed both: bare `email-<sha1(message_id)[:12]>` (the inbox
+  sourcer) and `corpus-<sha1(member ids)>` (the corpus synthesizer) are per-capture ids exactly
+  like `url-`/`doc-`, but were absent from the legacy allowlist, so the backfill would have left
+  that backlog in the ambiguous namespace forever. Both halves of the shape rule are unchanged,
+  so only the digest-shaped tags promote — a topical `email-marketing` is still left alone, and
+  `yt-` and `art-` stay unpromotable (the note above `@legacy_families` records why).
+  **Operator impact:** re-run the task; it is idempotent, so rows promoted by an earlier run are
+  untouched and only the newly-eligible families are written.
 
-  `yt-` is deliberately still unpromotable, and NOT because a `yt-` tag is a grouping tag rather
-  than a capture id (that reasoning ruled out `url-` and `doc-` as well). A YouTube id is
-  case-sensitive base64url, never lowercase hex, so it can never satisfy `<digest>`; the YouTube
-  sourcer emits `idem-yt-<sha1(video_id)[:12]>` itself for that reason.
+- **A tag with a trailing newline no longer satisfies the idempotency-tag shape rules.** Both
+  matchers were anchored with `$`, which in PCRE also matches immediately before a trailing
+  newline, so `idem-url-<digest>\n` stored as well-formed and a bare `email-<digest>\n` would
+  have been promoted into the reserved namespace with the newline embedded — after which
+  `--drop-legacy` deletes the only readable copy. Both anchors are now `\z`. **Operator impact:**
+  a create/update carrying such a tag is now rejected 422 instead of stored.
 
 - **Search ranking no longer keys on a document's provenance.** `Loopctl.Knowledge.RankingPriors`
   carried two priors keyed on where a document came from — a `source_type` authority table and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to loopctl are documented here.
 
 ### Changed
 
+- **`mix loopctl.reserve_idempotency_tags` now promotes the `email-` and `corpus-` families
+  too (#733).** The #583 census counted four families and missed two: `email-<sha1(id)[:12]>`
+  (claude-config's inbox sourcer) and `corpus-<sha1(member ids)>` (the corpus synthesizer) are
+  per-capture ids exactly like `url-`/`doc-`, but were absent from the legacy allowlist, so the
+  backfill would have left them in the ambiguous namespace forever. Both halves of the shape
+  rule are unchanged, so only the digest-shaped tags promote — a topical `email-marketing` is
+  still left alone. **Operator impact:** re-run the task; it is idempotent, so rows promoted by
+  an earlier run are untouched and only the newly-eligible families are written.
+
+  `yt-` is deliberately still unpromotable, and NOT because a `yt-` tag is a grouping tag rather
+  than a capture id (that reasoning ruled out `url-` and `doc-` as well). A YouTube id is
+  case-sensitive base64url, never lowercase hex, so it can never satisfy `<digest>`; the YouTube
+  sourcer emits `idem-yt-<sha1(video_id)[:12]>` itself for that reason.
+
 - **Search ranking no longer keys on a document's provenance.** `Loopctl.Knowledge.RankingPriors`
   carried two priors keyed on where a document came from — a `source_type` authority table and a
   first-party/third-party split keyed on the sourcers' capture tags (`book-`/`url-`/`yt-`/`doc-`

--- a/lib/loopctl/knowledge/idempotency_tag.ex
+++ b/lib/loopctl/knowledge/idempotency_tag.ex
@@ -75,9 +75,13 @@ defmodule Loopctl.Knowledge.IdempotencyTag do
   # before.
   #
   # This is NOT the question `Loopctl.Knowledge.ProvenanceTags` answers — which
-  # prefixes are provenance rather than subject, for MOC hub eligibility and the
-  # search vector. The two lists diverge: `email`/`corpus` are here and not
-  # there, so do not read either as a mirror of the other.
+  # prefixes are provenance rather than subject. The lists diverge because the
+  # MATCHERS do: this one requires the digest half, so `email` is safe here and
+  # `email-marketing` is left alone, while `topical?/1` and the search vector
+  # match the bare PREFIX, where `email-`/`corpus-` would drop those real topics
+  # the way a broad `p-` drops `p-value`. Its shape-aware
+  # `admissible_suggestion?/1` has no such problem and DOES still admit a bare
+  # `email-<digest>` — closable only by the SPLIT its moduledoc prescribes.
   #
   # `email` and `corpus` joined in #733, after the #583 census missed them. Both
   # ARE per-capture ids — `email-<sha1(message_id)[:12]>` and

--- a/lib/loopctl/knowledge/idempotency_tag.ex
+++ b/lib/loopctl/knowledge/idempotency_tag.ex
@@ -62,39 +62,45 @@ defmodule Loopctl.Knowledge.IdempotencyTag do
   @family_source "[a-z][a-z0-9]{1,15}"
   @digest_source "[0-9a-f]{12}|[0-9a-f]{40}"
 
-  # The source families the harvest sourcers actually emit, mirroring the
-  # provenance-id prefixes `Loopctl.Workers.KnowledgeMocWorker` already excludes
-  # from hub topics. This allowlist constrains the LEGACY matcher only, and the
-  # asymmetry is the point: the reserved form is EXPLICITLY claimed by its
-  # writer, so any family is legal there, while the legacy form is INFERRED by
-  # shape from an unprefixed tag and so must be conservative. A bare
-  # `<anything>-<12|40 hex>` also describes a git object id (`commit-<sha>`), a
-  # timestamp (`release-202604150930`) and a zero-padded id
-  # (`ticket-000000012345`) — promoting one of those fabricates a capture
-  # identity, and `--drop-legacy` would then DELETE the original. An unknown
-  # family is left alone instead, which costs only an unpromoted tag that still
-  # reads exactly as it did before.
+  # The source families the harvest sourcers write per-capture ids under. This
+  # allowlist constrains the LEGACY matcher only, and the asymmetry is the
+  # point: the reserved form is EXPLICITLY claimed by its writer, so any family
+  # is legal there, while the legacy form is INFERRED by shape from an
+  # unprefixed tag and so must be conservative. A bare `<anything>-<12|40 hex>`
+  # also describes a git object id (`commit-<sha>`), a timestamp
+  # (`release-202604150930`) and a zero-padded id (`ticket-000000012345`) —
+  # promoting one of those fabricates a capture identity, and `--drop-legacy`
+  # would then DELETE the original. An unknown family is left alone instead,
+  # which costs only an unpromoted tag that still reads exactly as it did
+  # before.
   #
-  # `email` and `corpus` joined the list in #733, after the #583 census counted
-  # only four families and missed them. Both ARE per-capture ids emitted by real
-  # sourcers — `email-<sha1(message_id)[:12]>` from claude-config's
-  # `extract_email_bodies.py` and `corpus-<sha1(member ids)>` from
-  # `synthesize_batch.py` — so promoting them invents no identity, which is the
-  # only hazard this allowlist exists to prevent. The digest half still does the
-  # discriminating: of 1,496 live `email-` tags, 1,104 are digest-shaped capture
-  # ids and the other 392 are topical (`email-marketing`), and only the first
-  # group promotes.
+  # This is NOT the question `Loopctl.Knowledge.ProvenanceTags` answers — which
+  # prefixes are provenance rather than subject, for MOC hub eligibility and the
+  # search vector. The two lists diverge: `email`/`corpus` are here and not
+  # there, so do not read either as a mirror of the other.
+  #
+  # `email` and `corpus` joined in #733, after the #583 census missed them. Both
+  # ARE per-capture ids — `email-<sha1(message_id)[:12]>` and
+  # `corpus-<sha1(member ids)>` — so promoting them invents no identity, which
+  # is the only hazard this allowlist exists to prevent. Their sourcers
+  # (claude-config's `extract_email_bodies.py` and `synthesize_batch.py`) emit
+  # the RESERVED form directly now; what this list reaches is the BACKLOG of
+  # bare tags written before that, which nothing else can promote. The digest
+  # half still does the discriminating, so a topical `email-marketing` is left
+  # alone. `art` was assessed at the same time and deliberately left out:
+  # claude-config's `prune_kb.py` names it in a local list, but no sourcer emits
+  # an `art-` capture id, and a family with no writer is exactly the guess this
+  # allowlist refuses to make.
   #
   # `yt` is in the list but can never match, and the reason is worth keeping so
-  # it is not re-litigated: a YouTube id is case-sensitive base64url
-  # (`yt-04pdq5IppL8`), never lowercase hex, so no `yt-` tag in the corpus
-  # satisfies `<digest>` — 0 of 14,191, measured. claude-config#222 reached the
-  # same "leave `yt-` alone" answer from the WRONG premise, that a `yt-` tag is
-  # a grouping tag rather than a capture identity; every family here is carried
-  # by all the atomic notes of one capture, so that would rule out `url` and
-  # `doc` too. SHAPE is the reason, and it is why the YouTube sourcer emits its
-  # own reserved `idem-yt-<sha1(video_id)[:12]>` instead: the server can never
-  # reach that family from the bare form.
+  # it is not re-litigated: a YouTube id is ELEVEN characters and
+  # `@digest_source` accepts only 12 or 40, so length refuses every `yt-<id>`
+  # whatever its alphabet. claude-config#222 reached the same "leave `yt-` alone"
+  # answer from the WRONG premise, that a `yt-` tag is a grouping tag rather than
+  # a capture identity; every family here is carried by all the atomic notes of
+  # one capture, so that would rule out `url` and `doc` too. That is why the
+  # YouTube sourcer emits its own reserved `idem-yt-<sha1(video_id)[:12]>`: the
+  # server can never reach that family from the bare form.
   @legacy_families ~w(url doc book yt repo img file vid web email corpus)
   @legacy_family_source "(?:" <> Enum.join(@legacy_families, "|") <> ")"
 
@@ -104,9 +110,9 @@ defmodule Loopctl.Knowledge.IdempotencyTag do
                       "(" <>
                       @family_source <>
                       ")-(" <>
-                      @digest_source <> ")$"
+                      @digest_source <> ")\\z"
                   )
-  @legacy_regex Regex.compile!("^(" <> @legacy_family_source <> ")-(" <> @digest_source <> ")$")
+  @legacy_regex Regex.compile!("^(" <> @legacy_family_source <> ")-(" <> @digest_source <> ")\\z")
 
   @shape "#{@reserved_prefix}<family>-<digest>"
   @example "#{@reserved_prefix}url-7ebe1ca33431"

--- a/lib/loopctl/knowledge/idempotency_tag.ex
+++ b/lib/loopctl/knowledge/idempotency_tag.ex
@@ -74,7 +74,28 @@ defmodule Loopctl.Knowledge.IdempotencyTag do
   # identity, and `--drop-legacy` would then DELETE the original. An unknown
   # family is left alone instead, which costs only an unpromoted tag that still
   # reads exactly as it did before.
-  @legacy_families ~w(url doc book yt repo img file vid web)
+  #
+  # `email` and `corpus` joined the list in #733, after the #583 census counted
+  # only four families and missed them. Both ARE per-capture ids emitted by real
+  # sourcers — `email-<sha1(message_id)[:12]>` from claude-config's
+  # `extract_email_bodies.py` and `corpus-<sha1(member ids)>` from
+  # `synthesize_batch.py` — so promoting them invents no identity, which is the
+  # only hazard this allowlist exists to prevent. The digest half still does the
+  # discriminating: of 1,496 live `email-` tags, 1,104 are digest-shaped capture
+  # ids and the other 392 are topical (`email-marketing`), and only the first
+  # group promotes.
+  #
+  # `yt` is in the list but can never match, and the reason is worth keeping so
+  # it is not re-litigated: a YouTube id is case-sensitive base64url
+  # (`yt-04pdq5IppL8`), never lowercase hex, so no `yt-` tag in the corpus
+  # satisfies `<digest>` — 0 of 14,191, measured. claude-config#222 reached the
+  # same "leave `yt-` alone" answer from the WRONG premise, that a `yt-` tag is
+  # a grouping tag rather than a capture identity; every family here is carried
+  # by all the atomic notes of one capture, so that would rule out `url` and
+  # `doc` too. SHAPE is the reason, and it is why the YouTube sourcer emits its
+  # own reserved `idem-yt-<sha1(video_id)[:12]>` instead: the server can never
+  # reach that family from the bare form.
+  @legacy_families ~w(url doc book yt repo img file vid web email corpus)
   @legacy_family_source "(?:" <> Enum.join(@legacy_families, "|") <> ")"
 
   @reserved_regex Regex.compile!(
@@ -93,6 +114,15 @@ defmodule Loopctl.Knowledge.IdempotencyTag do
   @doc "The reserved tag prefix. Single source of truth for every derived form."
   @spec reserved_prefix() :: String.t()
   def reserved_prefix, do: @reserved_prefix
+
+  @doc """
+  The source families `legacy?/1` will promote from the bare form.
+
+  Exposed so callers and tests read the enforced list rather than restating it —
+  a second copy is how a family gets added here and silently missed there.
+  """
+  @spec legacy_families() :: [String.t()]
+  def legacy_families, do: @legacy_families
 
   @doc "Human-readable shape of a well-formed reserved tag."
   @spec shape() :: String.t()

--- a/test/loopctl/knowledge/idempotency_tag_test.exs
+++ b/test/loopctl/knowledge/idempotency_tag_test.exs
@@ -58,7 +58,8 @@ defmodule Loopctl.Knowledge.IdempotencyTagTest do
 
     test "never matches a genuine topical tag" do
       for tag <- ~w(url-design url-generation url-encoding url-routing
-                    url-normalization url-management doc-string book-review elixir) do
+                    url-normalization url-management doc-string book-review elixir
+                    email-marketing email-deliverability corpus-linguistics) do
         refute Tag.legacy?(tag), tag
       end
     end
@@ -86,8 +87,29 @@ defmodule Loopctl.Knowledge.IdempotencyTagTest do
     end
 
     test "matches every family the sourcers emit" do
-      for family <- ~w(url doc book yt repo img file vid web) do
+      for family <- Tag.legacy_families() do
         assert Tag.legacy?("#{family}-#{@hex12}"), family
+      end
+
+      # Named, not just looped: the loop above passes vacuously if a family is
+      # dropped from the allowlist, and #733 was filed because a family that was
+      # never in it went unpromoted for months.
+      for family <- ~w(url doc book repo email corpus) do
+        assert family in Tag.legacy_families(), family
+        assert Tag.legacy?("#{family}-#{@hex12}"), family
+      end
+    end
+
+    test "a real YouTube id can never be promoted from the bare form, `yt` allowlisted or not" do
+      # A YouTube id is case-sensitive base64url, never lowercase hex, so the
+      # digest half refuses it even though `yt` is an allowlisted family. This is
+      # why the sourcer emits `idem-yt-<sha1(video_id)[:12]>` itself — see the
+      # note above @legacy_families.
+      assert "yt" in Tag.legacy_families()
+
+      for id <- ~w(04pdq5IppL8 1Ty_MHZu9nM y-8QpYH4lL0 vSwumoSlZTo) do
+        refute Tag.legacy?("yt-#{id}"), id
+        assert Tag.promote("yt-#{id}") == :error, id
       end
     end
   end

--- a/test/loopctl/knowledge/idempotency_tag_test.exs
+++ b/test/loopctl/knowledge/idempotency_tag_test.exs
@@ -45,6 +45,9 @@ defmodule Loopctl.Knowledge.IdempotencyTagTest do
       refute Tag.well_formed?("idem-url-#{String.upcase(@hex12)}")
       refute Tag.well_formed?("url-#{@hex12}")
       refute Tag.well_formed?(nil)
+      # PCRE `$` also matches before a trailing newline, so the anchors are `\\z`:
+      # a whitespace-dirty tag must not store as well-formed.
+      refute Tag.well_formed?("idem-url-#{@hex12}\n")
     end
   end
 
@@ -87,24 +90,28 @@ defmodule Loopctl.Knowledge.IdempotencyTagTest do
     end
 
     test "matches every family the sourcers emit" do
-      for family <- Tag.legacy_families() do
-        assert Tag.legacy?("#{family}-#{@hex12}"), family
-      end
+      # Named literally and pinned in BOTH directions: a loop over
+      # `legacy_families/0` alone asserts the list against itself and so passes
+      # vacuously when a family is dropped, which is the half #733 was filed for.
+      families = ~w(url doc book yt repo img file vid web email corpus)
+      assert Enum.sort(Tag.legacy_families()) == Enum.sort(families)
 
-      # Named, not just looped: the loop above passes vacuously if a family is
-      # dropped from the allowlist, and #733 was filed because a family that was
-      # never in it went unpromoted for months.
-      for family <- ~w(url doc book repo email corpus) do
-        assert family in Tag.legacy_families(), family
+      for family <- families do
         assert Tag.legacy?("#{family}-#{@hex12}"), family
       end
     end
 
+    test "a trailing newline is not a legacy tag — it must not promote" do
+      dirty = "email-#{@hex12}\n"
+      refute Tag.legacy?(dirty)
+      assert Tag.promote(dirty) == :error
+      assert Tag.promote_tags([dirty], drop_legacy: true) == [dirty]
+    end
+
     test "a real YouTube id can never be promoted from the bare form, `yt` allowlisted or not" do
-      # A YouTube id is case-sensitive base64url, never lowercase hex, so the
-      # digest half refuses it even though `yt` is an allowlisted family. This is
-      # why the sourcer emits `idem-yt-<sha1(video_id)[:12]>` itself — see the
-      # note above @legacy_families.
+      # A YouTube id is ELEVEN characters and the digest half accepts only 12 or
+      # 40, so LENGTH refuses it even though `yt` is allowlisted — the alphabet
+      # never gets a say. See the note above @legacy_families.
       assert "yt" in Tag.legacy_families()
 
       for id <- ~w(04pdq5IppL8 1Ty_MHZu9nM y-8QpYH4lL0 vSwumoSlZTo) do


### PR DESCRIPTION
## What

Adds `email` and `corpus` to `Loopctl.Knowledge.IdempotencyTag`'s `@legacy_families`, so
`mix loopctl.reserve_idempotency_tags` can promote them; exposes `legacy_families/0` so the
test reads the enforced list instead of restating it; and records, above the attribute, why
`yt-` can never be promoted by shape.

Picked up from the loopctl#733 handoff, whose item 2 asked for this to be decided
deliberately rather than left as it was.

## Why these two and not others

A full census of every digest-shaped tag in the hosted corpus returns exactly six families:

| family | tag instances |
|---|---|
| doc | 40,064 |
| book | 18,410 |
| url | 9,063 |
| **email** | **1,104** |
| repo | 1,021 |
| **corpus** | **3** |

`email-<sha1(message_id)[:12]>` comes from claude-config's `extract_email_bodies.py` and
`corpus-<sha1(member ids)>` from `synthesize_batch.py`. Both are per-capture identities in
exactly the sense `url-` and `doc-` are, so promoting them invents no identity - which is the
only hazard the allowlist exists to prevent. With these two added, the allowlist covers 100%
of the capture ids that are actually in the corpus; there is no `commit-`, `ticket-` or
`release-` shaped tag anywhere in it, so the conservative half of the rule is preventive
rather than reactive, and stays.

Both halves of the shape rule are untouched, so the 392 topical `email-` tags in the corpus
(`email-marketing` and friends) are left exactly as they are.

## yt-

Stays unpromotable, and the note now records why, because the reason on file was wrong.
claude-config#222 argued a `yt-` tag is a grouping tag rather than a capture identity. That
is true of `url-` and `doc-` as well - every atomic note of one capture carries the tag in
all five sourcers - so it does not separate `yt-` from anything. The actual reason is shape:
a YouTube id is case-sensitive base64url, never lowercase hex, so 0 of 14,191 `yt-` tags in
the corpus can satisfy the digest half. That is why the sourcer emits its own reserved
`idem-yt-<sha1(video_id)[:12]>` - the server can never reach that family from the bare form.

A test now pins this with four real video ids.

## Review

Enhanced review ran on this branch (run wf_599f2de9-383): 13 raw findings, 9 confirmed, 10 fixed
across eef65ab and f0f7a5e. It caught two factual errors in the original commit's comments - the
sourcers emit the RESERVED form now, so this allowlist reaches the historical backlog rather than
new captures, and the yt- refusal is decided by LENGTH (11 characters against a 12-or-40 digest),
not by alphabet - plus a live-corpus tally that violated the no-inventory-counts rule, and a real
defect neither the change nor the census had touched: both matchers were anchored with a dollar
sign, which in PCRE also matches immediately before a trailing newline, so a dirty tag stored as
well-formed and a bare one would have promoted with the newline embedded. Both anchors are now
backslash-z.

Verified against the hosted corpus: zero whitespace-dirty tags exist in 86,426 articles, so the
anchor change is hardening with no effect on the backfill now running.

Four findings were out of scope for this branch's files and are being fixed on a follow-up
branch: Article's own tag pattern carries the same dollar-anchor hole and its declared mirror in
memory.ex must move with it, and ProvenanceTags' shape-aware admissible_suggestion? still admits
a bare email-digest capture id.

## Testing

`mix precommit` green (7,786 tests, 0 failures; format, credo --strict and dialyzer clean).

Mutation-verified rather than assumed: removing `email` from the allowlist fails
`idempotency_tag_test.exs:97`. The family loop is backed by six named assertions so dropping
a family fails a test instead of shrinking the loop to a vacuous pass.

## Operator impact

Re-run `mix loopctl.reserve_idempotency_tags --apply` after this merges. It is idempotent -
rows promoted by an earlier run are untouched, and only the ~1,107 newly-eligible
email/corpus articles are written.

Refs #733, #583.
