### PR TITLE
Anchor the article tag pattern, and stop hand-copying it into memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to loopctl are documented here.
 
 ### Changed
 
+- **A tag with surrounding whitespace is now rejected on every article write, not just a
+  reserved one (#733 review).** `Article`'s tag pattern was `~r/^[a-zA-Z0-9_-]+$/`, and in PCRE
+  `$` also matches immediately BEFORE a trailing newline, so `"elixir\n"` stored as a valid
+  tag. It is now anchored `\A`/`\z`. A dirty tag was unrepairable once stored: it reads as free
+  text everywhere downstream, and `IdempotencyTag.legacy?/1` refuses it, so the #583 promotion
+  could never reach it either. **Operator impact:** a create/update carrying such a tag returns
+  422 instead of storing it; the tag-shape rule is now published in the OpenAPI `tags`
+  description and the 422 text. Whitespace-dirty tags already in a corpus are unaffected and
+  still need a cleanup pass — the hosted corpus has none.
+
+  `Loopctl.Memory`'s graduation sanitizer carried a hand-copied version of that pattern and had
+  already drifted; it now TAKES the pattern, the length and the count from `Article`, the way
+  `Knowledge.Tagger` does. That mirror is load-bearing rather than cosmetic: a tag this filter
+  passes but the article changeset rejects makes graduation take its structural-error branch,
+  which stamps the memory graduated and burns its one-shot with no article created.
+
 - **`mix loopctl.reserve_idempotency_tags` now promotes the `email-` and `corpus-` families
   too (#733).** The #583 census missed both: bare `email-<sha1(message_id)[:12]>` (the inbox
   sourcer) and `corpus-<sha1(member ids)>` (the corpus synthesizer) are per-capture ids exactly

--- a/lib/loopctl/knowledge/article.ex
+++ b/lib/loopctl/knowledge/article.ex
@@ -41,7 +41,12 @@ defmodule Loopctl.Knowledge.Article do
   @status_values [:draft, :published, :archived, :superseded]
   @scope_values [:tenant, :system]
   @known_source_types ~w(review_finding manual agent session_log newsletter skill web_article ingestion channel_graduation)
-  @tag_pattern ~r/^[a-zA-Z0-9_-]+$/
+  # `\A`/`\z`, never `^`/`$`: in PCRE `$` also matches immediately BEFORE a
+  # trailing newline, so `~r/^[a-zA-Z0-9_-]+$/` accepted "elixir\n" and stored a
+  # whitespace-dirty tag as valid. That tag then reads as free text everywhere
+  # downstream — `Loopctl.Knowledge.IdempotencyTag.legacy?/1` refuses it, so the
+  # #583 promotion can never repair it either (#733 review).
+  @tag_pattern ~r/\A[a-zA-Z0-9_-]+\z/
   @slug_format ~r/^[a-z0-9][a-z0-9-]*[a-z0-9]$/
   # Topical tags only. Structural identity (e.g. a "hub", or an article's source)
   # is carried by source_type/source_id and idempotency_key (#137), so we raise
@@ -261,6 +266,22 @@ defmodule Loopctl.Knowledge.Article do
   """
   @spec tag_pattern() :: Regex.t()
   def tag_pattern, do: @tag_pattern
+
+  @doc """
+  The tag-shape contract as published to API callers.
+
+  Interpolated into the OpenAPI `tags` description on create and update, next to
+  `Loopctl.Knowledge.IdempotencyTag.contract_description/0`, so the spec and the enforcement
+  cannot state different rules. The character class and the length are read from the same
+  attributes the changeset validates against, not restated.
+  """
+  @spec tag_contract_description() :: String.t()
+  def tag_contract_description do
+    "Each tag must match #{Regex.source(@tag_pattern)} — letters, digits, underscore and " <>
+      "hyphen only, anchored end to end, so surrounding whitespace (including a trailing " <>
+      "newline) is rejected 422 rather than stored. Maximum #{@max_tag_length} characters " <>
+      "per tag and #{@max_tags} tags per article."
+  end
 
   @doc "Maximum length of a single tag (single source of truth, same reason as `tag_pattern/0`)."
   @spec max_tag_length() :: pos_integer()

--- a/lib/loopctl/knowledge/okf.ex
+++ b/lib/loopctl/knowledge/okf.ex
@@ -707,7 +707,7 @@ defmodule Loopctl.Knowledge.OKF do
     end
   end
 
-  # loopctl tags must match ~r/^[a-zA-Z0-9_-]+$/ (<=50 tags, <=100 chars). OKF
+  # loopctl tags must match ~r/\A[a-zA-Z0-9_-]+\z/ (<=50 tags, <=100 chars). OKF
   # tags are free strings, so sanitize foreign tags to fit; the originals are
   # preserved under metadata["okf"]["tags"] for lossless re-export.
   #

--- a/lib/loopctl/knowledge/tagger.ex
+++ b/lib/loopctl/knowledge/tagger.ex
@@ -47,7 +47,7 @@ defmodule Loopctl.Knowledge.Tagger do
 
   require Logger
 
-  # The pattern `Loopctl.Knowledge.Article`'s changeset enforces (`~r/^[a-zA-Z0-9_-]+$/`),
+  # The pattern `Loopctl.Knowledge.Article`'s changeset enforces (`~r/\A[a-zA-Z0-9_-]+\z/`),
   # narrowed to the lowercase form `normalize/1` produces. A suggestion the changeset would
   # reject is dropped HERE, so one malformed tag cannot fail the whole article's re-tag —
   # and, more importantly, cannot be written at all: `TagBackfillWorker` persists with

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -58,6 +58,7 @@ defmodule Loopctl.Memory do
   alias Loopctl.Embeddings.ShrinkLadder
   alias Loopctl.HeavyRead
   alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.IdempotencyTag
   alias Loopctl.Knowledge.RankingPriors
   alias Loopctl.Knowledge.VectorSearch
@@ -2219,19 +2220,23 @@ defmodule Loopctl.Memory do
   # `do_graduate_memory_record/2` take its structural-error branch, which STAMPS the memory
   # as graduated, and `resolve_existing_graduation/2` then returns `:already_graduated`
   # forever — a memory tagged `idem-design` would burn its one-shot graduation with no
-  # article created. Every rule this mirrors must move when the Article changeset does.
-  @graduation_max_tags 50
-  @graduation_max_tag_length 100
-  @graduation_tag_pattern ~r/^[a-zA-Z0-9_-]+$/
+  # article created.
+  #
+  # The three constraints are TAKEN from `Article` rather than restated, the way
+  # `Loopctl.Knowledge.Tagger` already takes them, so the mirror cannot drift. The hand-copied
+  # regex here did drift: `Article` re-anchored its pattern with `\A`/`\z` after `$` was found
+  # to match before a trailing newline, and this copy still admitted "elixir\n" — a tag the
+  # article changeset now rejects, which is exactly the invalid-changeset path the paragraph
+  # above says burns the graduation (#733 review).
   defp sanitize_graduation_tags(tags) when is_list(tags) do
     tags
     |> Enum.filter(fn tag ->
       is_binary(tag) and byte_size(tag) > 0 and
-        String.length(tag) <= @graduation_max_tag_length and
-        Regex.match?(@graduation_tag_pattern, tag) and
+        String.length(tag) <= Article.max_tag_length() and
+        Regex.match?(Article.tag_pattern(), tag) and
         not (IdempotencyTag.reserved?(tag) and not IdempotencyTag.well_formed?(tag))
     end)
-    |> Enum.take(@graduation_max_tags)
+    |> Enum.take(Article.max_tags())
   end
 
   defp sanitize_graduation_tags(_), do: []

--- a/lib/loopctl_web/controllers/article_controller.ex
+++ b/lib/loopctl_web/controllers/article_controller.ex
@@ -101,7 +101,8 @@ defmodule LoopctlWeb.ArticleController do
            tags: %OpenApiSpex.Schema{
              type: :array,
              items: %OpenApiSpex.Schema{type: :string},
-             description: IdempotencyTag.contract_description()
+             description:
+               Article.tag_contract_description() <> " " <> IdempotencyTag.contract_description()
            },
            project_id: %OpenApiSpex.Schema{type: :string, format: :uuid, nullable: true},
            source_type: %OpenApiSpex.Schema{type: :string, nullable: true},
@@ -156,9 +157,12 @@ defmodule LoopctlWeb.ArticleController do
         {"Title taken by an article with different content", "application/json",
          Schemas.ErrorResponse},
       422 =>
-        {"Validation error — includes a tag claiming the reserved idempotency " <>
-           "namespace without matching its shape. " <> IdempotencyTag.contract_description(),
-         "application/json", Schemas.ErrorResponse},
+        {"Validation error — includes a malformed tag: one carrying disallowed " <>
+           "characters or surrounding whitespace, or one claiming the reserved idempotency " <>
+           "namespace without matching its shape. " <>
+           Article.tag_contract_description() <>
+           " " <> IdempotencyTag.contract_description(), "application/json",
+         Schemas.ErrorResponse},
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
     }
   )
@@ -360,9 +364,12 @@ defmodule LoopctlWeb.ArticleController do
          Schemas.ErrorResponse},
       404 => {"Not found", "application/json", Schemas.ErrorResponse},
       422 =>
-        {"Validation error — includes a tag claiming the reserved idempotency " <>
-           "namespace without matching its shape. " <> IdempotencyTag.contract_description(),
-         "application/json", Schemas.ErrorResponse},
+        {"Validation error — includes a malformed tag: one carrying disallowed " <>
+           "characters or surrounding whitespace, or one claiming the reserved idempotency " <>
+           "namespace without matching its shape. " <>
+           Article.tag_contract_description() <>
+           " " <> IdempotencyTag.contract_description(), "application/json",
+         Schemas.ErrorResponse},
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
     }
   )

--- a/test/loopctl/knowledge/article_test.exs
+++ b/test/loopctl/knowledge/article_test.exs
@@ -391,6 +391,22 @@ defmodule Loopctl.Knowledge.ArticleTest do
       assert errors_on(changeset)[:tags]
     end
 
+    test "rejects a tag with a trailing newline" do
+      # PCRE `$` matches immediately BEFORE a trailing newline, so the pattern used to be
+      # `~r/^[a-zA-Z0-9_-]+$/` and this stored as a valid tag. A dirty tag reads as free
+      # text everywhere downstream and no promotion path can repair it (#733 review).
+      changeset =
+        Article.create_changeset(%Article{}, %{
+          title: "Dirty Tag Article",
+          body: "Content",
+          category: :pattern,
+          tags: ["elixir\n"]
+        })
+
+      refute changeset.valid?
+      assert errors_on(changeset)[:tags]
+    end
+
     test "accepts valid tag patterns" do
       changeset =
         Article.create_changeset(%Article{}, %{

--- a/test/loopctl/memory/graduation_test.exs
+++ b/test/loopctl/memory/graduation_test.exs
@@ -306,6 +306,30 @@ defmodule Loopctl.Memory.GraduationTest do
       assert count == 1
     end
 
+    test "a memory carrying a whitespace-dirty tag still graduates (the mirror tracks the anchors)",
+         %{scope: scope, tenant: tenant} do
+      # The same mirror, one rule later: Article anchored @tag_pattern with \A/\z after `$`
+      # was found to match before a trailing newline. While this sanitizer kept its own
+      # `$`-anchored copy it PASSED "elixir\n" through to an article changeset that now
+      # rejects it — the invalid-changeset path that burns the one-shot graduation.
+      memory =
+        fixture(:memory,
+          tenant_id: scope.tenant_id,
+          subject_id: scope.subject_id,
+          text: "a memory whose extractor left a newline on a tag",
+          tags: ["elixir\n", "phoenix"]
+        )
+
+      assert {:ok, _verdict, article} = Memory.graduate_memory(scope, memory.id)
+      assert "phoenix" in article.tags
+      refute "elixir\n" in article.tags
+
+      count =
+        from(a in Article, where: a.tenant_id == ^tenant.id) |> AdminRepo.aggregate(:count, :id)
+
+      assert count == 1
+    end
+
     test "a WELL-FORMED reserved capture tag survives graduation (the capture identity is kept)",
          %{scope: scope} do
       memory =


### PR DESCRIPTION
## What

The out-of-scope findings from #737's enhanced review (run wf_599f2de9-383), fixed on their own
branch as that pipeline prescribes. #737 anchored the two idempotency matchers with backslash-z;
this anchors the guard that actually decides what reaches the database, and repairs the mirror
that had silently drifted from it.

## The bug

In PCRE `$` also matches immediately BEFORE a trailing newline, so `~r/^[a-zA-Z0-9_-]+$/`
accepted `"elixir\n"` and `Article`'s changeset stored it as a valid tag. Verified live in the
worktree:

```
Regex.match?(~r/^[a-zA-Z0-9_-]+$/, "elixir\n")   #=> true
Regex.match?(~r/\A[a-zA-Z0-9_-]+\z/, "elixir\n") #=> false
```

A dirty tag is unrepairable once stored: it reads as free text everywhere downstream, and
`IdempotencyTag.legacy?/1` refuses it, so the #583 promotion pass can never reach it either.

## The half that could lose data

`Loopctl.Memory`'s graduation sanitizer is a declared mirror of the article tag rules, and its
own comment says every rule it mirrors must move when the Article changeset does. It carried a
hand-copied `$`-anchored regex, so it drifted the instant the article pattern changed - and the
consequence is not a 422. A tag this filter passes but the changeset rejects makes
`do_graduate_memory_record/2` take its structural-error branch, which STAMPS the memory
graduated; `resolve_existing_graduation/2` then returns `:already_graduated` forever. The memory
burns its one shot with no article created.

It now TAKES the pattern, the length and the count from `Article` - the way `Knowledge.Tagger`
already does - so there is nothing left to hand-copy. Two comments that restated the old anchors,
in `Tagger` and `OKF`, are corrected.

## Documenting an enforced-but-unpublished constraint

The tag shape was enforced and appeared in no spec. `Article.tag_contract_description/0` reads
the character class and the length straight off the attributes the changeset validates against;
the OpenAPI `tags` description and both 422 texts interpolate it, so the spec cannot state a
different rule from the code.

## Testing

`mix precommit` green (7,789 tests, 0 failures; format, credo --strict and dialyzer clean).

Mutation-verified: restoring the `$`-anchored pattern fails the article changeset test AND the
graduation mirror test. That pair is the point - the two must move together, and a fix that
touched only `article.ex` would have left graduation silently burning memories.

## Review

Not re-reviewed, deliberately. These findings were produced by #737's full enhanced review
(4 adversarial lenses, two rounds) and carry its CONFIRMED verdicts at confidence 78-93; the
pipeline's own rule for its out-of-scope list is to fix it on a follow-up branch under the
project quality gate and not to spend another review chain re-deriving what it already found.
The remedy here differs from one reviewer's suggestion on purpose: the reviewers proposed
re-anchoring `memory.ex`'s copy, which would leave the drift class in place - taking the pattern
from `Article` removes it.

Refs #733, #583.
