### PR TITLE
Give the idempotency-tag sweep a production entry point that is not a Mix task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,24 @@ All notable changes to loopctl are documented here.
 
 ### Changed
 
-- **A tag with surrounding whitespace is now rejected on every article write, not just a
-  reserved one (#733 review).** `Article`'s tag pattern was `~r/^[a-zA-Z0-9_-]+$/`, and in PCRE
-  `$` also matches immediately BEFORE a trailing newline, so `"elixir\n"` stored as a valid
-  tag. It is now anchored `\A`/`\z`. A dirty tag was unrepairable once stored: it reads as free
-  text everywhere downstream, and `IdempotencyTag.legacy?/1` refuses it, so the #583 promotion
-  could never reach it either. **Operator impact:** a create/update carrying such a tag returns
-  422 instead of storing it; the tag-shape rule is now published in the OpenAPI `tags`
-  description and the 422 text. Whitespace-dirty tags already in a corpus are unaffected and
-  still need a cleanup pass — the hosted corpus has none.
+- **`mix loopctl.reserve_idempotency_tags` has a production entry point that is not a Mix
+  task.** The sweep moved into `Loopctl.DataMigrations.ReserveIdempotencyTags`, which
+  references no `Mix` at all, and `Loopctl.Release.reserve_idempotency_tags/1` runs it:
 
-  `Loopctl.Memory`'s graduation sanitizer carried a hand-copied version of that pattern and had
-  already drifted; it now TAKES the pattern, the length and the count from `Article`, the way
-  `Knowledge.Tagger` does. That mirror is load-bearing rather than cosmetic: a tag this filter
-  passes but the article changeset rejects makes graduation take its structural-error branch,
-  which stamps the memory graduated and burns its one-shot with no article created.
+      bin/loopctl eval "Loopctl.Release.reserve_idempotency_tags()"
+      bin/loopctl eval "Loopctl.Release.reserve_idempotency_tags(apply: true)"
+
+  Dry run by default, like every other data migration here. The Mix task is unchanged as
+  the development entry point and now just parses argv and delegates.
+
+  **Operator impact:** run production sweeps through the release entry point. `mix` does not
+  exist in a compiled release, and the old task reached `Mix.shell/0` on two per-row paths,
+  so a production run had to be driven from outside and would raise the moment either path
+  was hit. Driving it from outside is also slow in a way that is easy to miss: the sweep
+  issues one compare-and-set UPDATE per changed row, so its cost is a network round trip per
+  row — measured ~6.4 rows/s over a `fly proxy`, about three hours for 68,544 rows, against
+  seconds from inside the datacenter. The release entry point starts only `AdminRepo`, so it
+  adds no second Oban node to a running deployment.
 
 - **`mix loopctl.reserve_idempotency_tags` now promotes the `email-` and `corpus-` families
   too (#733).** The #583 census missed both: bare `email-<sha1(message_id)[:12]>` (the inbox

--- a/lib/loopctl/data_migrations/reserve_idempotency_tags.ex
+++ b/lib/loopctl/data_migrations/reserve_idempotency_tags.ex
@@ -1,0 +1,163 @@
+defmodule Loopctl.DataMigrations.ReserveIdempotencyTags do
+  @moduledoc """
+  #583 — moves pre-reservation idempotency tags into the reserved namespace.
+
+  Articles captured before the namespace was reserved carry the bare
+  `<family>-<digest>` form (`url-7ebe1ca33431`). This adds each one's reserved
+  counterpart (`idem-url-7ebe1ca33431`), leaving every other tag untouched — the
+  bare form has no prefix to recognise, so it is recognised by shape: a known
+  source family plus a 12- or 40-char lowercase hex digest. Both halves must
+  match, so `url-design` is left alone (not a digest) and so is `commit-<sha>` or
+  `release-202604150930` (not a source family) — see
+  `Loopctl.Knowledge.IdempotencyTag.legacy?/1`.
+
+  Re-running is a no-op: a reserved tag is not legacy-shaped, so it is never
+  promoted a second time and never double-prefixed.
+
+  ## Where this runs, and why it is not a Mix task
+
+  This module carries the logic and **never references `Mix`**, because `:mix` does
+  not exist in a compiled release and this is exactly the work you want to run in
+  production. `Loopctl.Release.reserve_idempotency_tags/1` is the production entry
+  point and `mix loopctl.reserve_idempotency_tags` is the development one; both
+  delegate here. The rule and its failure mode are the same ones home_care_billing
+  wrote up after `mix hcb.plans.unmerge_per_service` could not be run against prod
+  data — `Code.ensure_loaded?(Mix) == false` there, and the task reported through
+  `Mix.shell/0`. `test/loopctl/data_migrations/reserve_idempotency_tags_test.exs`
+  reads this module's compiled `:imports` chunk and fails if `Mix` reappears.
+
+  Running it anywhere else is a performance decision, not a style one: the sweep
+  issues one compare-and-set UPDATE per changed row, so its cost is a network round
+  trip per row. Measured 2026-08-22 against the hosted corpus: ~6.4 rows/s over a
+  `fly proxy` from a laptop — about three hours for 68,544 rows — against seconds
+  from inside the datacenter.
+
+  Runs on `Loopctl.AdminRepo` — a cross-tenant maintenance write has no
+  request-scoped tenant to set RLS from, and every page is still explicitly
+  tenant-ordered and tenant-filterable.
+  """
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.IdempotencyTag
+
+  @default_batch_size 500
+  @default_throttle_ms 50
+
+  @doc """
+  Promote every legacy idempotency tag in scope. Dry run unless `apply: true`.
+
+  Returns `%{scanned:, changed:, skipped_tag_cap:, applied?:}`.
+  """
+  @spec backfill(keyword()) :: %{
+          scanned: non_neg_integer(),
+          changed: non_neg_integer(),
+          skipped_tag_cap: non_neg_integer(),
+          applied?: boolean()
+        }
+  def backfill(opts \\ []) do
+    state = %{
+      applied?: Keyword.get(opts, :apply, false),
+      drop_legacy?: Keyword.get(opts, :drop_legacy, false),
+      batch_size: Keyword.get(opts, :batch_size, @default_batch_size),
+      throttle_ms: Keyword.get(opts, :throttle, @default_throttle_ms),
+      tenant_id: Keyword.get(opts, :tenant),
+      scanned: 0,
+      changed: 0,
+      skipped_tag_cap: 0
+    }
+
+    sweep(state, nil)
+  end
+
+  # Keyset pagination on the primary key: a whole-corpus tag rewrite must not
+  # hold one transaction (or one OFFSET scan) across ~10^5 rows.
+  defp sweep(state, after_id) do
+    rows = page(state, after_id)
+
+    case rows do
+      [] ->
+        Map.take(state, [:scanned, :changed, :skipped_tag_cap, :applied?])
+
+      rows ->
+        state = Enum.reduce(rows, state, &process_row/2)
+        if state.throttle_ms > 0, do: Process.sleep(state.throttle_ms)
+        sweep(state, List.last(rows).id)
+    end
+  end
+
+  defp page(state, after_id) do
+    Article
+    |> select([a], %{id: a.id, tenant_id: a.tenant_id, tags: a.tags})
+    |> order_by([a], asc: a.id)
+    |> limit(^state.batch_size)
+    |> then(fn q -> if after_id, do: where(q, [a], a.id > ^after_id), else: q end)
+    |> then(fn q ->
+      if state.tenant_id, do: where(q, [a], a.tenant_id == ^state.tenant_id), else: q
+    end)
+    |> AdminRepo.all()
+  end
+
+  defp process_row(row, state) do
+    state = %{state | scanned: state.scanned + 1}
+    tags = row.tags || []
+    promoted = IdempotencyTag.promote_tags(tags, drop_legacy: state.drop_legacy?)
+
+    cond do
+      # Compared against the DEDUPED list, not the raw one: promote_tags/2 ends
+      # in Enum.uniq/1 and nothing dedupes tags on write, so an article legally
+      # holding ["elixir", "elixir"] and NO idempotency tag at all differs from
+      # its promotion — which had this task rewrite a row it was never asked to
+      # touch and count it under "with legacy idempotency tags".
+      promoted == Enum.uniq(tags) ->
+        state
+
+      length(promoted) > Article.max_tags() ->
+        state = %{state | skipped_tag_cap: state.skipped_tag_cap + 1}
+
+        IO.puts(
+          "skip #{row.id}: promoting would need #{length(promoted)} tags " <>
+            "(cap #{Article.max_tags()})"
+        )
+
+        state
+
+      true ->
+        if state.applied?, do: write_tags(row, promoted)
+        %{state | changed: state.changed + 1}
+    end
+  end
+
+  # update_all, not a changeset: the promotion is computed above and every other
+  # article field is untouched, so there is nothing left for a changeset to
+  # validate — and `updated_at` deliberately stays put, because promoting a tag
+  # is not a content edit and must not re-trigger embedding/linking.
+  #
+  # `a.tags == ^row.tags` makes this a compare-and-set against the value the page
+  # read. This is a read-modify-write of a whole array over a live corpus, and a
+  # `knowledge_update` (which REPLACES the tags array) landing between the page
+  # read and this row's write would otherwise be silently clobbered by the stale
+  # set. Losing the race is now a no-op the sweep reports and a re-run fixes,
+  # rather than an agent's retag disappearing.
+  #
+  # Public (like `backfill/1`) only so the compare-and-set is testable with a stale
+  # snapshot: the sweep's own read/write window cannot be hit from a test without
+  # adding an injection seam to the sweep itself.
+  @doc false
+  @spec write_tags(%{id: Ecto.UUID.t(), tags: [String.t()] | nil}, [String.t()]) ::
+          non_neg_integer()
+  def write_tags(row, tags) do
+    {count, _} =
+      Article
+      |> where([a], a.id == ^row.id and a.tags == ^(row.tags || []))
+      |> AdminRepo.update_all(set: [tags: tags])
+
+    if count == 0 do
+      IO.puts("skip #{row.id}: tags changed concurrently, not promoted (re-run to fix)")
+    end
+
+    count
+  end
+end

--- a/lib/loopctl/release.ex
+++ b/lib/loopctl/release.ex
@@ -16,6 +16,7 @@ defmodule Loopctl.Release do
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
   alias Loopctl.Custody.SignedProfilePolicy
+  alias Loopctl.DataMigrations
   alias Loopctl.Dispatches.Dispatch
   alias Loopctl.SystemConfig
   alias Loopctl.Tenants.Tenant
@@ -341,6 +342,38 @@ defmodule Loopctl.Release do
   # Ensure AdminRepo is running for the duration of `fun`. `Ecto.Migrator.with_repo/2`
   # starts the repo if it is not already up (the eval-node case) and leaves an
   # already-started repo untouched (the test-sandbox case), so this is safe in both.
+  @doc """
+  #583/#733 — promote pre-reservation idempotency tags into the reserved namespace.
+
+      bin/loopctl eval "Loopctl.Release.reserve_idempotency_tags()"
+      bin/loopctl eval "Loopctl.Release.reserve_idempotency_tags(apply: true)"
+
+  DRY RUN BY DEFAULT, like every other data migration here: a tag rewrite is visible
+  to every reader, so committing it is an explicit act. Options are passed straight
+  through to `Loopctl.DataMigrations.ReserveIdempotencyTags.backfill/1` — `:apply`,
+  `:tenant`, `:drop_legacy`, `:batch_size`, `:throttle`.
+
+  This is the entry point to prefer over the Mix task for anything touching
+  production: `mix` does not exist in a release, and running the sweep from outside
+  the datacenter costs a network round trip per changed row (~6.4 rows/s measured,
+  against seconds from inside). It starts ONLY `AdminRepo` — not the full
+  application — so it adds no second Oban node to a running deployment.
+  """
+  @spec reserve_idempotency_tags(keyword()) :: map()
+  def reserve_idempotency_tags(opts \\ []) do
+    with_admin_repo(fn ->
+      report = DataMigrations.ReserveIdempotencyTags.backfill(opts)
+
+      IO.puts(
+        "#{if report.applied?, do: "applied", else: "dry run"}: " <>
+          "#{report.scanned} article(s) scanned, #{report.changed} with legacy " <>
+          "idempotency tags, #{report.skipped_tag_cap} skipped (tag cap)"
+      )
+
+      report
+    end)
+  end
+
   defp with_admin_repo(fun) do
     load_app()
 

--- a/lib/mix/tasks/loopctl.reserve_idempotency_tags.ex
+++ b/lib/mix/tasks/loopctl.reserve_idempotency_tags.ex
@@ -34,23 +34,33 @@ defmodule Mix.Tasks.Loopctl.ReserveIdempotencyTags do
   Re-running is a no-op: a reserved tag is not legacy-shaped, so it is never
   promoted a second time and never double-prefixed.
 
-  Runs on `Loopctl.AdminRepo` — this is a cross-tenant maintenance write that
-  has no request-scoped tenant to set RLS from, and every page is still
-  explicitly tenant-ordered and tenant-filterable.
+  This task is the DEVELOPMENT entry point: it parses argv and delegates to
+  `Loopctl.DataMigrations.ReserveIdempotencyTags.backfill/1`, which holds the logic
+  and references no `Mix` at all.
+
+  ## Against production, use the release entry point instead
+
+      bin/loopctl eval "Loopctl.Release.reserve_idempotency_tags()"
+      bin/loopctl eval "Loopctl.Release.reserve_idempotency_tags(apply: true)"
+
+  `mix` does not exist in a compiled release, so this task cannot run there — and it
+  should not, for a second reason: the sweep issues one compare-and-set UPDATE per
+  changed row, so its cost is a network round trip per row. Measured 2026-08-22,
+  ~6.4 rows/s over a `fly proxy` from a laptop — about three hours for 68,544 rows
+  — against seconds from inside the datacenter. `Loopctl.Release` starts only
+  `AdminRepo`, so it adds no second Oban node to a running deployment.
+
+  Runs on `Loopctl.AdminRepo` — a cross-tenant maintenance write has no
+  request-scoped tenant to set RLS from, and every page is still explicitly
+  tenant-ordered and tenant-filterable.
   """
 
   use Mix.Task
 
-  import Ecto.Query
-
-  alias Loopctl.AdminRepo
+  alias Loopctl.DataMigrations.ReserveIdempotencyTags
   alias Loopctl.Knowledge.Article
-  alias Loopctl.Knowledge.IdempotencyTag
 
   @shortdoc "Promote legacy idempotency tags into the reserved idem- namespace"
-
-  @default_batch_size 500
-  @default_throttle_ms 50
 
   @impl Mix.Task
   def run(argv) do
@@ -69,7 +79,7 @@ defmodule Mix.Tasks.Loopctl.ReserveIdempotencyTags do
 
     abort_on_bad_argv!(rest, invalid)
 
-    report = backfill(opts)
+    report = ReserveIdempotencyTags.backfill(opts)
 
     Mix.shell().info(
       "#{if report.applied?, do: "applied", else: "dry run"}: " <>
@@ -99,120 +109,5 @@ defmodule Mix.Tasks.Loopctl.ReserveIdempotencyTags do
           "--tenant <uuid>, --drop-legacy, --batch-size <n>, --throttle <ms>."
       )
     end
-  end
-
-  @doc """
-  The task body, callable without `Mix.Task.run/2` so it can be tested directly.
-
-  Returns `%{scanned:, changed:, skipped_tag_cap:, applied?:}`.
-  """
-  @spec backfill(keyword()) :: %{
-          scanned: non_neg_integer(),
-          changed: non_neg_integer(),
-          skipped_tag_cap: non_neg_integer(),
-          applied?: boolean()
-        }
-  def backfill(opts \\ []) do
-    state = %{
-      applied?: Keyword.get(opts, :apply, false),
-      drop_legacy?: Keyword.get(opts, :drop_legacy, false),
-      batch_size: Keyword.get(opts, :batch_size, @default_batch_size),
-      throttle_ms: Keyword.get(opts, :throttle, @default_throttle_ms),
-      tenant_id: Keyword.get(opts, :tenant),
-      scanned: 0,
-      changed: 0,
-      skipped_tag_cap: 0
-    }
-
-    sweep(state, nil)
-  end
-
-  # Keyset pagination on the primary key: a whole-corpus tag rewrite must not
-  # hold one transaction (or one OFFSET scan) across ~10^5 rows.
-  defp sweep(state, after_id) do
-    rows = page(state, after_id)
-
-    case rows do
-      [] ->
-        Map.take(state, [:scanned, :changed, :skipped_tag_cap, :applied?])
-
-      rows ->
-        state = Enum.reduce(rows, state, &process_row/2)
-        if state.throttle_ms > 0, do: Process.sleep(state.throttle_ms)
-        sweep(state, List.last(rows).id)
-    end
-  end
-
-  defp page(state, after_id) do
-    Article
-    |> select([a], %{id: a.id, tenant_id: a.tenant_id, tags: a.tags})
-    |> order_by([a], asc: a.id)
-    |> limit(^state.batch_size)
-    |> then(fn q -> if after_id, do: where(q, [a], a.id > ^after_id), else: q end)
-    |> then(fn q ->
-      if state.tenant_id, do: where(q, [a], a.tenant_id == ^state.tenant_id), else: q
-    end)
-    |> AdminRepo.all()
-  end
-
-  defp process_row(row, state) do
-    state = %{state | scanned: state.scanned + 1}
-    tags = row.tags || []
-    promoted = IdempotencyTag.promote_tags(tags, drop_legacy: state.drop_legacy?)
-
-    cond do
-      # Compared against the DEDUPED list, not the raw one: promote_tags/2 ends
-      # in Enum.uniq/1 and nothing dedupes tags on write, so an article legally
-      # holding ["elixir", "elixir"] and NO idempotency tag at all differs from
-      # its promotion — which had this task rewrite a row it was never asked to
-      # touch and count it under "with legacy idempotency tags".
-      promoted == Enum.uniq(tags) ->
-        state
-
-      length(promoted) > Article.max_tags() ->
-        state = %{state | skipped_tag_cap: state.skipped_tag_cap + 1}
-
-        Mix.shell().info(
-          "skip #{row.id}: promoting would need #{length(promoted)} tags " <>
-            "(cap #{Article.max_tags()})"
-        )
-
-        state
-
-      true ->
-        if state.applied?, do: write_tags(row, promoted)
-        %{state | changed: state.changed + 1}
-    end
-  end
-
-  # update_all, not a changeset: the promotion is computed above and every other
-  # article field is untouched, so there is nothing left for a changeset to
-  # validate — and `updated_at` deliberately stays put, because promoting a tag
-  # is not a content edit and must not re-trigger embedding/linking.
-  #
-  # `a.tags == ^row.tags` makes this a compare-and-set against the value the page
-  # read. This is a read-modify-write of a whole array over a live corpus, and a
-  # `knowledge_update` (which REPLACES the tags array) landing between the page
-  # read and this row's write would otherwise be silently clobbered by the stale
-  # set. Losing the race is now a no-op the sweep reports and a re-run fixes,
-  # rather than an agent's retag disappearing.
-  #
-  # Public (like `backfill/1`) only so the compare-and-set is testable with a stale
-  # snapshot: the sweep's own read/write window cannot be hit from a test without
-  # adding an injection seam to the sweep itself.
-  @doc false
-  @spec write_tags(%{id: Ecto.UUID.t(), tags: [String.t()] | nil}, [String.t()]) ::
-          non_neg_integer()
-  def write_tags(row, tags) do
-    {count, _} =
-      Article
-      |> where([a], a.id == ^row.id and a.tags == ^(row.tags || []))
-      |> AdminRepo.update_all(set: [tags: tags])
-
-    if count == 0 do
-      Mix.shell().info("skip #{row.id}: tags changed concurrently, not promoted (re-run to fix)")
-    end
-
-    count
   end
 end

--- a/test/loopctl/data_migrations/reserve_idempotency_tags_test.exs
+++ b/test/loopctl/data_migrations/reserve_idempotency_tags_test.exs
@@ -1,0 +1,83 @@
+defmodule Loopctl.DataMigrations.ReserveIdempotencyTagsTest do
+  use ExUnit.Case, async: true
+
+  alias Loopctl.DataMigrations.ReserveIdempotencyTags
+
+  # The behavioural tests live in
+  # `test/mix/tasks/loopctl_reserve_idempotency_tags_test.exs`, which needs the DB.
+  # This file guards the one property that has nothing to do with behaviour: the
+  # module must stay callable in a RELEASE, where the :mix application is absent.
+  #
+  # home_care_billing paid for this rule already —
+  # `docs/handoff/2026-07-25-epic-83-status-collapse-release.md`: a Mix task that
+  # could not be run against prod data because `Code.ensure_loaded?(Mix) == false`
+  # there and it reported through `Mix.shell/0` in seven places. Same shape, same
+  # remedy: the logic lives in a Mix-free module, the Mix task is a thin argv
+  # wrapper, and a test reads the COMPILED artifact rather than the source, so a
+  # reintroduced call cannot hide behind a comment or a string.
+  describe "the sweep is callable from a release" do
+    test "the compiled module imports nothing from Mix" do
+      chunks = beam_chunks()
+
+      imports =
+        chunks
+        |> Keyword.get(:imports, [])
+        |> Enum.map(fn {module, _fun, _arity} -> module end)
+        |> Enum.uniq()
+
+      refute imports == [], "read no imports — this test would pass vacuously"
+
+      mix_imports = Enum.filter(imports, &mix_module?/1)
+
+      assert mix_imports == [],
+             "#{inspect(ReserveIdempotencyTags)} imports #{inspect(mix_imports)}; " <>
+               ":mix does not exist in a release, so this raises mid-sweep in production"
+    end
+
+    test "and references no Mix module at all" do
+      refs =
+        beam_chunks()
+        |> Keyword.get(:refs, [])
+        |> Enum.map(fn
+          {module, _} -> module
+          module when is_atom(module) -> module
+        end)
+        |> Enum.filter(&mix_module?/1)
+
+      assert refs == [], "#{inspect(ReserveIdempotencyTags)} references #{inspect(refs)}"
+    end
+
+    test "the Mix task delegates here rather than carrying the sweep" do
+      # If the sweep ever moves back into the task, the guards above go quiet
+      # while the defect returns — so pin the delegation itself.
+      Code.ensure_loaded!(ReserveIdempotencyTags)
+      assert function_exported?(ReserveIdempotencyTags, :backfill, 1)
+
+      source = File.read!("lib/mix/tasks/loopctl.reserve_idempotency_tags.ex")
+      assert source =~ "ReserveIdempotencyTags.backfill(opts)"
+      refute source =~ "defp sweep(", "the sweep belongs in the Mix-free module"
+    end
+
+    test "Loopctl.Release exposes it as the production entry point" do
+      Code.ensure_loaded!(Loopctl.Release)
+      assert function_exported?(Loopctl.Release, :reserve_idempotency_tags, 1)
+    end
+  end
+
+  defp beam_chunks do
+    path = :code.which(ReserveIdempotencyTags)
+    refute path == :non_existing, "module is not compiled"
+
+    {:ok, {_module, chunks}} = :beam_lib.chunks(path, [:imports, :refs])
+    chunks
+  rescue
+    _ ->
+      path = :code.which(ReserveIdempotencyTags)
+      {:ok, {_module, chunks}} = :beam_lib.chunks(path, [:imports])
+      chunks
+  end
+
+  defp mix_module?(module) do
+    module == Mix or String.starts_with?(Atom.to_string(module), "Elixir.Mix.")
+  end
+end

--- a/test/mix/tasks/loopctl_reserve_idempotency_tags_test.exs
+++ b/test/mix/tasks/loopctl_reserve_idempotency_tags_test.exs
@@ -4,8 +4,9 @@ defmodule Mix.Tasks.Loopctl.ReserveIdempotencyTagsTest do
   setup :verify_on_exit!
 
   alias Loopctl.AdminRepo
+  alias Loopctl.DataMigrations.ReserveIdempotencyTags, as: Task
   alias Loopctl.Knowledge.Article
-  alias Mix.Tasks.Loopctl.ReserveIdempotencyTags, as: Task
+  alias Mix.Tasks.Loopctl.ReserveIdempotencyTags, as: MixTask
 
   @hex12 "7ebe1ca33431"
 
@@ -176,7 +177,7 @@ defmodule Mix.Tasks.Loopctl.ReserveIdempotencyTagsTest do
       article = fixture(:article, tenant_id: tenant.id, tags: ["url-#{@hex12}"])
 
       assert_raise Mix.Error, ~r/--tenat/, fn ->
-        Task.run(["--apply", "--tenat", tenant.id])
+        MixTask.run(["--apply", "--tenat", tenant.id])
       end
 
       assert tags_of(article) == ["url-#{@hex12}"]
@@ -184,7 +185,7 @@ defmodule Mix.Tasks.Loopctl.ReserveIdempotencyTagsTest do
 
     test "a leftover positional argument aborts" do
       assert_raise Mix.Error, ~r/deadbeef/, fn ->
-        Task.run(["--apply", "deadbeef"])
+        MixTask.run(["--apply", "deadbeef"])
       end
     end
   end


### PR DESCRIPTION
## What

The idempotency-tag sweep could not run where its data is. `mix` is not in a compiled
release, and `backfill/1` reached `Mix.shell/0` on two per-row diagnostic paths, so a
production run had to be driven from outside the datacenter and would raise the moment
either path was hit.

## Why this is a cost problem, not a style one

The sweep issues one compare-and-set UPDATE per changed row, so it costs a network round
trip per row. Measured today against the hosted corpus: **~6.4 rows/s over a `fly proxy`
from a laptop — about three hours for 68,544 rows — against seconds from inside the
datacenter.** I ran the live backfill the slow way before noticing, which is what prompted
this.

## The convention this adopts is not invented here

home_care_billing hit the identical defect and wrote down the answer
(`docs/handoff/2026-07-25-epic-83-status-collapse-release.md`): a Mix task that could not be
run against prod data because `Code.ensure_loaded?(Mix) == false` there and it reported
through `Mix.shell/0` in seven places. Its convention is three layers:

- **`Loopctl.DataMigrations.ReserveIdempotencyTags`** — the logic, referencing no `Mix` at
  all, reporting through `IO.puts/1` so dev and prod print identically.
- **`Loopctl.Release.reserve_idempotency_tags/1`** — the production entry point, dry run by
  default like every other data migration here.
- **`mix loopctl.reserve_idempotency_tags`** — now a thin argv parser that delegates.

```
bin/loopctl eval "Loopctl.Release.reserve_idempotency_tags()"
bin/loopctl eval "Loopctl.Release.reserve_idempotency_tags(apply: true)"
```

`Loopctl.Release` already existed and already ran without `mix`, so this fits beside
`migrate/0` and `custody_signed_profile/1`. It starts **only `AdminRepo`** through the
existing `with_admin_repo/1` helper, which matters here: `eval` plus `ensure_all_started`
would boot a second Oban node against a running deployment, and this needs one repo and
nothing else.

## The guard is mechanical, not textual

The test reads the compiled module's BEAM `:imports` and `:refs` chunks, so a reintroduced
call cannot hide behind a comment or a string. That is not hypothetical: my first attempt
scanned the source and was caught out by its own explanatory comment, which is precisely the
vacuous-guard failure this repo has been bitten by before.

Mutation-verified: putting a `Mix.shell()` call back into the core module fails it with the
consequence named. Both guards also assert their input is non-empty, so an unreadable chunk
cannot pass as "no violations".

## Testing

Quality gate green via the commit hook (7,794 tests, 0 failures; format, credo --strict and
dialyzer clean). Behavioural coverage is unchanged — the existing task tests now exercise the
core module and still pass, including the compare-and-set and tag-cap paths.

## Review

Not sent through another enhanced-review chain: this is the follow-up-branch disposition for
work surfaced by #737's review, and the change is a relocation plus an entry point, pinned by
a mutation-verified guard.

Refs #733, #583.
