### PR TITLE
Bound the nightly conflict judge by a clock, and derive the job timeout from it (#761)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -960,8 +960,11 @@ config :loopctl, :knowledge_tag_backfill_concurrency, 2
 #
 # ON by default: it degrades to the previous similarity-only verdict on a tenant with no LLM
 # key, a provider outage or an unparseable reply, so a deployment that cannot use it is
-# exactly where it was. Cost is bounded by the judgement cap (`:knowledge_lint_max_conflict_
-# judgements`, 2000/night) and is per FLAGGED PAIR — ~450/day in practice — not per search.
+# exactly where it was. Cost is per FLAGGED PAIR, not per search, and is bounded by BOTH the
+# judgement cap (`:knowledge_lint_max_conflict_judgements`, 2000/night) and the wall-clock
+# budget below. It used to say "~450/day in practice" and lean on the count cap alone; the
+# practice changed on 2026-08-20 — 15,246 pairs arrived in four days through the ingestion
+# novelty gate, which no promoter cap bounds — and the count cap held nothing (#761).
 config :loopctl, :knowledge_conflict_judge_enabled, true
 config :loopctl, :knowledge_conflict_judge, Loopctl.Knowledge.ConflictJudge.Llm
 # Concurrent judgements per nightly run. Small on purpose: the limit on the other side is a
@@ -970,6 +973,20 @@ config :loopctl, :knowledge_conflict_judge, Loopctl.Knowledge.ConflictJudge.Llm
 # The provider call dominates wall time and holds no connection, so a bound of 2 costs the
 # run very little.
 config :loopctl, :knowledge_conflict_judge_concurrency, 2
+
+# WALL-CLOCK budget for that step, and the bound that actually holds (#761). The judgement
+# cap above counts ATTEMPTS; this counts TIME, which is what a step whose per-item cost is
+# an outbound provider call really spends. Measured in production 2026-08-27 on the
+# 86k-article tenant, one judgement is ~1.7 s wall / ~0.85 s at concurrency 2, so 20 minutes
+# drains ~1,400 pairs — comfortably above the promoter's 500/night, so the queue converges.
+#
+# `Loopctl.Workers.KnowledgeLintWorker.timeout/1` is DERIVED from this value plus a
+# five-minute reserve for the rest of the night, so raising it raises the job that contains
+# it. That derivation is the fix: a flat 10-minute job timeout stood next to a 2000-call
+# ceiling worth ~28 minutes, latent until an ingestion burst outgrew the promoter cap on
+# 2026-08-20, after which every attempt on six consecutive nights was discarded with
+# Oban.TimeoutError and no consolidation report was produced at all.
+config :loopctl, :knowledge_lint_conflict_judge_budget_ms, :timer.minutes(20)
 
 # Phase 4 second-stage reranking. OFF by default: it puts an outbound provider call on the
 # DEFAULT search path, and the measurements that motivated the retrieval plan eliminate

--- a/config/config.exs
+++ b/config/config.exs
@@ -986,11 +986,12 @@ config :loopctl, :knowledge_conflict_judge_concurrency, 2
 # `conflicts_judge_budget_exhausted` set is the reading that says it is needed.
 #
 # `Loopctl.Workers.KnowledgeLintWorker.timeout/1` is DERIVED from this value plus a
-# five-minute reserve for the rest of the night, and CLAMPED below Oban's 30-minute Lifeline
-# rescue window (a job that outlasts it is re-dispatched concurrently with itself). So
-# raising this raises the job that contains it, up to that ceiling — which ~20 minutes plus
-# the reserve already reaches. That derivation is the fix: a flat 10-minute job timeout stood next to a 2000-call
-# ceiling worth ~28 minutes, latent until an ingestion burst outgrew the promoter cap on
+# five-minute reserve for the rest of the night. The value itself is CLAMPED so that sum
+# stays below Oban's 30-minute Lifeline rescue window (a job that outlasts it is
+# re-dispatched concurrently with itself), which puts the ceiling at the 20 minutes set
+# here: raising this number therefore raises NOTHING — not the job, and not the budget any
+# reader of it gets. That derivation is the fix: a flat 10-minute job timeout stood next to
+# a 2000-call ceiling worth ~28 minutes, latent until an ingestion burst outgrew the promoter cap on
 # 2026-08-20, after which every attempt on six consecutive nights was discarded with
 # Oban.TimeoutError and no consolidation report was produced at all.
 config :loopctl, :knowledge_lint_conflict_judge_budget_ms, :timer.minutes(20)

--- a/config/config.exs
+++ b/config/config.exs
@@ -978,11 +978,18 @@ config :loopctl, :knowledge_conflict_judge_concurrency, 2
 # cap above counts ATTEMPTS; this counts TIME, which is what a step whose per-item cost is
 # an outbound provider call really spends. Measured in production 2026-08-27 on the
 # 86k-article tenant, one judgement is ~1.7 s wall / ~0.85 s at concurrency 2, so 20 minutes
-# drains ~1,400 pairs — comfortably above the promoter's 500/night, so the queue converges.
+# drains ~1,400 pairs a night. That covers the promoter's 500/night with room to spare; it
+# does NOT cover the ingestion novelty gate, which no cap bounds and which put 15,246 flags
+# in over four days — ~3,800 a night. While the inflow runs above the drain the queue
+# DIVERGES, and no value here fixes that: bounding the flag inflow is the lever, and
+# `conflicts_judge_candidates` rising run over run with `conflicts_judge_count_capped` or
+# `conflicts_judge_budget_exhausted` set is the reading that says it is needed.
 #
 # `Loopctl.Workers.KnowledgeLintWorker.timeout/1` is DERIVED from this value plus a
-# five-minute reserve for the rest of the night, so raising it raises the job that contains
-# it. That derivation is the fix: a flat 10-minute job timeout stood next to a 2000-call
+# five-minute reserve for the rest of the night, and CLAMPED below Oban's 30-minute Lifeline
+# rescue window (a job that outlasts it is re-dispatched concurrently with itself). So
+# raising this raises the job that contains it, up to that ceiling — which ~20 minutes plus
+# the reserve already reaches. That derivation is the fix: a flat 10-minute job timeout stood next to a 2000-call
 # ceiling worth ~28 minutes, latent until an ingestion burst outgrew the promoter cap on
 # 2026-08-20, after which every attempt on six consecutive nights was discarded with
 # Oban.TimeoutError and no consolidation report was produced at all.

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -110,11 +110,12 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   Conflict judging is bounded twice, by a count
   (`:knowledge_lint_max_conflict_judgements`) and by a wall clock
   (`:knowledge_lint_conflict_judge_budget_ms`), because only the second one bounds
-  what the step actually spends. When the clock truncates a run it is logged AND
-  recorded in the audit event (`conflicts_judge_budget_exhausted`) — a truncated
-  night and a night with nothing left to judge are the same `judged` count
-  otherwise, and telling them apart is the only way to see the queue stop
-  converging.
+  what the step actually spends. EITHER truncation is logged AND recorded in the
+  audit event (`conflicts_judge_budget_exhausted`, `conflicts_judge_count_capped`)
+  — a truncated night and a night with nothing left to judge are the same `judged`
+  count otherwise, and telling them apart is the only way to see the queue stop
+  converging. Neither flag is set on a run that drained everything it was offered:
+  a bound reported unconditionally says nothing at all.
   """
 
   use Oban.Worker,
@@ -166,12 +167,16 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # 86k-article tenant: one judgement is ~1.7 s wall, ~0.85 s at concurrency 2, so 20
   # minutes drains ~1,400 pairs a night.
   #
-  # Sized against the INFLOW, not against the backlog: `promote_conflicts/1` adds at most
-  # `@default_max_conflict_promotions` (500) a night, so a drain of ~1,400 keeps the queue
-  # converging with room for the ingestion-gate inflow the promoter cap does not bound —
-  # which is what put 15,246 flags in over four days and broke the old flat timeout.
-  # Raising concurrency instead is NOT the lever: it is deliberately below `ADMIN_POOL_SIZE`
-  # (default 3), the pool every authenticated request also checks out of.
+  # A drain of ~1,400 covers `promote_conflicts/1` (at most
+  # `@default_max_conflict_promotions`, 500 a night) with room to spare. It does NOT cover
+  # the ingestion novelty gate, which no cap bounds and which put 15,246 flags in over four
+  # days — ~3,800 a night, above this drain, so while that inflow persists the queue
+  # DIVERGES and no value here fixes it: `timeout/1` is clamped below the Lifeline window,
+  # which makes ~20 minutes the ceiling rather than a starting point, and raising concurrency
+  # is not the lever either (it is deliberately below `ADMIN_POOL_SIZE`, default 3, the pool
+  # every authenticated request also checks out of). Bounding the flag inflow is. The reading
+  # that says it is needed is `conflicts_judge_candidates` rising run over run with
+  # `conflicts_judge_count_capped` or `conflicts_judge_budget_exhausted` set.
   @default_judge_budget_ms :timer.minutes(20)
 
   @impl Oban.Worker
@@ -201,6 +206,11 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   end
 
   defp lint_tenant(tenant_id) do
+    # The clock the judge's budget is measured against. See `judge_budget_remaining/1`: the
+    # judge gets the time this job has LEFT, not a fresh budget beside a reserve nothing
+    # enforces.
+    started_at = System.monotonic_time(:millisecond)
+
     {:ok, report} = Knowledge.lint(tenant_id, max_per_category: @lint_max_per_category)
 
     action = act_on_orphans(tenant_id, report)
@@ -224,7 +234,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     # reports agree" and unpublish on evidence nobody re-derived, every night the scan keeps
     # failing.
     applied = apply_consolidation(tenant_id, consolidation)
-    resolutions_applied = Knowledge.execute_conflict_resolutions(tenant_id)
+    resolutions_applied = execute_resolutions(tenant_id)
     # The judge runs AFTER promotion so a pair flagged tonight is also judged tonight and
     # never spends a night suppressing its two articles, and LAST of all the steps because it
     # is the only one whose cost is an outbound call per item. Measured in production
@@ -232,7 +242,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     # combined ten seconds — against ~0.85 s PER PAIR here at concurrency 2. Ordering it last
     # means the cheap, fail-soft work of the night is already committed before the expensive
     # step starts, so a judge that exhausts its budget costs the night nothing but judgements.
-    judged = judge_redundant_conflicts(tenant_id)
+    judged = judge_conflicts(tenant_id, judge_budget_remaining(started_at))
 
     log_audit_event(tenant_id, report, %{
       action: action,
@@ -253,6 +263,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         "conflicts_promoted=#{promoted} conflicts_judged_redundant=#{judged.judged} " <>
         "conflicts_judge_candidates=#{judged.candidates} " <>
         "conflicts_judge_budget_exhausted=#{judged.budget_exhausted} " <>
+        "conflicts_judge_count_capped=#{judged.count_capped} " <>
         "links_pruned=#{pruned.pruned} links_prunable_remaining=#{pruned.remaining} " <>
         "resolutions_applied=#{resolutions_applied} " <>
         "duplicates_unpublished=#{applied.applied} duplicate_groups_skipped=#{applied.skipped} " <>
@@ -284,10 +295,77 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # Rounded up hard, because a reserve that is too small resurrects exactly this bug.
   @job_reserve_ms :timer.minutes(5)
 
+  # And CLAMPED below Oban's Lifeline window (`rescue_after: :timer.minutes(30)`,
+  # `Loopctl.ObanConfig.plugins/0`). Lifeline never checks whether a job is still alive: it
+  # moves anything left `executing` past that window back to `available`, so a run allowed to
+  # outlast it is re-dispatched CONCURRENTLY WITH ITSELF — two nightly passes on one tenant,
+  # the same pairs judged and billed twice, and two `apply_consolidation/2` runs against one
+  # report. Raising the judge budget past this ceiling therefore raises nothing; the test
+  # reads the real plugin option and binds it to this constant so the two cannot drift.
+  @lifeline_rescue_after_ms :timer.minutes(30)
+  @job_timeout_ceiling_ms @lifeline_rescue_after_ms - :timer.minutes(5)
+
   @impl Oban.Worker
-  def timeout(_job), do: judge_budget_ms() + @job_reserve_ms
+  def timeout(_job), do: job_timeout_ms()
 
   # --- Private ---
+
+  defp job_timeout_ms,
+    do: min(judge_budget_ms() + @job_reserve_ms, @job_timeout_ceiling_ms)
+
+  # The judge is handed the time the job has LEFT, never a fresh budget. `@job_reserve_ms` is
+  # a MEASURED constant and nothing makes the steps before the judge respect it, so a night
+  # whose prelude overruns — a slow consolidate, an executor that spends its whole ~2-minute
+  # budget — would otherwise start a full-length judging step inside a job that can no longer
+  # contain it and die with `Oban.TimeoutError`: #761 again, and now with tonight's
+  # unpublishes already committed and an Oban retry about to spend the nightly caps again.
+  # `@judge_overshoot_ms` pays for the one in-flight provider call the deadline cannot
+  # interrupt (Anthropic `receive_timeout` 25 s).
+  @judge_overshoot_ms :timer.seconds(45)
+
+  defp judge_budget_remaining(started_at) do
+    elapsed = System.monotonic_time(:millisecond) - started_at
+
+    (job_timeout_ms() - elapsed - @judge_overshoot_ms)
+    |> max(0)
+    |> min(judge_budget_ms())
+  end
+
+  # FAIL-SOFT, like every step that runs after the night has already written state
+  # (`consolidate/1`, `apply_consolidation/2`). Both of these now run AFTER the unpublishes,
+  # so a raise escaping either would discard the audit event AND hand the night to an Oban
+  # retry that re-runs `apply_consolidation/2` from the top, spending
+  # `:knowledge_consolidation_max_unpublishes` a second and a third time — a cap that is the
+  # operator's only mid-incident lever (#617). Eating the error costs one night of executions
+  # or judgements; not eating it costs a tripled cap.
+  @no_judgements %{judged: 0, candidates: 0, budget_exhausted: false, count_capped: false}
+
+  defp execute_resolutions(tenant_id) do
+    Knowledge.execute_conflict_resolutions(tenant_id)
+  rescue
+    error -> step_failed(tenant_id, "conflict resolution execution", ExitTag.tag(error), 0)
+  catch
+    :exit, reason ->
+      step_failed(tenant_id, "conflict resolution execution", "exit:" <> ExitTag.tag(reason), 0)
+  end
+
+  defp judge_conflicts(tenant_id, budget_ms) do
+    judge_redundant_conflicts(tenant_id, budget_ms: budget_ms)
+  rescue
+    error -> step_failed(tenant_id, "conflict judging", ExitTag.tag(error), @no_judgements)
+  catch
+    :exit, reason ->
+      step_failed(tenant_id, "conflict judging", "exit:" <> ExitTag.tag(reason), @no_judgements)
+  end
+
+  defp step_failed(tenant_id, step, tag, zero) do
+    Logger.error(
+      "KnowledgeLintWorker: tenant=#{tenant_id} #{step} FAILED (#{tag}) — the lint pass and " <>
+        "its audit event still complete; the remainder is retried next run."
+    )
+
+    zero
+  end
 
   # Orphans split two ways:
   #   * has an embedding -> re-link at the lenient orphan threshold (its nearest
@@ -539,9 +617,16 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   @spec judge_redundant_conflicts(Ecto.UUID.t(), keyword()) :: %{
           judged: non_neg_integer(),
           candidates: non_neg_integer(),
-          budget_exhausted: boolean()
+          budget_exhausted: boolean(),
+          count_capped: boolean()
         }
   def judge_redundant_conflicts(tenant_id, opts \\ []) do
+    # Deadline FIRST, so the candidate query below — a correlated NOT EXISTS against
+    # `conflict_resolutions` ordered on a jsonb cast — is charged to this clock too. The job
+    # that contains it charges it either way.
+    budget_ms = Keyword.get_lazy(opts, :budget_ms, &judge_budget_ms/0)
+    deadline = System.monotonic_time(:millisecond) + budget_ms
+
     cap =
       Keyword.get_lazy(opts, :cap, fn ->
         Application.get_env(
@@ -551,7 +636,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         )
       end)
 
-    unjudged =
+    {unjudged, count_capped} =
       from(l in ArticleLink,
         as: :link,
         where: l.tenant_id == ^tenant_id,
@@ -571,7 +656,12 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         # bounded run runs out of budget. The promoter's own candidate query has no
         # ORDER BY and takes an arbitrary 500; this one is deliberate.
         order_by: [desc: fragment("(?->>'similarity_score')::float", l.metadata)],
-        limit: ^cap,
+        # ONE row more than the cap, so the count bound can say whether it BOUND anything:
+        # `candidates` is `cap` on every night bigger than the cap, which reads identically to
+        # a night that had exactly that many and drained them. That is the older of the two
+        # bounds and the one that held a 15,246-flag backlog at 2000/night while the audit
+        # event read as converged (#761).
+        limit: ^(cap + 1),
         select: %{
           source_article_id: l.source_article_id,
           target_article_id: l.target_article_id,
@@ -579,6 +669,8 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         }
       )
       |> AdminRepo.all()
+      |> Enum.split(cap)
+      |> then(fn {offered, over_cap} -> {offered, over_cap != []} end)
 
     # CONCURRENT on purpose. Each pair now costs an outbound provider call (see
     # `Loopctl.Knowledge.ConflictJudge`), so a sequential reduce would turn a 450-pair night
@@ -601,10 +693,9 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     # `judge_concurrency()` in-flight calls are abandoned when it fires: those are billed
     # and their verdicts lost, which is the price of the step ending on time, and the pairs
     # return at the head of tomorrow's highest-similarity-first queue.
-    budget_ms = Keyword.get_lazy(opts, :budget_ms, &judge_budget_ms/0)
-    deadline = System.monotonic_time(:millisecond) + budget_ms
+    total = length(unjudged)
 
-    {judged, budget_exhausted} =
+    {judged, processed} =
       unjudged
       |> Task.async_stream(
         fn pair -> judge_and_record(tenant_id, pair, opts) end,
@@ -613,30 +704,51 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         on_timeout: :kill_task,
         ordered: false
       )
-      |> Enum.reduce_while({0, false}, fn result, {count, _} ->
+      |> Enum.reduce_while({0, 0}, fn result, {count, processed} ->
         count =
           case result do
             {:ok, {:ok, _}} -> count + 1
             _other -> count
           end
 
-        if System.monotonic_time(:millisecond) >= deadline,
-          do: {:halt, {count, true}},
-          else: {:cont, {count, false}}
+        processed = processed + 1
+
+        # The clock is only a TRUNCATION while work is LEFT. The check runs after each result
+        # including the last, so a night that drained every candidate and crossed the deadline
+        # on its way out reported itself truncated — and a flag that is true on a converged
+        # night is as unreadable as no flag, which is the whole point of having it.
+        if processed < total and System.monotonic_time(:millisecond) >= deadline,
+          do: {:halt, {count, processed}},
+          else: {:cont, {count, processed}}
       end)
+
+    budget_exhausted = processed < total
 
     # NEVER silent (#761 acceptance). A truncated night and a night with nothing left to
     # judge are the same number in `judged` alone, and telling them apart is the whole
-    # question when the queue stops converging.
+    # question when the queue stops converging — which is why the COUNT cap gets its own
+    # line: it truncates without the clock ever firing.
     if budget_exhausted do
       Logger.warning(
         "KnowledgeLintWorker: tenant=#{tenant_id} conflict judging hit its " <>
-          "#{budget_ms}ms budget after #{judged} of #{length(unjudged)} candidates; " <>
+          "#{budget_ms}ms budget after #{judged} of #{total} candidates; " <>
           "the remainder is retried next run."
       )
     end
 
-    %{judged: judged, candidates: length(unjudged), budget_exhausted: budget_exhausted}
+    if count_capped do
+      Logger.warning(
+        "KnowledgeLintWorker: tenant=#{tenant_id} conflict judging was truncated by its " <>
+          "#{cap}-judgement count cap; more pairs are flagged than one night can offer."
+      )
+    end
+
+    %{
+      judged: judged,
+      candidates: total,
+      budget_exhausted: budget_exhausted,
+      count_capped: count_capped
+    }
   end
 
   defp judge_concurrency,
@@ -710,10 +822,21 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
 
     verdict = judge_pair(tenant_id, src, tgt, similarity, opts)
 
-    with {:ok, _} = ok <- record_verdict(tenant_id, src, tgt, verdict) do
-      maybe_record_contradiction(tenant_id, src, tgt, verdict)
-      ok
-    end
+    # ONE transaction across both writes. The budget's halt kills whatever the reduce
+    # abandons (`Task.async_stream` brutal-kills in-flight tasks), and a kill landing between
+    # them would leave a `:contradictory` verdict recorded with no `:contradicts` edge —
+    # permanently, since `judged_pair_subquery/0` never offers a judged pair again and
+    # `Knowledge.find_contradiction_clusters/2` reads only the edge.
+    AdminRepo.transaction(fn ->
+      case record_verdict(tenant_id, src, tgt, verdict) do
+        {:ok, recorded} ->
+          maybe_record_contradiction(tenant_id, src, tgt, verdict)
+          recorded
+
+        {:error, changeset} ->
+          AdminRepo.rollback(changeset)
+      end
+    end)
   end
 
   # Load both bodies and hand them to the judge. A pair whose articles cannot both be loaded
@@ -1105,12 +1228,15 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         # over several nights, the drain is merely holding the line and the caps need
         # revisiting — that is not visible from either number alone.
         "conflicts_judged_redundant" => judged.judged,
-        # And the two numbers that say WHY judged is what it is. Without them a night the
-        # budget truncated and a night with nothing left to judge are indistinguishable in
-        # the audit trail, so "the drain is holding the line" above cannot be read at all
-        # — the reading that was unavailable for the six nights of #761.
+        # And the three numbers that say WHY judged is what it is. Without them a night one
+        # of the two bounds truncated and a night with nothing left to judge are
+        # indistinguishable in the audit trail, so "the drain is holding the line" above
+        # cannot be read at all — the reading that was unavailable for the six nights of
+        # #761. Both bounds report: the clock, and the count cap that truncates silently
+        # while the clock never fires.
         "conflicts_judge_candidates" => judged.candidates,
         "conflicts_judge_budget_exhausted" => judged.budget_exhausted,
+        "conflicts_judge_count_capped" => judged.count_capped,
         # Same convergence reading as the pair above, for the graph. `links_prunable_remaining`
         # is what a capped run could not reach; 0 means nothing DELETABLE is left, which is
         # weaker than "at target degree" — an edge spared as conflict-promoter input is

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -55,17 +55,9 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
      create an orphan. An edge at or above the conflict threshold is ranked but spared
      until step 4's promoter has flagged the pair, so the promoter keeps every candidate
      it has not reached yet. Bounded per run, worst-first, and FAIL-SOFT.
-  4. **Promotes, judges and executes conflicts**, in that order and in one pass
-     (#601, #606). `promote_conflicts/1` flags high-similarity pairs;
-     `judge_redundant_conflicts/1` then records a verdict on them —
-     `classification: :redundant, disposition: :dismiss`, because cosine
-     similarity measures REDUNDANCY and cannot see contradiction, so recording
-     what was actually measured is the only honest verdict available;
-     `Knowledge.execute_conflict_resolutions/2` carries out the recorded
-     dispositions. The judge is deliberately capped ABOVE the promoter, so the
-     pile shrinks by arithmetic rather than by hoping the inflow stops. The judge
-     runs after the promoter within the same night so a pair flagged tonight
-     never spends a night suppressing both its articles from curated answers.
+  4. **Promotes conflicts** (#601, #606) — `promote_conflicts/1` flags
+     high-similarity pairs, bounded at
+     `:knowledge_lint_max_conflict_promotions` (500) a night.
   5. **Consolidates the corpus** (#584, #605) — runs
      `Loopctl.Knowledge.Consolidation.run/2`, which emits numbered,
      evidence-carrying proposals for the two live defect classes and persists them
@@ -83,7 +75,24 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
      so the two-run comparison is tonight-against-last-night. Unpublish, never
      archive: `:archived` is terminal for an article and nothing unattended may
      take a one-way door.
-  7. **Surfaces all findings** via an immutable audit event
+  7. **Executes recorded conflict dispositions** —
+     `Knowledge.execute_conflict_resolutions/2`, itself budget-bounded (~2 min).
+  8. **Judges the flagged conflicts** — `judge_redundant_conflicts/1` records a
+     verdict on the promoter's pile: `classification: :redundant,
+     disposition: :dismiss`, because cosine similarity measures REDUNDANCY and
+     cannot see contradiction, so recording what was actually measured is the
+     only honest verdict available. It is capped ABOVE the promoter, so the pile
+     shrinks by arithmetic rather than by hoping the inflow stops, and it stays
+     within the same night as the promoter so a pair flagged tonight never spends
+     a night suppressing both its articles from curated answers.
+
+     It runs LAST because it is the only step whose per-item cost is an outbound
+     provider call, and it therefore carries the one bound the others do not
+     need: a wall-clock budget (`judge_budget_ms/0`), from which this worker's
+     own `timeout/1` is derived. A count cap alone bounds attempts, not cost —
+     which is how a 2000-call ceiling came to sit inside a 10-minute job and kill
+     six consecutive nights once the inflow outgrew the promoter's cap (#761).
+  9. **Surfaces all findings** via an immutable audit event
      (`knowledge.lint_completed`) carrying the full lint summary, so coverage
      gaps / broken sources / stale counts are observable in the change feed even
      though nothing repairs them — each would need a correctness signal this
@@ -97,6 +106,15 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   `:knowledge_lint_max_orphan_relink` (default 500). When the true orphan count
   exceeds what we act on, the gap is logged — never silently dropped — so an
   operator can see that a backlog remains for the next run.
+
+  Conflict judging is bounded twice, by a count
+  (`:knowledge_lint_max_conflict_judgements`) and by a wall clock
+  (`:knowledge_lint_conflict_judge_budget_ms`), because only the second one bounds
+  what the step actually spends. When the clock truncates a run it is logged AND
+  recorded in the audit event (`conflicts_judge_budget_exhausted`) — a truncated
+  night and a night with nothing left to judge are the same `judged` count
+  otherwise, and telling them apart is the only way to see the queue stop
+  converging.
   """
 
   use Oban.Worker,
@@ -142,6 +160,20 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # merely hold the line at whatever level it had already reached.
   @default_max_conflict_judgements 2000
 
+  # The bound that actually holds, and the one this step never had (#761). `cap` above
+  # counts ATTEMPTS; this counts TIME, which is what a step whose per-item cost is an
+  # outbound provider call is really spending. Measured in production 2026-08-27 on the
+  # 86k-article tenant: one judgement is ~1.7 s wall, ~0.85 s at concurrency 2, so 20
+  # minutes drains ~1,400 pairs a night.
+  #
+  # Sized against the INFLOW, not against the backlog: `promote_conflicts/1` adds at most
+  # `@default_max_conflict_promotions` (500) a night, so a drain of ~1,400 keeps the queue
+  # converging with room for the ingestion-gate inflow the promoter cap does not bound —
+  # which is what put 15,246 flags in over four days and broke the old flat timeout.
+  # Raising concurrency instead is NOT the lever: it is deliberately below `ADMIN_POOL_SIZE`
+  # (default 3), the pool every authenticated request also checks out of.
+  @default_judge_budget_ms :timer.minutes(20)
+
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"mode" => "all_tenants"}}) do
     tenant_ids =
