### PR TITLE
Retire the refuted convergence claim at the three sites that still cite it (#761)

### DIFF
--- a/lib/loopctl/knowledge/consolidation.ex
+++ b/lib/loopctl/knowledge/consolidation.ex
@@ -1875,9 +1875,13 @@ defmodule Loopctl.Knowledge.Consolidation do
   # `:contradiction_candidate` WAS a class here. It is not any more, and the reason is
   # ownership rather than value.
   #
-  # `Loopctl.Workers.KnowledgeLintWorker.judge_redundant_conflicts/1` now resolves exactly
-  # these pairs automatically, recording `classification: :redundant, disposition: :dismiss`
-  # — capped ABOVE the promotion rate so the queue converges. Proposing them here as well
+  # `Loopctl.Workers.KnowledgeLintWorker.judge_redundant_conflicts/2` now resolves exactly
+  # these pairs automatically, recording `classification: :redundant, disposition: :dismiss`.
+  # The OWNERSHIP is what settles this, not a promise about latency: that drain is bounded by
+  # a wall clock since #761 (~1,400 pairs a night gross, ~900 net of the promoter's own
+  # share), so a backlog is worked through over days rather than cleared promptly — this
+  # comment used to say "capped ABOVE the promotion rate so the queue converges", which read
+  # as the latter. Proposing them here as well
   # put two subsystems on one pile: one resolving it, the other re-reporting it nightly.
   # That is the "second scheduler over the same corpus" failure #584 named, arrived at from
   # the other direction.

--- a/lib/loopctl/workers/article_linking_worker.ex
+++ b/lib/loopctl/workers/article_linking_worker.ex
@@ -70,8 +70,13 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
   `LinkPruning.reclaimable_query/1` says the prune can free. The cut runs AFTER the
   already-linked rejection, so a re-link (nightly orphan pass, a re-embed) tops the article up
   to K rather than adding K more. `:potential_conflict` is NOT capped — it has its own
-  threshold and its own draining consumer, and a second cap there would withhold pairs from a
-  queue designed to converge.
+  threshold and its own draining consumer
+  (`KnowledgeLintWorker.judge_redundant_conflicts/2`), and a second cap here would withhold
+  pairs from that consumer rather than protect anything. Note what that consumer's bound
+  actually is (#761): a WALL CLOCK, not the count cap it looks like, so the drain is roughly
+  1,400 pairs a night gross and ~900 net of the promoter's own share — NOT a queue that
+  converges by arithmetic regardless of inflow. It absorbs a burst over one to three weeks;
+  an inflow sustained above ~900 a night would need a bound, and this is where one would go.
 
   Two things this bound is NOT, stated because both are easy to read into it:
 
@@ -229,9 +234,11 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
         # spending its budget on.
         #
         # `:potential_conflict` is deliberately NOT capped here. It has its own (much higher)
-        # threshold and its own consumer — `KnowledgeLintWorker.judge_redundant_conflicts/1`
-        # drains it, capped above the promotion rate — so a second cap would silently withhold
-        # pairs from a queue that is already designed to converge.
+        # threshold and its own consumer — `KnowledgeLintWorker.judge_redundant_conflicts/2`
+        # drains it — so a second cap here would silently withhold pairs from that consumer.
+        # What it would NOT do is make the queue converge: since #761 the drain's real bound
+        # is a wall clock (~1,400 pairs a night gross, ~900 net of the promoter), not the
+        # count cap, so this queue absorbs a burst rather than converging by arithmetic.
         relates =
           build_links(
             article.id,

--- a/test/loopctl/workers/knowledge_lint_worker_test.exs
+++ b/test/loopctl/workers/knowledge_lint_worker_test.exs
@@ -927,8 +927,10 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
     test "the COUNT cap truncates visibly too, not only the clock" do
       # The count cap is the older bound and truncates while the clock never fires: with
       # `candidates` capped by the same limit, a night bigger than the cap reads exactly like
-      # a night that had that many and drained them — which is how 15,246 flags sat at
-      # 2000/night for eleven nights behind an audit event that said the queue had converged.
+      # a night that had that many and drained them. That silence is the whole reason this
+      # flag exists. It is NOT what happened during #761 — those runs were killed by the
+      # 10-minute job timeout and wrote no audit event at all, so there was nothing to
+      # misread; this guards the failure mode that would have replaced it.
       tenant = fixture(:tenant)
       a = published_article_with_embedding(tenant.id, similar_embedding())
       b = published_article_with_embedding(tenant.id, near_similar_embedding())


### PR DESCRIPTION
Follow-up to #763, which is merged. **Comments only, no behavior change.**

#763 corrected the drain arithmetic where it is DEFINED. Its enhanced review found three more sites still reasoning from the claim #763 refuted — that the conflict queue converges by arithmetic because the judge is capped above the promoter. Since #761 the judge's real bound is a **wall clock**, so the drain is ~1,400 pairs a night gross and ~900 net of the promoter's own share, and the queue **absorbs** a burst over one to three weeks rather than converging regardless of inflow.

Each of the three uses that claim to justify something, which is what makes them worth correcting rather than leaving:

| file | what the claim was holding up |
|---|---|
| `article_linking_worker.ex` (moduledoc + inline) | the reason `:potential_conflict` is left UNCAPPED at the inflow site |
| `consolidation.ex` | the premise under which `:contradiction_candidate` was dropped as a proposal class |
| `knowledge_lint_worker_test.exs` | the story the count-cap test tells about why the flag exists |

- **article_linking_worker** — leaving the inflow uncapped is still the right call, and the reason is now the honest one: a second cap here withholds pairs from the drain and protects nothing. Both sites now also note that this is *where a bound would go* if inflow ever ran sustained above ~900/night.
- **consolidation** — the OWNERSHIP argument is what settles dropping that proposal class and it stands untouched. The latency promise attached to it ("so the queue converges") does not, and a reader was entitled to conclude those pairs are always cleared promptly.
- **the test** — the comment attributed #761's six dead nights to the count cap hiding a backlog behind a converged audit event. Those runs were killed by the 10-minute job timeout and wrote **no audit event at all**, so there was nothing to misread. The test guards a real failure mode; just not that one.

## On the review gate

These came back as `outOfScope` from #763's enhanced review — real, confirmed, and outside that diff's write scope. Per the review skill's own rule, an out-of-scope list is fixed on a follow-up branch and is **not** re-reviewed: a full review already produced these findings, and re-reviewing its own output is the unbounded chain the skill's depth counter exists to stop. Gate green here (7,879 tests, credo, dialyzer via the pre-commit hook).