### PR TITLE
Stop a test naming a real machine as "another machine"

### DIFF
--- a/test/mix/tasks/loopctl_enrich_search_events_test.exs
+++ b/test/mix/tasks/loopctl_enrich_search_events_test.exs
@@ -75,6 +75,11 @@ defmodule Mix.Tasks.Loopctl.EnrichSearchEventsTest do
     to_string(name)
   end
 
+  # A host that is guaranteed NOT to be this machine, on every machine. Built from the
+  # local hostname so it cannot accidentally coincide with it, and suffixed .invalid
+  # (RFC 2606) so it can never name a real host in any fleet.
+  defp foreign_host, do: "not-" <> local_host() <> ".invalid"
+
   defp reload(event), do: AdminRepo.get!(SearchEvent, event.id)
 
   defp run(root, extra \\ []) do
@@ -166,7 +171,13 @@ defmodule Mix.Tasks.Loopctl.EnrichSearchEventsTest do
         record(tenant, %{
           query: "shared q",
           client_session_id: Ecto.UUID.generate(),
-          client_host: "Marks-Mac-mini.local"
+          # DERIVED from the local host, never a literal. This used to name a real
+          # machine in the fleet ("Marks-Mac-mini.local"), which made the test pass
+          # only where it was written: run it ON that machine and "another machine"
+          # IS this machine, so the row is legitimately enriched and the assertion
+          # inverts. The sibling test below is the positive case on local_host/0, so
+          # the two were asserting opposite outcomes for the same host.
+          client_host: foreign_host()
         })
 
       run(root)


### PR DESCRIPTION
## The defect

`test/mix/tasks/loopctl_enrich_search_events_test.exs` asserts that the enrichment task
will not answer *another machine's* row from *this machine's* transcripts. It built that
row with a literal `client_host` of `Marks-Mac-mini.local` — a real host in the fleet.

So the test passes everywhere except on the machine it names. On mac-mini, "another
machine" IS this machine: the row is legitimately this host's, the task correctly
enriches it, and the assertion inverts. The very next test in the file is the positive
case built on `local_host/0`, so the two were asserting opposite outcomes for the same
host.

Not a flake — a full stop. Every commit on that machine fails the pre-commit gate, on a
test unrelated to whatever is being committed. That is how this was found: it blocked an
unrelated coordination-bus change.

## The fix

Derive the foreign host instead of naming one:

```elixir
defp foreign_host, do: "not-" <> local_host() <> ".invalid"
```

Guaranteed to differ on every machine, and `.invalid` (RFC 2606) can never name a real
host in any fleet.

## Verification

Ran on mac-mini, where it previously failed: `11 tests, 0 failures` for the file, and the
full gate green at `7808 tests, 0 failures (86 excluded)`.

## Review

Reviewed inline against correctness and the repo's test conventions — a one-line test-only
change with no product surface, where a multi-agent panel would not have earned its tokens.