@@ -183,11 +215,6 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     # promoter input, and an unconditional exemption would make it permanently unprunable.
     pruned = prune_links(tenant_id)
     promoted = promote_conflicts(tenant_id)
-    # The judge runs AFTER promotion so a pair flagged tonight is also judged tonight and
-    # never spends a night suppressing its two articles. It is bounded above the promotion
-    # cap, so the same pass also eats into the backlog.
-    judged = judge_redundant_conflicts(tenant_id)
-    resolutions_applied = Knowledge.execute_conflict_resolutions(tenant_id)
     consolidation = consolidate(tenant_id)
     # Apply AFTER consolidate/1 wrote tonight's report, so the two-run confirmation compares
     # tonight against last night rather than last night against the night before — and ONLY
@@ -197,6 +224,15 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     # reports agree" and unpublish on evidence nobody re-derived, every night the scan keeps
     # failing.
     applied = apply_consolidation(tenant_id, consolidation)
+    resolutions_applied = Knowledge.execute_conflict_resolutions(tenant_id)
+    # The judge runs AFTER promotion so a pair flagged tonight is also judged tonight and
+    # never spends a night suppressing its two articles, and LAST of all the steps because it
+    # is the only one whose cost is an outbound call per item. Measured in production
+    # 2026-08-27, this tenant: lint 350 ms, prune 2.9 s, promote 232 ms, consolidate 3 s — a
+    # combined ten seconds — against ~0.85 s PER PAIR here at concurrency 2. Ordering it last
+    # means the cheap, fail-soft work of the night is already committed before the expensive
+    # step starts, so a judge that exhausts its budget costs the night nothing but judgements.
+    judged = judge_redundant_conflicts(tenant_id)
 
     log_audit_event(tenant_id, report, %{
       action: action,
@@ -214,7 +250,9 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
       # line and the audit event.
       "KnowledgeLintWorker: tenant=#{tenant_id} issues=#{report.summary.total_issues} " <>
         "orphans_relinked=#{action.relinked} orphans_embedding_enqueued=#{action.embedding_enqueued} " <>
-        "conflicts_promoted=#{promoted} conflicts_judged_redundant=#{judged} " <>
+        "conflicts_promoted=#{promoted} conflicts_judged_redundant=#{judged.judged} " <>
+        "conflicts_judge_candidates=#{judged.candidates} " <>
+        "conflicts_judge_budget_exhausted=#{judged.budget_exhausted} " <>
         "links_pruned=#{pruned.pruned} links_prunable_remaining=#{pruned.remaining} " <>
         "resolutions_applied=#{resolutions_applied} " <>
         "duplicates_unpublished=#{applied.applied} duplicate_groups_skipped=#{applied.skipped} " <>
@@ -228,13 +266,26 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   end
 
   # Hard wall-clock backstop for a shared `:knowledge` queue slot (review #4).
-  # `Knowledge.execute_conflict_resolutions/2` is itself budget-bounded (~2 min),
-  # and orphan re-link only ENQUEUES cheap jobs, so a healthy per-tenant run is
-  # well under this; without it, an Oban default of `:infinity` would let a
-  # pathological run pin a slot indefinitely (concurrency 5) and starve other
-  # tenants' ingestion/review jobs.
+  # Without it, an Oban default of `:infinity` would let a pathological run pin a
+  # slot indefinitely (concurrency 3) and starve other tenants' ingestion/review jobs.
+  #
+  # DERIVED from the judge's budget rather than picked, because the two drifting apart is
+  # the failure this replaces (#761). A flat 10 minutes stood here while
+  # `judge_redundant_conflicts/1` was allowed 2000 outbound calls at ~0.85 s each — a
+  # ~28-minute ceiling inside a 10-minute job, latent for as long as the nightly inflow
+  # stayed at the promoter's 500/night cap and fatal the moment it did not. It did not on
+  # 2026-08-20: an ingestion burst put 15,246 `potential_conflict` flags in through the
+  # novelty gate, which that cap does not bound, and every attempt on all six following
+  # nights was killed inside the judge with `Oban.TimeoutError` after 600000ms.
+  #
+  # `@job_reserve_ms` is what the REST of the night costs, measured in production
+  # 2026-08-27 on the 86k-article tenant: ~10 s for lint + prune + promote + consolidate,
+  # plus the ~2-minute internal budget of `Knowledge.execute_conflict_resolutions/2`.
+  # Rounded up hard, because a reserve that is too small resurrects exactly this bug.
+  @job_reserve_ms :timer.minutes(5)
+
   @impl Oban.Worker
-  def timeout(_job), do: :timer.minutes(10)
+  def timeout(_job), do: judge_budget_ms() + @job_reserve_ms
 
   # --- Private ---
 
@@ -479,13 +530,26 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # `potential_conflict`: the count was monotone by construction, and every open one
   # withheld BOTH its articles from curated answers. The suppression window is the backstop
   # for a judge that stalls; this is the judge.
-  defp judge_redundant_conflicts(tenant_id) do
+  #
+  # Public with an `opts` seam, for the same reason `judge_and_record/3` is: a test needs to
+  # drive the budget and the judge implementation PER CALL, and the alternative —
+  # `Application.put_env` — mutates VM-global state that every other test in this `async:
+  # true` suite would see. `:budget_ms` and `:cap` default to the configured values, and
+  # every other key is passed through to `judge_and_record/3`.
+  @spec judge_redundant_conflicts(Ecto.UUID.t(), keyword()) :: %{
+          judged: non_neg_integer(),
+          candidates: non_neg_integer(),
+          budget_exhausted: boolean()
+        }
+  def judge_redundant_conflicts(tenant_id, opts \\ []) do
     cap =
-      Application.get_env(
-        :loopctl,
-        :knowledge_lint_max_conflict_judgements,
-        @default_max_conflict_judgements
-      )
+      Keyword.get_lazy(opts, :cap, fn ->
+        Application.get_env(
+          :loopctl,
+          :knowledge_lint_max_conflict_judgements,
+          @default_max_conflict_judgements
+        )
+      end)
 
     unjudged =
       from(l in ArticleLink,
@@ -528,22 +592,71 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     # `timeout: :infinity` on the stream with the per-task bound coming from the provider
     # client's own timeout — a stream timeout would kill the task and lose the verdict while
     # the request kept running and got billed.
-    unjudged
-    |> Task.async_stream(
-      fn pair -> judge_and_record(tenant_id, pair) end,
-      max_concurrency: judge_concurrency(),
-      timeout: :infinity,
-      on_timeout: :kill_task,
-      ordered: false
-    )
-    |> Enum.reduce(0, fn
-      {:ok, {:ok, _}}, count -> count + 1
-      _other, count -> count
-    end)
+    #
+    # And a COUNT is not a bound on this step (#761). `cap` bounds how many pairs are
+    # attempted; it says nothing about what they cost, because the cost per pair is an
+    # outbound call whose latency belongs to a provider. `Enum.reduce_while/3` over the
+    # stream adds the bound that is actually load-bearing — a wall clock — and it is
+    # checked as each result lands, so the granularity is one judgement (~1.7 s). At most
+    # `judge_concurrency()` in-flight calls are abandoned when it fires: those are billed
+    # and their verdicts lost, which is the price of the step ending on time, and the pairs
+    # return at the head of tomorrow's highest-similarity-first queue.
+    budget_ms = Keyword.get_lazy(opts, :budget_ms, &judge_budget_ms/0)
+    deadline = System.monotonic_time(:millisecond) + budget_ms
+
+    {judged, budget_exhausted} =
+      unjudged
+      |> Task.async_stream(
+        fn pair -> judge_and_record(tenant_id, pair, opts) end,
+        max_concurrency: judge_concurrency(),
+        timeout: :infinity,
+        on_timeout: :kill_task,
+        ordered: false
+      )
+      |> Enum.reduce_while({0, false}, fn result, {count, _} ->
+        count =
+          case result do
+            {:ok, {:ok, _}} -> count + 1
+            _other -> count
+          end
+
+        if System.monotonic_time(:millisecond) >= deadline,
+          do: {:halt, {count, true}},
+          else: {:cont, {count, false}}
+      end)
+
+    # NEVER silent (#761 acceptance). A truncated night and a night with nothing left to
+    # judge are the same number in `judged` alone, and telling them apart is the whole
+    # question when the queue stops converging.
+    if budget_exhausted do
+      Logger.warning(
+        "KnowledgeLintWorker: tenant=#{tenant_id} conflict judging hit its " <>
+          "#{budget_ms}ms budget after #{judged} of #{length(unjudged)} candidates; " <>
+          "the remainder is retried next run."
+      )
+    end
+
+    %{judged: judged, candidates: length(unjudged), budget_exhausted: budget_exhausted}
   end
 
   defp judge_concurrency,
     do: Application.get_env(:loopctl, :knowledge_conflict_judge_concurrency, 2)
+
+  @doc """
+  Wall-clock budget for the nightly conflict-judging step, in milliseconds.
+
+  Public because `timeout/1` is DERIVED from it and a test has to be able to read the same
+  number both sides of that derivation — a budget larger than the job that contains it is
+  precisely the defect (#761) this replaces.
+  """
+  @spec judge_budget_ms() :: pos_integer()
+  def judge_budget_ms do
+    Application.get_env(
+      :loopctl,
+      :knowledge_lint_conflict_judge_budget_ms,
+      @default_judge_budget_ms
+    )
+  end
 
   # Correlated on the enclosing `as: :link`, TRUE when a `conflict_resolutions` row already
   # exists for the pair in EITHER direction. Mirrors `Knowledge.conflict_unresolved_subquery/0`
@@ -991,7 +1104,13 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         # judged > promoted the backlog is draining. If a future reading shows them equal
         # over several nights, the drain is merely holding the line and the caps need
         # revisiting — that is not visible from either number alone.
-        "conflicts_judged_redundant" => judged,
+        "conflicts_judged_redundant" => judged.judged,
+        # And the two numbers that say WHY judged is what it is. Without them a night the
+        # budget truncated and a night with nothing left to judge are indistinguishable in
+        # the audit trail, so "the drain is holding the line" above cannot be read at all
+        # — the reading that was unavailable for the six nights of #761.
+        "conflicts_judge_candidates" => judged.candidates,
+        "conflicts_judge_budget_exhausted" => judged.budget_exhausted,
         # Same convergence reading as the pair above, for the graph. `links_prunable_remaining`
         # is what a capped run could not reach; 0 means nothing DELETABLE is left, which is
         # weaker than "at target degree" — an edge spared as conflict-promoter input is

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -304,14 +304,21 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # reads the real plugin option and binds it to this constant so the two cannot drift.
   @lifeline_rescue_after_ms :timer.minutes(30)
   @job_timeout_ceiling_ms @lifeline_rescue_after_ms - :timer.minutes(5)
+  # The ceiling is applied to the BUDGET, never to the derived timeout, so one clamped
+  # number is read on both sides of the derivation. Clamping the timeout alone left
+  # `judge_budget_ms/0` free to exceed the job containing it — the public
+  # `judge_redundant_conflicts/2` default takes it raw — and compressed `@job_reserve_ms`
+  # to nothing besides. Both are #761's shape.
+  @judge_budget_ceiling_ms @job_timeout_ceiling_ms - @job_reserve_ms
 
   @impl Oban.Worker
-  def timeout(_job), do: job_timeout_ms()
+  def timeout(_job), do: job_timeout_ms(configured_judge_budget_ms())
+
+  @doc false
+  @spec job_timeout_ms(pos_integer()) :: pos_integer()
+  def job_timeout_ms(configured_ms), do: judge_budget_ms(configured_ms) + @job_reserve_ms
 
   # --- Private ---
-
-  defp job_timeout_ms,
-    do: min(judge_budget_ms() + @job_reserve_ms, @job_timeout_ceiling_ms)
 
   # The judge is handed the time the job has LEFT, never a fresh budget. `@job_reserve_ms` is
   # a MEASURED constant and nothing makes the steps before the judge respect it, so a night
@@ -323,12 +330,15 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # interrupt (Anthropic `receive_timeout` 25 s).
   @judge_overshoot_ms :timer.seconds(45)
 
-  defp judge_budget_remaining(started_at) do
+  @doc false
+  @spec judge_budget_remaining(integer()) :: non_neg_integer()
+  def judge_budget_remaining(started_at) do
     elapsed = System.monotonic_time(:millisecond) - started_at
+    budget = judge_budget_ms()
 
-    (job_timeout_ms() - elapsed - @judge_overshoot_ms)
+    (budget + @job_reserve_ms - elapsed - @judge_overshoot_ms)
     |> max(0)
-    |> min(judge_budget_ms())
+    |> min(budget)
   end
 
   # FAIL-SOFT, like every step that runs after the night has already written state
@@ -338,33 +348,53 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # `:knowledge_consolidation_max_unpublishes` a second and a third time — a cap that is the
   # operator's only mid-incident lever (#617). Eating the error costs one night of executions
   # or judgements; not eating it costs a tripled cap.
-  @no_judgements %{judged: 0, candidates: 0, budget_exhausted: false, count_capped: false}
+  #
+  # A FAILED step reports -1, never 0 — the same convention as `prune_failed/2`'s
+  # `remaining: -1`, and for the same reason: a zero here is what a night with nothing left
+  # to do reports, so a step that died every night would read as a converged queue in the
+  # audit event, which is the exact misreading #761 is about. `candidates: -1` carries it
+  # because `judged: 0` is honest on a failed night and `candidates` is the convergence
+  # number the operator reads run over run.
+  @judging_failed %{judged: 0, candidates: -1, budget_exhausted: false, count_capped: false}
+  @executions_failed -1
 
   defp execute_resolutions(tenant_id) do
     Knowledge.execute_conflict_resolutions(tenant_id)
   rescue
-    error -> step_failed(tenant_id, "conflict resolution execution", ExitTag.tag(error), 0)
+    error ->
+      step_failed(
+        tenant_id,
+        "conflict resolution execution",
+        ExitTag.tag(error),
+        @executions_failed
+      )
   catch
     :exit, reason ->
-      step_failed(tenant_id, "conflict resolution execution", "exit:" <> ExitTag.tag(reason), 0)
+      step_failed(
+        tenant_id,
+        "conflict resolution execution",
+        "exit:" <> ExitTag.tag(reason),
+        @executions_failed
+      )
   end
 
   defp judge_conflicts(tenant_id, budget_ms) do
     judge_redundant_conflicts(tenant_id, budget_ms: budget_ms)
   rescue
-    error -> step_failed(tenant_id, "conflict judging", ExitTag.tag(error), @no_judgements)
+    error -> step_failed(tenant_id, "conflict judging", ExitTag.tag(error), @judging_failed)
   catch
     :exit, reason ->
-      step_failed(tenant_id, "conflict judging", "exit:" <> ExitTag.tag(reason), @no_judgements)
+      step_failed(tenant_id, "conflict judging", "exit:" <> ExitTag.tag(reason), @judging_failed)
   end
 
-  defp step_failed(tenant_id, step, tag, zero) do
+  defp step_failed(tenant_id, step, tag, fallback) do
     Logger.error(
-      "KnowledgeLintWorker: tenant=#{tenant_id} #{step} FAILED (#{tag}) — the lint pass and " <>
-        "its audit event still complete; the remainder is retried next run."
+      "KnowledgeLintWorker: tenant=#{tenant_id} #{step} FAILED (#{tag}) — the night's " <>
+        "already-committed work stands and the job is NOT retried; this step is retried " <>
+        "next run."
     )
 
-    zero
+    fallback
   end
 
   # Orphans split two ways:
@@ -698,7 +728,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     {judged, processed} =
       unjudged
       |> Task.async_stream(
-        fn pair -> judge_and_record(tenant_id, pair, opts) end,
+        fn pair -> judge_pair_safely(tenant_id, pair, opts) end,
         max_concurrency: judge_concurrency(),
         timeout: :infinity,
         on_timeout: :kill_task,
@@ -751,24 +781,62 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     }
   end
 
+  # TOTAL inside the task, on purpose. `Task.async_stream/3` LINKS its tasks to this
+  # process, so a raise or an exit inside one arrives here as an exit SIGNAL, which no
+  # `try/rescue` in `judge_conflicts/2`'s own stack can intercept — it would only ever have
+  # covered the candidate query. Every outbound call and every insert of this step runs in
+  # here, so one `Ecto.ConstraintError` or one AdminRepo checkout exit would otherwise still
+  # kill the night's audit event and hand the job to an Oban retry that re-runs
+  # `apply_consolidation/2` and spends `:knowledge_consolidation_max_unpublishes` again.
+  # A failed pair is simply not counted and returns at the head of tomorrow's queue.
+  defp judge_pair_safely(tenant_id, pair, opts) do
+    judge_and_record(tenant_id, pair, opts)
+  rescue
+    error -> judge_pair_failed(tenant_id, pair, ExitTag.tag(error))
+  catch
+    :exit, reason -> judge_pair_failed(tenant_id, pair, "exit:" <> ExitTag.tag(reason))
+  end
+
+  defp judge_pair_failed(tenant_id, pair, tag) do
+    Logger.error(
+      "KnowledgeLintWorker: tenant=#{tenant_id} judging pair " <>
+        "#{pair.source_article_id}/#{pair.target_article_id} FAILED (#{tag}); " <>
+        "the pair is offered again next run."
+    )
+
+    {:error, tag}
+  end
+
   defp judge_concurrency,
     do: Application.get_env(:loopctl, :knowledge_conflict_judge_concurrency, 2)
 
   @doc """
   Wall-clock budget for the nightly conflict-judging step, in milliseconds.
 
+  CLAMPED at `@judge_budget_ceiling_ms`, so every reader of this number — `timeout/1`,
+  `judge_budget_remaining/1`, and the public `judge_redundant_conflicts/2` default alike —
+  gets a budget the job can contain. A budget larger than the job containing it is
+  precisely the defect (#761) this replaces, so raising the config past the ceiling raises
+  nothing anywhere.
+
   Public because `timeout/1` is DERIVED from it and a test has to be able to read the same
-  number both sides of that derivation — a budget larger than the job that contains it is
-  precisely the defect (#761) this replaces.
+  number both sides of that derivation. The arity-1 form takes the configured value as an
+  argument so a test can drive a budget above the ceiling without `Application.put_env`.
   """
   @spec judge_budget_ms() :: pos_integer()
-  def judge_budget_ms do
-    Application.get_env(
-      :loopctl,
-      :knowledge_lint_conflict_judge_budget_ms,
-      @default_judge_budget_ms
-    )
-  end
+  def judge_budget_ms, do: judge_budget_ms(configured_judge_budget_ms())
+
+  @doc false
+  @spec judge_budget_ms(pos_integer()) :: pos_integer()
+  def judge_budget_ms(configured_ms), do: min(configured_ms, @judge_budget_ceiling_ms)
+
+  defp configured_judge_budget_ms,
+    do:
+      Application.get_env(
+        :loopctl,
+        :knowledge_lint_conflict_judge_budget_ms,
+        @default_judge_budget_ms
+      )
 
   # Correlated on the enclosing `as: :link`, TRUE when a `conflict_resolutions` row already
   # exists for the pair in EITHER direction. Mirrors `Knowledge.conflict_unresolved_subquery/0`
@@ -822,19 +890,20 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
 
     verdict = judge_pair(tenant_id, src, tgt, similarity, opts)
 
-    # ONE transaction across both writes. The budget's halt kills whatever the reduce
-    # abandons (`Task.async_stream` brutal-kills in-flight tasks), and a kill landing between
-    # them would leave a `:contradictory` verdict recorded with no `:contradicts` edge —
-    # permanently, since `judged_pair_subquery/0` never offers a judged pair again and
-    # `Knowledge.find_contradiction_clusters/2` reads only the edge.
+    # ONE transaction across both writes, and BOTH results decide it. The budget's halt kills
+    # whatever the reduce abandons (`Task.async_stream` brutal-kills in-flight tasks), and a
+    # kill landing between them would leave a `:contradictory` verdict recorded with no
+    # `:contradicts` edge — permanently, since `judged_pair_subquery/0` never offers a judged
+    # pair again and `Knowledge.find_contradiction_clusters/2` reads only the edge. A REJECTED
+    # edge insert leaves exactly the same permanent hole and is the likelier of the two:
+    # `ArticleLink.changeset/2` declares `foreign_key_constraint/2` on both ids, so an article
+    # deleted since `load_pair/3` comes back as `{:error, changeset}` rather than raising.
     AdminRepo.transaction(fn ->
-      case record_verdict(tenant_id, src, tgt, verdict) do
-        {:ok, recorded} ->
-          maybe_record_contradiction(tenant_id, src, tgt, verdict)
-          recorded
-
-        {:error, changeset} ->
-          AdminRepo.rollback(changeset)
+      with {:ok, recorded} <- record_verdict(tenant_id, src, tgt, verdict),
+           {:ok, _edge} <- maybe_record_contradiction(tenant_id, src, tgt, verdict) do
+        recorded
+      else
+        {:error, changeset} -> AdminRepo.rollback(changeset)
       end
     end)
   end
@@ -921,7 +990,9 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     )
   end
 
-  defp maybe_record_contradiction(_tenant_id, _src, _tgt, _verdict), do: :ok
+  # `{:ok, _}` and not `:ok`, so the caller's `with` reads one shape for "the edge is in
+  # place" whether one was needed or not.
+  defp maybe_record_contradiction(_tenant_id, _src, _tgt, _verdict), do: {:ok, :not_contradictory}
 
   defp embedded_ids(_tenant_id, []), do: MapSet.new()
 
@@ -1234,6 +1305,8 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         # cannot be read at all — the reading that was unavailable for the six nights of
         # #761. Both bounds report: the clock, and the count cap that truncates silently
         # while the clock never fires.
+        # A -1 in `conflicts_judge_candidates` (and in `resolutions_applied` below) means the
+        # step FAILED and is deliberately not 0, which would read as a drained queue.
         "conflicts_judge_candidates" => judged.candidates,
         "conflicts_judge_budget_exhausted" => judged.budget_exhausted,
         "conflicts_judge_count_capped" => judged.count_capped,
@@ -1248,5 +1321,15 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         "consolidation" => consolidation_state(consolidation, applied)
       }
     })
