### PR TITLE
Split the provenance list so a shared prefix can be matched by shape

### DIFF
--- a/lib/loopctl/knowledge/provenance_tags.ex
+++ b/lib/loopctl/knowledge/provenance_tags.ex
@@ -51,6 +51,28 @@ defmodule Loopctl.Knowledge.ProvenanceTags do
               chapter- part-
             ) ++ [IdempotencyTag.reserved_prefix()]
 
+  # Families whose bare prefix is SHARED with genuine subject tags, so they may only ever be
+  # matched SHAPE-AWARE. `email-marketing` and `corpus-linguistics` are real topics, and
+  # `@prefixes` is matched by bare `String.starts_with?/2` in `topical?/1` and `sql_pattern/0`
+  # — putting `email-`/`corpus-` there would drop those the way a broad `p-` drops `p-value`,
+  # which is the hazard the comment above names. `admissible_suggestion?/1` is the one consumer
+  # that already discriminates by shape (`opaque_id?/2`), so it is the one that can carry them.
+  #
+  # This is the SPLIT the moduledoc prescribes rather than a widening of one list, and it is
+  # not hypothetical: #733 made `email`/`corpus` capture families in `IdempotencyTag`, and
+  # `admissible_suggestion?("email-a1b2c3d4e5f6")` returned true — so the re-tagger could mint
+  # one article's capture identity onto an unrelated one, which is exactly what makes the
+  # "have I captured this source?" query answer about the wrong row.
+  #
+  # The SEARCH-VECTOR half of the same gap is deliberately not closed here. A bare
+  # `email-<digest>` still indexes the lexeme `email`, an ordinary query word — but that
+  # pattern is baked into a generated column, so closing it costs a migration, and the operator
+  # pass that removes the cause outright is already sequenced: `mix
+  # loopctl.reserve_idempotency_tags --apply --drop-legacy` deletes the bare tags once their
+  # reserved counterparts are in place, and `idem-` is excluded above. Reach for the migration
+  # only if that pass is abandoned.
+  @opaque_only_prefixes ~w(email- corpus-)
+
   # Whole tags that describe an article's FORMAT or SOURCE TYPE rather than its subject.
   # Distinct from the prefixes above, which are opaque per-source ids: these are ordinary
   # words that are simply not what an article is ABOUT. `KnowledgeMocWorker` has excluded
@@ -95,11 +117,14 @@ defmodule Loopctl.Knowledge.ProvenanceTags do
   Whether a GENERATED tag may be WRITTEN at all. NOT `topical?/1` — hub eligibility drops a
   whole prefixed class for free and admission cannot (see `Tagger.merge/2`), so a prefix
   disqualifies only before an OPAQUE id (`url-42516bb95051`); `structural/0` is whole-word.
