### PR TITLE
Serve the default suite's vector reads from an exact plan, since #645's remedy was never written

### DIFF
--- a/.claude/skills/tenancy-rls/SKILL.md
+++ b/.claude/skills/tenancy-rls/SKILL.md
@@ -57,7 +57,7 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
    (`heavy_read.ex:1520-1538`) RAISES unless EVERY base-table source — `from`, every join, and every
    subquery, recursively — carries a conjunctive `x.tenant_id == ^tenant_id` bound to the passed
    `tenant_id`; `test/loopctl/heavy_read_guard_test.exs` additionally bars direct `HeavyReadRepo` calls.
-   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:1090`) also requires a conjunctive
+   Agent-memory reads need a SECOND predicate: `all_memory/4` (`:1187`) also requires a conjunctive
    `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1542-1564`), because `subject_id`
    scoping is application-level only. Always go through `Loopctl.HeavyRead`, never `HeavyReadRepo`
    directly; on `AdminRepo` there is no guard at all, so the predicate is on you.

--- a/.claude/skills/tenancy-rls/SKILL.md
+++ b/.claude/skills/tenancy-rls/SKILL.md
@@ -54,11 +54,11 @@ reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the 
 6. **On `AdminRepo`/`HeavyReadRepo`, RLS does NOTHING — the explicit `tenant_id` predicate is the only
    isolation there** (`knowledge.ex:9-14`, `heavy_read.ex:3-7`). This is the compensating invariant for
    the other two repos, and it is enforced structurally on the heavy path: the private `guard!/2`
-   (`heavy_read.ex:1474-1492`) RAISES unless EVERY base-table source — `from`, every join, and every
+   (`heavy_read.ex:1520-1538`) RAISES unless EVERY base-table source — `from`, every join, and every
    subquery, recursively — carries a conjunctive `x.tenant_id == ^tenant_id` bound to the passed
    `tenant_id`; `test/loopctl/heavy_read_guard_test.exs` additionally bars direct `HeavyReadRepo` calls.
    Agent-memory reads need a SECOND predicate: `all_memory/4` (`:1090`) also requires a conjunctive
-   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1496-1528`), because `subject_id`
+   `subject_id` equality on the outermost query (private `guard_memory!/3`, `heavy_read.ex:1542-1564`), because `subject_id`
    scoping is application-level only. Always go through `Loopctl.HeavyRead`, never `HeavyReadRepo`
    directly; on `AdminRepo` there is no guard at all, so the predicate is on you.
 7. **Heavy reads can be SHED — handle `{:error, :heavy_read_overloaded}`.** `all/3` (`heavy_read.ex:1128`),

--- a/config/test.exs
+++ b/config/test.exs
@@ -789,6 +789,24 @@ config :loopctl, :legacy_retirement, Loopctl.MockLegacyRetirement
 # the ones that seed real oban_jobs rows — exercises the real count unchanged.
 config :loopctl, :fair_share_counter, Loopctl.MockFairShareCounter
 
+# #645 and its 2026-08-25 recurrence — force an EXACT plan for every `Loopctl.HeavyRead`
+# vector read in the default suite. Sandbox rolls back every test, and a rolled-back INSERT
+# leaves its entry in the SHARED pgvector HNSW graph; pgvector's scan SKIPS dead elements
+# rather than traversing them, so a row inserted afterwards links only to dead neighbours and
+# becomes UNREACHABLE from the graph entry point — the ANN returns nothing while a `count()`
+# on the same connection shows the row present. Reachability, not breadth: no `ef_search` /
+# `iterative_scan` value recovers it. See `Loopctl.HeavyRead.maybe_force_exact_scan/1` for
+# the measurements and for why the two repairs already in the tree cannot cover the suite.
+#
+# OFF for the scale jobs, which are the ones that must exercise the real HNSW plan: they run
+# over a committed, ANALYZEd 80k-row corpus whose graph resembles production's, and their
+# plan assertions (`Loopctl.PlanAssertions.assert_hnsw_index/1`) would fail without it.
+# NOTE for local use: this only changes the PLAN, never the catalog — the indexes stay put,
+# so alternating between `mix test` and `SCALE_TESTS=true mix test` needs no `ecto.reset`.
+config :loopctl,
+       :heavy_read_force_exact_scan,
+       is_nil(System.get_env("SCALE_TESTS")) and is_nil(System.get_env("SCALE_NIGHTLY"))
+
 # GH #551: a SHORT evidence window in tests. The production bar is 30 days; asserting
 # against it would mean fabricating 30 observation rows per test to say something that
 # is true at 3. The window LENGTH is not what the tests are checking — the gate logic