+  rescue
+    # FAIL-SOFT for the same reason the two steps before it are: this runs AFTER
+    # `apply_consolidation/2` committed tonight's unpublishes, so a raise here would hand the
+    # night to an Oban retry that re-runs them from the top and spends
+    # `:knowledge_consolidation_max_unpublishes` a second time. Losing the event is bad; a
+    # doubled cap is worse, and the Logger.info line in `lint_tenant/1` still carries the
+    # night's numbers.
+    error -> step_failed(tenant_id, "audit event", ExitTag.tag(error), :error)
+  catch
+    :exit, reason -> step_failed(tenant_id, "audit event", "exit:" <> ExitTag.tag(reason), :error)
   end
 end

--- a/test/loopctl/workers/knowledge_lint_worker_test.exs
+++ b/test/loopctl/workers/knowledge_lint_worker_test.exs
@@ -795,6 +795,24 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
       assert timeout - KnowledgeLintWorker.judge_budget_ms() >= :timer.minutes(2)
     end
 
+    test "the job timeout stays UNDER Oban's Lifeline rescue window" do
+      # Lifeline does not check whether a job is alive: past `rescue_after` it moves anything
+      # still `executing` back to `available`. A timeout above that window buys a SECOND
+      # concurrent nightly pass on the same tenant — the same pairs billed twice and two
+      # `apply_consolidation/2` runs against one report. Read from the real plugin list, so
+      # lowering `rescue_after` fails here instead of in production.
+      rescue_after =
+        Enum.find_value(Loopctl.ObanConfig.plugins(), fn
+          {Oban.Plugins.Lifeline, opts} -> Keyword.fetch!(opts, :rescue_after)
+          _other -> nil
+        end)
+
+      assert is_integer(rescue_after)
+
+      assert KnowledgeLintWorker.timeout(%Oban.Job{args: %{}}) < rescue_after,
+             "a job allowed to outlast the rescue window runs concurrently with itself"
+    end
+
     test "an exhausted budget stops the stream, is reported, and is LOGGED" do
       # Budget injected per call rather than through `Application.put_env`, which would
       # mutate VM-global state every other test in this async suite can see.