+
+  Because it discriminates by SHAPE it also carries `@opaque_only_prefixes` — the families
+  whose bare prefix is shared with real subject tags and so cannot go in `@prefixes` at all.
   """
   @spec admissible_suggestion?(String.t()) :: boolean()
   def admissible_suggestion?(tag) when is_binary(tag) do
     tag not in @structural and not String.starts_with?(tag, IdempotencyTag.reserved_prefix()) and
-      not Enum.any?(@prefixes, &opaque_id?(tag, &1))
+      not Enum.any?(@prefixes ++ @opaque_only_prefixes, &opaque_id?(tag, &1))
   end
 
   def admissible_suggestion?(_tag), do: false
@@ -112,6 +137,15 @@ defmodule Loopctl.Knowledge.ProvenanceTags do
     Regex.match?(~r/^\d+(-\d+)*$/, s) or Regex.match?(~r/^[0-9a-f]{8,}$/, s) or
       (Regex.match?(~r/^[0-9a-z]{6,}$/, s) and Regex.match?(~r/\d/, s))
   end
+
+  @doc """
+  Prefixes matched only SHAPE-AWARE, by `admissible_suggestion?/1`.
+
+  Deliberately NOT part of `prefixes/0`: that list is matched bare, and these prefixes are
+  shared with genuine subject tags (`email-marketing`). See the note above the attribute.
+  """
+  @spec opaque_only_prefixes() :: [String.t()]
+  def opaque_only_prefixes, do: @opaque_only_prefixes
 
   @doc "The provenance/chunk-coordinate tag prefixes, each including its trailing hyphen."
   @spec prefixes() :: [String.t()]

--- a/test/loopctl/knowledge/provenance_tags_test.exs
+++ b/test/loopctl/knowledge/provenance_tags_test.exs
@@ -83,4 +83,45 @@ defmodule Loopctl.Knowledge.ProvenanceTagsTest do
       refute Regex.match?(regex, "docker")
     end
   end
+
+  describe "opaque_only_prefixes/0 — the families that may only be matched by shape" do
+    test "a bare capture id under one of them is refused admission" do
+      # #733: `email`/`corpus` became capture families in IdempotencyTag, and the re-tagger
+      # would otherwise mint one article's capture identity onto an unrelated one — after
+      # which the "have I captured this source?" query answers about the wrong row.
+      for prefix <- ProvenanceTags.opaque_only_prefixes() do
+        refute ProvenanceTags.admissible_suggestion?("#{prefix}a1b2c3d4e5f6"), prefix
+      end
+
+      # Named, so shrinking the list to [] cannot make the loop above pass vacuously.
+      assert Enum.sort(ProvenanceTags.opaque_only_prefixes()) == ~w(corpus- email-)
+    end
+
+    test "the genuine subject tags that share those prefixes are untouched" do
+      # This is WHY they are a separate list: `@prefixes` is matched bare, so putting
+      # `email-` there would drop these the way a broad `p-` drops `p-value`.
+      for tag <- ~w(email-marketing email-deliverability corpus-linguistics) do
+        assert ProvenanceTags.admissible_suggestion?(tag), tag
+        assert ProvenanceTags.topical?(tag), tag
+      end
+
+      {:ok, regex} = Regex.compile(ProvenanceTags.sql_pattern())
+
+      for tag <- ~w(email-marketing corpus-linguistics) do
+        refute Regex.match?(regex, tag), tag
+      end
+    end
+
+    test "they are deliberately absent from the bare-matched list" do
+      for prefix <- ProvenanceTags.opaque_only_prefixes() do
+        refute prefix in ProvenanceTags.prefixes(), prefix
+      end
+    end
+
+    test "the reserved counterpart is still refused by prefix alone" do
+      # Once the --drop-legacy pass runs, this is the only form left, and `idem-` covers it.
+      refute ProvenanceTags.admissible_suggestion?("idem-email-a1b2c3d4e5f6")
+      refute ProvenanceTags.topical?("idem-email-a1b2c3d4e5f6")
+    end
+  end
 end


### PR DESCRIPTION
## What

The last out-of-scope finding from #737's enhanced review. `ProvenanceTags` keeps one list of
provenance prefixes matched by bare `String.starts_with?/2`, which works because every prefix in
it is opaque — nothing real is called `url-something`. #733 made `email` and `corpus` capture
families, and those two are not like that.

## The defect, run rather than read

```
email-a1b2c3d4e5f6      topical?=true   admissible?=true
corpus-a1b2c3d4e5f6     topical?=true   admissible?=true
url-a1b2c3d4e5f6        topical?=false  admissible?=false
email-marketing         topical?=true   admissible?=true
idem-email-a1b2c3d4e5f6 topical?=false  admissible?=false
```

`admissible_suggestion?/1` returning true for a bare capture id means `Tagger.merge/2` can mint
one article's capture identity onto an unrelated article — after which the "have I captured this
source?" query answers about the wrong row. That is the corruption the reservation exists to
prevent, one layer down.

## Why the obvious fix is wrong

The round-1 reviewer suggested adding `email-`/`corpus-` to `@prefixes`. That list is matched
BARE, so it would also have dropped `email-marketing`, `email-deliverability` and
`corpus-linguistics` from hub eligibility and from the search vector — the way a broad `p-`
drops `p-value`, which is the hazard the module's own comment names. The corpus holds 392
topical `email-` tags.

So this is the split the moduledoc already prescribes for exactly this case: *"If they need to
diverge, split this into two lists rather than widening one."* `admissible_suggestion?/1` is the
one consumer that discriminates by shape (`opaque_id?/2`), so it is the one that can carry a
shared prefix safely. The new list is used there and nowhere else.

## What is deliberately left open

The search-vector half. A bare `email-<digest>` still indexes the lexeme `email`, an ordinary
query word, on ~1,104 rows. That pattern is baked into a generated column, so closing it costs a
migration — and the operator pass that removes the cause outright is already sequenced:
`--drop-legacy` deletes the bare tags once their reserved counterparts exist, and `idem-` is
already excluded by prefix. The reason is recorded at the attribute so the next reader does not
have to re-derive it, and the migration is the answer only if that pass is abandoned.

## Testing

`mix precommit` green (7,793 tests, 0 failures). Mutation-verified: emptying the new list fails
the suite. The list is pinned by name as well as looped over, so shrinking it cannot pass
vacuously.

No CHANGELOG entry — nothing here is operator-facing: no env var, no deploy step, no changed API
constraint.

## Review

Not re-reviewed, deliberately, for the same reason as #738: this finding came from #737's full
enhanced review and that pipeline's rule for its out-of-scope list is to fix it on a follow-up
branch under the project quality gate rather than spend another review chain on it.

Refs #733, #583.