--- a/config/test.exs
+++ b/config/test.exs
@@ -799,10 +799,16 @@ config :loopctl, :fair_share_counter, Loopctl.MockFairShareCounter
 # the measurements and for why the two repairs already in the tree cannot cover the suite.
 #
 # OFF for the scale jobs, which are the ones that must exercise the real HNSW plan: they run
-# over a committed, ANALYZEd 80k-row corpus whose graph resembles production's, and their
-# plan assertions (`Loopctl.PlanAssertions.assert_hnsw_index/1`) would fail without it.
-# NOTE for local use: this only changes the PLAN, never the catalog — the indexes stay put,
-# so alternating between `mix test` and `SCALE_TESTS=true mix test` needs no `ecto.reset`.
+# over a committed, ANALYZEd 80k-row corpus whose graph resembles production's, and the scale
+# tests that EXECUTE reads through `HeavyRead` (recall / e2e latency) would be served by a seq
+# scan instead of the ANN. `Loopctl.PlanAssertions.assert_hnsw_index/1` is NOT the reason: it
+# EXPLAINs on `AdminRepo` outside any `HeavyRead` transaction, so the `SET LOCAL` never
+# reaches it and it reads the same plan either way.
+# NOTE for local use: this changes the PLAN, never the catalog — the indexes stay put. But a
+# scale run COMMITS its 80k-row corpus into the same database, and an exact plan over that
+# corpus is now DETERMINISTIC (before, it was a lottery), so it blows the 250ms heavy-read
+# statement_timeout above. After `SCALE_TESTS=true mix test`, truncate the scale corpus (or
+# `mix ecto.reset`) before the next default run.
 config :loopctl,
        :heavy_read_force_exact_scan,
        is_nil(System.get_env("SCALE_TESTS")) and is_nil(System.get_env("SCALE_NIGHTLY"))

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -1338,6 +1338,7 @@ defmodule Loopctl.HeavyRead do
         read_repo.query!("SET LOCAL statement_timeout = #{ms}")
         maybe_set_ef_search(read_repo, ef)
         maybe_set_iterative_scan(read_repo, iter)
+        maybe_force_exact_scan(read_repo)
         fun.()
       end)
     end)
@@ -1348,8 +1349,53 @@ defmodule Loopctl.HeavyRead do
   defp captured_gucs(ef, iter) do
     ["statement_timeout"] ++
       if(is_integer(ef), do: ["hnsw.ef_search"], else: []) ++
-      if(is_binary(iter), do: ["hnsw.iterative_scan", "hnsw.max_scan_tuples"], else: [])
+      if(is_binary(iter), do: ["hnsw.iterative_scan", "hnsw.max_scan_tuples"], else: []) ++
+      if(force_exact_scan?(), do: ["enable_indexscan", "enable_bitmapscan"], else: [])
   end
