### PR TITLE
Correct the conflict-flag inflow figure: it was a burst, not a nightly rate (#761)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -962,9 +962,10 @@ config :loopctl, :knowledge_tag_backfill_concurrency, 2
 # key, a provider outage or an unparseable reply, so a deployment that cannot use it is
 # exactly where it was. Cost is per FLAGGED PAIR, not per search, and is bounded by BOTH the
 # judgement cap (`:knowledge_lint_max_conflict_judgements`, 2000/night) and the wall-clock
-# budget below. It used to say "~450/day in practice" and lean on the count cap alone; the
-# practice changed on 2026-08-20 — 15,246 pairs arrived in four days through the ingestion
-# novelty gate, which no promoter cap bounds — and the count cap held nothing (#761).
+# budget below. It used to say "~450/day in practice" and lean on the count cap alone; on
+# 2026-08-20 a BURST through the ingestion novelty gate, which no promoter cap bounds, put
+# 15,246 pairs in over four days and the count cap held nothing (#761). Take the burst-vs-
+# rate reading from the budget comment below, never from that figure on its own.
 config :loopctl, :knowledge_conflict_judge_enabled, true
 config :loopctl, :knowledge_conflict_judge, Loopctl.Knowledge.ConflictJudge.Llm
 # Concurrent judgements per nightly run. Small on purpose: the limit on the other side is a
@@ -978,15 +979,21 @@ config :loopctl, :knowledge_conflict_judge_concurrency, 2
 # cap above counts ATTEMPTS; this counts TIME, which is what a step whose per-item cost is
 # an outbound provider call really spends. Measured in production 2026-08-27 on the
 # 86k-article tenant, one judgement is ~1.7 s wall / ~0.85 s at concurrency 2, so 20 minutes
-# drains ~1,400 pairs a night, which covers the promoter's 500/night with room to spare.
+# drains ~1,400 pairs a night GROSS — ~900 net of the promoter's own 500/night cap, which
+# feeds the same queue.
 #
 # The ingestion-time novelty gate is a SECOND producer that no promoter cap bounds, but its
-# #761 numbers are a BURST and not a rate: flags per day were a flat 500 through 08-19, then
-# 8,569 / 1,506 / 656 / 4,515 on 08-20 through 08-23, then ZERO on 08-24 through 08-27. A
-# burst of that shape truncates some nights, says so, and drains at ~1,400/night until it is
-# caught up. Only an inflow sustained above the drain would need a bound of its own, and the
-# reading that would say so — never yet observed — is `conflicts_judge_candidates` rising run
-# over run with `conflicts_judge_count_capped` or `conflicts_judge_budget_exhausted` set.
+# #761 numbers are a BURST and not a rate: TOTAL flags per day were a flat 500 through 08-19
+# (the promoter saturating its cap), then 8,569 / 1,506 / 656 / 4,515 on 08-20 through 08-23,
+# then zero on 08-24 through 08-27, with the backlog down to 227 by 08-27. A burst of that
+# shape truncates some nights, says so, and drains at ~900-1,400/night until it is caught up
+# — 15,246 takes roughly seventeen nights, and its causes (a tag backfill, a structural-
+# linking pass) are operator-started and repeatable. Only an inflow sustained above the drain
+# needs a bound of its own, and the reading that says so is `conflicts_judge_count_capped` /
+# `conflicts_judge_budget_exhausted` STAYING SET beyond the nights a burst of known size
+# needs — NOT `conflicts_judge_candidates` rising, which saturates at the judgement cap by
+# construction and reads flat on a queue of any size above it. Both flags shipped with this
+# budget in #762 and no night has reported through them yet, so their silence is not evidence.
 #
 # `Loopctl.Workers.KnowledgeLintWorker.timeout/1` is DERIVED from this value plus a
 # five-minute reserve for the rest of the night. The value itself is CLAMPED so that sum

--- a/config/config.exs
+++ b/config/config.exs
@@ -960,12 +960,14 @@ config :loopctl, :knowledge_tag_backfill_concurrency, 2
 #
 # ON by default: it degrades to the previous similarity-only verdict on a tenant with no LLM
 # key, a provider outage or an unparseable reply, so a deployment that cannot use it is
-# exactly where it was. Cost is per FLAGGED PAIR, not per search, and is bounded by BOTH the
-# judgement cap (`:knowledge_lint_max_conflict_judgements`, 2000/night) and the wall-clock
-# budget below. It used to say "~450/day in practice" and lean on the count cap alone; on
-# 2026-08-20 a BURST through the ingestion novelty gate, which no promoter cap bounds, put
-# 15,246 pairs in over four days and the count cap held nothing (#761). Take the burst-vs-
-# rate reading from the budget comment below, never from that figure on its own.
+# exactly where it was. Cost is per FLAGGED PAIR, not per search, and the bound that holds is
+# the wall-clock budget below (~1,400 judgements a night); the judgement cap
+# (`:knowledge_lint_max_conflict_judgements`, 2000) sits ABOVE it and never fires first. It
+# used to say "~450/day in practice" and lean on that count cap alone; on 2026-08-20 a BURST
+# through the ingestion novelty gate, which no promoter cap bounds, put ~13,000 of a
+# 15,246-pair four-day total in — the rest is the promoter saturating its own 500/day cap —
+# and the count cap held nothing (#761). Take the burst-vs-rate reading from the budget
+# comment below, never from that figure on its own.
 config :loopctl, :knowledge_conflict_judge_enabled, true
 config :loopctl, :knowledge_conflict_judge, Loopctl.Knowledge.ConflictJudge.Llm
 # Concurrent judgements per nightly run. Small on purpose: the limit on the other side is a
@@ -985,15 +987,23 @@ config :loopctl, :knowledge_conflict_judge_concurrency, 2
 # The ingestion-time novelty gate is a SECOND producer that no promoter cap bounds, but its
 # #761 numbers are a BURST and not a rate: TOTAL flags per day were a flat 500 through 08-19
 # (the promoter saturating its cap), then 8,569 / 1,506 / 656 / 4,515 on 08-20 through 08-23,
-# then zero on 08-24 through 08-27, with the backlog down to 227 by 08-27. A burst of that
-# shape truncates some nights, says so, and drains at ~900-1,400/night until it is caught up
-# — 15,246 takes roughly seventeen nights, and its causes (a tag backfill, a structural-
-# linking pass) are operator-started and repeatable. Only an inflow sustained above the drain
+# then zero on 08-24 through 08-27, with the backlog down to 227 by 08-27. That observed
+# drain ran ~2,150/night, ABOVE the fixed path's ceiling, because the broken 3x10-minute path
+# incidentally judged 1,700-2,800 a night by dying three times — losing the night's audit
+# event and re-spending the nightly caps per attempt, so it is not a throughput to miss. A
+# burst of that shape truncates some nights, says so, and drains at ~900-1,400/night until it
+# is caught up — 15,246 takes ELEVEN nights at the promoter rate measured on 2026-08-27 (0
+# candidates) and SEVENTEEN if the promoter saturates its 500/night cap. Its causes (a tag
+# backfill, a structural-linking pass) are operator-started and repeatable. Only an inflow
+# sustained above the drain
 # needs a bound of its own, and the reading that says so is `conflicts_judge_count_capped` /
 # `conflicts_judge_budget_exhausted` STAYING SET beyond the nights a burst of known size
 # needs — NOT `conflicts_judge_candidates` rising, which saturates at the judgement cap by
-# construction and reads flat on a queue of any size above it. Both flags shipped with this
-# budget in #762 and no night has reported through them yet, so their silence is not evidence.
+# construction and reads flat on a queue of any size above it. `candidates` still carries the
+# other half of the reading: -1 run over run is the step FAILING, and it is the only field in
+# the event that says so, since both flags report `false` on a failed night. Both flags
+# shipped with this budget in #762 and no night has reported through them yet, so their
+# silence is not evidence.
 #
 # `Loopctl.Workers.KnowledgeLintWorker.timeout/1` is DERIVED from this value plus a
 # five-minute reserve for the rest of the night. The value itself is CLAMPED so that sum

--- a/config/config.exs
+++ b/config/config.exs
@@ -978,12 +978,15 @@ config :loopctl, :knowledge_conflict_judge_concurrency, 2
 # cap above counts ATTEMPTS; this counts TIME, which is what a step whose per-item cost is
 # an outbound provider call really spends. Measured in production 2026-08-27 on the
 # 86k-article tenant, one judgement is ~1.7 s wall / ~0.85 s at concurrency 2, so 20 minutes
-# drains ~1,400 pairs a night. That covers the promoter's 500/night with room to spare; it
-# does NOT cover the ingestion novelty gate, which no cap bounds and which put 15,246 flags
-# in over four days — ~3,800 a night. While the inflow runs above the drain the queue
-# DIVERGES, and no value here fixes that: bounding the flag inflow is the lever, and
-# `conflicts_judge_candidates` rising run over run with `conflicts_judge_count_capped` or
-# `conflicts_judge_budget_exhausted` set is the reading that says it is needed.
+# drains ~1,400 pairs a night, which covers the promoter's 500/night with room to spare.
+#
+# The ingestion-time novelty gate is a SECOND producer that no promoter cap bounds, but its
+# #761 numbers are a BURST and not a rate: flags per day were a flat 500 through 08-19, then
+# 8,569 / 1,506 / 656 / 4,515 on 08-20 through 08-23, then ZERO on 08-24 through 08-27. A
+# burst of that shape truncates some nights, says so, and drains at ~1,400/night until it is
+# caught up. Only an inflow sustained above the drain would need a bound of its own, and the
+# reading that would say so — never yet observed — is `conflicts_judge_candidates` rising run
+# over run with `conflicts_judge_count_capped` or `conflicts_judge_budget_exhausted` set.
 #
 # `Loopctl.Workers.KnowledgeLintWorker.timeout/1` is DERIVED from this value plus a
 # five-minute reserve for the rest of the night. The value itself is CLAMPED so that sum

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -155,39 +155,56 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   @default_orphan_link_threshold 0.5
   @default_max_conflict_promotions 500
 
-  # The DRAIN for auto-generated `potential_conflict` links, and it is deliberately LARGER
-  # than the promotion cap above so the queue converges instead of oscillating. At 500
-  # promoted and 2000 judged per night the backlog falls by 1500/night; equal caps would
-  # merely hold the line at whatever level it had already reached.
+  # The SECONDARY drain bound for auto-generated `potential_conflict` links: larger than the
+  # promotion cap above, so a count can never be what holds the queue level. It is not the
+  # drain, though — 2000 judgements is ~28 minutes at ~0.85 s each and the wall clock below
+  # cuts in first (#761). The drain that actually holds is ~1,400 a night, ~900 net of the
+  # promoter; see `@default_judge_budget_ms`. This number's remaining job is bounding the
+  # candidate query.
   @default_max_conflict_judgements 2000
 
   # The bound that actually holds, and the one this step never had (#761). `cap` above
   # counts ATTEMPTS; this counts TIME, which is what a step whose per-item cost is an
   # outbound provider call is really spending. Measured in production 2026-08-27 on the
   # 86k-article tenant: one judgement is ~1.7 s wall, ~0.85 s at concurrency 2, so 20
-  # minutes drains ~1,400 pairs a night.
-  #
-  # A drain of ~1,400 covers `promote_conflicts/1` (at most
-  # `@default_max_conflict_promotions`, 500 a night) with room to spare, which is what makes
-  # the queue converge in the steady state.
+  # minutes drains ~1,400 pairs a night GROSS. `promote_conflicts/1` feeds the same queue up
+  # to `@default_max_conflict_promotions` (500) a night, so against an existing backlog the
+  # NET drain is ~900 — and 500 is a CAP, not a rate (2026-08-27 measured the promoter at 0
+  # candidates), so ~900 is the worst case and ~1,400 the best.
   #
   # The SECOND producer is the ingestion-time novelty gate, and no promoter cap bounds it.
-  # Do not read its #761 numbers as a rate: flags created per day were a flat 500 through
-  # 08-19, then 8,569 / 1,506 / 656 / 4,515 on 08-20 through 08-23, then **ZERO on 08-24
-  # through 08-27** (measured, 2026-08-27). That was a BURST — a corpus tag backfill and a
-  # structural-linking pass landing together — not a nightly inflow, and averaging its four
-  # days into "~3,800 a night" is a mistake this comment made until it was checked against
-  # the per-day counts.
+  # Do not read its #761 numbers as a rate. TOTAL flags created per day — both producers —
+  # were a flat 500 through 08-19 (the promoter saturating its own cap), then 8,569 / 1,506
+  # / 656 / 4,515 on 08-20 through 08-23, then zero on 08-24 through 08-27, with the backlog
+  # itself down to 227 by 08-27. So ~13,000 of the 15,246 was a BURST — a corpus tag
+  # backfill and a structural-linking pass landing together — and averaging four days of it
+  # into "~3,800 a night" is a mistake this comment made until the per-day counts were
+  # checked. Weigh the zeros lightly on their own: the judge was dying nightly across that
+  # same window, so it is the drained backlog, not the zeros, that says the burst ended.
   #
-  # So a burst is absorbed rather than fatal: it truncates some nights, says so, and drains
-  # at ~1,400 a night until it is caught up (the 15,246-flag burst clears in about eleven).
+  # A burst is therefore absorbed rather than fatal: it truncates some nights, says so, and
+  # drains at ~900-1,400 a night until it is caught up — 15,246 takes roughly SEVENTEEN
+  # nights, not eleven, because the promoter keeps its share of the drain. That holds only
+  # while a fresh burst does not land before the last one clears, and both causes are
+  # operator-started and repeatable (`TagBackfillWorker` is deliberately not on a cron), so
+  # a re-run means another ~17 truncated nights rather than a fault. The broken 3x10-minute
+  # path incidentally judged 1,700-2,800 a night by dying three times; it also lost the
+  # night's audit event and re-spent the nightly caps per attempt, so that is not a
+  # throughput to miss.
+  #
   # What no value HERE could fix is an inflow that ran above the drain INDEFINITELY —
   # `timeout/1` is clamped below the Lifeline window, so ~20 minutes is a ceiling rather
   # than a starting point, and raising concurrency is not the lever either (it is
-  # deliberately below `ADMIN_POOL_SIZE`, default 3, the pool every authenticated request
-  # also checks out of). Bounding the flag inflow would be. The reading that would say it is
-  # needed — and which has never been observed — is `conflicts_judge_candidates` rising run
-  # over run with `conflicts_judge_count_capped` or `conflicts_judge_budget_exhausted` set.
+  # deliberately below `ADMIN_POOL_SIZE`, default 3 at `config/runtime.exs:277`, the pool
+  # every authenticated request also checks out of). Bounding the flag inflow would be, and
+  # the reading that says so is `conflicts_judge_count_capped` or
+  # `conflicts_judge_budget_exhausted` STAYING SET beyond the nights a burst of known size
+  # needs. It is NOT `conflicts_judge_candidates` rising run over run: that number cannot
+  # rise above `cap`, because the candidate query takes `limit: cap + 1` and splits at
+  # `cap`, so a 2,001-pair night and a 200,000-pair night both report a flat 2,000 forever
+  # — a divergent queue looks IDENTICAL to a converged one there. And no night has reported
+  # through either flag yet (both shipped with this clock bound in #762), so their silence
+  # so far is an absence of instrument, not an absence of divergence.
   @default_judge_budget_ms :timer.minutes(20)
 
   @impl Oban.Worker

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -81,10 +81,11 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
      verdict on the promoter's pile: `classification: :redundant,
      disposition: :dismiss`, because cosine similarity measures REDUNDANCY and
      cannot see contradiction, so recording what was actually measured is the
-     only honest verdict available. It is capped ABOVE the promoter, so the pile
-     shrinks by arithmetic rather than by hoping the inflow stops, and it stays
-     within the same night as the promoter so a pair flagged tonight never spends
-     a night suppressing both its articles from curated answers.
+     only honest verdict available. The pile is drained by a WALL CLOCK and not
+     by the count cap — ~1,400 pairs a night gross, ~900 net of the promoter's
+     own 500 (see `@default_judge_budget_ms`) — and the drain stays within the
+     same night as the promoter so a pair flagged tonight never spends a night
+     suppressing both its articles from curated answers.
 
      It runs LAST because it is the only step whose per-item cost is an outbound
      provider call, and it therefore carries the one bound the others do not
@@ -183,8 +184,9 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # same window, so it is the drained backlog, not the zeros, that says the burst ended.
   #
   # A burst is therefore absorbed rather than fatal: it truncates some nights, says so, and
-  # drains at ~900-1,400 a night until it is caught up — 15,246 takes roughly SEVENTEEN
-  # nights, not eleven, because the promoter keeps its share of the drain. That holds only
+  # drains at ~900-1,400 a night until it is caught up — 15,246 takes ELEVEN nights at the
+  # promoter rate measured on 2026-08-27 (0 candidates) and SEVENTEEN if the promoter
+  # saturates its 500/night cap; quote the range, not one end of it. That holds only
   # while a fresh burst does not land before the last one clears, and both causes are
   # operator-started and repeatable (`TagBackfillWorker` is deliberately not on a cron), so
   # a re-run means another ~17 truncated nights rather than a fault. The broken 3x10-minute
@@ -197,14 +199,16 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # than a starting point, and raising concurrency is not the lever either (it is
   # deliberately below `ADMIN_POOL_SIZE`, default 3 at `config/runtime.exs:277`, the pool
   # every authenticated request also checks out of). Bounding the flag inflow would be, and
-  # the reading that says so is `conflicts_judge_count_capped` or
-  # `conflicts_judge_budget_exhausted` STAYING SET beyond the nights a burst of known size
-  # needs. It is NOT `conflicts_judge_candidates` rising run over run: that number cannot
-  # rise above `cap`, because the candidate query takes `limit: cap + 1` and splits at
-  # `cap`, so a 2,001-pair night and a 200,000-pair night both report a flat 2,000 forever
-  # — a divergent queue looks IDENTICAL to a converged one there. And no night has reported
-  # through either flag yet (both shipped with this clock bound in #762), so their silence
-  # so far is an absence of instrument, not an absence of divergence.
+  # the reading takes BOTH halves of the audit event. DIVERGENCE is
+  # `conflicts_judge_count_capped` or `conflicts_judge_budget_exhausted` STAYING SET beyond
+  # the nights a burst of known size needs. STEP FAILURE is `conflicts_judge_candidates` at
+  # -1 run over run, and only that: both flags are hardcoded `false` in `@judging_failed`, so
+  # a judge that dies every night reports through them exactly as a drained queue does. What
+  # `candidates` can never show is queue DEPTH — it cannot rise above `cap`, because the
+  # candidate query takes `limit: cap + 1` and splits at `cap`, so a 2,001-pair night and a
+  # 200,000-pair night both report a flat 2,000 forever. And no night has reported through
+  # either flag yet (both shipped with this clock bound in #762), so their silence so far is
+  # an absence of instrument, not an absence of divergence.
   @default_judge_budget_ms :timer.minutes(20)
 
   @impl Oban.Worker
@@ -381,8 +385,10 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # `remaining: -1`, and for the same reason: a zero here is what a night with nothing left
   # to do reports, so a step that died every night would read as a converged queue in the
   # audit event, which is the exact misreading #761 is about. `candidates: -1` carries it
-  # because `judged: 0` is honest on a failed night and `candidates` is the convergence
-  # number the operator reads run over run.
+  # because `judged: 0` is honest on a failed night, and because it is the ONLY field here
+  # that can: both bound flags are hardcoded `false`, so they report a died-every-night step
+  # exactly as they report a drained queue. `candidates` is a FAILURE marker, not a
+  # queue-depth reading — above `cap` it saturates (see `@default_judge_budget_ms`).
   @judging_failed %{judged: 0, candidates: -1, budget_exhausted: false, count_capped: false}
   @executions_failed -1
 
@@ -717,8 +723,9 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         # ONE row more than the cap, so the count bound can say whether it BOUND anything:
         # `candidates` is `cap` on every night bigger than the cap, which reads identically to
         # a night that had exactly that many and drained them. That is the older of the two
-        # bounds and the one that held a 15,246-flag backlog at 2000/night while the audit
-        # event read as converged (#761).
+        # bounds and it held NOTHING through #761: the 10-minute job timeout killed the run
+        # long before 2000 attempts, and those nights wrote no audit event at all. This flag
+        # is what makes the truncation legible now.
         limit: ^(cap + 1),
         select: %{
           source_article_id: l.source_article_id,
@@ -1322,10 +1329,11 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         "orphans_relinked" => action.relinked,
         "orphans_embedding_enqueued" => action.embedding_enqueued,
         "conflicts_promoted" => promoted,
-        # Both numbers are recorded because the DIFFERENCE is the convergence signal: while
-        # judged > promoted the backlog is draining. If a future reading shows them equal
-        # over several nights, the drain is merely holding the line and the caps need
-        # revisiting — that is not visible from either number alone.
+        # Both numbers are recorded because the DIFFERENCE bounds the NET drain: while
+        # judged > promoted the backlog is falling. It is not the convergence reading on its
+        # own — `judged` is clock-truncated below the count cap, so `judged > promoted` holds
+        # on every night of a long burst drain and every night of an unbounded divergence
+        # alike. The convergence reading is the two truncation flags below (#761).
         "conflicts_judged_redundant" => judged.judged,
         # And the three numbers that say WHY judged is what it is. Without them a night one
         # of the two bounds truncated and a night with nothing left to judge are
@@ -1338,7 +1346,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         "conflicts_judge_candidates" => judged.candidates,
         "conflicts_judge_budget_exhausted" => judged.budget_exhausted,
         "conflicts_judge_count_capped" => judged.count_capped,
-        # Same convergence reading as the pair above, for the graph. `links_prunable_remaining`
+        # Same drain-vs-remaining pair as above, for the graph. `links_prunable_remaining`
         # is what a capped run could not reach; 0 means nothing DELETABLE is left, which is
         # weaker than "at target degree" — an edge spared as conflict-promoter input is
         # over-degree and uncounted. A -1 means the prune FAILED and is deliberately not 0 — a

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -168,15 +168,26 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # minutes drains ~1,400 pairs a night.
   #
   # A drain of ~1,400 covers `promote_conflicts/1` (at most
-  # `@default_max_conflict_promotions`, 500 a night) with room to spare. It does NOT cover
-  # the ingestion novelty gate, which no cap bounds and which put 15,246 flags in over four
-  # days — ~3,800 a night, above this drain, so while that inflow persists the queue
-  # DIVERGES and no value here fixes it: `timeout/1` is clamped below the Lifeline window,
-  # which makes ~20 minutes the ceiling rather than a starting point, and raising concurrency
-  # is not the lever either (it is deliberately below `ADMIN_POOL_SIZE`, default 3, the pool
-  # every authenticated request also checks out of). Bounding the flag inflow is. The reading
-  # that says it is needed is `conflicts_judge_candidates` rising run over run with
-  # `conflicts_judge_count_capped` or `conflicts_judge_budget_exhausted` set.
+  # `@default_max_conflict_promotions`, 500 a night) with room to spare, which is what makes
+  # the queue converge in the steady state.
+  #
+  # The SECOND producer is the ingestion-time novelty gate, and no promoter cap bounds it.
+  # Do not read its #761 numbers as a rate: flags created per day were a flat 500 through
+  # 08-19, then 8,569 / 1,506 / 656 / 4,515 on 08-20 through 08-23, then **ZERO on 08-24
+  # through 08-27** (measured, 2026-08-27). That was a BURST — a corpus tag backfill and a
+  # structural-linking pass landing together — not a nightly inflow, and averaging its four
+  # days into "~3,800 a night" is a mistake this comment made until it was checked against
+  # the per-day counts.
+  #
+  # So a burst is absorbed rather than fatal: it truncates some nights, says so, and drains
+  # at ~1,400 a night until it is caught up (the 15,246-flag burst clears in about eleven).
+  # What no value HERE could fix is an inflow that ran above the drain INDEFINITELY —
+  # `timeout/1` is clamped below the Lifeline window, so ~20 minutes is a ceiling rather
+  # than a starting point, and raising concurrency is not the lever either (it is
+  # deliberately below `ADMIN_POOL_SIZE`, default 3, the pool every authenticated request
+  # also checks out of). Bounding the flag inflow would be. The reading that would say it is
+  # needed — and which has never been observed — is `conflicts_judge_candidates` rising run
+  # over run with `conflicts_judge_count_capped` or `conflicts_judge_budget_exhausted` set.
   @default_judge_budget_ms :timer.minutes(20)
 
   @impl Oban.Worker


### PR DESCRIPTION
Follows #762, which is already merged and deployed. Comments only, no behavior change.

#762 shipped two comments — one in `knowledge_lint_worker.ex`, one in `config/config.exs` — asserting that the ingestion novelty gate adds roughly 3,800 `potential_conflict` flags a night, above the judge's ~1,400/night drain, and concluding from that arithmetic that the queue **diverges** and that bounding the inflow is an open lever.

That figure is a four-day burst divided by four. The per-day counts, measured in production 2026-08-27:

| day | flags created |
|---|---|
| 08-19 | 500 (the promoter's own cap — the steady state) |
| 08-20 | 8,569 |
| 08-21 | 1,506 |
| 08-22 | 656 |
| 08-23 | 4,515 |
| 08-24 .. 08-27 | **0** |

The burst was a corpus tag backfill and a structural-linking pass landing on the same days. It ended on 08-23 and nothing has arrived since.

So the conclusion inverts. In the steady state the only producer is the promoter at 500/night against a 1,400 drain, and the queue converges with a 2.8x margin. A burst is **absorbed rather than fatal**: it truncates some nights, reports that it did via `conflicts_judge_budget_exhausted`, and drains at ~1,400/night until caught up — the 15,246-flag burst clears in about eleven nights. Only an inflow sustained above the drain would need a bound of its own, and that reading has never been observed.

Worth a PR rather than a quiet edit because a divergence claim in a comment is exactly what a later session reasons from, and this one would have sent someone to build a bound nothing needs.