### PR TITLE
Refuse to score against a database still holding a previous run's corpus

### DIFF
--- a/lib/mix/tasks/loopctl.retrieval.eval.ex
+++ b/lib/mix/tasks/loopctl.retrieval.eval.ex
@@ -116,6 +116,7 @@ defmodule Mix.Tasks.Loopctl.Retrieval.Eval do
     json: :boolean,
     cleanup: :boolean,
     allow_prod: :boolean,
+    allow_dirty: :boolean,
     min_age: :integer,
     graph_lane: :boolean,
     graph_weight: :float,
@@ -139,8 +140,50 @@ defmodule Mix.Tasks.Loopctl.Retrieval.Eval do
     if Keyword.get(opts, :cleanup, false) do
       reap_leaked_tenants(opts)
     else
+      refuse_on_leaked_corpus!(opts)
       run_eval(opts)
     end
+  end
+
+  # REFUSE to score against a database that still holds another run's seeded corpus.
+  #
+  # The ANN is ONE HNSW index shared by every tenant, and `search_semantic` applies the
+  # tenant predicate as a residual AFTER the index returns its neighbourhood (see the wiki
+  # article "Multi-tenant HNSW: residual filter drops results under cross-tenant density").
+  # So a leaked corpus is not inert background: it crowds the neighbourhood, and this
+  # tenant's own answers fall outside the window and simply do not come back.
+  #
+  # Measured 2026-08-25, and it is why this guard exists. A `--filler` sweep was killed
+  # mid-run by a timeout, leaving 12,500 filler rows in two abandoned tenants. Every later
+  # cell of that sweep then scored against a progressively dirtier index, and nine golden
+  # questions went from MRR 1.000 to 0.000 — the answer not demoted but ABSENT. Read as a
+  # pool-depth curve it said "a deeper pool is worse", which is a conclusion about run
+  # ORDER wearing a pool's clothes. Every number from that sweep was discarded.
+  #
+  # Fails CLOSED, and names the remedy: a sweep that silently tolerates this produces
+  # confident numbers that mean nothing.
+  defp refuse_on_leaked_corpus!(opts) do
+    leaked =
+      AdminRepo.aggregate(
+        from(a in Loopctl.Knowledge.Article,
+          where: fragment("coalesce((?->>'retrieval_eval')::boolean, false)", a.metadata)
+        ),
+        :count
+      )
+
+    if leaked > 0 and not Keyword.get(opts, :allow_dirty, false) do
+      Mix.raise("""
+      retrieval eval: #{leaked} seeded eval row(s) from a previous run are still in this       database.
+
+      The ANN index is shared across tenants and the tenant filter is applied AFTER it, so       a leaked corpus crowds this run's neighbourhood and its answers silently drop out of       the results. Any metric produced now would describe the leftovers, not the ranking.
+
+      Reap them first:   mix loopctl.retrieval.eval --cleanup
+
+      (--allow-dirty overrides this, for diagnosing the leak itself. Never for a measurement.)
+      """)
+    end
+
+    :ok
   end
 
   defp guard_prod!(opts) do
@@ -497,6 +540,32 @@ defmodule Mix.Tasks.Loopctl.Retrieval.Eval do
           select: t.id
         )
       )
+
+    # Seeded rows can outlive their tenant row: a killed run leaves both, but a partly-torn-
+    # down one can leave articles whose tenant was already deleted. Reaping by tenant alone
+    # left those behind, and they are exactly as damaging to the shared ANN index — so sweep
+    # the marker too, independently of which tenants are found.
+    seeded =
+      from(a in Loopctl.Knowledge.Article,
+        where: fragment("coalesce((?->>'retrieval_eval')::boolean, false)", a.metadata),
+        select: a.id
+      )
+
+    # LINKS FIRST. `article_links` FKs both endpoints with `on_delete: :restrict`, so
+    # deleting a linked article raises a foreign-key violation and reaps NOTHING —
+    # `delete_corpus/2` carries the same ordering and the same comment, and this reaper
+    # was written without it and failed on its first real run against a dirty database.
+    AdminRepo.delete_all(
+      from(l in Loopctl.Knowledge.ArticleLink,
+        where: l.source_article_id in subquery(seeded) or l.target_article_id in subquery(seeded)
+      )
+    )
+
+    {orphaned, _} = AdminRepo.delete_all(seeded)
+
+    if orphaned > 0 do
+      Mix.shell().info("Retrieval eval cleanup: deleted #{orphaned} seeded eval article(s).")
+    end
 
     if tenant_ids == [] do
       Mix.shell().info("Retrieval eval cleanup: no leaked eval tenants found.")


### PR DESCRIPTION
A retrieval-eval run that is killed — a timeout, a Ctrl-C, an OOM — never reaches its cleanup and leaves its seeded corpus behind. **That is not inert clutter.** The ANN is one HNSW index shared by every tenant, with the tenant predicate applied as a residual *after* it, so leftovers crowd the next run's neighbourhood and that run's own answers drop out of the results entirely.

Measured 2026-08-25: a killed sweep left **12,500 rows in two abandoned tenants**, and the runs that followed scored against a progressively dirtier index. Nine golden questions went from MRR 1.000 to 0.000 — the answer *absent* rather than demoted — which read as a clean downward curve and was really a statement about run order. Every number from that session was discarded.

The eval now fails **closed** when any seeded row survives, naming the count and the remedy. It caught 15,872 leftovers the first time it ran. `--allow-dirty` exists for diagnosing the leak itself, never for a measurement.

`--cleanup` also reaps seeded **articles**, not only tenants. Rows can outlive their tenant row — a partly-torn-down run leaves exactly that — and those orphans are as damaging to the shared index as any other, so reaping by tenant alone left the harmful half behind. Links are deleted first: `article_links` restricts both endpoints, so deleting a linked article raises a foreign-key violation and reaps **nothing**. The neighbouring `delete_corpus/2` already carries that ordering and a comment explaining it; this reaper was written without either and failed on its first real run.

Verified end to end: a clean database runs, one leftover row makes the run refuse, `--cleanup` reaps it, the next run is clean again.

Extracted from an abandoned branch whose synthetic-filler work was dropped on the owner's instruction — these two fixes are independent of it and fix a real defect in the existing harness.