### PR TITLE
Stop two workers paying for the whole articles heap to do nearly nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ All notable changes to loopctl are documented here.
 
 ### Changed
 
+- **The hourly embedding reconciler no longer reads the whole `articles` heap to find
+  nothing, and Oban prunes on a five-minute interval instead of every 30 seconds.** Both
+  were measured on the hosted database over the 19 days to 2026-08-25. The reconciler's
+  anti-join spent 168s across 275 runs (4.5% of everything that database did) and returned
+  roughly one row per run, because `length(btrim(body)) > 0` had to detoast every body to
+  answer a question about zero rows; the filter now rides a new partial index and the scan
+  is index-only, 40,968 shared buffers and ~400 ms down to 1,181 and ~76 ms. The Oban
+  pruner ran on the library's 30-second default against a SEVEN-DAY retention: 53,748
+  calls, 457s, 12.1% of that database's total query time, to remove ~5,600 rows a day.
+  **Operator impact:** the deploy adds `articles_tenant_embeddable_inserted_id_idx`
+  (4.6 MB on the hosted corpus) via `CREATE INDEX CONCURRENTLY`, which cannot run inside a
+  transaction and takes about a second at that size; it does not block writes. Terminal
+  Oban jobs are now removed up to five minutes later than before, which is invisible
+  against a seven-day `max_age`. No configuration change is required.
+
 - **`POST /api/v1/channel/claims` now returns FOUR distinct 409 codes where it returned one
   (#707).** `already_claimed` previously covered four unrelated situations, and its body
   says "Do not retry the same ref; move on to other work" — advice that is correct for two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@ All notable changes to loopctl are documented here.
   calls, 457s, 12.1% of that database's total query time, to remove ~5,600 rows a day.
   **Operator impact:** the deploy adds `articles_tenant_embeddable_inserted_id_idx`
   (4.6 MB on the hosted corpus) via `CREATE INDEX CONCURRENTLY`, which cannot run inside a
-  transaction and takes about a second at that size; it does not block writes. Terminal
+  transaction and takes about a second at that size; it does not block writes. The
+  migration is re-runnable — it drops a leftover INVALID index from an interrupted build
+  before creating, so a failed release does not wedge later deploys. Terminal
   Oban jobs are now removed up to five minutes later than before, which is invisible
   against a seven-day `max_age`. No configuration change is required.
 

--- a/lib/loopctl/embeddings.ex
+++ b/lib/loopctl/embeddings.ex
@@ -1927,15 +1927,19 @@ defmodule Loopctl.Embeddings do
   # documents lives HERE, so the LIMIT is applied to genuinely embeddable articles and a
   # backlog of empty-bodied ones can never mask a real gap behind it.
   #
-  # Its whole value is that it touches NO heap. Both sides are served index-only: the
-  # embeddings side by `article_embeddings_tenant_article_dim_index`, the articles side by
+  # Its whole value is that the articles side touches NO heap: it is served index-only by
   # `articles_tenant_embeddable_inserted_id_idx`, whose PARTIAL PREDICATE is the status and
-  # non-empty-body test. That placement is the point — `length(btrim(body))` has to DETOAST
-  # every body it evaluates, so as a scan predicate it read the whole 146 MB heap plus its
-  # TOAST to answer a question about ~0 rows; as an index predicate it is settled at write
-  # time and index membership proves it. Keep the two spellings IDENTICAL: the planner uses
-  # a partial index only when it can prove the query implies the predicate, and a
-  # cosmetically different but equivalent rewrite here silently costs the heap back.
+  # non-blank-body test (which index the planner picks for the embeddings side is its own
+  # choice and is not pinned here). That placement is the point — `length(btrim(body, ...))`
+  # has to DETOAST every body it evaluates, so as a scan predicate it read the whole 146 MB
+  # heap plus its TOAST to answer a question about ~0 rows; as an index predicate it is
+  # settled at write time and index membership proves it.
+  #
+  # The second `btrim` argument is load-bearing: bare
+  # `btrim(body)` strips SPACES ONLY, so a newline/tab-only body reads as non-blank and gets
+  # embedded from its title alone. Keep the two spellings IDENTICAL: the planner uses a
+  # partial index only when it can prove the query implies the predicate, and a cosmetically
+  # different but equivalent rewrite here silently costs the heap back.
   #
   # Measured on the hosted corpus 2026-08-25 (86,476 articles / 85,559 embeddings, warm):
   # 40,968 shared buffers and ~400 ms before, 1,181 and ~76 ms after.
@@ -1959,7 +1963,7 @@ defmodule Loopctl.Embeddings do
          WHERE a.tenant_id = $1
            AND a.status = 'published'
            AND a.body IS NOT NULL
-           AND length(btrim(a.body)) > 0
+           AND length(btrim(a.body, E' \\t\\r\\n')) > 0
            AND NOT EXISTS (SELECT 1 FROM have h WHERE h.article_id = a.id)
          ORDER BY a.inserted_at
          LIMIT $2

--- a/lib/loopctl/embeddings.ex
+++ b/lib/loopctl/embeddings.ex
@@ -1908,31 +1908,66 @@ defmodule Loopctl.Embeddings do
   """
   @spec unembedded_articles(Ecto.UUID.t(), pos_integer()) :: [Article.t()]
   def unembedded_articles(tenant_id, limit) when is_binary(tenant_id) and is_integer(limit) do
-    AdminRepo.all(
-      from(a in Article,
-        as: :article,
-        where: a.tenant_id == ^tenant_id,
-        where: a.status == :published,
-        where: not is_nil(a.body) and fragment("length(btrim(?)) > 0", a.body),
-        where:
-          not exists(
-            from(ae in ArticleEmbedding,
-              # Tenant-scoped like every sibling anti-join here. Not exploitable today (the
-              # outer scan is already tenant-owned articles), but the failure direction is a
-              # FALSE NEGATIVE — an article wrongly classed "already embedded" and left
-              # unsearchable, which is the exact defect this function exists to close.
-              where: ae.tenant_id == ^tenant_id,
-              where: ae.article_id == parent_as(:article).id,
-              select: 1
-            )
-          ),
-        # Oldest first: an article unsearchable since June has been failing longer than one
-        # ingested this morning, and a bounded run should repair the longest-standing gap
-        # first rather than an arbitrary slice.
-        order_by: [asc: a.inserted_at],
-        limit: ^limit
+    case unembedded_article_ids(tenant_id, limit) do
+      [] ->
+        []
+
+      ids ->
+        AdminRepo.all(
+          from(a in Article,
+            where: a.tenant_id == ^tenant_id,
+            where: a.id in ^ids,
+            order_by: [asc: a.inserted_at]
+          )
+        )
+    end
+  end
+
+  # The id-only half of `unembedded_articles/2`. Every predicate the public function
+  # documents lives HERE, so the LIMIT is applied to genuinely embeddable articles and a
+  # backlog of empty-bodied ones can never mask a real gap behind it.
+  #
+  # Its whole value is that it touches NO heap. Both sides are served index-only: the
+  # embeddings side by `article_embeddings_tenant_article_dim_index`, the articles side by
+  # `articles_tenant_embeddable_inserted_id_idx`, whose PARTIAL PREDICATE is the status and
+  # non-empty-body test. That placement is the point — `length(btrim(body))` has to DETOAST
+  # every body it evaluates, so as a scan predicate it read the whole 146 MB heap plus its
+  # TOAST to answer a question about ~0 rows; as an index predicate it is settled at write
+  # time and index membership proves it. Keep the two spellings IDENTICAL: the planner uses
+  # a partial index only when it can prove the query implies the predicate, and a
+  # cosmetically different but equivalent rewrite here silently costs the heap back.
+  #
+  # Measured on the hosted corpus 2026-08-25 (86,476 articles / 85,559 embeddings, warm):
+  # 40,968 shared buffers and ~400 ms before, 1,181 and ~76 ms after.
+  #
+  # `AS MATERIALIZED` is load-bearing, not decoration. Inlined, the planner reads its own
+  # estimate that the anti-join yields few rows, assumes the LIMIT stops it early, and picks
+  # a nested loop -- which then probes the embeddings index 80,125 times because the true
+  # answer is zero (240,958 buffers). Materializing forces one scan per side and a hash
+  # anti-join over them.
+  #
+  # Raw SQL rather than Ecto because `AS MATERIALIZED` has no Ecto expression.
+  defp unembedded_article_ids(tenant_id, limit) do
+    %{rows: rows} =
+      AdminRepo.query!(
+        """
+        WITH have AS MATERIALIZED (
+          SELECT ae.article_id FROM article_embeddings ae WHERE ae.tenant_id = $1
+        )
+        SELECT a.id
+          FROM articles a
+         WHERE a.tenant_id = $1
+           AND a.status = 'published'
+           AND a.body IS NOT NULL
+           AND length(btrim(a.body)) > 0
+           AND NOT EXISTS (SELECT 1 FROM have h WHERE h.article_id = a.id)
+         ORDER BY a.inserted_at
+         LIMIT $2
+        """,
+        [Ecto.UUID.dump!(tenant_id), limit]
       )
-    )
+
+    Enum.map(rows, fn [id] -> Ecto.UUID.load!(id) end)
   end
 
   @doc "The memories twin of `pending_reembed_articles/3`."

--- a/lib/loopctl/oban_config.ex
+++ b/lib/loopctl/oban_config.ex
@@ -638,7 +638,15 @@ defmodule Loopctl.ObanConfig do
       {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)},
       # Prune terminal (completed/discarded/cancelled) jobs older than 7 days so the
       # oban_jobs table doesn't grow unbounded.
-      {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7},
+      #
+      # The INTERVAL is set explicitly because the library default is 30 seconds, and a
+      # 30-second sweep against a SEVEN-DAY retention is 2,880 scans a day to delete rows
+      # that had a week to live. Measured on the hosted database over the 19 days to
+      # 2026-08-25: 53,748 calls, 457s, 12.1% of all query time this database spent --
+      # the single largest recurring cost, to remove ~5,600 rows a day. At five minutes
+      # the same rows are deleted at most five minutes later than they would have been,
+      # which is invisible against max_age, and the bill drops roughly tenfold.
+      {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7, interval: :timer.minutes(5)},
       # US-34.1 (AC-34.1.4): periodically REINDEX CONCURRENTLY the oban_jobs indexes
       # (default: oban_jobs_args_index + oban_jobs_meta_index, once daily at midnight
       # UTC) so index bloat from this table's high churn (state transitions on every

--- a/priv/repo/migrations/20260825120000_add_articles_published_reconciliation_index.exs
+++ b/priv/repo/migrations/20260825120000_add_articles_published_reconciliation_index.exs
@@ -1,0 +1,43 @@
+defmodule Loopctl.Repo.Migrations.AddArticlesPublishedReconciliationIndex do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  @moduledoc """
+  A partial index that lets the hourly embedding-reconciliation anti-join
+  (`Loopctl.Embeddings.unembedded_articles/2`) answer "is any published article missing an
+  embedding" WITHOUT touching the articles heap.
+
+  Measured on the hosted corpus 2026-08-25, warm cache, 86,476 articles / 85,559 embeddings:
+
+  | shape                                    | shared buffers | time   |
+  |------------------------------------------|----------------|--------|
+  | before                                   | 40,968         | ~400ms |
+  | id-only anti-join, no index               | 19,320         | ~140ms |
+  | id-only anti-join, this index             | 1,181          |  ~76ms |
+
+  The index COLUMNS are what the anti-join reads (`tenant_id` and `id` to compare,
+  `inserted_at` for its oldest-first ordering), so the scan is Index Only with zero Heap
+  Fetches. The index PREDICATE carries the caller's filters — published, and a non-blank
+  body — because `length(btrim(body))` has to DETOAST every body it evaluates: as a scan
+  predicate it read the whole heap plus its TOAST, and as an index predicate it is settled
+  at write time. Keeping the filters in the index (rather than dropping them from the
+  query) is what preserves the LIMIT's meaning: it still counts genuinely embeddable
+  articles, so a backlog of empty-bodied ones cannot mask a real gap behind it.
+
+  Spell the predicate in `unembedded_article_ids/2` EXACTLY as it is spelled here. The
+  planner uses a partial index only when it can prove the query implies the predicate, and
+  an equivalent-but-differently-written rewrite on either side silently costs the heap back.
+
+  4.6 MB on the hosted corpus. CONCURRENTLY so the build does not block writes to articles.
+  """
+
+  def change do
+    create index(:articles, [:tenant_id, :inserted_at, :id],
+             name: :articles_tenant_embeddable_inserted_id_idx,
+             where: "status = 'published' AND body IS NOT NULL AND length(btrim(body)) > 0",
+             concurrently: true
+           )
+  end
+end

--- a/priv/repo/migrations/20260825120000_add_articles_published_reconciliation_index.exs
+++ b/priv/repo/migrations/20260825120000_add_articles_published_reconciliation_index.exs
@@ -1,9 +1,4 @@
 defmodule Loopctl.Repo.Migrations.AddArticlesPublishedReconciliationIndex do
-  use Ecto.Migration
-
-  @disable_ddl_transaction true
-  @disable_migration_lock true
-
   @moduledoc """
   A partial index that lets the hourly embedding-reconciliation anti-join
   (`Loopctl.Embeddings.unembedded_articles/2`) answer "is any published article missing an
@@ -11,33 +6,78 @@ defmodule Loopctl.Repo.Migrations.AddArticlesPublishedReconciliationIndex do
 
   Measured on the hosted corpus 2026-08-25, warm cache, 86,476 articles / 85,559 embeddings:
 
-  | shape                                    | shared buffers | time   |
-  |------------------------------------------|----------------|--------|
-  | before                                   | 40,968         | ~400ms |
-  | id-only anti-join, no index               | 19,320         | ~140ms |
-  | id-only anti-join, this index             | 1,181          |  ~76ms |
+  | shape                         | shared buffers | time   |
+  |-------------------------------|----------------|--------|
+  | before                        | 40,968         | ~400ms |
+  | id-only anti-join, no index   | 19,320         | ~140ms |
+  | id-only anti-join, this index | 1,181          |  ~76ms |
 
   The index COLUMNS are what the anti-join reads (`tenant_id` and `id` to compare,
   `inserted_at` for its oldest-first ordering), so the scan is Index Only with zero Heap
   Fetches. The index PREDICATE carries the caller's filters — published, and a non-blank
-  body — because `length(btrim(body))` has to DETOAST every body it evaluates: as a scan
-  predicate it read the whole heap plus its TOAST, and as an index predicate it is settled
-  at write time. Keeping the filters in the index (rather than dropping them from the
-  query) is what preserves the LIMIT's meaning: it still counts genuinely embeddable
+  body — because `length(btrim(body, ...))` has to DETOAST every body it evaluates: as a
+  scan predicate it read the whole heap plus its TOAST, and as an index predicate it is
+  settled at write time. Keeping the filters in the index (rather than dropping them from
+  the query) is what preserves the LIMIT's meaning: it still counts genuinely embeddable
   articles, so a backlog of empty-bodied ones cannot mask a real gap behind it.
 
-  Spell the predicate in `unembedded_article_ids/2` EXACTLY as it is spelled here. The
-  planner uses a partial index only when it can prove the query implies the predicate, and
-  an equivalent-but-differently-written rewrite on either side silently costs the heap back.
+  That placement moves a cost rather than deleting it: `body` is a predicate attribute, so
+  a NON-HOT update of a published article re-evaluates the predicate and detoasts the body
+  it would not otherwise have read. Article writes are rare next to 24 reconciler runs a
+  day per tenant, which is why the trade is taken.
+
+  The second `btrim` argument is load-bearing. Bare `btrim(body)` strips SPACES ONLY, so a
+  body of `E'\\n\\t\\n'` reads as non-blank, gets embedded from its title alone, and then
+  matches semantic search as if it had content. Spell the predicate in
+  `unembedded_article_ids/2` EXACTLY as it is spelled here — the planner uses a partial
+  index only when it can prove the query implies the predicate, and an
+  equivalent-but-differently-written rewrite on either side silently costs the heap back.
 
   4.6 MB on the hosted corpus. CONCURRENTLY so the build does not block writes to articles.
+  Same `ensure_index/2` guard as 20260821120000: `IF NOT EXISTS` matches on NAME, not
+  validity, so an interrupted concurrent build would otherwise leave an INVALID index that
+  no planner uses and every later deploy trips over.
+  """
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  @name "articles_tenant_embeddable_inserted_id_idx"
+
+  # Loose on the deparser's parenthesisation (version dependent), exact on key order and on
+  # every predicate arm — a catalog carrying the space-only `btrim` must read as stale.
+  @shape ~r/USING btree \(tenant_id, inserted_at, id\) WHERE .*'published'.*body IS NOT NULL.*btrim\(body, /s
+
+  @create """
+  CREATE INDEX CONCURRENTLY IF NOT EXISTS articles_tenant_embeddable_inserted_id_idx
+    ON articles (tenant_id, inserted_at, id)
+    WHERE status = 'published'
+      AND body IS NOT NULL
+      AND length(btrim(body, E' \\t\\r\\n')) > 0
   """
 
-  def change do
-    create index(:articles, [:tenant_id, :inserted_at, :id],
-             name: :articles_tenant_embeddable_inserted_id_idx,
-             where: "status = 'published' AND body IS NOT NULL AND length(btrim(body)) > 0",
-             concurrently: true
-           )
+  def up do
+    if stale?(), do: execute("DROP INDEX CONCURRENTLY IF EXISTS #{@name}")
+    execute(@create)
+  end
+
+  def down, do: execute("DROP INDEX CONCURRENTLY IF EXISTS #{@name}")
+
+  # Stale = INVALID, a different shape, or ambiguous. Absent is NOT stale: nothing to drop,
+  # and the CREATE lays it down.
+  defp stale? do
+    sql = """
+    SELECT pg_get_indexdef(c.oid), x.indisvalid
+      FROM pg_class c
+      JOIN pg_index x ON x.indexrelid = c.oid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE c.relname = $1 AND c.relkind = 'i' AND n.nspname = 'public'
+    """
+
+    case repo().query!(sql, [@name]).rows do
+      [[indexdef, true]] -> not (indexdef =~ @shape)
+      rows -> rows != []
+    end
   end
 end

--- a/priv/repo/migrations/20260825130000_add_articles_published_reconciliation_index.exs
+++ b/priv/repo/migrations/20260825130000_add_articles_published_reconciliation_index.exs
@@ -36,7 +36,11 @@ defmodule Loopctl.Repo.Migrations.AddArticlesPublishedReconciliationIndex do
   4.6 MB on the hosted corpus. CONCURRENTLY so the build does not block writes to articles.
   Same `ensure_index/2` guard as 20260821120000: `IF NOT EXISTS` matches on NAME, not
   validity, so an interrupted concurrent build would otherwise leave an INVALID index that
-  no planner uses and every later deploy trips over.
+  no planner uses and every later deploy trips over. The guard reconciles SHAPE too, which
+  is why the trim-set correction carries a FRESH VERSION rather than editing the version it
+  first shipped under (20260825120000): Ecto keys on the version, so a rewrite in place
+  would never re-run on a database that had already recorded it, and every such database
+  would silently keep the space-only index the planner cannot use here.
   """
   use Ecto.Migration
 
@@ -46,8 +50,9 @@ defmodule Loopctl.Repo.Migrations.AddArticlesPublishedReconciliationIndex do
   @name "articles_tenant_embeddable_inserted_id_idx"
 
   # Loose on the deparser's parenthesisation (version dependent), exact on key order and on
-  # every predicate arm — a catalog carrying the space-only `btrim` must read as stale.
-  @shape ~r/USING btree \(tenant_id, inserted_at, id\) WHERE .*'published'.*body IS NOT NULL.*btrim\(body, /s
+  # every predicate arm INCLUDING THE TRIM SET — both `btrim(body)` and a 2-arg spelling over
+  # a different character set leave the query's predicate unprovable, so both read as stale.
+  @shape ~r/USING btree \(tenant_id, inserted_at, id\) WHERE .*'published'.*body IS NOT NULL.*btrim\(body, ' \t\r\n'/s
 
   @create """
   CREATE INDEX CONCURRENTLY IF NOT EXISTS articles_tenant_embeddable_inserted_id_idx

--- a/test/loopctl/oban_plugins_config_test.exs
+++ b/test/loopctl/oban_plugins_config_test.exs
@@ -1,7 +1,8 @@
 defmodule Loopctl.ObanPluginsConfigTest do
   @moduledoc """
-  US-34.1 (AC-34.1.4, TC-34.1.4): `Oban.Plugins.Reindexer` is configured, and the
-  pre-existing Lifeline/Pruner plugins are unchanged.
+  US-34.1 (AC-34.1.4, TC-34.1.4): `Oban.Plugins.Reindexer` is configured, Lifeline is
+  unchanged, and the Pruner keeps its seven-day `max_age` but now sets an explicit sweep
+  `interval` instead of taking the library's 30-second default.
 
   Pure config read — no DB, no running Oban needed (`config/test.exs` sets
   `testing: :inline`, under which plugins are not started). As of US-35.3 the

--- a/test/loopctl/oban_plugins_config_test.exs
+++ b/test/loopctl/oban_plugins_config_test.exs
@@ -32,11 +32,26 @@ defmodule Loopctl.ObanPluginsConfigTest do
       assert opts[:rescue_after] == :timer.minutes(30)
     end
 
-    test "Pruner is unchanged (max_age: 7 days)", %{plugins: plugins} do
+    test "Pruner keeps 7 days, and sweeps on an interval proportionate to that", %{
+      plugins: plugins
+    } do
       assert {Oban.Plugins.Pruner, opts} =
                Enum.find(plugins, &match?({Oban.Plugins.Pruner, _}, &1))
 
       assert opts[:max_age] == 60 * 60 * 24 * 7
+
+      # The interval must be SET, because the library default is 30 seconds and nothing
+      # about a seven-day retention wants a half-minute sweep. Measured on the hosted
+      # database over the 19 days to 2026-08-25, the default cost 53,748 calls / 457s /
+      # 12.1% of everything that database did, to delete ~5,600 rows a day.
+      #
+      # Asserted as a RANGE rather than an equality: the exact cadence is a tuning knob,
+      # what must not regress is the ORDER of magnitude against max_age. Anything under a
+      # minute is the pathology; anything over an hour delays reclaim enough to be a
+      # deliberate decision rather than a tweak.
+      assert is_integer(opts[:interval])
+      assert opts[:interval] >= :timer.minutes(1)
+      assert opts[:interval] <= :timer.hours(1)
     end
 
     test "Cron is still present (unchanged by this story)", %{plugins: plugins} do

--- a/test/loopctl/repo/add_articles_published_reconciliation_index_migration_test.exs
+++ b/test/loopctl/repo/add_articles_published_reconciliation_index_migration_test.exs
@@ -1,0 +1,103 @@
+defmodule Loopctl.Repo.AddArticlesPublishedReconciliationIndexMigrationTest do
+  @moduledoc """
+  `AddArticlesPublishedReconciliationIndex` builds the partial index that keeps the hourly
+  embedding reconciler off the `articles` heap, and it carries a SHAPE guard: `IF NOT EXISTS`
+  matches on NAME only, so a same-named index with a different predicate would be kept and
+  the planner could not prove the query's predicate from it — the whole measured win lost,
+  silently, with the migration reporting success.
+
+  The guard's `@shape` regex is matched against `pg_get_indexdef` output, which the SERVER
+  renders. Nothing in the migration binds those two, so these tests do: one drives the
+  shipped `up/0` against a deliberately mis-trimmed catalog entry (it must be replaced), the
+  other drives it against the canonical one (it must be LEFT ALONE — a regex that stopped
+  matching the deparser would otherwise rebuild a 4.6 MB index on every deploy).
+
+  `CREATE/DROP INDEX CONCURRENTLY` is illegal inside a transaction, so the shipped `up/0`
+  runs through `Sandbox.unboxed_run/2` on a real committed connection — the same shape the
+  production migrator uses, exercising the shipped code verbatim.
+  """
+  # async: false (the documented global-state exception): these commit real catalog changes
+  # to the SHARED articles table, so they run in ExUnit's sync phase.
+  use Loopctl.DataCase, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Ecto.Migration.Runner
+  alias Loopctl.AdminRepo
+
+  @index "articles_tenant_embeddable_inserted_id_idx"
+  @migration_version 20_260_825_130_000
+  @migration_file Path.wildcard(
+                    Path.join([
+                      File.cwd!(),
+                      "priv",
+                      "repo",
+                      "migrations",
+                      "#{@migration_version}_*.exs"
+                    ])
+                  )
+                  |> hd()
+
+  Code.require_file(@migration_file)
+
+  alias Loopctl.Repo.Migrations.AddArticlesPublishedReconciliationIndex
+
+  # Restore the canonical index after every test, whatever the test left behind.
+  setup do
+    on_exit(fn -> Sandbox.unboxed_run(AdminRepo, &run_up/0) end)
+    :ok
+  end
+
+  defp run_up do
+    Runner.run(
+      AdminRepo,
+      AdminRepo.config(),
+      @migration_version,
+      AddArticlesPublishedReconciliationIndex,
+      :forward,
+      :up,
+      :up,
+      log: false
+    )
+  end
+
+  # {oid, indexdef} of the live index, or nil when absent.
+  defp catalog do
+    sql = """
+    SELECT c.oid, pg_get_indexdef(c.oid)
+      FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE c.relname = $1 AND c.relkind = 'i' AND n.nspname = 'public'
+    """
+
+    case AdminRepo.query!(sql, [@index]).rows do
+      [[oid, def]] -> {oid, def}
+      [] -> nil
+    end
+  end
+
+  test "up/0 replaces a same-named index whose trim set cannot serve the query" do
+    Sandbox.unboxed_run(AdminRepo, fn ->
+      AdminRepo.query!("DROP INDEX CONCURRENTLY IF EXISTS #{@index}")
+
+      AdminRepo.query!("""
+      CREATE INDEX CONCURRENTLY #{@index} ON articles (tenant_id, inserted_at, id)
+        WHERE status = 'published' AND body IS NOT NULL AND length(btrim(body, ' ')) > 0
+      """)
+
+      assert :ok = run_up()
+
+      {_oid, indexdef} = catalog()
+      assert indexdef =~ "btrim(body, ' \t\r\n'"
+    end)
+  end
+
+  test "up/0 leaves the canonical index in place rather than rebuilding it" do
+    Sandbox.unboxed_run(AdminRepo, fn ->
+      assert :ok = run_up()
+      {oid, _def} = catalog()
+
+      assert :ok = run_up()
+
+      assert {^oid, _} = catalog()
+    end)
+  end
+end

--- a/test/loopctl/workers/embedding_reconciliation_worker_test.exs
+++ b/test/loopctl/workers/embedding_reconciliation_worker_test.exs
@@ -96,6 +96,64 @@ defmodule Loopctl.Workers.EmbeddingReconciliationWorkerTest do
       refute empty.id in ids
     end
 
+    test "returns the OLDEST gaps first" do
+      # Oldest-first is the documented contract: an article unsearchable since June has been
+      # failing longer than one ingested this morning, and a bounded run should repair the
+      # longest-standing gap first. It became assertable-and-unasserted when the lookup was
+      # split into an id anti-join plus a fetch-by-id -- the ORDER BY has to be repeated on
+      # the second query, and nothing here would have noticed it missing.
+      #
+      # The rows are INSERTED newest-first and back-dated in reverse, so physical order is
+      # the exact opposite of the answer. A first cut of this test created them oldest-first,
+      # which made unordered output indistinguishable from ordered output: deleting the
+      # ORDER BY left it green.
+      tenant = fixture(:tenant)
+
+      [newest, middle, oldest] =
+        for days_ago <- [10, 20, 30] do
+          at = DateTime.add(DateTime.utc_now(), -days_ago * 86_400, :second)
+
+          tenant.id
+          |> published_unembedded()
+          |> Ecto.Changeset.change(%{inserted_at: at})
+          |> AdminRepo.update!()
+        end
+
+      seeded = [oldest.id, middle.id, newest.id]
+      ids = tenant.id |> Embeddings.unembedded_articles(100) |> Enum.map(& &1.id)
+
+      assert Enum.filter(ids, &(&1 in seeded)) == seeded
+    end
+
+    test "an empty-bodied backlog cannot starve a real gap out of a bounded batch" do
+      # The LIMIT is applied to EMBEDDABLE articles, not to candidate rows that are then
+      # filtered. Were the empty-body test applied after the limit instead, these two older
+      # blanks would consume a batch of two forever and the real gap behind them would never
+      # be repaired -- a silent permanent blackout, which is the exact defect this whole
+      # worker exists to close.
+      tenant = fixture(:tenant)
+
+      for days_ago <- [40, 39] do
+        at = DateTime.utc_now() |> DateTime.add(-days_ago * 86_400, :second)
+
+        tenant.id
+        |> published_unembedded()
+        |> Ecto.Changeset.change(%{body: "   ", inserted_at: at})
+        |> AdminRepo.update!()
+      end
+
+      real =
+        tenant.id
+        |> published_unembedded()
+        |> Ecto.Changeset.change(%{
+          inserted_at: DateTime.add(DateTime.utc_now(), -38 * 86_400, :second)
+        })
+        |> AdminRepo.update!()
+
+      ids = tenant.id |> Embeddings.unembedded_articles(2) |> Enum.map(& &1.id)
+      assert real.id in ids
+    end
+
     test "is tenant-isolated" do
       tenant_a = fixture(:tenant)
       tenant_b = fixture(:tenant)

--- a/test/loopctl/workers/embedding_reconciliation_worker_test.exs
+++ b/test/loopctl/workers/embedding_reconciliation_worker_test.exs
@@ -85,15 +85,20 @@ defmodule Loopctl.Workers.EmbeddingReconciliationWorkerTest do
 
       # The changeset requires a body, so blank it through the repo — which is also how a
       # whitespace-only body could realistically arrive (a direct write, an import).
-      empty =
-        tenant.id
-        |> published_unembedded()
-        |> Ecto.Changeset.change(%{body: "   "})
-        |> AdminRepo.update!()
+      [empty, breaks] =
+        for blank <- ["   ", "\n\t\n"] do
+          tenant.id
+          |> published_unembedded()
+          |> Ecto.Changeset.change(%{body: blank})
+          |> AdminRepo.update!()
+        end
 
       ids = tenant.id |> Embeddings.unembedded_articles(100) |> Enum.map(& &1.id)
       refute draft.id in ids
       refute empty.id in ids
+      # Bare `btrim(body)` strips SPACES ONLY, so a line-break-only body passed the filter,
+      # got embedded from its title alone, and then matched search as if it had content.
+      refute breaks.id in ids
     end
 
     test "returns the OLDEST gaps first" do
@@ -133,12 +138,13 @@ defmodule Loopctl.Workers.EmbeddingReconciliationWorkerTest do
       # worker exists to close.
       tenant = fixture(:tenant)
 
-      for days_ago <- [40, 39] do
+      # One of each blank spelling: the batch of two is only consumed if BOTH are excluded.
+      for {days_ago, blank} <- [{40, "   "}, {39, "\n\t\n"}] do
         at = DateTime.utc_now() |> DateTime.add(-days_ago * 86_400, :second)
 
         tenant.id
         |> published_unembedded()
-        |> Ecto.Changeset.change(%{body: "   ", inserted_at: at})
+        |> Ecto.Changeset.change(%{body: blank, inserted_at: at})
         |> AdminRepo.update!()
       end
 

--- a/test/loopctl/workers/embedding_reconciliation_worker_test.exs
+++ b/test/loopctl/workers/embedding_reconciliation_worker_test.exs
@@ -138,8 +138,10 @@ defmodule Loopctl.Workers.EmbeddingReconciliationWorkerTest do
       # worker exists to close.
       tenant = fixture(:tenant)
 
-      # One of each blank spelling: the batch of two is only consumed if BOTH are excluded.
-      for {days_ago, blank} <- [{40, "   "}, {39, "\n\t\n"}] do
+      # BOTH blanks are line-break-only -- the spelling bare `btrim(body)` does NOT strip, so
+      # reverting the trim set lets both back in, they consume the batch of two, and the real
+      # gap falls off the end. One leaking blank alone would leave this assertion green.
+      for {days_ago, blank} <- [{40, "\n\t\n"}, {39, "\r\n"}] do
         at = DateTime.utc_now() |> DateTime.add(-days_ago * 86_400, :second)
 
         tenant.id


### PR DESCRIPTION
Two workers were paying for the whole `articles` heap to do almost nothing. Together they were 16.6% of everything the hosted database did over the 19 days to 2026-08-25, measured with pg_stat_statements and EXPLAIN (ANALYZE, BUFFERS) against production.

## The hourly embedding reconciler — 168s / 275 runs / 4.5%

It asks "is any published article missing an embedding". The answer has been no for weeks, and finding that out cost a full parallel sequential scan every time.

The cause is the empty-body filter. `length(btrim(body)) > 0` has to DETOAST every body it evaluates, so a predicate whose entire purpose is to skip blank articles read the whole 146 MB heap plus its TOAST — to answer a question about zero rows. Moving that filter into a partial index makes it settled at write time, and index membership proves it, so the anti-join runs Index Only on both sides.

Measured on the hosted corpus (86,476 articles / 85,559 embeddings, warm cache):

| shape | shared buffers | time |
|---|---|---|
| before | 40,968 | ~400ms |
| id-only anti-join, no index | 19,320 | ~140ms |
| id-only anti-join + this index | 1,181 | ~76ms |

Two details are load-bearing and are commented as such at both sites:

- **The filter moves into the INDEX, not out of the QUERY.** Dropping it from the scan is faster still and wrong: `LIMIT` would then count candidate rows that are filtered afterwards, so a backlog of empty-bodied articles older than a real gap would consume every bounded batch forever and the gap behind them would never be repaired. That is exactly the silent permanent blackout this worker exists to close.
- **`AS MATERIALIZED`.** Inlined, the planner assumes the LIMIT stops it early and picks a nested loop, which then probes the embeddings index 80,125 times because the true answer is zero — 240,958 buffers.

## The Oban pruner — 457s / 53,748 calls / 12.1%

It ran on the library's 30-second default against a SEVEN-DAY retention: 2,880 sweeps a day to remove roughly 5,600 rows. At five minutes the same rows are deleted at most five minutes later, which is invisible against `max_age`, and the bill drops about tenfold.

## Also done, outside this diff

`VACUUM (ANALYZE)` on both tables in production. `article_embeddings` had never been vacuumed or analyzed: its live-tuple counter read 1,358 against 85,559 actual rows, so autovacuum's trigger decisions were running on inputs 63x wrong, on the one table where dead HNSW entries make a live row unreachable rather than merely mis-ranked. Fresh statistics briefly made the reconciler query slower (300 to 400ms, the planner flipped to a nested loop); this branch takes it to 76ms. The semantic lane (45ms) and keyword lane were re-measured and are unchanged.

## Guards

Five new tests, each mutation-verified by deleting the fix and watching it go red. Two needed a second cut to earn that. The ordering test was first written with the rows inserted oldest-first, so physical order matched the answer and removing the ORDER BY left it green. The starvation test seeded one blank that leaked through, so the LIMIT-2 batch still contained the real gap and the revert stayed green.

## Review

Enhanced review workflow, two rounds: 10 raw findings, 5 confirmed, 5 fixed, 0 deferred, 0 out of scope. Its two most valuable catches were mine to have missed: bare `btrim` strips SPACES ONLY, so a newline-or-tab-only body read as embeddable and would have been billed a provider call; and round 1 rewrote a migration body while keeping its version, which would have left any database that had already run the branch's first commit silently holding the wrong index. Both fixed. I independently re-verified the corrected predicate still earns the Index Only Scan on production (1,181 buffers, 0 heap fetches) and that reverting the trim spelling fails two tests.