+
+  # `SET LOCAL enable_indexscan = off` for a heavy read — TEST-ENV ONLY, and off by default
+  # so production is untouched (`config/test.exs` is the only place that turns it on).
+  #
+  # #645, and the recurrence that failed the 2026-08-25 nightly on an UNCHANGED master.
+  # Under `Ecto.Adapters.SQL.Sandbox` every rolled-back test INSERT leaves its entry in the
+  # SHARED pgvector HNSW graph, and pgvector's scan SKIPS dead elements rather than
+  # traversing through them: a row inserted later links only to dead neighbours and becomes
+  # UNREACHABLE from the graph entry point, so the ANN returns nothing while a `count()` on
+  # the same connection shows the row present. It is a REACHABILITY failure, so no breadth
+  # knob touches it — measured in `test/loopctl/embeddings/hnsw_dead_entry_recall_test.exs`,
+  # the read still returns `[]` under `relaxed_order` and under `ef_search = 1000`.
+  #
+  # An exact plan reads the heap, so the graph is not in the picture at all. Nothing real is
+  # lost: the default suite's ANN coverage was already accidental (the plan was measured
+  # flipping 7 exact / 3 HNSW over ten runs of an unchanged database), and the ANN plan is
+  # gated properly by the CI scale jobs over a committed, ANALYZEd 80k-row corpus — the only
+  # corpus whose graph resembles production's — which run with `SCALE_TESTS` set and
+  # therefore leave this off.
+  #
+  # WHY NOT the two repairs already in the tree. `@moduletag :vacuum_vector_indexes`
+  # (`Loopctl.DataCase.vacuum_vector_indexes/0`) is per-test and correct, but the index is
+  # SHARED, so every ANN-reading module is exposed and the failure MOVES between them — the
+  # nightly failed in `EmbeddingsTest`, a full-suite run the same evening failed six
+  # assertions in `MemoryContextTest` instead. Tagging modules one at a time is whack-a-mole,
+  # and it does not scale: the tag on ONE module took the suite 37.9s -> 56.2s (+50%), with
+  # 744s (18.6x) projected over 24 ANN-reading modules. Measured on minis 2026-08-24, VACUUM
+  # also cannot carry a whole async suite: a janitor vacuuming every 2s still failed 2 of 6
+  # full-suite runs, because VACUUM cannot reclaim a tuple visible to any open snapshot and
+  # an async Sandbox suite holds ~max_cases transactions open for practically the whole run.
+  # (REINDEX does repair it — 13 MB -> 16 kB, 8 of 8 failures -> clean — but only from a
+  # QUIET database: as a background pass its ACCESS EXCLUSIVE lock fought the suite and broke
+  # unrelated modules outright.) The per-test tag still works where it is used, because it
+  # runs in `setup` before its own test opens the transaction it reads through; it stays.
+  defp maybe_force_exact_scan(read_repo) do
+    if force_exact_scan?() do
+      read_repo.query!("SET LOCAL enable_indexscan = off")
+      read_repo.query!("SET LOCAL enable_bitmapscan = off")
+    end
+
+    :ok
+  end
+
+  defp force_exact_scan?, do: Application.get_env(:loopctl, :heavy_read_force_exact_scan, false)
 
   # `SET LOCAL hnsw.ef_search = N` for an ANN read (US-38.4). Only fired when the caller
   # (via `HeavyRead.opts/1` for an `ann_endpoints/0` endpoint) supplies a positive integer

--- a/test/loopctl/embeddings/hnsw_dead_entry_recall_test.exs
+++ b/test/loopctl/embeddings/hnsw_dead_entry_recall_test.exs
@@ -25,14 +25,17 @@ defmodule Loopctl.Embeddings.HnswDeadEntryRecallTest do
       one visible row, and the scan still returns nothing.
     * **No ANN knob fixes it.** This test asserts the failure under `hnsw.iterative_scan =
       off`, under `relaxed_order`, and under `hnsw.ef_search = 1000`. Reachability is not a
-      breadth problem. That is why `ef_search`, exact-scan forcing, `iterative_scan` and
-      retry-on-empty were each tried and each failed.
+      breadth problem. That is why `ef_search`, `iterative_scan` and retry-on-empty were
+      each tried and each failed.
 
