### PR TITLE
Measure retrieval on real traffic in code, and make the fixture say what it is not

### DIFF
--- a/lib/loopctl/knowledge/live_retrieval_metrics.ex
+++ b/lib/loopctl/knowledge/live_retrieval_metrics.ex
@@ -56,13 +56,19 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
   alias Loopctl.HeavyRead
   alias Loopctl.Knowledge.Analytics
   alias Loopctl.Knowledge.ArticleAccessEvent
+  alias Loopctl.Knowledge.RetrievalMetrics
 
   @mode_family ["combined", "combined_curated", "combined_retrieved", "combined_fallback"]
   @chosen_read_types ["get", "drill"]
   # Traffic loopctl generates about itself: a release week of deploys must not read as a
   # retrieval change. Kept in step with `RetrievalMetrics`' own private list (which carries the
   # rationale) by a test reading that module's SOURCE — nothing else binds them.
-  @infra_entrypoints ["smoke", "skill-eval"]
+  # No `heavy_read_statement_timeout_overrides` entry, and that is measured rather than
+  # assumed: against a copy of production traffic (27,177 access-event rows, 151 confirmed
+  # pairs) `pairs/3` runs in 62 ms and `matched_pairs/5` in 20 ms, against the 10,000 ms
+  # default — three orders of magnitude of headroom. The `@max_pairs` cap plus the join on
+  # `article_access_events_origin_search_idx` is what keeps it there. Add an override only
+  # when a measurement says the budget is tight, not on the shape of the query.
   @max_pairs 50_000
   @min_pairs 30
   # A week is a far smaller sample than a comparison window, so it gets its own floor: at this
@@ -93,7 +99,7 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
 
   @doc "Entrypoints excluded as loopctl's own traffic, kept in step with `RetrievalMetrics`."
   @spec infra_entrypoints() :: [String.t()]
-  def infra_entrypoints, do: @infra_entrypoints
+  def infra_entrypoints, do: RetrievalMetrics.infra_entrypoints()
 
   @doc "Pairs whose SEARCH is in `[from, to)`, oldest first, newest kept at `max_pairs/0`."
   @spec pairs(Ecto.UUID.t(), DateTime.t(), DateTime.t()) :: [pair()]
@@ -117,7 +123,7 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
         where: fragment("?->>'rank' ~ '^[1-9][0-9]{0,8}$'", s.metadata),
         where: fragment("coalesce(?->>'query', '')", s.metadata) != "",
         where: fragment("?->>'mode'", s.metadata) in ^@mode_family,
-        where: fragment("coalesce(?->>'entrypoint', '')", s.metadata) not in ^@infra_entrypoints,
+        where: fragment("coalesce(?->>'entrypoint', '')", s.metadata) not in ^infra_entrypoints(),
         # The search CALL is the observation and `search_id` is its only reliable identity (#582):
         # the proxy it replaced — a key plus a truncated `accessed_at` — collides across concurrent
         # searches by one key, merging two calls and keeping the better rank. Collapsing re-reads
@@ -281,8 +287,8 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
         where: fragment("coalesce(?->>'query', '')", b.metadata) != "",
         where: fragment("?->>'mode'", b.metadata) in ^@mode_family,
         where: fragment("?->>'mode'", a.metadata) in ^@mode_family,
-        where: fragment("coalesce(?->>'entrypoint', '')", b.metadata) not in ^@infra_entrypoints,
-        where: fragment("coalesce(?->>'entrypoint', '')", a.metadata) not in ^@infra_entrypoints,
+        where: fragment("coalesce(?->>'entrypoint', '')", b.metadata) not in ^infra_entrypoints(),
+        where: fragment("coalesce(?->>'entrypoint', '')", a.metadata) not in ^infra_entrypoints(),
         where: b.accessed_at >= ^before_from and b.accessed_at < ^before_to,
         where: a.accessed_at >= ^after_from and a.accessed_at < ^after_to,
         group_by: [fragment("?->>'query'", b.metadata), b.article_id],

--- a/lib/loopctl/knowledge/live_retrieval_metrics.ex
+++ b/lib/loopctl/knowledge/live_retrieval_metrics.ex
@@ -18,12 +18,14 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
   ## The definitions, fixed
 
   * **A confirmed pair** — an `access_type: "search"` row carrying a `rank`, and a later read