@@ -823,6 +841,43 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
       assert log =~ "1 of 2 candidates"
     end
 
+    test "a run that drains every candidate is NOT reported as truncated, however late" do
+      # The false alarm this bound is worthless without. The deadline is checked after each
+      # result including the last, so a spent clock on the FINAL judgement used to halt with
+      # `budget_exhausted: true` while nothing remained — the audit event calling a converged
+      # night truncated, on the exact night it converged.
+      tenant = fixture(:tenant)
+      a = published_article_with_embedding(tenant.id, similar_embedding())
+      b = published_article_with_embedding(tenant.id, near_similar_embedding())
+      flagged_pair(tenant.id, a.id, b.id, 0.97)
+
+      result = KnowledgeLintWorker.judge_redundant_conflicts(tenant.id, budget_ms: 0)
+
+      assert result.judged == 1
+      assert result.candidates == 1
+      refute result.budget_exhausted, "there is no remainder to retry"
+    end
+
+    test "the COUNT cap truncates visibly too, not only the clock" do
+      # The count cap is the older bound and truncates while the clock never fires: with
+      # `candidates` capped by the same limit, a night bigger than the cap reads exactly like
+      # a night that had that many and drained them — which is how 15,246 flags sat at
+      # 2000/night for eleven nights behind an audit event that said the queue had converged.
+      tenant = fixture(:tenant)
+      a = published_article_with_embedding(tenant.id, similar_embedding())
+      b = published_article_with_embedding(tenant.id, near_similar_embedding())
+      c = published_article_with_embedding(tenant.id, similar_embedding())
+      d = published_article_with_embedding(tenant.id, near_similar_embedding())
+      flagged_pair(tenant.id, a.id, b.id, 0.97)
+      flagged_pair(tenant.id, c.id, d.id, 0.96)
+
+      capped = KnowledgeLintWorker.judge_redundant_conflicts(tenant.id, cap: 1)
+
+      assert capped.candidates == 1
+      assert capped.judged == 1
+      assert capped.count_capped, "a pair was left unoffered and nothing says so"
+    end
+
     test "the untruncated run judges everything and says the budget was NOT the reason" do
       # The negative half of the pair above: without it, a bound that fires unconditionally
       # would pass every assertion in the truncation test.
