### PR TITLE
Correct a comment that #739 made false the same day it was written

### DIFF
--- a/lib/loopctl/knowledge/idempotency_tag.ex
+++ b/lib/loopctl/knowledge/idempotency_tag.ex
@@ -80,8 +80,9 @@ defmodule Loopctl.Knowledge.IdempotencyTag do
   # `email-marketing` is left alone, while `topical?/1` and the search vector
   # match the bare PREFIX, where `email-`/`corpus-` would drop those real topics
   # the way a broad `p-` drops `p-value`. Its shape-aware
-  # `admissible_suggestion?/1` has no such problem and DOES still admit a bare
-  # `email-<digest>` — closable only by the SPLIT its moduledoc prescribes.
+  # `admissible_suggestion?/1` has no such problem, so that is where those two
+  # families live over there: `ProvenanceTags.opaque_only_prefixes/0`, the SPLIT
+  # its moduledoc prescribes, added in #739.
   #
   # `email` and `corpus` joined in #733, after the #583 census missed them. Both
   # ARE per-capture ids — `email-<sha1(message_id)[:12]>` and


### PR DESCRIPTION
The note above the legacy-families attribute said `ProvenanceTags.admissible_suggestion?/1`
"DOES still admit a bare `email-<digest>` — closable only by the SPLIT its moduledoc
prescribes". #739 did that split, so the sentence describes a gap that no longer exists and
points at no fix. It now names where those two families actually live on the other side:
`ProvenanceTags.opaque_only_prefixes/0`.

Comment only, no behaviour change. Caught while reconciling the three merged PRs from the #733
handoff against each other — this repo spends whole PRs scrubbing docs that describe removed
behaviour as live (#736), and this one was forty minutes old.

Quality gate green via the commit hook (7,793 tests, 0 failures).

Refs #733, #739.