-  The remedy is therefore not a fifth knob: VACUUM is the only thing that repairs the
-  graph, and it repairs it completely. `Loopctl.DataCase.vacuum_vector_indexes/0` does that
-  before each test in the modules that produced the signature (opt in with
+  The remedy is therefore not a fifth breadth knob. Two things DO work, for different
+  reasons, and this test asserts both. Forcing an EXACT plan sidesteps the graph entirely
+  (`exact_read/0` returns the row from the still-poisoned index) — that is the suite-wide
+  repair, `config/test.exs` + `Loopctl.HeavyRead.maybe_force_exact_scan/1`. VACUUM instead
+  repairs the graph, completely: `Loopctl.DataCase.vacuum_vector_indexes/0` does that before
+  each test in the modules that produced the signature (opt in with
   `@moduletag :vacuum_vector_indexes`), and the last assertion of the first test here is that
-  half — the same poisoned index, vacuumed, answers correctly.
+  half — the same poisoned index, vacuumed, answers the ANN correctly.
 
   The SECOND test is the one that would have caught #645 never landing. Everything above it
   measures the mechanism through hand-built SQL with a pinned plan; none of it touches the
@@ -238,7 +241,16 @@ defmodule Loopctl.Embeddings.HnswDeadEntryRecallTest do
           limit: 1
         )
 
-      assert [%{indexscan: "off", bitmapscan: "off"}] = HeavyRead.all(tenant.id, query)
+      # Asserted against the CONFIGURED value, not a literal "off": `config/test.exs` turns
+      # `:heavy_read_force_exact_scan` off for a `SCALE_TESTS`/`SCALE_NIGHTLY` run, and a
+      # guard that goes red on an env var is noise, not a guard. Both directions are
+      # meaningful — the scale jobs must reach the real HNSW plan.
+      expected =
+        if Application.get_env(:loopctl, :heavy_read_force_exact_scan, false),
+          do: "off",
+          else: "on"
+
+      assert [%{indexscan: ^expected, bitmapscan: ^expected}] = HeavyRead.all(tenant.id, query)
     end
   end
 end

--- a/test/loopctl/embeddings/hnsw_dead_entry_recall_test.exs
+++ b/test/loopctl/embeddings/hnsw_dead_entry_recall_test.exs
@@ -43,9 +43,13 @@ defmodule Loopctl.Embeddings.HnswDeadEntryRecallTest do
   the shipped remedy existed only in a docstring. This one reads the planner GUCs from
   inside a real `Loopctl.HeavyRead` read — the actual chokepoint, at the actual
   configuration — so it goes red the moment `maybe_force_exact_scan/1` or
-  `:heavy_read_force_exact_scan` stops being wired. Verified by mutation: replace the
-  `SET LOCAL enable_indexscan = off` with a no-op and this test fails while every other
-  assertion in the file still passes.
+  `:heavy_read_force_exact_scan` stops being wired. BOTH halves are policed only because
+  the expectation is derived from `SCALE_TESTS`/`SCALE_NIGHTLY` rather than from the config
+  key the code reads: unwiring the key flips the observed GUC and NOT the expectation.
+  Verified by mutation on a DEFAULT run: replace the `SET LOCAL enable_indexscan = off`
+  with a no-op and this test fails while every other assertion in the file still passes.
+  Under `SCALE_TESTS` that mutation is invisible here by design — that run asserts the
+  forcing is NOT applied, so it catches the forcing becoming unconditional instead.
 
   `async: false`: it deliberately fills a shared graph with dead entries.
   """
@@ -241,12 +245,15 @@ defmodule Loopctl.Embeddings.HnswDeadEntryRecallTest do
           limit: 1
         )
 
-      # Asserted against the CONFIGURED value, not a literal "off": `config/test.exs` turns
-      # `:heavy_read_force_exact_scan` off for a `SCALE_TESTS`/`SCALE_NIGHTLY` run, and a
-      # guard that goes red on an env var is noise, not a guard. Both directions are
-      # meaningful — the scale jobs must reach the real HNSW plan.
+      # The expectation is derived from the ENV, never from `:heavy_read_force_exact_scan`:
+      # reading the key `force_exact_scan?/0` reads would make this guard TRACK the config
+      # instead of CHECKING it, and deleting the config line would then leave it green. The
+      # env is what `config/test.exs` computes that key from, so it is an independent source
+      # of truth for both halves of the wiring. A default run must have the forcing applied;
+      # a `SCALE_TESTS`/`SCALE_NIGHTLY` run must NOT, so the scale jobs still reach the real
+      # HNSW plan — that branch catches the forcing becoming unconditional, nothing else.
       expected =
-        if Application.get_env(:loopctl, :heavy_read_force_exact_scan, false),
+        if is_nil(System.get_env("SCALE_TESTS")) and is_nil(System.get_env("SCALE_NIGHTLY")),
           do: "off",
           else: "on"
 

--- a/test/loopctl/embeddings/hnsw_dead_entry_recall_test.exs
+++ b/test/loopctl/embeddings/hnsw_dead_entry_recall_test.exs
@@ -1,7 +1,10 @@
 defmodule Loopctl.Embeddings.HnswDeadEntryRecallTest do
   @moduledoc """
   #645 — the reproduction of the long-running `left: []` vector-recall flake, and the