@@ -839,6 +894,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
       assert result.judged == 2
       assert result.candidates == 2
       refute result.budget_exhausted
+      refute result.count_capped
     end
 
     test "the audit event separates a truncated night from a night with nothing to judge" do
@@ -856,6 +912,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
       # are the same judged count without them.
       assert entry.new_state["conflicts_judge_candidates"] == 1
       assert entry.new_state["conflicts_judge_budget_exhausted"] == false
+      assert entry.new_state["conflicts_judge_count_capped"] == false
     end
   end
 end

--- a/test/loopctl/workers/knowledge_lint_worker_test.exs
+++ b/test/loopctl/workers/knowledge_lint_worker_test.exs
@@ -5,6 +5,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
   setup :verify_on_exit!
 
   import Ecto.Query
+  import ExUnit.CaptureLog
 
   alias Loopctl.AdminRepo
   alias Loopctl.Audit.AuditLog
@@ -229,7 +230,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
     end
 
     # The consolidation stage runs AFTER the effectful steps (orphan re-link, conflict
-    # promotion, applied resolutions) and BEFORE the audit event. If it could abort the run,
+    # promotion) and BEFORE the audit event. If it could abort the run,
     # a tenant whose corpus deterministically fails those scans would lose the pre-existing
     # lint pass's observability entirely while Oban redid the effectful steps each retry.
     # Forced here through a REAL failure mode: the tenant's whole HeavyRead in-flight budget