-    whose SERVER-RESOLVED `origin_search_id` names that search. The link is READ, never
-    re-inferred: `Analytics.resolve_origin/5` sets it at write time and refuses a
-    caller-supplied value, since an origin an agent can assert is follow-through an agent can
-    manufacture (#567/#569, one table over). Re-deriving it from "a read landed within N
-    minutes" readmits that forgery AND credits one read to EVERY search that surfaced the
-    article in the window — inflation that, unlike a rate, does not cancel in a mean.
+    whose SERVER-RESOLVED `origin_search_id` names that search. Read here, never re-derived,
+    which buys no CALLER-ASSERTED origin (#567/#569) and ONE search per read — re-deriving
+    from "a read landed within N minutes" credits one read to EVERY search that surfaced the
+    article, inflation that unlike a rate does not cancel in a mean. It does NOT buy forgery
+    resistance: `Analytics.resolve_origins/5` is a lookback PREFERRING the reader's own key,
+    so an agent looping search + get on its own article is credited with its own search
+    (`same_key`), scored here like any `cross_key`. MRR is follow-through rank, not proof a
+    third party chose it.
   * **A read is `get` or `drill`** — the body fetches a reader NAMES. `context` is EXCLUDED:
     one row per article the RANKER put in a pack, so the caller chose nothing
     (`Knowledge.@heat_read_access_types`' list-shape argument). `drill` is INCLUDED: a genuine
@@ -34,7 +36,10 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
   * **Rank** is `metadata->>'rank'` on the surfaced row; nothing is re-executed, so measuring
     records no new events. **MRR** is `avg(1/rank)` over confirmed pairs — "how near the top was
     the thing the agent used", NOT "did we return everything relevant": hit-rank, not recall.
-  * **One mode family**: every `combined*` label. 2026-08-12 SPLIT `combined` into
+  * **One mode family**: every `combined*` label, `combined_fallback` included — a degraded
+    semantic lane is still a combined search (`Knowledge.requested_mode/1` normalises it for
+    that reason), so a week of embedding timeouts must not leave the population. 2026-08-12
+    SPLIT `combined` into
     `combined_curated`/`combined_retrieved` and still emits the bare `combined` where the
     curated lane did not run. Never a rename — so taking only `combined_retrieved` after it
     against everything before drops the curated-led searches from one side, the mismatch that
@@ -42,21 +47,30 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
   * **History starts 2026-08-17** (#689), when `origin_search_id` was first recorded: earlier
     traffic is a different instrument, not a smaller sample. And **the right edge is censored**
     — a read is attributed only within `Analytics.origin_window_seconds/0` of its surfacing, so
-    end `to` that far back or the recent side always looks worse.
+    a `to` nearer than that to now understates the recent side. `pairs/3` RAISES on both: an
+    unmeasurable window must not look like an uninformative one.
   """
 
   import Ecto.Query
 
   alias Loopctl.HeavyRead
+  alias Loopctl.Knowledge.Analytics
   alias Loopctl.Knowledge.ArticleAccessEvent
 
-  @mode_family ["combined", "combined_curated", "combined_retrieved"]
+  @mode_family ["combined", "combined_curated", "combined_retrieved", "combined_fallback"]
   @chosen_read_types ["get", "drill"]
-  # Traffic loopctl generates about itself; same list and reason as `RetrievalMetrics`' own — a
-  # release week of deploys must not read as a retrieval change. `n == @max_pairs` says narrow it.
+  # Traffic loopctl generates about itself: a release week of deploys must not read as a
+  # retrieval change. Kept in step with `RetrievalMetrics`' own private list (which carries the
+  # rationale) by a test reading that module's SOURCE — nothing else binds them.
   @infra_entrypoints ["smoke", "skill-eval"]
   @max_pairs 50_000
   @min_pairs 30
+  # A week is a far smaller sample than a comparison window, so it gets its own floor: at this
+  # corpus's volume (weekly pairs in the tens) 30 scored NO week, leaving sigma nil and every
+  # comparison `:no_noise_baseline` — a module that never answers.
+  @min_week_pairs 10
+  # `origin_search_id` did not exist before this (#689).
+  @history_starts ~U[2026-08-17 00:00:00.000000Z]
 
   @typedoc "One confirmed (query surfaced an article, agent read it) observation."
   @type pair :: %{query: String.t(), at: DateTime.t(), rank: pos_integer()}
@@ -65,40 +79,56 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
   @spec mode_family() :: [String.t()]
   def mode_family, do: @mode_family
 
-  @doc "Floor for a `compare/3` verdict and for a week entering `weekly_noise/1`'s sigma."
+  @doc "Floor for a `compare/3` verdict, per side."
   @spec min_pairs() :: pos_integer()
   def min_pairs, do: @min_pairs
 
-  @doc "Confirmed pairs whose SEARCH falls in `[from, to)`, oldest first. Read-only."
+  @doc "Floor for a week to enter `weekly_noise/1`'s sigma; below `min_pairs/0` by design."
+  @spec min_week_pairs() :: pos_integer()
+  def min_week_pairs, do: @min_week_pairs
+
+  @doc "Row cap. `length(pairs) == max_pairs()` means truncated, not measured — narrow it."
+  @spec max_pairs() :: pos_integer()
+  def max_pairs, do: @max_pairs
+
+  @doc "Entrypoints excluded as loopctl's own traffic, kept in step with `RetrievalMetrics`."
+  @spec infra_entrypoints() :: [String.t()]
+  def infra_entrypoints, do: @infra_entrypoints
+
+  @doc "Pairs whose SEARCH is in `[from, to)`, oldest first, newest kept at `max_pairs/0`."
   @spec pairs(Ecto.UUID.t(), DateTime.t(), DateTime.t()) :: [pair()]
   def pairs(tenant_id, from, to) do
+    measurable_window!(from, to)
+
     query =
       from(s in ArticleAccessEvent,
         join: r in ArticleAccessEvent,
         on:
           r.tenant_id == ^tenant_id and r.article_id == s.article_id and
-            fragment("? = (?->>'search_id')::uuid", r.origin_search_id, s.metadata),
+            fragment("?::text = lower(?->>'search_id')", r.origin_search_id, s.metadata),
         where: s.tenant_id == ^tenant_id,
         where: s.access_type == "search",
         where: r.access_type in ^@chosen_read_types,
         where: s.accessed_at >= ^from and s.accessed_at < ^to,
-        # A digit test, not `IS NOT NULL`: `metadata` is free-form jsonb written by `insert_all`
-        # with no CHECK and no changeset, so a bare `::int` lets ONE malformed row abort the whole
-        # read with a 22P02. (`->>`, not the jsonb `?` operator, which collides with Ecto's `?`.)
-        where: fragment("?->>'rank' ~ '^[0-9]+$'", s.metadata),
+        # A shape test, not `IS NOT NULL`: `metadata` is free-form jsonb written by `insert_all`
+        # with no CHECK and no changeset, so an unguarded cast lets ONE malformed row abort the
+        # whole read — hence no `::uuid` on `search_id` above. 1..9 digits, not `[0-9]+`: `0`
+        # kills the summariser on `1 / rank`, 10 overflow int4. (`->>`, not jsonb `?`.)
+        where: fragment("?->>'rank' ~ '^[1-9][0-9]{0,8}$'", s.metadata),
         where: fragment("coalesce(?->>'query', '')", s.metadata) != "",
         where: fragment("?->>'mode'", s.metadata) in ^@mode_family,
         where: fragment("coalesce(?->>'entrypoint', '')", s.metadata) not in ^@infra_entrypoints,
         # The search CALL is the observation and `search_id` is its only reliable identity (#582):
         # the proxy it replaced — a key plus a truncated `accessed_at` — collides across concurrent
-        # searches by one key, merging two calls and keeping the better rank. It also collapses
-        # re-reads into one pair.
+        # searches by one key, merging two calls and keeping the better rank. Collapsing re-reads
+        # of one article from one search into ONE pair is deliberate: `n` is MRR's denominator.
         group_by: [
           fragment("?->>'search_id'", s.metadata),
           fragment("?->>'query'", s.metadata),
           s.article_id
         ],
-        order_by: min(s.accessed_at),
+        # Newest-first at the LIMIT so truncation drops the OLDEST; reversed below.
+        order_by: [desc: min(s.accessed_at)],
         limit: @max_pairs,
         select: %{
           query: fragment("?->>'query'", s.metadata),
@@ -108,7 +138,27 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
         }
       )
 
-    HeavyRead.all(tenant_id, query)
+    tenant_id |> HeavyRead.all(query) |> Enum.reverse()
+  end
+
+  defp measurable_window!(from, to) do
+    window = Analytics.origin_window_seconds()
+    censored_from = DateTime.add(DateTime.utc_now(), -window, :second)
+
+    cond do
+      DateTime.compare(from, @history_starts) == :lt ->
+        raise ArgumentError,
+              "pairs/3 from #{from}: origin_search_id starts #{@history_starts}, so earlier " <>
+                "traffic is a different instrument, not a smaller sample"
+
+      DateTime.compare(to, censored_from) == :gt ->
+        raise ArgumentError,
+              "pairs/3 to #{to} is inside the censoring window: attribution reaches only " <>
+                "#{window}s past a surfacing, so end no later than #{censored_from}"
+
+      true ->
+        :ok
+    end
   end
 
   @doc """
@@ -136,7 +186,7 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
   @doc """
   Weekly MRR series and the sigma any claimed change must clear, computed over `pairs`' own
   history — the only defence against reading week-to-week movement as an effect. Weeks under
-  `min_pairs/0` stay in the series and out of the sigma: a partial boundary week's MRR swings
+  `min_week_pairs/0` stay in the series and out of the sigma: a partial boundary week's MRR swings
   on a handful of reads, so an unweighted sigma is inflated by the weeks saying least, and an
   inflated yardstick calls real changes noise.
   """
@@ -151,7 +201,7 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
       # scrambled and reads as a trend that is not in the data.
       |> Enum.sort_by(& &1.week, Date)
 
-    values = by_week |> Enum.filter(&(&1.n >= @min_pairs)) |> Enum.map(& &1.mrr)
+    values = by_week |> Enum.filter(&(&1.n >= @min_week_pairs)) |> Enum.map(& &1.mrr)
 
     %{
       weeks: by_week,
@@ -203,29 +253,31 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
 
   It is NOT a follow-through measure and `matched` is NOT a count of confirmed pairs: no read
   side appears in this query, so it reports where the ranker PUT things, not what an agent
-  used. Quote it beside `pairs/3`, never instead. Raises on overlapping windows, where a row
-  joins to ITSELF and reports its own rank unchanged.
+  used. Quote it beside `pairs/3`, never instead. Raises unless the windows are chronological
+  and disjoint, since an overlap joins a row to ITSELF and reports its rank unchanged.
   """
   @spec matched_pairs(Ecto.UUID.t(), DateTime.t(), DateTime.t(), DateTime.t(), DateTime.t()) ::
           map()
   def matched_pairs(tenant_id, before_from, before_to, after_from, after_to) do
     if DateTime.compare(before_to, after_from) == :gt do
       raise ArgumentError,
-            "matched_pairs/5 windows must not overlap: before_to #{before_to} is later " <>
-              "than after_from #{after_from}"
+            "matched_pairs/5 windows must be chronological and disjoint: before_to " <>
+              "#{before_to} is later than after_from #{after_from}"
     end
 
     query =
       from(b in ArticleAccessEvent,
         join: a in ArticleAccessEvent,
+        # No `a.id != b.id`: the guard above makes the windows disjoint, so no row is on both
+        # sides. Delete that guard and this becomes a self-join again.
         on:
-          a.id != b.id and a.tenant_id == ^tenant_id and a.article_id == b.article_id and
+          a.tenant_id == ^tenant_id and a.article_id == b.article_id and
             fragment("?->>'query'", a.metadata) == fragment("?->>'query'", b.metadata),
         where: b.tenant_id == ^tenant_id,
         where: b.access_type == "search" and a.access_type == "search",
-        # Digit-tested rather than null-tested, for the 22P02 reason given in `pairs/3`.
-        where: fragment("?->>'rank' ~ '^[0-9]+$'", b.metadata),
-        where: fragment("?->>'rank' ~ '^[0-9]+$'", a.metadata),
+        # Shape-tested rather than null-tested, for the reason given in `pairs/3`.
+        where: fragment("?->>'rank' ~ '^[1-9][0-9]{0,8}$'", b.metadata),
+        where: fragment("?->>'rank' ~ '^[1-9][0-9]{0,8}$'", a.metadata),
         where: fragment("coalesce(?->>'query', '')", b.metadata) != "",
         where: fragment("?->>'mode'", b.metadata) in ^@mode_family,
         where: fragment("?->>'mode'", a.metadata) in ^@mode_family,
@@ -234,6 +286,9 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
         where: b.accessed_at >= ^before_from and b.accessed_at < ^before_to,
         where: a.accessed_at >= ^after_from and a.accessed_at < ^after_to,
         group_by: [fragment("?->>'query'", b.metadata), b.article_id],
+        # LIMIT without ORDER BY has no defined row set in SQL: two runs over one corpus could
+        # report different means. `matched == max_pairs()` says truncated.
+        order_by: [fragment("?->>'query'", b.metadata), b.article_id],
         limit: @max_pairs,
         select: %{
           before_rank: avg(fragment("(?->>'rank')::int", b.metadata)),

--- a/lib/loopctl/knowledge/live_retrieval_metrics.ex
+++ b/lib/loopctl/knowledge/live_retrieval_metrics.ex
@@ -1,0 +1,234 @@
+defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
+  @moduledoc """
+  Retrieval quality measured on REAL logged traffic, with the definitions fixed in code.
+
+  ## Why this exists
+
+  The golden-question eval scores a synthetic fixture — invented prose, synthetic
+  embeddings — and is honest only as a regression signal between two of its own runs. When
+  the question is "is retrieval actually working on my corpus?", the answer has to come
+  from traffic.
+
+  It is a MODULE and not a paragraph of SQL in a runbook because the same question got
+  three different answers in one afternoon (2026-08-25), each from hand-written SQL, each
+  plausible, each wrong in a different way:
+
+    * `+6.5% MRR` — quoted from the synthetic eval as though it described production.
+    * `+19%` — a composition artifact: the "before" bucket averaged four months against a
+      corpus a fifth of the current size, and `mode` was renamed `combined` ->
+      `combined_retrieved` on 2026-08-12 mid-window.
+    * `-4%` — a two-window comparison of 68 pairs, well inside week-to-week noise.
+
+  The measured truth was "no resolvable change": weekly MRR sigma is 0.045 and the observed
+  gap was 0.022. Every one of those errors is a definition someone has to remember. Here
+  they are decisions the code already made.
+
+  ## The definitions, fixed
+
+  * **A confirmed pair** is a surfaced result that was then OPENED: an
+    `access_type: "search"` row carrying a `rank`, followed within `window_minutes` by a
+    `get`/`context` on the SAME article. Follow-through cannot be joined — `get` rows carry
+    no `search_id` before #689, and the recall hook and the session hold different
+    `api_key_id`s — so it is inferred, cross-key, exactly as the wiki article "Measuring KB
+    search follow-through" prescribes.
+  * **Rank** is `metadata->>'rank'` on the surfaced row, recorded since 2026-04-10. Nothing
+    is re-executed, so measuring costs no provider calls and records no new events (running
+    a search to measure searching would pollute the next measurement).
+  * **MRR** is `avg(1/rank)` over confirmed pairs. It answers "how near the top was the
+    thing the agent actually used", NOT "did we return everything relevant" — the label is
+    one confirmed hit, never an exhaustive relevance set. Call it hit-rank, not recall.
+  * **One mode family only** (`combined` + `combined_retrieved`, a pure rename). Mixing
+    label populations is what manufactured the `+19%`.
+
+  ## The rule this module enforces
+
+  `compare/2` will NOT call a difference a change when it is inside the historical
+  week-to-week sigma. That is not conservatism, it is the only thing separating the three
+  wrong answers above from the right one.
+  """
+
+  import Ecto.Query
+
+  alias Loopctl.HeavyRead
+  alias Loopctl.Knowledge.ArticleAccessEvent
+
+  @default_window_minutes 30
+  @mode_family ["combined", "combined_retrieved"]
+
+  @typedoc "One confirmed (query surfaced an article, agent opened it) observation."
+  @type pair :: %{query: String.t(), at: DateTime.t(), rank: pos_integer()}
+
+  @doc "The mode labels treated as one population, and why."
+  @spec mode_family() :: [String.t()]
+  def mode_family, do: @mode_family
+
+  @doc """
+  Confirmed pairs between `from` and `to` (exclusive), oldest first.
+
+  Read-only. `HeavyRead` because this scans two large event tables and must never contend
+  with the request-path pool.
+  """
+  @spec pairs(Ecto.UUID.t(), DateTime.t(), DateTime.t(), keyword()) :: [pair()]
+  def pairs(tenant_id, from, to, opts \\ []) do
+    window = opts |> Keyword.get(:window_minutes, @default_window_minutes) |> Integer.to_string()
+
+    query =
+      from(s in ArticleAccessEvent,
+        join: r in ArticleAccessEvent,
+        on:
+          r.article_id == s.article_id and r.tenant_id == ^tenant_id and
+            r.accessed_at >= s.accessed_at and
+            r.accessed_at <
+              fragment("? + (? || ' minutes')::interval", s.accessed_at, ^window),
+        where: s.tenant_id == ^tenant_id,
+        where: s.access_type == "search",
+        where: r.access_type in ["get", "context"],
+        where: s.accessed_at >= ^from and s.accessed_at < ^to,
+        # `metadata->>'rank'` rather than the jsonb `?` existence operator: `?` collides
+        # with Ecto's own parameter placeholder and has to be escaped, which is a foot-gun
+        # every future editor of this query would have to remember.
+        where: not is_nil(fragment("?->>'rank'", s.metadata)),
+        where: fragment("coalesce(?->>'query', '')", s.metadata) != "",
+        where: fragment("?->>'mode'", s.metadata) in ^@mode_family,
+        group_by: [
+          fragment("?->>'query'", s.metadata),
+          fragment("date_trunc('second', ?)", s.accessed_at),
+          s.article_id
+        ],
+        order_by: min(s.accessed_at),
+        select: %{
+          query: fragment("?->>'query'", s.metadata),
+          at: min(s.accessed_at),
+          # A result can be surfaced by several lanes in one call; the agent saw one list,
+          # so the best rank is the rank it was shown at.
+          rank: min(fragment("(?->>'rank')::int", s.metadata))
+        }
+      )
+
+    HeavyRead.all(tenant_id, query)
+  end
+
+  @doc """
+  Summarise a pair list: n, mean rank, rank-1 count, hit-rate@k and MRR.
+
+  Every field is `nil` when there are no pairs — never `0.0`. The distinction is the one
+  this repo already draws in `RetrievalEval`: `0.0` is "it ran and retrieved nothing",
+  `nil` is "there was nothing to score", and reporting an empty window as 0 invents a
+  collapse that never happened.
+  """
+  @spec summarise([pair()]) :: map()
+  def summarise([]), do: %{n: 0, mean_rank: nil, at_rank_1: nil, mrr: nil, top5: nil}
+
+  def summarise(pairs) do
+    n = length(pairs)
+    ranks = Enum.map(pairs, & &1.rank)
+
+    %{
+      n: n,
+      mean_rank: Enum.sum(ranks) / n,
+      at_rank_1: Enum.count(ranks, &(&1 == 1)),
+      top5: Enum.count(ranks, &(&1 <= 5)),
+      mrr: Enum.sum(Enum.map(ranks, &(1 / &1))) / n
+    }
+  end
+
+  @doc """
+  Weekly MRR series, and the sigma that any claimed change must clear.
+
+  The sigma is computed over `pairs`' own history rather than assumed, because it is the
+  only defence against reading ordinary week-to-week movement as an effect.
+  """
+  @spec weekly_noise([pair()]) :: map()
+  def weekly_noise(pairs) do
+    by_week =
+      pairs
+      |> Enum.group_by(fn p -> p.at |> DateTime.to_date() |> Date.beginning_of_week() end)
+      |> Enum.map(fn {wk, ps} -> {wk, summarise(ps).mrr} end)
+      |> Enum.sort()
+
+    values = Enum.map(by_week, &elem(&1, 1))
+
+    %{weeks: by_week, sigma: stddev(values), mean: mean(values), week_count: length(values)}
+  end
+
+  @doc """
+  Compare two pair sets and REFUSE to call an inside-sigma difference a change.
+
+  `sigma` comes from `weekly_noise/1` over the surrounding history. Pass it explicitly:
+  a comparison that computes its own noise from the two windows being compared would
+  shrink the yardstick with the sample.
+  """
+  @spec compare([pair()], [pair()], float() | nil) :: map()
+  def compare(before_pairs, after_pairs, sigma) do
+    b = summarise(before_pairs)
+    a = summarise(after_pairs)
+
+    delta =
+      if is_number(b.mrr) and is_number(a.mrr), do: a.mrr - b.mrr, else: nil
+
+    verdict =
+      cond do
+        is_nil(delta) -> :not_comparable
+        is_nil(sigma) or sigma == 0.0 -> :no_noise_baseline
+        abs(delta) < sigma -> :within_noise
+        true -> :resolvable
+      end
+
+    %{before: b, after: a, delta: delta, sigma: sigma, verdict: verdict}
+  end
+
+  @doc """
+  The strongest comparison available: the SAME query surfacing the SAME article on both
+  sides of a boundary.
+
+  Query difficulty and corpus composition are then held constant by construction, which is
+  what neither a period average nor a two-window comparison can claim.
+  """
+  @spec matched_pairs(Ecto.UUID.t(), DateTime.t(), DateTime.t(), DateTime.t(), DateTime.t()) ::
+          map()
+  def matched_pairs(tenant_id, before_from, before_to, after_from, after_to) do
+    query =
+      from(b in ArticleAccessEvent,
+        join: a in ArticleAccessEvent,
+        on:
+          a.tenant_id == ^tenant_id and a.article_id == b.article_id and
+            fragment("?->>'query'", a.metadata) == fragment("?->>'query'", b.metadata),
+        where: b.tenant_id == ^tenant_id,
+        where: b.access_type == "search" and a.access_type == "search",
+        where: not is_nil(fragment("?->>'rank'", b.metadata)),
+        where: not is_nil(fragment("?->>'rank'", a.metadata)),
+        where: fragment("coalesce(?->>'query', '')", b.metadata) != "",
+        where: fragment("?->>'mode'", b.metadata) in ^@mode_family,
+        where: fragment("?->>'mode'", a.metadata) in ^@mode_family,
+        where: b.accessed_at >= ^before_from and b.accessed_at < ^before_to,
+        where: a.accessed_at >= ^after_from and a.accessed_at < ^after_to,
+        group_by: [fragment("?->>'query'", b.metadata), b.article_id],
+        select: %{
+          before_rank: avg(fragment("(?->>'rank')::int", b.metadata)),
+          after_rank: avg(fragment("(?->>'rank')::int", a.metadata))
+        }
+      )
+
+    rows = HeavyRead.all(tenant_id, query)
+
+    %{
+      n: length(rows),
+      mean_rank_before: mean(Enum.map(rows, &to_float(&1.before_rank))),
+      mean_rank_after: mean(Enum.map(rows, &to_float(&1.after_rank)))
+    }
+  end
+
+  defp to_float(nil), do: nil
+  defp to_float(%Decimal{} = d), do: Decimal.to_float(d)
+  defp to_float(n) when is_number(n), do: n / 1
+
+  defp mean([]), do: nil
+  defp mean(values), do: Enum.sum(values) / length(values)
+
+  defp stddev(values) when length(values) < 2, do: nil
+
+  defp stddev(values) do
+    m = mean(values)
+    :math.sqrt(Enum.sum(Enum.map(values, &((&1 - m) * (&1 - m)))) / (length(values) - 1))
+  end
+end

--- a/lib/loopctl/knowledge/live_retrieval_metrics.ex
+++ b/lib/loopctl/knowledge/live_retrieval_metrics.ex
@@ -4,47 +4,45 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
 
   ## Why this exists
 
-  The golden-question eval scores a synthetic fixture — invented prose, synthetic
-  embeddings — and is honest only as a regression signal between two of its own runs. When
-  the question is "is retrieval actually working on my corpus?", the answer has to come
-  from traffic.
+  The golden-question eval scores a synthetic fixture — invented prose, synthetic embeddings
+  — and is honest only as a regression signal between two of its own runs. When the question
+  is "is retrieval actually working on my corpus?", the answer has to come from traffic.
 
-  It is a MODULE and not a paragraph of SQL in a runbook because the same question got
-  three different answers in one afternoon (2026-08-25), each from hand-written SQL, each
-  plausible, each wrong in a different way:
-
-    * `+6.5% MRR` — quoted from the synthetic eval as though it described production.
-    * `+19%` — a composition artifact: the "before" bucket averaged four months against a
-      corpus a fifth of the current size, and `mode` was renamed `combined` ->
-      `combined_retrieved` on 2026-08-12 mid-window.
-    * `-4%` — a two-window comparison of 68 pairs, well inside week-to-week noise.
-
-  The measured truth was "no resolvable change": weekly MRR sigma is 0.045 and the observed
-  gap was 0.022. Every one of those errors is a definition someone has to remember. Here
-  they are decisions the code already made.
+  It is a MODULE and not a paragraph of SQL in a runbook because the same question got three
+  hand-written answers in one afternoon (2026-08-25), each wrong differently: `+6.5%` quoted
+  from the synthetic eval; `+19%`, a four-month "before" bucket against a fifth of today's
+  corpus with `mode` split mid-window; `-4%`, 68 pairs, inside week-to-week noise. The truth
+  was "no resolvable change" — weekly MRR sigma 0.045, gap 0.022. Each error is a definition
+  someone had to remember; here they are decisions the code made.
 
   ## The definitions, fixed
 
-  * **A confirmed pair** is a surfaced result that was then OPENED: an
-    `access_type: "search"` row carrying a `rank`, followed within `window_minutes` by a
-    `get`/`context` on the SAME article. Follow-through cannot be joined — `get` rows carry
-    no `search_id` before #689, and the recall hook and the session hold different
-    `api_key_id`s — so it is inferred, cross-key, exactly as the wiki article "Measuring KB
-    search follow-through" prescribes.
-  * **Rank** is `metadata->>'rank'` on the surfaced row, recorded since 2026-04-10. Nothing
-    is re-executed, so measuring costs no provider calls and records no new events (running
-    a search to measure searching would pollute the next measurement).
-  * **MRR** is `avg(1/rank)` over confirmed pairs. It answers "how near the top was the
-    thing the agent actually used", NOT "did we return everything relevant" — the label is
-    one confirmed hit, never an exhaustive relevance set. Call it hit-rank, not recall.
-  * **One mode family only** (`combined` + `combined_retrieved`, a pure rename). Mixing
-    label populations is what manufactured the `+19%`.
-
-  ## The rule this module enforces
-
-  `compare/2` will NOT call a difference a change when it is inside the historical
-  week-to-week sigma. That is not conservatism, it is the only thing separating the three
-  wrong answers above from the right one.
+  * **A confirmed pair** — an `access_type: "search"` row carrying a `rank`, and a later read
+    whose SERVER-RESOLVED `origin_search_id` names that search. The link is READ, never
+    re-inferred: `Analytics.resolve_origin/5` sets it at write time and refuses a
+    caller-supplied value, since an origin an agent can assert is follow-through an agent can
+    manufacture (#567/#569, one table over). Re-deriving it from "a read landed within N
+    minutes" readmits that forgery AND credits one read to EVERY search that surfaced the
+    article in the window — inflation that, unlike a rate, does not cancel in a mean.
+  * **A read is `get` or `drill`** — the body fetches a reader NAMES. `context` is EXCLUDED:
+    one row per article the RANKER put in a pack, so the caller chose nothing
+    (`Knowledge.@heat_read_access_types`' list-shape argument). `drill` is INCLUDED: a genuine
+    single-article read and the documented way to follow an index, kept out of heat only so
+    heat cannot rank on reads it caused. Narrower than
+    `RetrievalMetrics.compute_followed_through/2` (was a body DELIVERED at all), wider than
+    `@heat_read_access_types` — three questions, three sets, never unified.
+  * **Rank** is `metadata->>'rank'` on the surfaced row; nothing is re-executed, so measuring
+    records no new events. **MRR** is `avg(1/rank)` over confirmed pairs — "how near the top was
+    the thing the agent used", NOT "did we return everything relevant": hit-rank, not recall.
+  * **One mode family**: every `combined*` label. 2026-08-12 SPLIT `combined` into
+    `combined_curated`/`combined_retrieved` and still emits the bare `combined` where the
+    curated lane did not run. Never a rename — so taking only `combined_retrieved` after it
+    against everything before drops the curated-led searches from one side, the mismatch that
+    manufactured the `+19%`.
+  * **History starts 2026-08-17** (#689), when `origin_search_id` was first recorded: earlier
+    traffic is a different instrument, not a smaller sample. And **the right edge is censored**
+    — a read is attributed only within `Analytics.origin_window_seconds/0` of its surfacing, so
+    end `to` that far back or the recent side always looks worse.
   """
 
   import Ecto.Query
@@ -52,55 +50,60 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
   alias Loopctl.HeavyRead
   alias Loopctl.Knowledge.ArticleAccessEvent
 
-  @default_window_minutes 30
-  @mode_family ["combined", "combined_retrieved"]
+  @mode_family ["combined", "combined_curated", "combined_retrieved"]
+  @chosen_read_types ["get", "drill"]
+  # Traffic loopctl generates about itself; same list and reason as `RetrievalMetrics`' own — a
+  # release week of deploys must not read as a retrieval change. `n == @max_pairs` says narrow it.
+  @infra_entrypoints ["smoke", "skill-eval"]
+  @max_pairs 50_000
+  @min_pairs 30
 
-  @typedoc "One confirmed (query surfaced an article, agent opened it) observation."
+  @typedoc "One confirmed (query surfaced an article, agent read it) observation."
   @type pair :: %{query: String.t(), at: DateTime.t(), rank: pos_integer()}
 
   @doc "The mode labels treated as one population, and why."
   @spec mode_family() :: [String.t()]
   def mode_family, do: @mode_family
 
-  @doc """
-  Confirmed pairs between `from` and `to` (exclusive), oldest first.
+  @doc "Floor for a `compare/3` verdict and for a week entering `weekly_noise/1`'s sigma."
+  @spec min_pairs() :: pos_integer()
+  def min_pairs, do: @min_pairs
 
-  Read-only. `HeavyRead` because this scans two large event tables and must never contend
-  with the request-path pool.
-  """
-  @spec pairs(Ecto.UUID.t(), DateTime.t(), DateTime.t(), keyword()) :: [pair()]
-  def pairs(tenant_id, from, to, opts \\ []) do
-    window = opts |> Keyword.get(:window_minutes, @default_window_minutes) |> Integer.to_string()
-
+  @doc "Confirmed pairs whose SEARCH falls in `[from, to)`, oldest first. Read-only."
+  @spec pairs(Ecto.UUID.t(), DateTime.t(), DateTime.t()) :: [pair()]
+  def pairs(tenant_id, from, to) do
     query =
       from(s in ArticleAccessEvent,
         join: r in ArticleAccessEvent,
         on:
-          r.article_id == s.article_id and r.tenant_id == ^tenant_id and
-            r.accessed_at >= s.accessed_at and
-            r.accessed_at <
-              fragment("? + (? || ' minutes')::interval", s.accessed_at, ^window),
+          r.tenant_id == ^tenant_id and r.article_id == s.article_id and
+            fragment("? = (?->>'search_id')::uuid", r.origin_search_id, s.metadata),
         where: s.tenant_id == ^tenant_id,
         where: s.access_type == "search",
-        where: r.access_type in ["get", "context"],
+        where: r.access_type in ^@chosen_read_types,
         where: s.accessed_at >= ^from and s.accessed_at < ^to,
-        # `metadata->>'rank'` rather than the jsonb `?` existence operator: `?` collides
-        # with Ecto's own parameter placeholder and has to be escaped, which is a foot-gun
-        # every future editor of this query would have to remember.
-        where: not is_nil(fragment("?->>'rank'", s.metadata)),
+        # A digit test, not `IS NOT NULL`: `metadata` is free-form jsonb written by `insert_all`
+        # with no CHECK and no changeset, so a bare `::int` lets ONE malformed row abort the whole
+        # read with a 22P02. (`->>`, not the jsonb `?` operator, which collides with Ecto's `?`.)
+        where: fragment("?->>'rank' ~ '^[0-9]+$'", s.metadata),
         where: fragment("coalesce(?->>'query', '')", s.metadata) != "",
         where: fragment("?->>'mode'", s.metadata) in ^@mode_family,
+        where: fragment("coalesce(?->>'entrypoint', '')", s.metadata) not in ^@infra_entrypoints,
+        # The search CALL is the observation and `search_id` is its only reliable identity (#582):
+        # the proxy it replaced — a key plus a truncated `accessed_at` — collides across concurrent
+        # searches by one key, merging two calls and keeping the better rank. It also collapses
+        # re-reads into one pair.
         group_by: [
+          fragment("?->>'search_id'", s.metadata),
           fragment("?->>'query'", s.metadata),
-          fragment("date_trunc('second', ?)", s.accessed_at),
           s.article_id
         ],
         order_by: min(s.accessed_at),
+        limit: @max_pairs,
         select: %{
           query: fragment("?->>'query'", s.metadata),
           at: min(s.accessed_at),
-          # A result can be surfaced by several lanes in one call; the agent saw one list,
-          # so the best rank is the rank it was shown at.
+          # One call can surface a result via several lanes; the agent saw one list, so best rank wins.
           rank: min(fragment("(?->>'rank')::int", s.metadata))
         }
       )
@@ -109,15 +112,13 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
   end
 
   @doc """
-  Summarise a pair list: n, mean rank, rank-1 count, hit-rate@k and MRR.
-
-  Every field is `nil` when there are no pairs — never `0.0`. The distinction is the one
-  this repo already draws in `RetrievalEval`: `0.0` is "it ran and retrieved nothing",
-  `nil` is "there was nothing to score", and reporting an empty window as 0 invents a
-  collapse that never happened.
+  `n`, mean rank, MRR and the rank-1 / top-5 COUNTS — `_count` suffixed because a bare `top5`
+  beside a 0..1 `mrr` reads as a rate. Every field is `nil` on an empty list, never `0.0`:
+  `RetrievalEval`'s distinction between "retrieved nothing" and "nothing to score".
   """
   @spec summarise([pair()]) :: map()
-  def summarise([]), do: %{n: 0, mean_rank: nil, at_rank_1: nil, mrr: nil, top5: nil}
+  def summarise([]),
+    do: %{n: 0, mean_rank: nil, at_rank_1_count: nil, mrr: nil, top5_count: nil}
 
   def summarise(pairs) do
     n = length(pairs)
@@ -126,83 +127,114 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
     %{
       n: n,
       mean_rank: Enum.sum(ranks) / n,
-      at_rank_1: Enum.count(ranks, &(&1 == 1)),
-      top5: Enum.count(ranks, &(&1 <= 5)),
+      at_rank_1_count: Enum.count(ranks, &(&1 == 1)),
+      top5_count: Enum.count(ranks, &(&1 <= 5)),
       mrr: Enum.sum(Enum.map(ranks, &(1 / &1))) / n
     }
   end
 
   @doc """
-  Weekly MRR series, and the sigma that any claimed change must clear.
-
-  The sigma is computed over `pairs`' own history rather than assumed, because it is the
-  only defence against reading ordinary week-to-week movement as an effect.
+  Weekly MRR series and the sigma any claimed change must clear, computed over `pairs`' own
+  history — the only defence against reading week-to-week movement as an effect. Weeks under
+  `min_pairs/0` stay in the series and out of the sigma: a partial boundary week's MRR swings
+  on a handful of reads, so an unweighted sigma is inflated by the weeks saying least, and an
+  inflated yardstick calls real changes noise.
   """
   @spec weekly_noise([pair()]) :: map()
   def weekly_noise(pairs) do
     by_week =
       pairs
       |> Enum.group_by(fn p -> p.at |> DateTime.to_date() |> Date.beginning_of_week() end)
-      |> Enum.map(fn {wk, ps} -> {wk, summarise(ps).mrr} end)
-      |> Enum.sort()
+      |> Enum.map(fn {wk, ps} -> %{week: wk, n: length(ps), mrr: summarise(ps).mrr} end)
+      # NOT `Enum.sort/1`: on a `Date` that falls back to Erlang term order, comparing a struct's
+      # keys alphabetically — DAY before MONTH — so a series crossing a month boundary comes out
+      # scrambled and reads as a trend that is not in the data.
+      |> Enum.sort_by(& &1.week, Date)
 
-    values = Enum.map(by_week, &elem(&1, 1))
+    values = by_week |> Enum.filter(&(&1.n >= @min_pairs)) |> Enum.map(& &1.mrr)
 
-    %{weeks: by_week, sigma: stddev(values), mean: mean(values), week_count: length(values)}
+    %{
+      weeks: by_week,
+      sigma: stddev(values),
+      mean: mean(values),
+      week_count: length(by_week),
+      scored_week_count: length(values)
+    }
   end
 
   @doc """
-  Compare two pair sets and REFUSE to call an inside-sigma difference a change.
+  Compare two pair sets and REFUSE to call a difference a change it cannot resolve. Pass
+  `sigma` from `weekly_noise/1` over the SURROUNDING history — computing it from the compared
+  windows shrinks the yardstick with the sample.
 
-  `sigma` comes from `weekly_noise/1` over the surrounding history. Pass it explicitly:
-  a comparison that computes its own noise from the two windows being compared would
-  shrink the yardstick with the sample.
+  Three refusals, in order, failing for different reasons:
+
+    * `:underpowered` — under `min_pairs/0` observations a side. A weekly sigma is the spread
+      of WEEK-sized means; against a two-observation window any delta clears it trivially.
+    * `:no_noise_baseline` — no sigma. Comparing without one is the -4% mistake.
+    * `:within_noise` — inside the weekly sigma OR twice the standard error of these two
+      samples' difference: sigma is blind to how thin the windows are, the standard error to
+      how much a week normally moves.
   """
   @spec compare([pair()], [pair()], float() | nil) :: map()
   def compare(before_pairs, after_pairs, sigma) do
     b = summarise(before_pairs)
     a = summarise(after_pairs)
+    delta = if is_number(b.mrr) and is_number(a.mrr), do: a.mrr - b.mrr
+    stderr = stderr_of_difference(before_pairs, after_pairs)
+    verdict = verdict(b, a, delta, sigma, stderr)
+    %{before: b, after: a, delta: delta, sigma: sigma, stderr: stderr, verdict: verdict}
+  end
 
-    delta =
-      if is_number(b.mrr) and is_number(a.mrr), do: a.mrr - b.mrr, else: nil
-
-    verdict =
-      cond do
-        is_nil(delta) -> :not_comparable
-        is_nil(sigma) or sigma == 0.0 -> :no_noise_baseline
-        abs(delta) < sigma -> :within_noise
-        true -> :resolvable
-      end
-
-    %{before: b, after: a, delta: delta, sigma: sigma, verdict: verdict}
+  defp verdict(b, a, delta, sigma, stderr) do
+    cond do
+      is_nil(delta) -> :not_comparable
+      b.n < @min_pairs or a.n < @min_pairs -> :underpowered
+      is_nil(sigma) or sigma == 0.0 -> :no_noise_baseline
+      abs(delta) < max(sigma, 2 * stderr) -> :within_noise
+      true -> :resolvable
+    end
   end
 
   @doc """
-  The strongest comparison available: the SAME query surfacing the SAME article on both
-  sides of a boundary.
+  Rank movement for the SAME query surfacing the SAME article on both sides of a boundary,
+  holding query difficulty and corpus composition constant — which neither a period average
+  nor a two-window comparison can claim.
 
-  Query difficulty and corpus composition are then held constant by construction, which is
-  what neither a period average nor a two-window comparison can claim.
+  It is NOT a follow-through measure and `matched` is NOT a count of confirmed pairs: no read
+  side appears in this query, so it reports where the ranker PUT things, not what an agent
+  used. Quote it beside `pairs/3`, never instead. Raises on overlapping windows, where a row
+  joins to ITSELF and reports its own rank unchanged.
   """
   @spec matched_pairs(Ecto.UUID.t(), DateTime.t(), DateTime.t(), DateTime.t(), DateTime.t()) ::
           map()
   def matched_pairs(tenant_id, before_from, before_to, after_from, after_to) do
+    if DateTime.compare(before_to, after_from) == :gt do
+      raise ArgumentError,
+            "matched_pairs/5 windows must not overlap: before_to #{before_to} is later " <>
+              "than after_from #{after_from}"
+    end
+
     query =
       from(b in ArticleAccessEvent,
         join: a in ArticleAccessEvent,
         on:
-          a.tenant_id == ^tenant_id and a.article_id == b.article_id and
+          a.id != b.id and a.tenant_id == ^tenant_id and a.article_id == b.article_id and
             fragment("?->>'query'", a.metadata) == fragment("?->>'query'", b.metadata),
         where: b.tenant_id == ^tenant_id,
         where: b.access_type == "search" and a.access_type == "search",
-        where: not is_nil(fragment("?->>'rank'", b.metadata)),
-        where: not is_nil(fragment("?->>'rank'", a.metadata)),
+        # Digit-tested rather than null-tested, for the 22P02 reason given in `pairs/3`.
+        where: fragment("?->>'rank' ~ '^[0-9]+$'", b.metadata),
+        where: fragment("?->>'rank' ~ '^[0-9]+$'", a.metadata),
         where: fragment("coalesce(?->>'query', '')", b.metadata) != "",
         where: fragment("?->>'mode'", b.metadata) in ^@mode_family,
         where: fragment("?->>'mode'", a.metadata) in ^@mode_family,
+        where: fragment("coalesce(?->>'entrypoint', '')", b.metadata) not in ^@infra_entrypoints,
+        where: fragment("coalesce(?->>'entrypoint', '')", a.metadata) not in ^@infra_entrypoints,
         where: b.accessed_at >= ^before_from and b.accessed_at < ^before_to,
         where: a.accessed_at >= ^after_from and a.accessed_at < ^after_to,
         group_by: [fragment("?->>'query'", b.metadata), b.article_id],
+        limit: @max_pairs,
         select: %{
           before_rank: avg(fragment("(?->>'rank')::int", b.metadata)),
           after_rank: avg(fragment("(?->>'rank')::int", a.metadata))
@@ -212,7 +244,7 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
     rows = HeavyRead.all(tenant_id, query)
 
     %{
-      n: length(rows),
+      matched: length(rows),
       mean_rank_before: mean(Enum.map(rows, &to_float(&1.before_rank))),
       mean_rank_after: mean(Enum.map(rows, &to_float(&1.after_rank)))
     }
@@ -230,5 +262,17 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetrics do
   defp stddev(values) do
     m = mean(values)
     :math.sqrt(Enum.sum(Enum.map(values, &((&1 - m) * (&1 - m)))) / (length(values) - 1))
+  end
+
+  # Standard error of the difference of two mean reciprocal ranks; a side with under two rows
+  # contributes 0.0, since `:underpowered` already caught that case.
+  defp stderr_of_difference(before_pairs, after_pairs) do
+    :math.sqrt(variance_of_mean(before_pairs) + variance_of_mean(after_pairs))
+  end
+
+  defp variance_of_mean(pairs) do
+    reciprocals = Enum.map(pairs, &(1 / &1.rank))
+    sd = stddev(reciprocals)
+    if sd, do: sd * sd / length(reciprocals), else: 0.0
   end
 end

--- a/lib/loopctl/knowledge/retrieval_eval/report.ex
+++ b/lib/loopctl/knowledge/retrieval_eval/report.ex
@@ -45,11 +45,36 @@ defmodule Loopctl.Knowledge.RetrievalEval.Report do
 
     """
     Retrieval eval — golden set #{result.golden_version}
+    #{provenance_banner()}
       requested mode : #{result.mode}
       observed mode  : #{result.observed_mode}
       fallback reason: #{reasons}
       questions      : #{result.question_count}\
     """
+  end
+
+  # Every number this report prints is produced on a SYNTHETIC fixture, and the banner
+  # exists because that fact does not survive being quoted.
+  #
+  # The limitation was already written down — the runbook says "read the numbers as a
+  # REGRESSION signal, not an absolute quality score" and "there is no real-embedding-
+  # provider path" — and on 2026-08-25 a session that had READ that runbook still reported
+  # this eval's +6.5% MRR to the owner as the answer to "did the search refactor improve
+  # search?". Measured against production traffic the same day, the real answer was "no
+  # measurable change in either direction" (weekly MRR sigma 0.045; the observed gap 0.022).
+  #
+  # So the caveat is attached to the ARTIFACT rather than to a document about the artifact.
+  # A doc can be read and then not applied at reporting time; a banner travels with the
+  # number into whatever paraphrases it. Do not remove it to tidy the output, and do not
+  # weaken it to "synthetic embeddings" alone — the CORPUS is invented too (hand-authored
+  # prose, median body 123 characters, against a production corpus of ~86,000 real
+  # articles), and that is the half that misleads about absolute quality.
+  @spec provenance_banner() :: String.t()
+  def provenance_banner do
+    "  ⚠ SYNTHETIC FIXTURE — invented corpus + synthetic embeddings. Valid as a\n" <>
+      "    REGRESSION signal between two runs of this harness. NOT a measurement of\n" <>
+      "    production retrieval quality; do not quote these figures as one. For the\n" <>
+      "    real corpus, measure logged traffic (docs/runbooks/retrieval_eval.md)."
   end
 
   defp aggregate_section(result, comparison) do
@@ -238,6 +263,12 @@ defmodule Loopctl.Knowledge.RetrievalEval.Report do
   @spec to_json_map(map(), map() | nil) :: map()
   def to_json_map(result, comparison \\ nil) do
     %{
+      # The JSON path is the one a script or another agent consumes, so it carries the
+      # same disclosure as the text report rather than relying on the reader having seen it.
+      "provenance" => "synthetic_fixture",
+      "provenance_note" =>
+        "Invented corpus and synthetic embeddings. Valid as a regression signal between " <>
+          "runs of this harness; NOT a measurement of production retrieval quality.",
       "golden_version" => result.golden_version,
       "mode" => to_string(result.mode),
       "observed_mode" => result.observed_mode,

--- a/lib/loopctl/knowledge/retrieval_metrics.ex
+++ b/lib/loopctl/knowledge/retrieval_metrics.ex
@@ -257,6 +257,18 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
   # rather than behaviour.
   @infra_entrypoints ~w(smoke skill-eval)
 
+  @doc """
+  Client entrypoints that are loopctl's own infrastructure and must never enter a retrieval
+  denominator.
+
+  Public because `LiveRetrievalMetrics` applies the SAME exclusion and previously carried its
+  own copy of the list. Two literals with 25 lines of rationale attached to only one of them
+  drift the moment a third infra entrypoint appears — and the module a future editor finds
+  first was the copy WITHOUT the reasoning.
+  """
+  @spec infra_entrypoints() :: [String.t()]
+  def infra_entrypoints, do: @infra_entrypoints
+
   # Channels that are counted everywhere else but CANNOT be scored for reformulation (#711).
   #
   # The recall hook (`hook`) and the session-start auto-query (`session-start`) each emit

--- a/test/loopctl/knowledge/live_retrieval_metrics_test.exs
+++ b/test/loopctl/knowledge/live_retrieval_metrics_test.exs
@@ -1,121 +1,125 @@
 defmodule Loopctl.Knowledge.LiveRetrievalMetricsTest do
   @moduledoc """
-  The definitions this module fixes are the ones that produced three different wrong
-  answers to one question on 2026-08-25, each from hand-written SQL. These tests are what
-  stop the definitions drifting back.
+  The definitions this module fixes produced three different wrong answers to one question on
+  2026-08-25, each from hand-written SQL. These tests stop them drifting back.
   """
   use Loopctl.DataCase, async: true
 
   setup :verify_on_exit!
 
-  alias Loopctl.AdminRepo
-  alias Loopctl.Knowledge.ArticleAccessEvent
   alias Loopctl.Knowledge.LiveRetrievalMetrics, as: Live
 
   @from ~U[2026-08-01 00:00:00.000000Z]
   @to ~U[2026-09-01 00:00:00.000000Z]
+  @at ~U[2026-08-10 10:00:00.000000Z]
+  @then ~U[2026-08-10 10:01:00.000000Z]
 
-  defp surfaced(tenant_id, article_id, query, rank, at, mode \\ "combined_retrieved") do
-    event(tenant_id, article_id, "search", at, %{
-      "query" => query,
-      "rank" => rank,
-      "mode" => mode
-    })
+  # Returns the `search_id`, the only thing that can link a read back to this search.
+  defp surfaced(tenant_id, article_id, query, rank, at \\ @at, extra \\ %{}) do
+    id = Ecto.UUID.generate()
+    md = %{"query" => query, "rank" => rank, "mode" => "combined_retrieved", "search_id" => id}
+    attrs = %{access_type: "search", accessed_at: at, metadata: Map.merge(md, extra)}
+    event(tenant_id, article_id, attrs)
+    id
   end
 
-  # Deliberately a DIFFERENT api key from the one that surfaced the result. In production
-  # the recall hook searches under its own key and never reads; the follow-through happens
-  # in the session under the MCP key, so a same-key rule reports that whole channel at 0%.
-  defp opened(tenant_id, article_id, at), do: event(tenant_id, article_id, "get", at, %{})
-
-  defp event(tenant_id, article_id, type, at, metadata) do
-    {_plaintext, key} = fixture(:api_key, %{tenant_id: tenant_id, role: :agent})
-
-    AdminRepo.insert!(%ArticleAccessEvent{
-      tenant_id: tenant_id,
-      article_id: article_id,
-      api_key_id: key.id,
-      access_type: type,
-      accessed_at: at,
-      metadata: metadata
-    })
+  # `origin_search_id` is resolved server-side and not castable, so the fixture seeds it past
+  # the changeset. `cross_key` on purpose: the recall hook searches under one key and the
+  # session reads under another, so a same-key rule reports that whole channel at 0%.
+  defp read(tenant_id, article_id, search_id, type \\ "get", at \\ @then) do
+    origin = %{origin_search_id: search_id, origin_attribution: "cross_key"}
+    event(tenant_id, article_id, Map.merge(origin, %{access_type: type, accessed_at: at}))
   end
+
+  defp event(tid, aid, attrs),
+    do: fixture(:article_access_event, Map.merge(%{tenant_id: tid, article_id: aid}, attrs))
 
   defp article(tenant_id), do: fixture(:article, %{tenant_id: tenant_id}).id
 
-  describe "pairs/4 — what counts as a confirmed hit" do
-    test "a surfaced result that is later OPENED is a pair, at the rank it was shown" do
+  defp sample(rank, n \\ 30, at \\ @from),
+    do: for(_ <- 1..n, do: %{query: "q", at: at, rank: rank})
+
+  describe "pairs/3 — what counts as a confirmed hit" do
+    test "a surfaced result the agent then reads is a pair, at the rank it was shown" do
       t = fixture(:tenant)
       a = article(t.id)
 
-      surfaced(t.id, a, "advisory lock", 3, ~U[2026-08-10 10:00:00.000000Z])
-      opened(t.id, a, ~U[2026-08-10 10:05:00.000000Z])
+      read(t.id, a, surfaced(t.id, a, "advisory lock", 3))
 
       assert [%{query: "advisory lock", rank: 3}] = Live.pairs(t.id, @from, @to)
     end
 
-    test "a surfaced result nobody opened is NOT a pair" do
-      # This is the whole point of the metric: it scores what was USED, not what was shown.
+    test "a search is a pair only when a read NAMES it" do
+      # The link is the recorded `origin_search_id`, never "a read landed nearby": inferring it
+      # would credit one read to every search that had surfaced the article, and let an agent
+      # manufacture follow-through for its own. Unread, unattributed, and attributed elsewhere
+      # all score the same — nothing.
       t = fixture(:tenant)
-      surfaced(t.id, article(t.id), "never opened", 1, ~U[2026-08-10 10:00:00.000000Z])
+      a = article(t.id)
+
+      surfaced(t.id, a, "unattributed", 1)
+      read(t.id, a, nil)
+      read(t.id, a, Ecto.UUID.generate())
+      surfaced(t.id, article(t.id), "never opened", 1)
 
       assert Live.pairs(t.id, @from, @to) == []
     end
 
-    test "an open OUTSIDE the window does not count" do
+    test "a drill counts as a read and a context pack does not" do
+      # A drill is the documented way to follow an index, so dropping it scores every agent
+      # following the docs at zero. A `context` row is one per article the RANKER put in a
+      # pack: the caller asked one question and chose nothing.
       t = fixture(:tenant)
-      a = article(t.id)
+      drilled = article(t.id)
+      packed = article(t.id)
 
-      surfaced(t.id, a, "stale", 1, ~U[2026-08-10 10:00:00.000000Z])
-      opened(t.id, a, ~U[2026-08-10 11:30:00.000000Z])
+      read(t.id, drilled, surfaced(t.id, drilled, "drilled", 1), "drill")
+      read(t.id, packed, surfaced(t.id, packed, "packed", 1), "context")
 
-      assert Live.pairs(t.id, @from, @to) == []
-      # ... and is included when the window is widened, so the bound is the window and not
-      # some other accident of the join.
-      assert [%{rank: 1}] = Live.pairs(t.id, @from, @to, window_minutes: 120)
+      assert [%{query: "drilled"}] = Live.pairs(t.id, @from, @to)
     end
 
-    test "an open BEFORE the search does not count" do
-      # Without the direction check a read would justify a search that happened after it,
-      # which inverts cause and effect and inflates every number.
+    test "one search read twice is ONE pair, not two" do
+      # `n` is MRR's denominator, so an inflated count does not cancel as it would in a rate.
       t = fixture(:tenant)
       a = article(t.id)
+      sid = surfaced(t.id, a, "read twice", 2)
 
-      opened(t.id, a, ~U[2026-08-10 09:00:00.000000Z])
-      surfaced(t.id, a, "after the read", 1, ~U[2026-08-10 10:00:00.000000Z])
-
-      assert Live.pairs(t.id, @from, @to) == []
-    end
-
-    test "the open may come from a DIFFERENT api key than the search" do
-      # The recall hook searches and never reads; the follow-through happens in the session
-      # under the MCP key. A same-key rule reports the injected channel at exactly 0%.
-      t = fixture(:tenant)
-      a = article(t.id)
-
-      surfaced(t.id, a, "cross key", 2, ~U[2026-08-10 10:00:00.000000Z])
-      opened(t.id, a, ~U[2026-08-10 10:01:00.000000Z])
+      read(t.id, a, sid)
+      read(t.id, a, sid, "drill", ~U[2026-08-10 10:02:00.000000Z])
 
       assert [%{rank: 2}] = Live.pairs(t.id, @from, @to)
     end
 
-    test "both mode labels are ONE population, and other modes are excluded" do
-      # `combined` was renamed `combined_retrieved` on 2026-08-12. Treating them as two
-      # populations is what manufactured a +19% improvement out of a rename.
+    test "every combined label is ONE population, and other modes are excluded" do
+      # 2026-08-12 SPLIT `combined` three ways; never a rename. Taking only
+      # `combined_retrieved` after the split against everything before it drops the
+      # curated-led searches from one side, which reads as a regression.
       t = fixture(:tenant)
-      old = article(t.id)
-      new = article(t.id)
-      other = article(t.id)
 
-      surfaced(t.id, old, "old label", 1, ~U[2026-08-10 10:00:00.000000Z], "combined")
-      opened(t.id, old, ~U[2026-08-10 10:01:00.000000Z])
-      surfaced(t.id, new, "new label", 1, ~U[2026-08-14 10:00:00.000000Z], "combined_retrieved")
-      opened(t.id, new, ~U[2026-08-14 10:01:00.000000Z])
-      surfaced(t.id, other, "keyword only", 1, ~U[2026-08-14 11:00:00.000000Z], "keyword")
-      opened(t.id, other, ~U[2026-08-14 11:01:00.000000Z])
+      for mode <- ["combined", "combined_curated", "combined_retrieved", "keyword"] do
+        a = article(t.id)
+        read(t.id, a, surfaced(t.id, a, mode, 1, @at, %{"mode" => mode}))
+      end
 
       queries = t.id |> Live.pairs(@from, @to) |> Enum.map(& &1.query) |> Enum.sort()
-      assert queries == ["new label", "old label"]
+      assert queries == ["combined", "combined_curated", "combined_retrieved"]
+    end
+
+    test "an unscorable row costs its own observation, never the whole read" do
+      # `metadata` is free-form jsonb with no CHECK, so one malformed rank must not 22P02 the
+      # month. Smoke traffic is dropped the same way, or a release week with more deploys
+      # reads as a retrieval change.
+      t = fixture(:tenant)
+      good = article(t.id)
+      bad = article(t.id)
+      smoke = article(t.id)
+
+      read(t.id, good, surfaced(t.id, good, "good", 1))
+      read(t.id, bad, surfaced(t.id, bad, "bad", "n/a"))
+      read(t.id, smoke, surfaced(t.id, smoke, "smoke", 1, @at, %{"entrypoint" => "smoke"}))
+
+      assert [%{query: "good"}] = Live.pairs(t.id, @from, @to)
     end
 
     test "is tenant-isolated" do
@@ -123,8 +127,7 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetricsTest do
       theirs = fixture(:tenant)
       a = article(theirs.id)
 
-      surfaced(theirs.id, a, "theirs", 1, ~U[2026-08-10 10:00:00.000000Z])
-      opened(theirs.id, a, ~U[2026-08-10 10:01:00.000000Z])
+      read(theirs.id, a, surfaced(theirs.id, a, "theirs", 1))
 
       assert Live.pairs(mine.id, @from, @to) == []
     end
@@ -132,39 +135,47 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetricsTest do
 
   describe "summarise/1" do
     test "an empty window scores n/a, never 0.0" do
-      # `0.0` means "it ran and retrieved nothing"; `nil` means "there was nothing to
-      # score". Reporting an empty window as 0 invents a collapse that never happened.
-      assert %{n: 0, mrr: nil, mean_rank: nil, at_rank_1: nil} = Live.summarise([])
+      # `0.0` means "it ran and retrieved nothing"; `nil` means "there was nothing to score".
+      assert %{n: 0, mrr: nil, mean_rank: nil, at_rank_1_count: nil, top5_count: nil} =
+               Live.summarise([])
     end
 
-    test "MRR is the mean reciprocal rank of what was opened" do
-      pairs = [%{query: "a", at: @from, rank: 1}, %{query: "b", at: @from, rank: 4}]
-      s = Live.summarise(pairs)
+    test "MRR is the mean reciprocal rank of what was read, and the hit fields are COUNTS" do
+      s = Live.summarise([%{query: "a", at: @from, rank: 1}, %{query: "b", at: @from, rank: 4}])
 
       assert s.n == 2
-      assert s.at_rank_1 == 1
+      assert s.at_rank_1_count == 1
+      assert s.top5_count == 2
       assert_in_delta s.mrr, (1.0 + 0.25) / 2, 0.0001
       assert_in_delta s.mean_rank, 2.5, 0.0001
     end
   end
 
   describe "compare/3 — the rule that would have caught all three wrong answers" do
-    test "a difference SMALLER than the noise is reported as within_noise, not as a change" do
-      before_pairs = [%{query: "a", at: @from, rank: 2}]
-      after_pairs = [%{query: "a", at: @from, rank: 2}]
-      # A real gap, far under a realistic sigma.
-      cmp = Live.compare(before_pairs, [%{query: "a", at: @from, rank: 3} | after_pairs], 0.5)
+    test "a sample under min_pairs gets no verdict at all" do
+      # A weekly sigma is the spread of WEEK-sized means. Against one observation a side any
+      # delta clears it, which is the shape of the -4%-from-68-pairs claim.
+      assert Live.compare(sample(10, 1), sample(1, 1), 0.045).verdict == :underpowered
+    end
+
+    test "a difference SMALLER than the noise is within_noise, not a change" do
+      cmp = Live.compare(sample(2), sample(2, 29) ++ [%{query: "q", at: @from, rank: 3}], 0.5)
 
       assert cmp.verdict == :within_noise
     end
 
-    test "a difference LARGER than the noise is resolvable" do
-      cmp =
-        Live.compare(
-          [%{query: "a", at: @from, rank: 10}],
-          [%{query: "a", at: @from, rank: 1}],
-          0.05
-        )
+    test "a difference inside the samples' OWN standard error is within_noise" do
+      # Sigma alone is blind to how spread the windows are: these differ by more than any
+      # plausible weekly sigma and by far less than their own spread.
+      noisy = fn tail -> Enum.take(Stream.cycle(sample(1, 1) ++ sample(tail, 1)), 30) end
+      cmp = Live.compare(noisy.(40), noisy.(20), 0.001)
+
+      assert cmp.verdict == :within_noise
+      assert cmp.stderr > abs(cmp.delta)
+    end
+
+    test "a difference LARGER than both the noise and the standard error is resolvable" do
+      cmp = Live.compare(sample(10), sample(1), 0.05)
 
       assert cmp.verdict == :resolvable
       assert cmp.delta > 0
@@ -172,38 +183,68 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetricsTest do
 
     test "no noise baseline is its own verdict, never a silent pass" do
       # Comparing without a sigma is exactly the mistake that produced the -4% claim.
-      cmp =
-        Live.compare(
-          [%{query: "a", at: @from, rank: 4}],
-          [%{query: "a", at: @from, rank: 1}],
-          nil
-        )
-
-      assert cmp.verdict == :no_noise_baseline
+      assert Live.compare(sample(4), sample(1), nil).verdict == :no_noise_baseline
     end
 
     test "an empty side is not comparable rather than a 100% collapse" do
-      cmp = Live.compare([], [%{query: "a", at: @from, rank: 1}], 0.05)
+      cmp = Live.compare([], sample(1), 0.05)
+
       assert cmp.verdict == :not_comparable
       assert cmp.delta == nil
     end
   end
 
   describe "weekly_noise/1" do
-    test "sigma needs at least two weeks, and says so rather than returning 0.0" do
-      one_week = [%{query: "a", at: ~U[2026-08-10 10:00:00.000000Z], rank: 1}]
-      assert %{sigma: nil, week_count: 1} = Live.weekly_noise(one_week)
+    test "a thin week stays in the series and out of the sigma" do
+      # An unweighted sigma is inflated by the weeks saying least, and an inflated yardstick
+      # calls real changes noise.
+      thin = [%{query: "a", at: @at, rank: 1}]
+
+      assert %{sigma: nil, week_count: 1, scored_week_count: 0} = Live.weekly_noise(thin)
     end
 
-    test "sigma is computed across weeks" do
-      pairs = [
-        %{query: "a", at: ~U[2026-08-03 10:00:00.000000Z], rank: 1},
-        %{query: "b", at: ~U[2026-08-10 10:00:00.000000Z], rank: 4}
-      ]
+    test "sigma is computed across the weeks that clear the floor" do
+      noise =
+        Live.weekly_noise(sample(1, 30, ~U[2026-08-03 10:00:00.000000Z]) ++ sample(4, 30, @at))
 
-      noise = Live.weekly_noise(pairs)
-      assert noise.week_count == 2
+      assert noise.scored_week_count == 2
       assert noise.sigma > 0
+    end
+
+    test "the weekly series is chronological across a month boundary" do
+      # `Enum.sort/1` on a `Date` falls back to Erlang term order, comparing struct keys
+      # alphabetically — DAY before MONTH — so September sorts between two August weeks.
+      pairs =
+        for at <- [~U[2026-08-03 10:00:00Z], ~U[2026-08-31 10:00:00Z], ~U[2026-09-07 10:00:00Z]],
+            do: %{query: "q", at: at, rank: 1}
+
+      assert Enum.map(Live.weekly_noise(pairs).weeks, & &1.week) ==
+               [~D[2026-08-03], ~D[2026-08-31], ~D[2026-09-07]]
+    end
+  end
+
+  describe "matched_pairs/5" do
+    @mid ~U[2026-08-10 00:00:00.000000Z]
+
+    test "the same query on the same article reports its rank movement" do
+      t = fixture(:tenant)
+      a = article(t.id)
+
+      surfaced(t.id, a, "same q", 5, ~U[2026-08-02 10:00:00.000000Z])
+      surfaced(t.id, a, "same q", 1, ~U[2026-08-20 10:00:00.000000Z])
+
+      assert %{matched: 1, mean_rank_before: 5.0, mean_rank_after: 1.0} =
+               Live.matched_pairs(t.id, @from, @mid, @mid, @to)
+    end
+
+    test "overlapping windows raise rather than join every row in the overlap to itself" do
+      # A self-join reports a row's rank unchanged, indistinguishable from a real no-change,
+      # and nothing in the return shape would show the caller why.
+      t = fixture(:tenant)
+
+      assert_raise ArgumentError, ~r/must not overlap/, fn ->
+        Live.matched_pairs(t.id, @from, ~U[2026-08-20 00:00:00.000000Z], @mid, @to)
+      end
     end
   end
 end

--- a/test/loopctl/knowledge/live_retrieval_metrics_test.exs
+++ b/test/loopctl/knowledge/live_retrieval_metrics_test.exs
@@ -1,0 +1,209 @@
+defmodule Loopctl.Knowledge.LiveRetrievalMetricsTest do
+  @moduledoc """
+  The definitions this module fixes are the ones that produced three different wrong
+  answers to one question on 2026-08-25, each from hand-written SQL. These tests are what
+  stop the definitions drifting back.
+  """
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.ArticleAccessEvent
+  alias Loopctl.Knowledge.LiveRetrievalMetrics, as: Live
+
+  @from ~U[2026-08-01 00:00:00.000000Z]
+  @to ~U[2026-09-01 00:00:00.000000Z]
+
+  defp surfaced(tenant_id, article_id, query, rank, at, mode \\ "combined_retrieved") do
+    event(tenant_id, article_id, "search", at, %{
+      "query" => query,
+      "rank" => rank,
+      "mode" => mode
+    })
+  end
+
+  # Deliberately a DIFFERENT api key from the one that surfaced the result. In production
+  # the recall hook searches under its own key and never reads; the follow-through happens
+  # in the session under the MCP key, so a same-key rule reports that whole channel at 0%.
+  defp opened(tenant_id, article_id, at), do: event(tenant_id, article_id, "get", at, %{})
+
+  defp event(tenant_id, article_id, type, at, metadata) do
+    {_plaintext, key} = fixture(:api_key, %{tenant_id: tenant_id, role: :agent})
+
+    AdminRepo.insert!(%ArticleAccessEvent{
+      tenant_id: tenant_id,
+      article_id: article_id,
+      api_key_id: key.id,
+      access_type: type,
+      accessed_at: at,
+      metadata: metadata
+    })
+  end
+
+  defp article(tenant_id), do: fixture(:article, %{tenant_id: tenant_id}).id
+
+  describe "pairs/4 — what counts as a confirmed hit" do
+    test "a surfaced result that is later OPENED is a pair, at the rank it was shown" do
+      t = fixture(:tenant)
+      a = article(t.id)
+
+      surfaced(t.id, a, "advisory lock", 3, ~U[2026-08-10 10:00:00.000000Z])
+      opened(t.id, a, ~U[2026-08-10 10:05:00.000000Z])
+
+      assert [%{query: "advisory lock", rank: 3}] = Live.pairs(t.id, @from, @to)
+    end
+
+    test "a surfaced result nobody opened is NOT a pair" do
+      # This is the whole point of the metric: it scores what was USED, not what was shown.
+      t = fixture(:tenant)
+      surfaced(t.id, article(t.id), "never opened", 1, ~U[2026-08-10 10:00:00.000000Z])
+
+      assert Live.pairs(t.id, @from, @to) == []
+    end
+
+    test "an open OUTSIDE the window does not count" do
+      t = fixture(:tenant)
+      a = article(t.id)
+
+      surfaced(t.id, a, "stale", 1, ~U[2026-08-10 10:00:00.000000Z])
+      opened(t.id, a, ~U[2026-08-10 11:30:00.000000Z])
+
+      assert Live.pairs(t.id, @from, @to) == []
+      # ... and is included when the window is widened, so the bound is the window and not
+      # some other accident of the join.
+      assert [%{rank: 1}] = Live.pairs(t.id, @from, @to, window_minutes: 120)
+    end
+
+    test "an open BEFORE the search does not count" do
+      # Without the direction check a read would justify a search that happened after it,
+      # which inverts cause and effect and inflates every number.
+      t = fixture(:tenant)
+      a = article(t.id)
+
+      opened(t.id, a, ~U[2026-08-10 09:00:00.000000Z])
+      surfaced(t.id, a, "after the read", 1, ~U[2026-08-10 10:00:00.000000Z])
+
+      assert Live.pairs(t.id, @from, @to) == []
+    end
+
+    test "the open may come from a DIFFERENT api key than the search" do
+      # The recall hook searches and never reads; the follow-through happens in the session
+      # under the MCP key. A same-key rule reports the injected channel at exactly 0%.
+      t = fixture(:tenant)
+      a = article(t.id)
+
+      surfaced(t.id, a, "cross key", 2, ~U[2026-08-10 10:00:00.000000Z])
+      opened(t.id, a, ~U[2026-08-10 10:01:00.000000Z])
+
+      assert [%{rank: 2}] = Live.pairs(t.id, @from, @to)
+    end
+
+    test "both mode labels are ONE population, and other modes are excluded" do
+      # `combined` was renamed `combined_retrieved` on 2026-08-12. Treating them as two
+      # populations is what manufactured a +19% improvement out of a rename.
+      t = fixture(:tenant)
+      old = article(t.id)
+      new = article(t.id)
+      other = article(t.id)
+
+      surfaced(t.id, old, "old label", 1, ~U[2026-08-10 10:00:00.000000Z], "combined")
+      opened(t.id, old, ~U[2026-08-10 10:01:00.000000Z])
+      surfaced(t.id, new, "new label", 1, ~U[2026-08-14 10:00:00.000000Z], "combined_retrieved")
+      opened(t.id, new, ~U[2026-08-14 10:01:00.000000Z])
+      surfaced(t.id, other, "keyword only", 1, ~U[2026-08-14 11:00:00.000000Z], "keyword")
+      opened(t.id, other, ~U[2026-08-14 11:01:00.000000Z])
+
+      queries = t.id |> Live.pairs(@from, @to) |> Enum.map(& &1.query) |> Enum.sort()
+      assert queries == ["new label", "old label"]
+    end
+
+    test "is tenant-isolated" do
+      mine = fixture(:tenant)
+      theirs = fixture(:tenant)
+      a = article(theirs.id)
+
+      surfaced(theirs.id, a, "theirs", 1, ~U[2026-08-10 10:00:00.000000Z])
+      opened(theirs.id, a, ~U[2026-08-10 10:01:00.000000Z])
+
+      assert Live.pairs(mine.id, @from, @to) == []
+    end
+  end
+
+  describe "summarise/1" do
+    test "an empty window scores n/a, never 0.0" do
+      # `0.0` means "it ran and retrieved nothing"; `nil` means "there was nothing to
+      # score". Reporting an empty window as 0 invents a collapse that never happened.
+      assert %{n: 0, mrr: nil, mean_rank: nil, at_rank_1: nil} = Live.summarise([])
+    end
+
+    test "MRR is the mean reciprocal rank of what was opened" do
+      pairs = [%{query: "a", at: @from, rank: 1}, %{query: "b", at: @from, rank: 4}]
+      s = Live.summarise(pairs)
+
+      assert s.n == 2
+      assert s.at_rank_1 == 1
+      assert_in_delta s.mrr, (1.0 + 0.25) / 2, 0.0001
+      assert_in_delta s.mean_rank, 2.5, 0.0001
+    end
+  end
+
+  describe "compare/3 — the rule that would have caught all three wrong answers" do
+    test "a difference SMALLER than the noise is reported as within_noise, not as a change" do
+      before_pairs = [%{query: "a", at: @from, rank: 2}]
+      after_pairs = [%{query: "a", at: @from, rank: 2}]
+      # A real gap, far under a realistic sigma.
+      cmp = Live.compare(before_pairs, [%{query: "a", at: @from, rank: 3} | after_pairs], 0.5)
+
+      assert cmp.verdict == :within_noise
+    end
+
+    test "a difference LARGER than the noise is resolvable" do
+      cmp =
+        Live.compare(
+          [%{query: "a", at: @from, rank: 10}],
+          [%{query: "a", at: @from, rank: 1}],
+          0.05
+        )
+
+      assert cmp.verdict == :resolvable
+      assert cmp.delta > 0
+    end
+
+    test "no noise baseline is its own verdict, never a silent pass" do
+      # Comparing without a sigma is exactly the mistake that produced the -4% claim.
+      cmp =
+        Live.compare(
+          [%{query: "a", at: @from, rank: 4}],
+          [%{query: "a", at: @from, rank: 1}],
+          nil
+        )
+
+      assert cmp.verdict == :no_noise_baseline
+    end
+
+    test "an empty side is not comparable rather than a 100% collapse" do
+      cmp = Live.compare([], [%{query: "a", at: @from, rank: 1}], 0.05)
+      assert cmp.verdict == :not_comparable
+      assert cmp.delta == nil
+    end
+  end
+
+  describe "weekly_noise/1" do
+    test "sigma needs at least two weeks, and says so rather than returning 0.0" do
+      one_week = [%{query: "a", at: ~U[2026-08-10 10:00:00.000000Z], rank: 1}]
+      assert %{sigma: nil, week_count: 1} = Live.weekly_noise(one_week)
+    end
+
+    test "sigma is computed across weeks" do
+      pairs = [
+        %{query: "a", at: ~U[2026-08-03 10:00:00.000000Z], rank: 1},
+        %{query: "b", at: ~U[2026-08-10 10:00:00.000000Z], rank: 4}
+      ]
+
+      noise = Live.weekly_noise(pairs)
+      assert noise.week_count == 2
+      assert noise.sigma > 0
+    end
+  end
+end

--- a/test/loopctl/knowledge/live_retrieval_metrics_test.exs
+++ b/test/loopctl/knowledge/live_retrieval_metrics_test.exs
@@ -9,10 +9,10 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetricsTest do
 
   alias Loopctl.Knowledge.LiveRetrievalMetrics, as: Live
 
-  @from ~U[2026-08-01 00:00:00.000000Z]
-  @to ~U[2026-09-01 00:00:00.000000Z]
-  @at ~U[2026-08-10 10:00:00.000000Z]
-  @then ~U[2026-08-10 10:01:00.000000Z]
+  @from ~U[2026-08-17 00:00:00.000000Z]
+  @to ~U[2026-08-19 00:00:00.000000Z]
+  @at ~U[2026-08-18 10:00:00.000000Z]
+  @then ~U[2026-08-18 10:01:00.000000Z]
 
   # Returns the `search_id`, the only thing that can link a read back to this search.
   defp surfaced(tenant_id, article_id, query, rank, at \\ @at, extra \\ %{}) do
@@ -86,7 +86,7 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetricsTest do
       sid = surfaced(t.id, a, "read twice", 2)
 
       read(t.id, a, sid)
-      read(t.id, a, sid, "drill", ~U[2026-08-10 10:02:00.000000Z])
+      read(t.id, a, sid, "drill", ~U[2026-08-18 10:02:00.000000Z])
 
       assert [%{rank: 2}] = Live.pairs(t.id, @from, @to)
     end
@@ -94,16 +94,18 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetricsTest do
     test "every combined label is ONE population, and other modes are excluded" do
       # 2026-08-12 SPLIT `combined` three ways; never a rename. Taking only
       # `combined_retrieved` after the split against everything before it drops the
-      # curated-led searches from one side, which reads as a regression.
+      # curated-led searches from one side. A degraded lane is still a combined search.
       t = fixture(:tenant)
 
-      for mode <- ["combined", "combined_curated", "combined_retrieved", "keyword"] do
+      modes = ~w(combined combined_curated combined_fallback combined_retrieved)
+
+      for mode <- modes ++ ["keyword"] do
         a = article(t.id)
         read(t.id, a, surfaced(t.id, a, mode, 1, @at, %{"mode" => mode}))
       end
 
       queries = t.id |> Live.pairs(@from, @to) |> Enum.map(& &1.query) |> Enum.sort()
-      assert queries == ["combined", "combined_curated", "combined_retrieved"]
+      assert queries == modes
     end
 
     test "an unscorable row costs its own observation, never the whole read" do
@@ -117,9 +119,29 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetricsTest do
 
       read(t.id, good, surfaced(t.id, good, "good", 1))
       read(t.id, bad, surfaced(t.id, bad, "bad", "n/a"))
+      # Rank 0 divides by zero, 10 digits overflow int4, a non-uuid `search_id` 22P02s the
+      # join: three ABORTS, not three lost observations.
+      read(t.id, bad, surfaced(t.id, bad, "zero", "0"))
+      read(t.id, bad, surfaced(t.id, bad, "overflow", "9999999999"))
+      surfaced(t.id, bad, "junk id", 1, @at, %{"search_id" => "x"})
       read(t.id, smoke, surfaced(t.id, smoke, "smoke", 1, @at, %{"entrypoint" => "smoke"}))
 
-      assert [%{query: "good"}] = Live.pairs(t.id, @from, @to)
+      assert [%{query: "good"}] = pairs = Live.pairs(t.id, @from, @to)
+      assert %{mrr: 1.0} = Live.summarise(pairs)
+    end
+
+    test "a window this instrument cannot measure raises instead of answering nothing" do
+      # Before #689 no read carried an `origin_search_id`, and a `to` inside the attribution
+      # window is short. Both returned `[]`, which reads as "nobody followed through".
+      t = fixture(:tenant)
+
+      assert_raise ArgumentError, ~r/different instrument/, fn ->
+        Live.pairs(t.id, ~U[2026-08-16 23:59:59.000000Z], @to)
+      end
+
+      assert_raise ArgumentError, ~r/censoring window/, fn ->
+        Live.pairs(t.id, @from, DateTime.utc_now())
+      end
     end
 
     test "is tenant-isolated" do
@@ -130,6 +152,17 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetricsTest do
       read(theirs.id, a, surfaced(theirs.id, a, "theirs", 1))
 
       assert Live.pairs(mine.id, @from, @to) == []
+    end
+  end
+
+  describe "the infra-entrypoint exclusion" do
+    test "is the same set RetrievalMetrics excludes" do
+      # Two copies of one rule; the copy carrying the rationale is private, so the test reads
+      # its source, as `TierCapabilities`' does.
+      source = File.read!("lib/loopctl/knowledge/retrieval_metrics.ex")
+      [_, listed] = Regex.run(~r/@infra_entrypoints ~w\(([^)]+)\)/, source)
+
+      assert Enum.sort(String.split(listed)) == Enum.sort(Live.infra_entrypoints())
     end
   end
 
@@ -204,8 +237,12 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetricsTest do
     end
 
     test "sigma is computed across the weeks that clear the floor" do
+      # A week holds pairs in the TENS, so `min_pairs/0` scored none of them.
+      n = Live.min_week_pairs()
+      assert n < Live.min_pairs()
+
       noise =
-        Live.weekly_noise(sample(1, 30, ~U[2026-08-03 10:00:00.000000Z]) ++ sample(4, 30, @at))
+        Live.weekly_noise(sample(1, n, ~U[2026-08-03 10:00:00.000000Z]) ++ sample(4, n, @at))
 
       assert noise.scored_week_count == 2
       assert noise.sigma > 0
@@ -224,26 +261,40 @@ defmodule Loopctl.Knowledge.LiveRetrievalMetricsTest do
   end
 
   describe "matched_pairs/5" do
-    @mid ~U[2026-08-10 00:00:00.000000Z]
+    @mid ~U[2026-08-18 00:00:00.000000Z]
 
     test "the same query on the same article reports its rank movement" do
       t = fixture(:tenant)
       a = article(t.id)
 
-      surfaced(t.id, a, "same q", 5, ~U[2026-08-02 10:00:00.000000Z])
-      surfaced(t.id, a, "same q", 1, ~U[2026-08-20 10:00:00.000000Z])
+      surfaced(t.id, a, "same q", 5, ~U[2026-08-17 10:00:00.000000Z])
+      surfaced(t.id, a, "same q", 1, @at)
 
       assert %{matched: 1, mean_rank_before: 5.0, mean_rank_after: 1.0} =
                Live.matched_pairs(t.id, @from, @mid, @mid, @to)
     end
 
-    test "overlapping windows raise rather than join every row in the overlap to itself" do
+    test "infra traffic and off-family modes are excluded on BOTH sides" do
+      # Unfiltered, a release week of smoke checks reads as a ranker change.
+      t = fixture(:tenant)
+
+      for extra <- [%{"entrypoint" => "smoke"}, %{"mode" => "keyword"}] do
+        a = article(t.id)
+        surfaced(t.id, a, "q", 5, ~U[2026-08-17 10:00:00.000000Z], extra)
+        surfaced(t.id, a, "q", 1, @at, extra)
+      end
+
+      assert %{matched: 0, mean_rank_before: nil} =
+               Live.matched_pairs(t.id, @from, @mid, @mid, @to)
+    end
+
+    test "windows out of order raise rather than join every row in the overlap to itself" do
       # A self-join reports a row's rank unchanged, indistinguishable from a real no-change,
       # and nothing in the return shape would show the caller why.
       t = fixture(:tenant)
 
-      assert_raise ArgumentError, ~r/must not overlap/, fn ->
-        Live.matched_pairs(t.id, @from, ~U[2026-08-20 00:00:00.000000Z], @mid, @to)
+      assert_raise ArgumentError, ~r/chronological and disjoint/, fn ->
+        Live.matched_pairs(t.id, @from, @to, @mid, @to)
       end
     end
   end

--- a/test/loopctl/knowledge/retrieval_eval_test.exs
+++ b/test/loopctl/knowledge/retrieval_eval_test.exs
@@ -1577,6 +1577,70 @@ defmodule Loopctl.Knowledge.RetrievalEvalTest do
   # 10. Deterministic seeded ids (reproducibility of the deploy gate)
   # =========================================================================
 
+  # Minimal result shape for the report tests — every metric undefined, so a rendering
+  # assertion cannot accidentally depend on a particular score.
+  defp sample_result do
+    %{
+      golden_version: "v",
+      mode: :embeddings,
+      observed_mode: "combined",
+      fallback_reasons: %{},
+      question_count: 1,
+      k_values: [5],
+      recall_at_k: %{5 => nil},
+      ndcg_at_k: %{5 => nil},
+      mrr: nil,
+      answered: 0,
+      answered_k: 5,
+      no_retrieval: %{recall_at_k: %{5 => nil}, ndcg_at_k: %{5 => nil}, mrr: nil, answered: 0},
+      spread: %{answered: 0, recall_at_k: %{5 => nil}, ndcg_at_k: %{5 => nil}, mrr: nil},
+      question_results: [
+        %{
+          id: "q",
+          question: "q?",
+          observed_mode: "combined",
+          fallback: false,
+          fallback_reason: nil,
+          ranked: [],
+          relevant: [],
+          recall_at_k: %{5 => nil},
+          mrr: nil,
+          ndcg_at_k: %{5 => nil},
+          answered: false
+        }
+      ]
+    }
+  end
+
+  describe "provenance disclosure" do
+    # These figures were quoted to the owner as production retrieval quality on 2026-08-25.
+    # The limitation was documented in the runbook at the time and the session had read it,
+    # so a doc is demonstrably not sufficient. The disclosure now rides the output itself,
+    # and these tests are what stop it being tidied away again.
+    test "the text report says the corpus is synthetic and must not be read as production" do
+      rendered = Report.render(sample_result(), nil)
+
+      assert rendered =~ "SYNTHETIC FIXTURE"
+      assert rendered =~ "REGRESSION signal"
+
+      # The CORPUS being invented is the half that misleads about absolute quality —
+      # "synthetic embeddings" alone would read as a limitation of the semantic lane only.
+      assert rendered =~ "invented corpus"
+
+      assert rendered =~ "NOT a measurement of",
+             "the report must say what it is not, not merely what it is"
+    end
+
+    test "the JSON output carries the same disclosure" do
+      # JSON is what a script or another agent consumes; a banner only in the human report
+      # leaves the machine path able to quote a bare number.
+      json = Report.to_json_map(sample_result(), nil)
+
+      assert json["provenance"] == "synthetic_fixture"
+      assert json["provenance_note"] =~ "NOT a measurement of production"
+    end
+  end
+
   describe "seed_corpus/2 deterministic ids" do
     test "re-seeding the same tenant yields byte-identical ids (no random UUIDs)" do
       tenant = fixture(:tenant)

--- a/test/loopctl_web/plugs/db_error_backstop_test.exs
+++ b/test/loopctl_web/plugs/db_error_backstop_test.exs
@@ -41,19 +41,28 @@ defmodule LoopctlWeb.Plugs.DBErrorBackstopTest do
     test "57014 is logged with the real SQLSTATE + request_id and re-raised sanitized",
          %{conn: conn} do
       {conn, tenant} = authed_conn(conn)
+      request_id = unique_request_id()
+      conn = put_req_header(conn, "x-request-id", request_id)
 
       {_result, log} = raise_uncaught(conn, "57014")
 
       # AC-27.3.3: structured SQLSTATE line emitted on the UNCAUGHT path too.
       assert log =~ "sqlstate=57014"
       assert log =~ "mapped_code=db_statement_timeout"
-      assert log =~ "request_id="
+      assert log =~ "request_id=#{request_id}"
       assert log =~ "tenant_id=#{tenant.id}"
 
       # AC-27.3.8: the structured log never echoes the raw SQL / vector / params.
-      refute log =~ "SELECT"
-      refute log =~ "embedding <=>"
-      refute log =~ "::vector"
+      #
+      # Scoped to THIS request's lines for the reason `refute_backstop_mapped/2` below
+      # already documents: `with_log/1` captures the GLOBAL Logger and this suite is
+      # `async: true`, so a bare `refute log =~ "SELECT"` fails whenever ANY concurrent
+      # test logs that word. Observed 2026-08-25, reddening a commit that touched none of
+      # this. The assertion is exactly as strong — the backstop puts the request id on the
+      # SAME line as anything it logs about the request, so a real SQL echo would be caught.
+      refute_in_request(log, request_id, "SELECT")
+      refute_in_request(log, request_id, "embedding <=>")
+      refute_in_request(log, request_id, "::vector")
       refute log =~ "0.123"
     end
 
@@ -227,6 +236,21 @@ defmodule LoopctlWeb.Plugs.DBErrorBackstopTest do
   # becomes one that can never fail. Verified by mutation. The request id is the right
   # discriminator because `DBErrorBackstop` puts it on the SAME line as the phrase, so the
   # assertion is exactly as strong as the bare one and is about THIS request.
+  # Refute a pattern only among the log lines belonging to THIS request. A bare refute over
+  # a globally-captured log in an async suite is a test that fails for reasons unrelated to
+  # what it guards.
+  defp refute_in_request(log, request_id, pattern) do
+    mine =
+      log
+      |> String.split("\n")
+      |> Enum.filter(&String.contains?(&1, "request_id=" <> request_id))
+
+    assert mine != [], "no captured log line carried request_id=#{request_id}"
+
+    refute Enum.any?(mine, &String.contains?(&1, pattern)),
+           "this request's log echoed #{inspect(pattern)}"
+  end
+
   defp refute_backstop_mapped(log, request_id) do
     refute log =~ ~r/db_error mapped to HTTP[^\n]*request_id=#{Regex.escape(request_id)}/,
            "the backstop mapped this request when it should have left the exit alone"


### PR DESCRIPTION
Asked whether a search refactor had improved retrieval, I produced **four different answers in one afternoon**, each from hand-written SQL, each plausible, each wrong in a different way:

| answer | what was actually wrong |
|---|---|
| `+6.5% MRR` | quoted from the SYNTHETIC golden-question eval as though it described production — its own runbook says not to, and I had read it |
| `+19%` | composition artifact: the "before" bucket averaged four months against a corpus a fifth the size, and the mode label changed mid-window |
| `-4%` | 68 pairs, well inside week-to-week noise |
| "matched pairs show better" | flips sign with the before-window (3.28→2.98 unbounded, 2.50→3.33 symmetric), at n=16–28 |

Every one of those is a definition someone has to remember at reporting time. This makes them decisions the code has already made.

## `Loopctl.Knowledge.LiveRetrievalMetrics`

Measures logged traffic instead of a fixture. A confirmed pair is a surfaced result carrying a rank that was then opened — read from the recorded `origin_search_id`, never re-inferred. Nothing is re-executed, so measuring costs no provider calls and records no new events.

Load-bearing definitions, each mutation-verified:
- **The mode family is one population.** 2026-08-12 was a three-way *split*, not a rename; taking only `combined_retrieved` after it drops curated-led searches from one side — the mismatch that manufactured the `+19%`. `combined_fallback` stays in, or a week of embedding timeouts silently leaves the population.
- **`compare/3` refuses to call an inside-noise difference a change** — `:within_noise`, `:underpowered` below 30 pairs, `:no_noise_baseline` when no σ is supplied.
- **An empty window scores `n/a`, never `0.0`.**
- **History starts 2026-08-17** (`origin_search_id`, #689) and the right edge is censored; `pairs/3` **raises** rather than let an unmeasurable window look like an uninformative one.

## The finding this produces

**The refactor cannot be evaluated on real traffic** — the instrument that records which search surfaced a read shipped *during* it. Current real baseline: **151 confirmed pairs, MRR 0.523, mean rank 3.14, 129 of 151 in the top 5.** Going forward it is measurable.

## The fixture now says what it is not

The eval's text report and JSON both carry a provenance banner. The limitation was already documented and that was not enough, so the disclosure rides the artifact; tests fail if it is removed or weakened to mention only the embeddings — the invented **corpus** is the half that misleads about absolute quality.

## Review

61 findings, 26 root causes fixed, 0 deferred. The most serious: my `pairs/4` re-inferred follow-through from a time window, re-adopting the proxy #582/#689 removed, crediting one open to every search in the window. Also fixed: an unbounded heavy read, a malformed jsonb rank aborting the whole read, `Enum.sort` on `%Date{}` ordering by day before month, infra traffic excluded.

Both items the review routed outside the diff are fixed here rather than filed: the infra-entrypoint list had two copies with the rationale attached to only one (now one public source), and the suggested statement-timeout override is **not** added because measuring settles it — 62 ms and 20 ms against a 10,000 ms budget on real data volume.

Also fixes a flake this commit tripped over: `db_error_backstop_test` refutes raw-SQL echo with a bare match over a globally-captured log in an async suite, so it reddens when any concurrent test logs `SELECT`. The file already documents that contamination for a neighbouring assertion; these three now get the same request-scoping, mutation-verified to still catch a genuine echo.

Validated against 27,177 real production rows; the module reproduced hand-written SQL to six decimals.