### PR TITLE
Put the snippet-backfill ANN tests on their own embedding axis (#645)

### DIFF
--- a/test/loopctl/knowledge/snippet_backfill_test.exs
+++ b/test/loopctl/knowledge/snippet_backfill_test.exs
@@ -21,7 +21,25 @@ defmodule Loopctl.Knowledge.SnippetBackfillTest do
   # cannot discriminate on its own. Seed a known vector explicitly and query with it — the
   # same approach the retrieval eval takes, and it keeps these tests about the SNIPPET
   # rather than about ranking.
-  defp query_vector, do: [1.0 | List.duplicate(0.0, 1535)]
+  # Every vector here — the stored embeddings AND the query — rides `test_vec/2`, so this
+  # test's rows occupy its OWN sparse dimensions of the shared pgvector HNSW index
+  # (`Process.put(:test_vec_axis, ...)` in DataCase.setup). The literal it replaced was
+  # `[1.0 | zeros]`: dimension 0, shared by every test in this file and colliding with any
+  # peer that also reached for the obvious vector.
+  #
+  # That literal is why this file hit #645 in CI on 2026-08-22 ("the canonical must be
+  # retrievable for this assertion to mean anything", green on rerun). The sandbox rolls
+  # each test back, a rolled-back INSERT leaves a dead entry in the graph, and a live row
+  # that links only to dead neighbours becomes UNREACHABLE — so the ANN read returns nothing
+  # while the row is demonstrably present. Sharing one axis is what puts this file's rows in
+  # the same corner of the graph as everyone else's corpses.
+  #
+  # The alternative repair, `@moduletag :vacuum_vector_indexes`, works but is not free:
+  # measured on this suite, adding it to this ONE module took the full run from 37.9s to
+  # 56.2s (+50%), because the VACUUM contends with every other async worker rather than
+  # costing anything much on its own. Prefer the axis; reach for the vacuum only where an
+  # ANN assertion genuinely cannot be isolated onto one.
+  defp query_vector, do: test_vec(1536, :primary)
 
   defp published(tenant_id, title, body) do
     {:ok, article} =

--- a/test/loopctl/knowledge/snippet_backfill_test.exs
+++ b/test/loopctl/knowledge/snippet_backfill_test.exs
@@ -22,23 +22,30 @@ defmodule Loopctl.Knowledge.SnippetBackfillTest do
   # same approach the retrieval eval takes, and it keeps these tests about the SNIPPET
   # rather than about ranking.
   # Every vector here — the stored embeddings AND the query — rides `test_vec/2`, so this
-  # test's rows occupy its OWN sparse dimensions of the shared pgvector HNSW index
+  # module's rows occupy its OWN sparse dimensions of the shared pgvector HNSW index
   # (`Process.put(:test_vec_axis, ...)` in DataCase.setup). The literal it replaced was
-  # `[1.0 | zeros]`: dimension 0, shared by every test in this file and colliding with any
-  # peer that also reached for the obvious vector.
+  # `[1.0 | zeros]`: dimension 0, shared by all ten tests in this file.
   #
-  # That literal is why this file hit #645 in CI on 2026-08-22 ("the canonical must be
-  # retrievable for this assertion to mean anything", green on rerun). The sandbox rolls
-  # each test back, a rolled-back INSERT leaves a dead entry in the graph, and a live row
-  # that links only to dead neighbours becomes UNREACHABLE — so the ANN read returns nothing
-  # while the row is demonstrably present. Sharing one axis is what puts this file's rows in
-  # the same corner of the graph as everyone else's corpses.
+  # THE MECHANISM IS THE DISTANCE-0 CLIQUE, not dead tuples. Ten rows at an identical
+  # vector are all exact ties, and under concurrent full-suite load the graph walk cannot
+  # navigate that clique — it non-deterministically misses exact matches. That is KB
+  # `4e5ccb17` and `0bdadd52` ("the fix is per-tenant mock embeddings, NOT raising
+  # ef_search"), and it is the same reason `DataCase`'s default `MockEmbeddingClient` stub
+  # keys `deterministic_embedding/1` on `tenant_id` rather than returning a constant.
   #
-  # The alternative repair, `@moduletag :vacuum_vector_indexes`, works but is not free:
-  # measured on this suite, adding it to this ONE module took the full run from 37.9s to
-  # 56.2s (+50%), because the VACUUM contends with every other async worker rather than
-  # costing anything much on its own. Prefer the axis; reach for the vacuum only where an
-  # ANN assertion genuinely cannot be isolated onto one.
+  # Do NOT re-explain this as "rolled-back tuples crowd out the live row". KB `c6fd1e5d`
+  # lists that as a DEAD THEORY, disproved by probe: pgvector returns the live row past
+  # 2000 rolled-back distance-0 ties, because it skips invisible tuples and keeps scanning.
+  # That article exists because this family has been misdiagnosed twice, each time costing
+  # reverted fixes — so match on the mechanism, and read it before touching this.
+  #
+  # WHY NOT `@moduletag :vacuum_vector_indexes`. It is the other documented repair and it
+  # works, but it is not free, and the cost is invisible if you measure one file: adding it
+  # to this ONE module took the full suite from 37.9s to 56.2s (+50%), and on 24 ANN-reading
+  # modules to 744s (18.6x). The VACUUM contends with every other async worker rather than
+  # costing much on its own, so it taxes the WHOLE suite, not the module that opts in. The
+  # axis is free — 37.97s against a 37.85s baseline. Prefer the axis; reach for the vacuum
+  # only where an ANN assertion genuinely cannot be isolated onto one.
   defp query_vector, do: test_vec(1536, :primary)
 
   defp published(tenant_id, title, body) do


### PR DESCRIPTION
## The failure

CI failed on `SnippetBackfillTest`, "a system-scope canonical gets a lead too, not a bare
title", at its retrievability precondition — the ANN read returned no row for an article
the test had just inserted — and passed on rerun. It surfaced on an unrelated PR (#746, a
route-index change), which is how this class of flake wastes time: it reads as "your change
broke something".

## Mechanism — the distance-0 clique

All ten tests in this file shared the literal `[1.0 | zeros]` for both the stored embeddings
and the query. Rows at an identical vector are exact ties, and under concurrent full-suite
load the HNSW graph walk cannot navigate that clique — it non-deterministically misses exact
matches. That is KB `4e5ccb17` and `0bdadd52` ("the fix is per-tenant mock embeddings, NOT
raising ef_search"), and it is the same reason `DataCase`'s default `MockEmbeddingClient`
stub keys `deterministic_embedding/1` on `tenant_id` rather than returning a constant.

**Correction, made before merge.** My first commit on this branch explained it as a
rolled-back INSERT leaving a dead graph entry that makes the live row unreachable. KB
`c6fd1e5d` lists that as a **dead theory**, disproved by probe: pgvector returns the live
row past 2000 rolled-back distance-0 ties, because it skips invisible tuples and keeps
scanning. That article opens by saying this family has been misdiagnosed twice and each
misdiagnosis cost multiple reverted fixes — so the second commit replaces the explanation
and warns the next reader off it. The fix itself is unchanged: `test_vec/2` is correct
either way, and now correct for the better-supported reason.

## The fix

`DataCase.setup` already assigns each test its own sparse axis and exposes it as
`test_vec/2`, precisely so tests don't collide in the shared index. The literal opted out of
it. It now uses the axis.

## Why not `@moduletag :vacuum_vector_indexes`

The other documented repair. It works and it is not free — the cost is invisible if you
measure one file:

| configuration | full suite |
|---|---|
| no tag | **37.9s** |
| tag on this **one** module | **56.2s** (+50%) |
| tag on 24 ANN-reading modules | **744s** (18.6x) |

Per-call cost is ~16ms on an idle machine. The real cost is `VACUUM` contending with every
other async worker, so it's superlinear in the number of vacuuming modules and taxes the
**whole** suite, not the module that opts in. The axis is free: **37.97s against a 37.85s
baseline**, 7827 tests green.

## Scope — what I checked and did not change

- **11 of 23** ANN-reading modules already use `test_vec/2`.
- The default `MockEmbeddingClient` stub is tenant-keyed and tenants are per-test, so
  everything reaching the index through `Memory.remember/2` or article ingest is already
  separated.
- What remains is a test passing an **explicit, non-per-test vector** into an ANN path.
  `embeddings_test.exs` is the one confirmed other instance (`vec(dim) = sin(i/dim)`, dense
  and identical across tests). It is its own module with its own dimension-migration
  assertions; it gets its own branch rather than being bundled here.

## Verification

Full gate green on both commits: 7827 tests, 0 failures (86 excluded), credo `--strict`
clean, dialyzer clean. Timing measured three ways above, A/B'd under identical conditions.

## Review

Reviewed inline, then corrected against the KB — which is what caught the wrong mechanism.
The change is one helper in one test file, established by measurement rather than argument.