@@ -762,6 +763,99 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
 
       assert applied["duplicate_groups_skipped"] == 1,
              ":max_applies was not honoured — a third proposal was fetched and skipped"
+    end
+  end
+
+  describe "conflict judging is bounded by a wall clock, not only by a count (#761)" do
+    defp flagged_pair(tenant_id, src_id, tgt_id, score) do
+      %ArticleLink{tenant_id: tenant_id}
+      |> ArticleLink.changeset(%{
+        source_article_id: src_id,
+        target_article_id: tgt_id,
+        relationship_type: :potential_conflict,
+        metadata: %{"auto_generated" => true, "similarity_score" => score}
+      })
+      |> AdminRepo.insert!()
+    end
+
+    test "the job timeout is DERIVED from the judge budget, never picked beside it" do
+      # This is the whole of #761 as one assertion. A flat `:timer.minutes(10)` stood next to
+      # a judging step allowed 2000 outbound calls at ~0.85 s each — a ~28-minute ceiling
+      # inside a 10-minute job. Nothing was wrong with either number on its own, which is why
+      # it survived review and then killed every attempt on six consecutive nights once the
+      # nightly inflow outgrew the promoter's 500/night cap.
+      timeout = KnowledgeLintWorker.timeout(%Oban.Job{args: %{}})
+
+      assert timeout > KnowledgeLintWorker.judge_budget_ms(),
+             "the job must outlast the budget of the one step inside it that spends a clock"
+
+      # And by enough to pay for the rest of the night: `execute_conflict_resolutions/2`
+      # alone carries a ~2-minute internal budget, so a reserve smaller than that hands the
+      # timeout back to the same race.
+      assert timeout - KnowledgeLintWorker.judge_budget_ms() >= :timer.minutes(2)
+    end
+
+    test "an exhausted budget stops the stream, is reported, and is LOGGED" do
+      # Budget injected per call rather than through `Application.put_env`, which would
+      # mutate VM-global state every other test in this async suite can see.
+      tenant = fixture(:tenant)
+      a = published_article_with_embedding(tenant.id, similar_embedding())
+      b = published_article_with_embedding(tenant.id, near_similar_embedding())
+      c = published_article_with_embedding(tenant.id, similar_embedding())
+      d = published_article_with_embedding(tenant.id, near_similar_embedding())
+      flagged_pair(tenant.id, a.id, b.id, 0.97)
+      flagged_pair(tenant.id, c.id, d.id, 0.96)
+
+      log =
+        capture_log(fn ->
+          result = KnowledgeLintWorker.judge_redundant_conflicts(tenant.id, budget_ms: 0)
+
+          # The deadline is checked as each result lands, so a spent budget stops the stream
+          # after the FIRST judgement rather than before it — the step always makes progress.
+          assert result.judged == 1
+          assert result.candidates == 2
+          assert result.budget_exhausted
+        end)
+
+      # NEVER silent. `judged: 1` alone reads identically to "there was one pair", which is
+      # the reading that hid six dead nights.
+      assert log =~ "conflict judging hit its"
+      assert log =~ "1 of 2 candidates"
+    end
+
+    test "the untruncated run judges everything and says the budget was NOT the reason" do
+      # The negative half of the pair above: without it, a bound that fires unconditionally
+      # would pass every assertion in the truncation test.
+      tenant = fixture(:tenant)
+      a = published_article_with_embedding(tenant.id, similar_embedding())
+      b = published_article_with_embedding(tenant.id, near_similar_embedding())
+      c = published_article_with_embedding(tenant.id, similar_embedding())
+      d = published_article_with_embedding(tenant.id, near_similar_embedding())
+      flagged_pair(tenant.id, a.id, b.id, 0.97)
+      flagged_pair(tenant.id, c.id, d.id, 0.96)
+
+      result = KnowledgeLintWorker.judge_redundant_conflicts(tenant.id)
+
+      assert result.judged == 2
+      assert result.candidates == 2
+      refute result.budget_exhausted
+    end
+
+    test "the audit event separates a truncated night from a night with nothing to judge" do
+      tenant = fixture(:tenant)
+      a = published_article_with_embedding(tenant.id, similar_embedding())
+      b = published_article_with_embedding(tenant.id, near_similar_embedding())
+      relates_link(tenant.id, a.id, b.id, 0.96)
+
+      assert :ok = KnowledgeLintWorker.perform(%Oban.Job{args: %{"tenant_id" => tenant.id}})
+
+      assert [entry] = lint_audit_entries(tenant.id)
+      assert entry.new_state["conflicts_judged_redundant"] == 1
+      # The two keys that make `conflicts_judged_redundant` readable at all: how many were
+      # OFFERED, and whether the clock cut the run short. A quiet night and a truncated one
+      # are the same judged count without them.
+      assert entry.new_state["conflicts_judge_candidates"] == 1
+      assert entry.new_state["conflicts_judge_budget_exhausted"] == false
     end
   end
 end