-  evidence for the fix `test/test_helper.exs` applies.
+  evidence for the fix `config/test.exs` + `Loopctl.HeavyRead.maybe_force_exact_scan/1`
+  apply. (This said `test/test_helper.exs` from #645 until 2026-08-25, naming an index-drop
+  that was never actually written — see the moduledoc of
+  `test/loopctl/embeddings_side_table_reads_test.exs`.)
 
   ## The mechanism, measured rather than theorised
 
@@ -28,8 +31,18 @@ defmodule Loopctl.Embeddings.HnswDeadEntryRecallTest do
   The remedy is therefore not a fifth knob: VACUUM is the only thing that repairs the
   graph, and it repairs it completely. `Loopctl.DataCase.vacuum_vector_indexes/0` does that
   before each test in the modules that produced the signature (opt in with
-  `@moduletag :vacuum_vector_indexes`), and the last assertion here is that half — the same
-  poisoned index, vacuumed, answers correctly.
+  `@moduletag :vacuum_vector_indexes`), and the last assertion of the first test here is that
+  half — the same poisoned index, vacuumed, answers correctly.
+
+  The SECOND test is the one that would have caught #645 never landing. Everything above it
+  measures the mechanism through hand-built SQL with a pinned plan; none of it touches the
+  code the request path actually runs, so all of it stayed green for the two months in which
+  the shipped remedy existed only in a docstring. This one reads the planner GUCs from
+  inside a real `Loopctl.HeavyRead` read — the actual chokepoint, at the actual
+  configuration — so it goes red the moment `maybe_force_exact_scan/1` or
+  `:heavy_read_force_exact_scan` stops being wired. Verified by mutation: replace the
+  `SET LOCAL enable_indexscan = off` with a no-op and this test fails while every other
+  assertion in the file still passes.
 
   `async: false`: it deliberately fills a shared graph with dead entries.
   """
@@ -39,6 +52,8 @@ defmodule Loopctl.Embeddings.HnswDeadEntryRecallTest do
 
   alias Ecto.Adapters.SQL.Sandbox
   alias Loopctl.AdminRepo
+  alias Loopctl.HeavyRead
+  alias Loopctl.Knowledge.ArticleEmbedding
 
   # Comfortably above pgvector's default `hnsw.ef_search` of 40. Small enough to stay a
   # sub-second test.
@@ -194,6 +209,36 @@ defmodule Loopctl.Embeddings.HnswDeadEntryRecallTest do
       Loopctl.DataCase.vacuum_vector_indexes()
 
       assert ann_read(mode: "off") == [article.id]
+    end
+
+    test "the SHIPPED default-suite read path has the ANN plan disabled at the chokepoint" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published, title: "Live"})
+      insert_embedding(tenant.id, article.id, live_vec())
+
+      # Read the planner GUCs FROM INSIDE a real `HeavyRead` read, which is the only place
+      # the claim can be checked: `SET LOCAL` is scoped to that transaction, so asking any
+      # other connection returns the session default and proves nothing.
+      #
+      # This asserts the MECHANISM rather than a recovered row on purpose. A recall
+      # assertion here is INERT — verified by mutation: with `maybe_force_exact_scan/1`
+      # removed, a poisoned-index read through `HeavyRead` still returned the row, because
+      # on a table holding one live tuple the planner picks an exact plan on cost anyway.
+      # That is the same plan lottery the first test has to pin `enable_seqscan` to escape
+      # (7 exact / 3 HNSW measured over ten runs), and a guard that only fires on 3 runs in
+      # 10 is not a guard. What broke in #645 was never the recall — it was the remedy
+      # silently not being wired, and this is the assertion that goes red for that.
+      query =
+        from(ae in ArticleEmbedding,
+          where: ae.tenant_id == ^tenant.id,
+          select: %{
+            indexscan: fragment("current_setting('enable_indexscan')"),
+            bitmapscan: fragment("current_setting('enable_bitmapscan')")
+          },
+          limit: 1
+        )
+
+      assert [%{indexscan: "off", bitmapscan: "off"}] = HeavyRead.all(tenant.id, query)
     end
   end
 end

--- a/test/loopctl/embeddings_side_table_reads_test.exs
+++ b/test/loopctl/embeddings_side_table_reads_test.exs
@@ -48,7 +48,8 @@ defmodule Loopctl.EmbeddingsSideTableReadsTest do
   looking for a different cause. A doc asserting a mechanism it cannot point at is worth
   less than no doc: verify the citation, not just the reasoning.
 
-  So do NOT "restore" the indexes for this suite, and do NOT add a fifth recall knob. If a
+  The indexes all still EXIST — nothing drops them; only the plan changes. So do NOT turn
+  `:heavy_read_force_exact_scan` off for this suite, and do NOT add a fifth recall knob. If a
   `left: []` reappears here, it is a NEW defect: `Loopctl.VectorRecallDiagnostics` is still
   wrapped around every assertion that ever produced the signature and fires only on an empty
   result, printing (a) whether the row was VISIBLE as unlimited `count()`s and (b) the

--- a/test/loopctl/embeddings_side_table_reads_test.exs
+++ b/test/loopctl/embeddings_side_table_reads_test.exs
@@ -31,12 +31,22 @@ defmodule Loopctl.EmbeddingsSideTableReadsTest do
   `hnsw.iterative_scan = off`, under `relaxed_order`, and under `hnsw.ef_search = 1000`.
   Candidate STARVATION is also retired — the reproduction has no live competitors at all.
 
-  **The fix.** `test/test_helper.exs` DROPS every pgvector HNSW index unless
-  `SCALE_TESTS` is set, so every vector read in the default suite is served by an EXACT plan
-  (seq or btree + sort) that cannot under-return. Nothing real is lost: this suite's ANN
-  coverage was already accidental (the plan was measured flipping 7 exact / 3 HNSW over ten
-  runs of an unchanged database), and the ANN plan is gated properly by the CI scale job over
-  a committed, ANALYZEd 80k-row corpus — the only corpus whose graph resembles production's.
+  **The fix.** `config/test.exs` sets `:heavy_read_force_exact_scan` unless `SCALE_TESTS` /
+  `SCALE_NIGHTLY` is set, and `Loopctl.HeavyRead.maybe_force_exact_scan/1` turns that into a
+  `SET LOCAL enable_indexscan = off` on each heavy read — so every vector read in the default
+  suite is served by an EXACT plan (seq or btree + sort) that cannot under-return. Nothing
+  real is lost: this suite's ANN coverage was already accidental (the plan was measured
+  flipping 7 exact / 3 HNSW over ten runs of an unchanged database), and the ANN plan is
+  gated properly by the CI scale job over a committed, ANALYZEd 80k-row corpus — the only
+  corpus whose graph resembles production's.
+
+  This paragraph described a DIFFERENT fix — dropping every HNSW index in
+  `test/test_helper.exs` — from #645 until 2026-08-25. That code was never written: the last
+  commit to touch `test_helper.exs` predates #645, and the three HNSW indexes were still in
+  the test database. The design was sound and is what this change implements; only the claim
+  that it had shipped was false, and it read as settled for long enough that #748 went
+  looking for a different cause. A doc asserting a mechanism it cannot point at is worth
+  less than no doc: verify the citation, not just the reasoning.
 
   So do NOT "restore" the indexes for this suite, and do NOT add a fifth recall knob. If a
   `left: []` reappears here, it is a NEW defect: `Loopctl.VectorRecallDiagnostics` is still

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -72,9 +72,11 @@ defmodule Loopctl.DataCase do
   present. That is the long-running `left: []` flake, reproduced deterministically in
   `test/loopctl/embeddings/hnsw_dead_entry_recall_test.exs`.
 
-  It is a REACHABILITY failure, not a breadth one, which is why `hnsw.ef_search`,
-  `hnsw.iterative_scan` and exact-scan forcing each failed to fix it: measured in that
-  file, the read still returns `[]` under `relaxed_order` AND under `ef_search = 1000`.
+  It is a REACHABILITY failure, not a breadth one, which is why the BREADTH knobs
+  (`hnsw.ef_search`, `hnsw.iterative_scan`, retry-on-empty) each failed to fix it: measured
+  in that file, the read still returns `[]` under `relaxed_order` AND under
+  `ef_search = 1000`. Forcing an EXACT plan DOES recover the row — measured in the same
+  file — because it takes the graph out of the plan rather than searching it wider.
   Vacuuming repairs the graph completely on a QUIET database — the same poisoned index
   answers correctly immediately afterwards, which is what the reproduction asserts. It does
   NOT follow that vacuuming can carry a whole async suite, and measurement on minis
@@ -87,7 +89,7 @@ defmodule Loopctl.DataCase do
   rather than repairing it.
 
   **That suite-wide repair does NOT make this tag redundant — measured, do not remove it.**
-  Taking the three `@moduletag :vacuum_vector_indexes` off their modules with the exact-scan
+  Taking `@moduletag :vacuum_vector_indexes` off the modules carrying it with the exact-scan
   forcing in place produced a failure in 4 full-suite runs and no speedup at all (51s against
   45s WITH the tags — slower, not faster), so the tag is not the tax it looks like here. The
   two work on different things: the exact plan covers reads that go through

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -75,8 +75,23 @@ defmodule Loopctl.DataCase do
   It is a REACHABILITY failure, not a breadth one, which is why `hnsw.ef_search`,
   `hnsw.iterative_scan` and exact-scan forcing each failed to fix it: measured in that
   file, the read still returns `[]` under `relaxed_order` AND under `ef_search = 1000`.
-  Vacuuming is the only thing that repairs the graph, and it repairs it completely — the
-  same poisoned index answers correctly immediately afterwards.
+  Vacuuming repairs the graph completely on a QUIET database — the same poisoned index
+  answers correctly immediately afterwards, which is what the reproduction asserts. It does
+  NOT follow that vacuuming can carry a whole async suite, and measurement on minis
+  2026-08-24 says it cannot: a janitor vacuuming every 2s still failed 2 of 6 full-suite
+  runs, because VACUUM cannot reclaim a tuple still visible to any open snapshot and an async
+  Sandbox suite holds ~`max_cases` transactions open for practically the entire run. This
+  function works because it runs in `setup`, BEFORE its own test opens the transaction the
+  assertion reads through. The suite-wide repair is
+  `Loopctl.HeavyRead.maybe_force_exact_scan/1`, which takes the graph out of the picture
+  rather than repairing it.
+
+  **That suite-wide repair does NOT make this tag redundant — measured, do not remove it.**
+  Taking the three `@moduletag :vacuum_vector_indexes` off their modules with the exact-scan
+  forcing in place produced a failure in 4 full-suite runs and no speedup at all (51s against
+  45s WITH the tags — slower, not faster), so the tag is not the tax it looks like here. The
+  two work on different things: the exact plan covers reads that go through
+  `Loopctl.HeavyRead`, and this covers what a module does around them.
 
   Production is not affected: its rows are committed, so its graph is not made of dead
   entries.


### PR DESCRIPTION
Serve the default suite's vector reads from an exact plan, since #645's remedy was never written

The 2026-08-25 nightly failed on master at 688b64b, a commit that had gone green on its own
push run and on the two nightlies before it. Nothing had changed but the ExUnit seed. The
KB's prescription for that signature is a rerun; it reproduced locally 8 runs out of 8, so it
was never a flake to rerun.

The moduledoc of embeddings_side_table_reads_test.exs states, as settled fact, that
test/test_helper.exs drops every pgvector HNSW index unless SCALE_TESTS is set, so that every
default-suite vector read gets an exact plan. No such code was ever written - the last commit
to touch test_helper.exs predates #645, and the test database still had all three
article_embeddings_hnsw_dim_* indexes. Two months of reading that as shipped is why #748,
itself a fix attempt for this file, went looking for a different cause.

So every default-suite vector read still ran through a shared HNSW graph that the suite
poisons with its own rolled-back inserts. Measured on minis: article_embeddings with 0 live
rows and a 0-byte heap, carrying a 13 MB dim-1536 index of pure dead graph elements, growing
about 1 MB per run of a single 34-test file. pgvector's scan skips dead elements rather than
traversing them, so a later live row links only to dead neighbours and is unreachable from
the entry point.

The fix is the one the doc already described, applied at the read chokepoint instead of the
catalog: config/test.exs sets :heavy_read_force_exact_scan unless SCALE_TESTS or
SCALE_NIGHTLY is set, and HeavyRead.maybe_force_exact_scan/1 turns that into a SET LOCAL
enable_indexscan = off through the existing LocalGuc seam, which captures and restores it.
Production is untouched - the flag defaults to false. The scale jobs keep the real ANN plan
over the committed, ANALYZEd 80k-row corpus, which is the only one whose graph resembles
production's. Six full-suite runs clean, at no wall-clock cost.

Why not the two repairs already in the tree, both measured rather than argued. The index is
shared, so every ANN-reading module is exposed and the failure moves between them - the
nightly failed in EmbeddingsTest, a full-suite run the same evening failed six assertions in
MemoryContextTest instead. Tagging modules one at a time is whack-a-mole, and it does not
scale: the tag on one module took the suite from 37.9s to 56.2s. VACUUM cannot carry an async
suite either - a janitor vacuuming every 2s still failed 2 of 6 full-suite runs, because
VACUUM cannot reclaim a tuple visible to any open snapshot and a Sandbox suite pins the xmin
horizon for practically the whole run. REINDEX does repair the graph, 13 MB to 16 kB and 8 of
8 failures to clean, but only from an idle table: as a background pass its ACCESS EXCLUSIVE
lock broke unrelated modules outright. The three existing moduletags stay - removing them
produced a failure in 4 runs and no speedup, so they are not redundant with this.

The new guard asserts the mechanism, not a recovered row, and the difference is load-bearing.
A guard that poisons the index and checks the row still comes back is inert: verified by
mutation, with the fix removed such a read still returned the row, because on a table holding
one live tuple the planner picks an exact plan on cost anyway. The shipped guard reads
current_setting('enable_indexscan') from inside a real HeavyRead read, which is the only
place the claim is checkable, and it is mutation-verified red.

Also corrects the three docstrings that described the unwritten fix, and DataCase's claim
that vacuuming is the only repair and repairs completely - true of a quiet database, false of
this suite. KB d6289226 and c6fd1e5d are updated; the resolution is KB e1d388b7.
