### PR TITLE
Replay the exact-scan GUCs in the recall diagnostic, so its EXPLAIN describes the read it is explaining

### DIFF
--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -1395,7 +1395,16 @@ defmodule Loopctl.HeavyRead do
     :ok
   end
 
-  defp force_exact_scan?, do: Application.get_env(:loopctl, :heavy_read_force_exact_scan, false)
+  @doc """
+  Whether heavy reads are currently forced onto an EXACT plan (see
+  `maybe_force_exact_scan/1`). FALSE in every non-test environment.
+
+  Public because `Loopctl.VectorRecallDiagnostics` must reproduce the read's GUCs around its
+  EXPLAIN — a diagnostic that explains a different plan than the read it is diagnosing is
+  worse than none, which is the whole reason that wrapper exists.
+  """
+  @spec force_exact_scan?() :: boolean()
+  def force_exact_scan?, do: Application.get_env(:loopctl, :heavy_read_force_exact_scan, false)
 
   # `SET LOCAL hnsw.ef_search = N` for an ANN read (US-38.4). Only fired when the caller
   # (via `HeavyRead.opts/1` for an `ann_endpoints/0` endpoint) supplies a positive integer

--- a/test/support/vector_recall_diagnostics.ex
+++ b/test/support/vector_recall_diagnostics.ex
@@ -81,6 +81,14 @@ defmodule Loopctl.VectorRecallDiagnostics do
   # let the EXPLAIN walk further than the read could.
   @read_gucs ["hnsw.ef_search", "hnsw.iterative_scan", "hnsw.max_scan_tuples"]
 
+  # The planner GUCs `HeavyRead` sets on EVERY heavy read when
+  # `:heavy_read_force_exact_scan` is on (the default suite — see
+  # `Loopctl.HeavyRead.maybe_force_exact_scan/1`). They are tracked separately from
+  # `@read_gucs` because they are not ANN opts: `@read_gucs` is armed only for a read that
+  # asked for an ef_search, while these apply to a bare `HeavyRead.all/2` as well, which is
+  # exactly the `:session_defaults` case below.
+  @exact_scan_gucs ["enable_indexscan", "enable_bitmapscan"]
+
   @doc """
   Prints the (a)-visibility / (b)-plan diagnostic when `observed` is empty, and returns
   `observed` unchanged so it can be used inline or as a bare statement before the assertion.
@@ -314,22 +322,53 @@ defmodule Loopctl.VectorRecallDiagnostics do
   # arming ef_search/iterative_scan here would print a healthy plan for a read that ran
   # without them, and iterative-scan-on-vs-off is exactly the difference between an ANN that
   # under-returns past its first batch and one that does not.
+  # `:session_defaults` reproduces a read that set no ANN GUC — but "no ANN GUC" was never
+  # "no GUC at all". When exact-scan forcing is on, `HeavyRead` applies it to EVERY heavy
+  # read including a bare `HeavyRead.all/2`, so this branch must arm it too or it prints an
+  # INDEX plan for a read that could not have used the index.
   defp with_read_gucs(:session_defaults, fun) do
-    {:ok, result} = AdminRepo.transaction(fn -> fun.() end)
+    {:ok, result} =
+      AdminRepo.transaction(fn ->
+        LocalGuc.scoped(AdminRepo, exact_scan_gucs(), fn ->
+          set_exact_scan()
+          fun.()
+        end)
+      end)
+
     result
   end
 
   defp with_read_gucs(ef_search, fun) do
     {:ok, result} =
       AdminRepo.transaction(fn ->
-        LocalGuc.scoped(AdminRepo, @read_gucs, fn ->
+        LocalGuc.scoped(AdminRepo, @read_gucs ++ exact_scan_gucs(), fn ->
           set_iterative_scan()
+          set_exact_scan()
           AdminRepo.query!("SET LOCAL hnsw.ef_search = #{ef_search}", [])
           fun.()
         end)
       end)
 
     result
+  end
+
+  # Deliberately reads the SAME source of truth `HeavyRead` reads
+  # (`HeavyRead.force_exact_scan?/0` -> `:heavy_read_force_exact_scan`). This is the
+  # opposite of the rule the chokepoint GUARD in
+  # `test/loopctl/embeddings/hnsw_dead_entry_recall_test.exs` follows, and the difference is
+  # the point: a guard needs an INDEPENDENT source or it moves with the thing it guards and
+  # goes vacuous, while a diagnostic needs the SAME source or it stops describing the read
+  # it is explaining. Do not "fix" this one to derive from `SCALE_TESTS`.
+  defp exact_scan_gucs do
+    if HeavyRead.force_exact_scan?(), do: @exact_scan_gucs, else: []
+  end
+
+  defp set_exact_scan do
+    if HeavyRead.force_exact_scan?() do
+      Enum.each(@exact_scan_gucs, &AdminRepo.query!("SET LOCAL #{&1} = off", []))
+    end
+
+    :ok
   end
 
   defp set_iterative_scan do


### PR DESCRIPTION
Replay the exact-scan GUCs in the recall diagnostic, so its EXPLAIN describes the read it is explaining

VectorRecallDiagnostics wraps every assertion that ever produced the left: [] signature and,
on an empty result, prints the plan of the query that just came back empty. Its whole value
rests on one property, which its own comment states: an EXPLAIN at session defaults can
describe a different execution than the read it is diagnosing, so the wrapper re-applies the
GUCs HeavyRead set.

The previous commit added enable_indexscan and enable_bitmapscan at that same chokepoint and
did not extend the list, so the diagnostic reopened exactly the divergence it exists to close.
It would have printed an HNSW index plan for a read that could not have used the index -
worse than printing nothing, because the plan looks authoritative and sends the reader after
the ANN.

Both branches need it, and the session-defaults branch is the one that is easy to miss. Its
existing comment is right that a bare HeavyRead.all/2 carries no hnsw_* opts and therefore
emits no ANN SET LOCAL - but no ANN GUC was never no GUC at all. Exact-scan forcing is applied
to EVERY heavy read when the flag is on, bare reads included, so that branch has to arm it too.

force_exact_scan?/0 becomes public for this, with a docstring saying why. The diagnostic reads
the SAME source of truth HeavyRead reads, which is the opposite of the rule the chokepoint
guard in hnsw_dead_entry_recall_test.exs follows, and the comment says so: a guard needs an
INDEPENDENT source or it moves with the thing it guards and goes vacuous, while a diagnostic
needs the SAME source or it stops describing the read. Both mistakes were made in this branch
already, one in each direction, which is why the distinction is written down next to the code.

Found by the enhanced review on the parent branch, where it was the one confirmed finding that
fell outside the reviewed diff.