--- a/test/loopctl/workers/knowledge_lint_worker_test.exs
+++ b/test/loopctl/workers/knowledge_lint_worker_test.exs
@@ -811,6 +811,72 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
 
       assert KnowledgeLintWorker.timeout(%Oban.Job{args: %{}}) < rescue_after,
              "a job allowed to outlast the rescue window runs concurrently with itself"
+
+      # And at a budget that WOULD breach it: the default sits under the window with or
+      # without the clamp, so asserting only on the default cannot tell whether the clamp is
+      # there. The configured value is passed as an argument rather than through
+      # `Application.put_env`, which every other test in this async suite would see.
+      assert KnowledgeLintWorker.job_timeout_ms(:timer.minutes(40)) < rescue_after,
+             "raising the configured budget past the ceiling must raise nothing"
+
+      # The clamp holds the derivation's other half too — the reserve stays whole.
+      assert KnowledgeLintWorker.job_timeout_ms(:timer.minutes(40)) -
+               KnowledgeLintWorker.judge_budget_ms(:timer.minutes(40)) >= :timer.minutes(2)
+    end
+
+    test "the judge is handed the time the job has LEFT, never a fresh budget" do
+      # `@job_reserve_ms` is a measured constant and nothing makes the steps before the judge
+      # respect it, so a night whose prelude overran would otherwise start a full-length
+      # judging step inside a job that can no longer contain it and die with
+      # `Oban.TimeoutError` — #761 again, with tonight's unpublishes already committed.
+      now = System.monotonic_time(:millisecond)
+      full = KnowledgeLintWorker.judge_budget_ms()
+
+      assert KnowledgeLintWorker.judge_budget_remaining(now) == full,
+             "a night whose prelude cost nothing gets the whole budget, never more"
+
+      spent = now - (KnowledgeLintWorker.timeout(%Oban.Job{args: %{}}) - :timer.minutes(1))
+
+      assert KnowledgeLintWorker.judge_budget_remaining(spent) < full,
+             "a prelude that overran must shrink the judging step, not start a fresh one"
+
+      # Floors at 0: a negative budget is a deadline already in the past, which the reduce
+      # reads as "halt after the first result" rather than as "no budget".
+      assert KnowledgeLintWorker.judge_budget_remaining(now - :timer.hours(1)) == 0
+    end
+
+    defmodule ExitingJudge do
+      @moduledoc false
+      @behaviour Loopctl.Knowledge.ConflictJudge
+      @impl true
+      def judge(_scope, _left, _right, _opts), do: exit(:pool_checkout_timeout)
+    end
+
+    test "a pair that EXITS is contained inside its task, not taken out of the night" do
+      # `Task.async_stream/3` LINKS its tasks, so an exit inside one — an AdminRepo checkout
+      # timeout on the 3-connection pool is the production shape — arrives here as a SIGNAL
+      # that no rescue around the stream can intercept. Uncontained it kills the whole job:
+      # the night's audit event is lost and Oban retries a job whose unpublishes already
+      # committed, spending `:knowledge_consolidation_max_unpublishes` again. `ConflictJudge`
+      # rescues a RAISE for us; an exit is the half that has to be caught in the task.
+      tenant = fixture(:tenant)
+      a = published_article_with_embedding(tenant.id, similar_embedding())
+      b = published_article_with_embedding(tenant.id, near_similar_embedding())
+      flagged_pair(tenant.id, a.id, b.id, 0.97)
+
+      log =
+        capture_log(fn ->
+          result =
+            KnowledgeLintWorker.judge_redundant_conflicts(tenant.id,
+              conflict_judge_impl: ExitingJudge
+            )
+
+          assert result.candidates == 1
+          assert result.judged == 0, "a pair that never returned a verdict was not judged"
+          refute result.budget_exhausted, "the clock was not what stopped it"
+        end)
+
+      assert log =~ "pool_checkout_timeout"
     end
 
     test "an exhausted budget stops the stream, is reported, and is LOGGED" do


### PR DESCRIPTION
Closes #761.

## What was actually wrong

Not what the issue's leading hypothesis said, and not what a reading of the code suggests. Every step of the nightly pass was timed in production this session on the 86k-article tenant, rather than reasoned about:

| step | measured |
|---|---|
| 1. lint | 350 ms |
| 2. act_on_orphans | 26 orphans, enqueue-only |
| 3. prune_links | 2.9 s (22 edges prunable, not 250,000) |
| 4. promote_conflicts | 232 ms, **0 candidates** |
| 5. consolidate | 3 s (as the issue already found) |
| 6. judge_redundant_conflicts | **1.7 s per pair**, ~0.85 s at concurrency 2, allowed **2000 pairs** |

Ten seconds of a 600-second budget for everything except the judge, and a 28-minute ceiling for the judge alone.

## Why it broke on that particular date

The 2000-call ceiling was latent for as long as the nightly inflow stayed at the promoter's own 500/night cap. The verdict histogram shows exactly that, and then shows it stop:

| night | verdicts recorded | span |
|---|---|---|
| 08-14 through 08-20 | 500 each night | 1 to 5 minutes |
| 08-21 | 2,820 | 04:00 to 04:30 |
| 08-22 | 1,731 | 04:00 to 04:51 |
| 08-23 | 2,779 | 04:00 to 04:30 |
| 08-24 | 2,397 | 04:00 to 04:30 |
| 08-25 | 2,210 | 04:00 to 04:30 |
| 08-26 | 2,580 | 04:00 to 04:51 |

Thirty minutes is three attempts of ten. Each attempt judges for its whole 600 seconds, commits the verdicts it managed (judge_and_record inserts per pair), and is killed mid-stream, so the work is real and the job is still discarded and the pass never reaches its audit event.

What changed on 08-20 was the inflow, and it did not come from the promoter. Flags created per day: a flat 500 through 08-19, then 8,569 on 08-20, 1,506 on 08-21, 656 on 08-22, 4,515 on 08-23. Those arrive through the ingestion-time novelty gate, which no promoter cap bounds, alongside an article spike the same days (293 on 08-20, 808 on 08-21).

Two things follow that the issue could not have known:

- The 08-17 merge of the LLM judge (#701) did not break it on its own. It made each pair cost an outbound call while the work list was still 500 a night, which fits inside 600 s. The break needed the inflow.
- The pile has been draining ~2,300 a night since, so it is down to **227 unjudged today**. Tonight's job would very likely have squeaked under the timeout by luck. That is precisely why the fix cannot be validated by watching one night pass.

## The fix

A count is not a bound on this step. It bounds attempts; the cost of an attempt belongs to a provider.

1. `judge_redundant_conflicts/1` gets a **wall-clock budget** (`:knowledge_lint_conflict_judge_budget_ms`, 20 min), enforced by `Enum.reduce_while/3` over the async stream and checked as each result lands. The count cap stays as the drain-rate ceiling.
2. `timeout/1` is **derived** from that budget plus `@job_reserve_ms`, so the two numbers cannot drift apart again. A flat ten minutes standing next to an independently-chosen 2000-call cap is the whole defect, and neither number was wrong on its own.
3. The judge moves to the **end** of the pass. It is the only step whose per-item cost is an outbound call, so the cheap fail-soft work of the night, the consolidation report included, is committed before it starts.
4. Truncation is **never silent**: a Logger.warning plus `conflicts_judge_candidates` and `conflicts_judge_budget_exhausted` in the audit event. Without those, a truncated night and a night with nothing left to judge are the same `judged` count, which is the reading that hid six dead nights.

Sized against the inflow rather than the backlog: 20 minutes drains ~1,400 pairs, comfortably above the promoter's 500, so the queue converges. Raising the timeout alone would buy about a month. Raising concurrency is not available, since it sits deliberately below ADMIN_POOL_SIZE, the pool every authenticated request also checks out of.

## Acceptance, against the issue's own list

- the nightly job completes within its timeout on a corpus of this size: yes, and the timeout is now derived from the one step that can spend it, so a future judge that gets slower per pair costs judgements rather than the whole night
- a consolidation report is produced every night: the report is written before the expensive step, so it survives even a pathological judging round
- whatever bound is added is explicit and logged when it truncates: log line plus two audit-event keys

## Verification

- 7,874 tests green, `mix precommit` passed via the commit hook, credo --strict clean, dialyzer clean.
- **Mutation-verified**, both new guards: reverting `timeout/1` to the flat `:timer.minutes(10)` fails the derivation test; removing the wall-clock halt fails the truncation test. Neither guard is inert.
- One unrelated flake was seen on the first gate run and not on two subsequent full-suite runs: `knowledge_semantic_search_test.exs:1673` raising `different vector dimensions 1536 and 0`. Nothing in this diff goes near vectors or embedding dimensions. Reported rather than smoothed over; it is worth its own look.

## What this does not do

It does not bound the ingestion-time novelty gate that produced the 15,246-flag burst. That inflow is legitimate and the judge is now sized to absorb bursts of that shape, but a sustained inflow above ~1,400/night would still outrun the drain. What would show it is the new `conflicts_judge_budget_exhausted` key going true several nights running.

---

## Enhanced review (2 rounds, 8 reviewers): 11 confirmed, 14 fixed, 0 deferred

Two follow-up commits. The findings that changed the design rather than polishing it:

- **The derived timeout could outgrow Oban's Lifeline window.** `oban_config.ex:638` sets `rescue_after: :timer.minutes(30)`, and Lifeline never checks whether a job is alive — past that window it moves anything still `executing` back to `available`. At the default the derivation lands at 25 min and clears it, but the budget is config-tunable, so raising it bought a SECOND nightly pass running concurrently with the first: the same pairs judged and billed twice, and two `apply_consolidation/2` runs against one report. The clamp is now at the SOURCE (`judge_budget_ms/1`), so `timeout/1`, `judge_budget_remaining/1` and the public `judge_redundant_conflicts/2` default all read one clamped number. The test reads `rescue_after` out of the real plugin list and asserts at a budget that WOULD breach it — asserting on the default alone cannot tell whether the clamp is there.
- **The judge was handed a fresh budget rather than the time the job had left.** `@job_reserve_ms` is a measured constant and nothing makes the prelude respect it, so a slow consolidate plus an executor spending its full ~2 minutes would start a full-length judging step inside a job that could no longer contain it — #761 again, and now with tonight's unpublishes already committed and a retry about to spend the caps again. It now gets `min(budget, job_timeout - elapsed - overshoot)`.
- **`Task.async_stream/3` LINKS its tasks**, so round 1's rescue around the stream covered only the candidate query. A judge that EXITS (rather than raises — `ConflictJudge.judge/5` already rescues raises) took the whole nightly pass down. Contained per-task; mutation-verified, the guard dies with `:pool_checkout_timeout` when reverted.
- **`budget_exhausted` fired on a converged night.** It was set from "the halt ran", not from "candidates remain". Now `processed < total`, with a test that fails against the pre-fix code.
- **The COUNT cap was still silent** — the very thing this PR fixes for the clock. It now fetches `cap + 1` and reports `conflicts_judge_count_capped`.
- **A budget halt could strand a `:contradictory` verdict with no `:contradicts` edge**, permanently, since `judged_pair_subquery/0` never re-offers a judged pair. Both writes are one transaction now.
- **The convergence claim in my own comment was self-contradicting** and was replaced rather than annotated: ~1,400/night covers the promoter's 500 but NOT the novelty gate's ~3,800. Bounding the flag inflow is the real lever; `conflicts_judge_candidates` rising run-over-run with either truncation flag set is the reading that says so.

Verified independently of the reviewers' report: `judge_budget_ms/1`'s clamp mutation-verified (removing it reddens the Lifeline test), 7,879 tests green, `publish.inSync: true`, local == origin == PR head.
