### PR TITLE
Give the draft pile an automatic consumer, so captured knowledge reaches the corpus (#765)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -826,8 +826,10 @@ config :loopctl,
 # deploy, and 0 is an explicit PAUSE that leaves every draft held.
 #
 # Deliberately ABOVE the producer rate rather than below it: the capture path adds ~11 drafts a
-# night, so a cap at or under that is not a drain at all. At 30 the standing backlog measured on
-# 2026-08-27 (113) clears in four nights while inflow is absorbed.
+# night, so a cap at or under that is not a drain at all. Read the NET drain, never the cap: at
+# 30 offered against ~11 arriving the backlog falls by ~19 a night, so the 113 standing drafts
+# measured on 2026-08-27 clear in about SIX nights — 113/30 gives four only by leaving inflow
+# out of the denominator.
 config :loopctl, :knowledge_draft_consumer_max_publishes, 30
 
 # LinkPruning (#611 stage 0): how many over-degree `relates_to` edges one nightly run may

--- a/config/config.exs
+++ b/config/config.exs
@@ -817,6 +817,19 @@ config :loopctl,
   knowledge_consolidation_max_retitles: 25,
   knowledge_consolidation_min_duplicate_similarity: 0.80
 
+# DraftConsumer (#765/#766): how many held DRAFT articles one nightly run may OFFER to the
+# consumer. It bounds the candidate query only — each item costs an outbound EMBEDDING call,
+# so the bound that actually holds is a WALL CLOCK
+# (Loopctl.Workers.KnowledgeLintWorker.draft_budget_remaining/1), carved out of the same job
+# timeout so it can never exceed the job containing it. It also resolves through a SystemConfig
+# DB row first (knowledge_draft_consumer_max_publishes) so an operator can move it without a
+# deploy, and 0 is an explicit PAUSE that leaves every draft held.
+#
+# Deliberately ABOVE the producer rate rather than below it: the capture path adds ~11 drafts a
+# night, so a cap at or under that is not a drain at all. At 30 the standing backlog measured on
+# 2026-08-27 (113) clears in four nights while inflow is absorbed.
+config :loopctl, :knowledge_draft_consumer_max_publishes, 30
+
 # LinkPruning (#611 stage 0): how many over-degree `relates_to` edges one nightly run may
 # DELETE, worst-first. Sized to converge in a few nights rather than a few months — the
 # standing backlog on the hosted corpus was ~903,600 edges (1,402,699 total, 499,058

--- a/lib/loopctl/knowledge/draft_consumer.ex
+++ b/lib/loopctl/knowledge/draft_consumer.ex
@@ -1,0 +1,590 @@
+defmodule Loopctl.Knowledge.DraftConsumer do
+  @moduledoc """
+  The automatic consumer for articles left in `status: :draft`.
+
+  ## The leak this closes
+
+  A draft is invisible: no read path serves one, so an agent cannot distinguish a held
+  draft from a capture that never happened. Measured in production 2026-08-27, **113
+  articles sat in `:draft`, growing ~11 a night** (10, 11, 5, 17, 20, 10, 13, 9, 10, 7
+  over ten days) with **zero automatic consumers**. A holding area with no drain is not a
+  safety mechanism, it is a landfill — the same argument
+  `Loopctl.Workers.DraftDuplicateSweepWorker` makes about its own half of the queue.
+
+  ## Why the default is PUBLISH, and why the gate's job is annotation rather than gatekeeping
+
+  Owner decision, 2026-08-27: **there is no human approver and there never will be.** That
+  settles the asymmetry the whole design turns on.
+
+    * holding is **TOTAL LOSS** — an agent never sees a draft, so a held article is
+      indistinguishable from one that was never captured at all;
+    * publishing is **RECOVERABLE** — an agent can read a caveat, the redundancy is
+      recorded as a link, and `Knowledge.unpublish_article/3` is the exact inverse of the
+      `publish_article/3` this takes.
+
+  So reversibility replaces approval, and **there are no terminal acts here**.
+
+  ## Why it ASSESSES rather than reading a stamp
+
+  loopctl#765 specifies disposing of drafts by their `metadata.proposal_novelty` stamp.
+  That mechanism does not exist for these rows: all 113 carry EMPTY metadata, because they
+  were created directly as drafts by an orchestrator key (`article.created`) and never went
+  through `Knowledge.propose_article/3`'s novelty branch. Only ONE of the 113 carries an
+  embedding, either — publishing enqueues one, being created as a draft does not.
+
+  So the per-item cost is a real embedding call, and the assessment is made here through the
+  EXISTING seam, `Loopctl.Knowledge.ProposalGate.assess/3` (the
+  `ProposalAssessorBehaviour`), rather than in a second novelty implementation that would
+  drift from the one the write path uses.
+
+  A draft is therefore embedded TWICE across the night: once synchronously here to assess
+  it, and once asynchronously by the embedding worker that `publish_article/3` enqueues,
+  which is what writes the STORED vector and chains on to `ArticleLinkingWorker`. The gate
+  returns a verdict and neighbours, never the vector, so the second call is the price of
+  reusing it. It is paid on a bounded handful of drafts a night (`default_max_publishes/0`),
+  inside a job whose clock this step is carved out of.
+
+  ## What happens to each draft
+
+    * `:novel` → **published**. The common case and the default.
+    * `:low_novelty` / `:duplicate` → **published AND linked** to its nearest published
+      neighbour with a `relates_to` edge carrying the cosine `similarity_score` and
+      `auto_generated: true`. That edge is exactly what
+      `KnowledgeLintWorker.promote_conflicts/1` reads, so a pair at or above the conflict
+      threshold is flagged `:potential_conflict` and judged the SAME night, and a confirmed
+      duplicate is later retracted by the nightly consolidation pass with `unpublish` —
+      reversibly. The redundancy is handled by machinery that already works (226/226 pairs
+      judged on 2026-08-27) instead of by a decision taken here.
+    * assessment genuinely **unavailable** (`:unknown` — provider down, no BYO key, heavy
+      read shed) → the draft is **left alone and counted**. `ProposalGate` falls open by
+      contract, so `:unknown` means "not assessed", never "not a duplicate". Publishing on
+      it would publish unassessed drafts through a provider outage, and dropping it would be
+      the loss this worker exists to stop.
+
+  ## What it must NOT do: archive
+
+  loopctl#765 item 4 proposes archiving the twin of a near-duplicate on the premise that
+  archive is a soft delete and therefore reversible. **The premise is false.**
+  `Loopctl.Knowledge.Article`'s `@valid_transitions` carries no `{:archived, _}` entry and
+  there is no unarchive function, so `:archived` is TERMINAL: only a `user`-role PATCH
+  carrying an explicit status brings a row back. Non-destructive and reversible are
+  different properties (#605/#606), and an unattended writer may only have the second. It is
+  why the consolidation pass retracts with `unpublish` and never `archive` (#608), and it is
+  why nothing here merges bodies or discards one.
+
+  ## The flip-flop guard
+
+  Consolidation's retraction of a confirmed duplicate PRODUCES a draft. Republishing it
+  would put this step in a nightly fight with that one — publish, retract, publish — burning
+  an embedding call each way, forever. So a draft carrying
+  `articles.consolidation_retracted_at` is never a candidate, and neither is one the
+  `audit_log` shows `worker:consolidation` unpublished (the marker only exists from
+  migration `20260818055453` onward). Both records are read for exactly the reason
+  `DraftDuplicateSweepWorker` reads both.
+
+  Unlike that worker, this one does NOT additionally fail closed past the audit-retention
+  horizon. The direction of the danger is inverted: the sweep's action is terminal, so an
+  unprovable retraction must be spared; this step's action is reversible, so the cost of
+  getting it wrong on a pre-marker retraction is one republish, which consolidation
+  re-confirms and retracts — stamping the durable marker as it does, after which this step
+  never offers it again. The flip-flop terminates in one round, whereas failing closed here
+  would strand every pre-marker draft permanently, which is the total loss.
+
+  ## What bounds one night
+
+  A **WALL CLOCK** (`:budget_ms`), because the per-item cost is an outbound provider call
+  and a count bounds attempts rather than cost — #761, in this same job, for six consecutive
+  nights. `:max_publishes` bounds the candidate QUERY only, and `0` PAUSES the drain
+  (`gate: :drain_disabled`) without a deploy, through the
+  `knowledge_draft_consumer_max_publishes` `SystemConfig` row.
+
+  The cap sits deliberately ABOVE the producer rate: ~11 drafts a night arrive, so
+  `default_max_publishes/0` both clears the 113-draft backlog inside four nights and stays
+  ahead of inflow. A cap at or below the producer rate is not a drain at all.
+
+  The return carries `offered` and `budget_exhausted` so a truncated night and a night with
+  nothing to do are never the same numbers; the worker puts both in its log line and in the
+  `knowledge.lint_completed` audit event. `published + unassessed + skipped + failed` is
+  what was PROCESSED, so it falls below `offered` exactly when the clock fired.
+
+  ## Overlap with `DraftDuplicateSweepWorker`
+
+  That worker ARCHIVES a draft whose nearest published neighbour clears 0.95. This one
+  PUBLISHES the same draft and links it. They disagree, and running nightly against its
+  weekly schedule means this one reaches the capture-path backlog first. That is the owner
+  decision applied — the sweep predates it — not an oversight; it is called out here because
+  a reader arriving from that moduledoc will expect the two to agree.
+  """
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Embeddings.TextBudget
+  alias Loopctl.ExitTag
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ArticleLink
+  alias Loopctl.Knowledge.ProposalGate
+  alias Loopctl.Llm
+
+  @actor_label "worker:draft_consumer"
+
+  # The nightly consolidation pass's actor label. Its retractions are SPARED — see the
+  # flip-flop guard in the moduledoc and `draft_scope/1`.
+  @consolidation_actor "worker:consolidation"
+
+  # How many drafts one nightly run may OFFER. Bounds the candidate query, never the step:
+  # each item costs an outbound embedding call, so the bound that holds is the wall clock
+  # below (#761). Chosen ABOVE the measured producer rate (~11 a night) so the backlog
+  # actually falls: at 30 the 113 standing drafts clear in four nights while inflow is
+  # absorbed. `0` is honoured as an explicit operator PAUSE.
+  @default_max_publishes 30
+  @hard_max_publishes 500
+
+  # Fallback wall clock. `Loopctl.Workers.KnowledgeLintWorker` always passes `:budget_ms` —
+  # the time ITS job has left (`draft_budget_remaining/1`) — so this applies only to a direct
+  # call, and it is deliberately not larger than the reserve that worker carves out for this
+  # step. `test/loopctl/workers/knowledge_lint_worker_test.exs` binds the two so they cannot
+  # drift into a budget bigger than the job containing it.
+  @default_budget_ms :timer.minutes(2)
+
+  @type tally :: %{
+          published: non_neg_integer(),
+          linked: non_neg_integer(),
+          link_failed: non_neg_integer(),
+          unassessed: non_neg_integer(),
+          skipped: non_neg_integer(),
+          failed: non_neg_integer(),
+          offered: non_neg_integer(),
+          budget_exhausted: boolean(),
+          gate: :open | :drain_disabled
+        }
+
+  @doc "Default cap on drafts one run may offer to the consumer."
+  @spec default_max_publishes() :: pos_integer()
+  def default_max_publishes, do: @default_max_publishes
+
+  @doc "Fallback wall-clock budget (ms) when no `:budget_ms` is given."
+  @spec default_budget_ms() :: pos_integer()
+  def default_budget_ms, do: @default_budget_ms
+
+  @doc "The actor label every publish and every link this step writes is attributed to."
+  @spec actor_label() :: String.t()
+  def actor_label, do: @actor_label
+
+  @doc """
+  Assess every eligible draft and publish it, linking a near-duplicate to its neighbour.
+
+  ## Options
+
+    * `:max_publishes` — candidate-query cap; `0` pauses the drain. Defaults to
+      `default_max_publishes/0`, clamped to `#{@hard_max_publishes}`.
+    * `:budget_ms` — wall clock for the whole drain. Defaults to `default_budget_ms/0`.
+    * `:proposal_assessor` — the `ProposalAssessorBehaviour` implementation, PER CALL. The
+      config layer underneath is untouched and still resolves to `ProposalGate` in
+      production and to the Mox mock in tests; the opt exists because a test must drive one
+      call's assessor without `Application.put_env`, which mutates VM-global state every
+      other test in this `async: true` suite would see. Mirrors
+      `Loopctl.Knowledge.Consolidation.extractor/1` and `ConflictJudge.impl/1` exactly.
+  """
+  @spec consume(Ecto.UUID.t(), keyword()) :: tally()
+  def consume(tenant_id, opts \\ []) do
+    cap = clamp_cap(Keyword.get(opts, :max_publishes, @default_max_publishes))
+
+    if cap == 0 do
+      Logger.info(
+        "DraftConsumer: tenant=#{tenant_id} drain is PAUSED by its cap (0); drafts stay held."
+      )
+
+      tally(:drain_disabled)
+    else
+      drain(tenant_id, candidates(tenant_id, cap), opts)
+    end
+  end
+
+  @doc """
+  The novelty assessor this step calls.
+
+  See the `:proposal_assessor` option on `consume/2` for why the seam is per-call.
+  """
+  @spec assessor(keyword()) :: module()
+  def assessor(opts \\ []) do
+    Keyword.get(
+      opts,
+      :proposal_assessor,
+      Application.get_env(:loopctl, :proposal_assessor, ProposalGate)
+    )
+  end
+
+  # --- Private ---
+
+  # A NEGATIVE cap is a pause, not a licence: `0` and below both stop the drain rather than
+  # wrapping round to "unbounded". A non-integer falls back to the default rather than
+  # raising inside the nightly's rescue, where it would surface as an outage instead of the
+  # config typo it is (the `coerce_int/2` lesson).
+  defp clamp_cap(value) when is_integer(value) and value <= 0, do: 0
+  defp clamp_cap(value) when is_integer(value), do: min(value, @hard_max_publishes)
+
+  defp clamp_cap(other) do
+    Logger.warning(
+      "DraftConsumer: ignoring non-integer cap #{inspect(other)}; using #{@default_max_publishes}."
+    )
+
+    @default_max_publishes
+  end
+
+  # ONE constructor for every tally, so no fail-soft path can ship a map missing a key the
+  # worker's summary line interpolates — the `empty_tally/2` lesson, which once cost a
+  # fail-soft rescue a KeyError one line after it had swallowed the original error.
+  defp tally(gate) do
+    %{
+      published: 0,
+      linked: 0,
+      link_failed: 0,
+      unassessed: 0,
+      skipped: 0,
+      failed: 0,
+      offered: 0,
+      budget_exhausted: false,
+      gate: gate
+    }
+  end
+
+  defp candidates(tenant_id, cap) do
+    tenant_id
+    |> draft_scope()
+    # OLDEST FIRST. A capped run must drain the standing backlog rather than skim tonight's
+    # arrivals off the top, which at a cap above the producer rate would leave the 113 oldest
+    # drafts held forever while the queue looked healthy.
+    |> order_by([draft: a], asc: a.inserted_at)
+    |> limit(^cap)
+    |> select([draft: a], a.id)
+    |> AdminRepo.all()
+  end
+
+  # The ONE definition of "a draft this step may touch", composed into both the candidate
+  # query and the per-item live re-fetch. Two hand-copied predicate lists is how the offer
+  # and the write come to disagree about the same row.
+  defp draft_scope(tenant_id) do
+    from(a in Article,
+      as: :draft,
+      where: a.tenant_id == ^tenant_id,
+      where: a.status == :draft,
+      # TENANT scope only. A `:system` canonical is shared-corpus content that no per-tenant
+      # nightly pass owns, and publishing one on a tenant's behalf is not this step's call.
+      where: a.scope == :tenant,
+      # SHARED visibility only, the same filter `Consolidation.shared_only/1` applies for the
+      # same reason: this step ships the article's own bytes to an embedding provider, and an
+      # agent's `private`/`owner` memory must not leave on a pass it never asked for. Such a
+      # draft stays held, which for a row only its owner could ever read is not the loss the
+      # moduledoc is about.
+      where:
+        fragment("COALESCE(?->>'visibility', 'shared') NOT IN ('private','owner')", a.metadata),
+      # The flip-flop guard, in its two independent records. See the moduledoc: the durable
+      # column is authoritative and survives audit retention; the audit_log is still read
+      # because the column only exists from migration 20260818055453 onward. `tenant_id` is
+      # constrained inside the subquery so the correlated NOT EXISTS can use
+      # `audit_log_tenant_entity_idx`, whose leading column it is.
+      where: is_nil(a.consolidation_retracted_at),
+      where:
+        not exists(
+          from(al in "audit_log",
+            where: al.tenant_id == parent_as(:draft).tenant_id,
+            where: al.entity_id == parent_as(:draft).id,
+            where: al.entity_type == "article",
+            where: al.action == "article.unpublished",
+            where: al.actor_label == ^@consolidation_actor,
+            select: 1
+          )
+        )
+    )
+  end
+
+  # SEQUENTIAL, deliberately, where the conflict judge is concurrent. `Task.async_stream/3`
+  # LINKS its tasks, so every failure mode of the work has to be made total INSIDE the task
+  # or one raise takes the night's audit event with it — the defect the #766 review caught.
+  # A capped handful of items at ~2 s each fits the 2-minute reserve with room to spare, so
+  # concurrency buys nothing here and the hazard is simply not taken on.
+  defp drain(tenant_id, ids, opts) do
+    # Deadline taken before the first item and checked BEFORE each one, never after. A
+    # post-item check is unconditionally committed to item #1, so a budget of exactly 0 — the
+    # state a night whose prelude overran arrives in, and `draft_budget_remaining/1` floors at
+    # 0 — would still buy a full provider call and a publish out of a reserve already spent.
+    # Checking at the head also keeps the flag honest for free: a night that processed its
+    # LAST candidate and only then crossed the deadline never reaches another check, so a
+    # DRAINED night is never reported as truncated.
+    budget_ms = Keyword.get(opts, :budget_ms, @default_budget_ms)
+    deadline = System.monotonic_time(:millisecond) + budget_ms
+    offered = length(ids)
+
+    result =
+      Enum.reduce_while(ids, %{tally(:open) | offered: offered}, fn id, acc ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          {:halt, %{acc | budget_exhausted: true}}
+        else
+          {:cont, tally_draft(tenant_id, id, acc, opts)}
+        end
+      end)
+
+    log_truncation(tenant_id, budget_ms, result)
+    log_provider_unconfigured(tenant_id, result)
+    result
+  end
+
+  # Per-item containment, exactly like `Consolidation.tally_retitle/4`: this reduce is not
+  # transactional, so a raise escaping it would discard the tally of the drafts ALREADY
+  # published and report zero writes that really happened.
+  defp tally_draft(tenant_id, id, acc, opts) do
+    case consume_draft(tenant_id, id, opts) do
+      :published ->
+        %{acc | published: acc.published + 1}
+
+      :published_linked ->
+        %{acc | published: acc.published + 1, linked: acc.linked + 1}
+
+      :published_link_failed ->
+        %{acc | published: acc.published + 1, link_failed: acc.link_failed + 1}
+
+      :unassessed ->
+        %{acc | unassessed: acc.unassessed + 1}
+
+      :skip ->
+        %{acc | skipped: acc.skipped + 1}
+
+      {:failed, tag} ->
+        draft_failed(tenant_id, id, tag, acc)
+    end
+  rescue
+    e -> draft_failed(tenant_id, id, ExitTag.tag(e), acc)
+  catch
+    :exit, reason -> draft_failed(tenant_id, id, "exit:" <> ExitTag.tag(reason), acc)
+  end
+
+  defp draft_failed(tenant_id, id, tag, acc) do
+    Logger.error(
+      "DraftConsumer: tenant=#{tenant_id} draft #{id} could not be consumed (#{tag}); " <>
+        "it stays held and is offered again next run."
+    )
+
+    %{acc | failed: acc.failed + 1}
+  end
+
+  defp consume_draft(tenant_id, id, opts) do
+    case live_draft(tenant_id, id) do
+      {:ok, draft} ->
+        assess_and_publish(tenant_id, draft, opts)
+
+      :gone ->
+        Logger.info(
+          "DraftConsumer: tenant=#{tenant_id} draft #{id} is no longer an eligible draft; skipped."
+        )
+
+        :skip
+    end
+  end
+
+  # Re-derivation, not trust — the twin of `Consolidation.live_placeholder/2`. Between the
+  # candidate query and the provider call a human may have published, archived or retitled
+  # the draft, or consolidation may have stamped it; spending an embedding call and then a
+  # publish on a row that has moved is the failure this re-read costs one indexed lookup to
+  # avoid. The body comes back PRE-TRUNCATED from SQL at the same cap the gate's own
+  # `TextBudget.initial/1` would apply, so this can never pull 30 x 100 KB bodies into memory
+  # to hand the gate bytes it would immediately discard.
+  defp live_draft(tenant_id, id) do
+    tenant_id
+    |> draft_scope()
+    |> where([draft: a], a.id == ^id)
+    |> select([draft: a], %{
+      id: a.id,
+      title: a.title,
+      project_id: a.project_id,
+      body: fragment("substring(? from 1 for ?)", a.body, ^TextBudget.initial_chars())
+    })
+    |> AdminRepo.one()
+    |> case do
+      nil -> :gone
+      draft -> {:ok, draft}
+    end
+  end
+
+  defp assess_and_publish(tenant_id, draft, opts) do
+    attrs = %{"title" => draft.title, "body" => draft.body, "project_id" => draft.project_id}
+
+    case assessor(opts).assess(tenant_id, attrs, []) do
+      %{verdict: :novel} ->
+        publish(tenant_id, draft, :novel, nil)
+
+      %{verdict: verdict} = assessment when verdict in [:low_novelty, :duplicate] ->
+        publish(tenant_id, draft, verdict, neighbour(assessment, draft.id))
+
+      %{verdict: :unknown} ->
+        unassessed(tenant_id, draft, "gate_unavailable")
+
+      other ->
+        # An implementation that answers outside the behaviour's four verdicts. Treated as
+        # NOT ASSESSED rather than defaulted to novel: publishing on a verdict nobody
+        # produced is exactly the unassessed publish the `:unknown` branch refuses.
+        unassessed(tenant_id, draft, "unrecognised_verdict:#{ExitTag.tag(other)}")
+    end
+  end
+
+  defp unassessed(tenant_id, draft, reason) do
+    Logger.info(
+      "DraftConsumer: tenant=#{tenant_id} draft #{draft.id} was not assessed (#{reason}); " <>
+        "it stays held and is offered again next run."
+    )
+
+    :unassessed
+  end
+
+  # The nearest PUBLISHED neighbour the gate scored, or `nil`. A `:low_novelty`/`:duplicate`
+  # verdict is DERIVED from the top neighbour's score, so an empty list here is an
+  # implementation contradicting itself; the draft is still published (that is the default,
+  # and withholding it over a malformed assessment would be the total loss), it simply
+  # carries no annotation.
+  defp neighbour(%{neighbors: [%{id: id, similarity_score: score} | _]}, draft_id)
+       when is_binary(id) and id != draft_id,
+       do: %{id: id, similarity_score: score}
+
+  defp neighbour(_assessment, _draft_id), do: nil
+
+  defp publish(tenant_id, draft, verdict, neighbour) do
+    case Knowledge.publish_article(tenant_id, draft.id,
+           actor_type: "system",
+           actor_label: @actor_label
+         ) do
+      {:ok, _article} ->
+        link(tenant_id, draft, verdict, neighbour)
+
+      # The row moved between the live re-fetch and the write, or the transition is no longer
+      # legal (someone else published or archived it). A SKIP, never a failure: nothing is
+      # wrong and nothing is owed.
+      {:error, :not_found} ->
+        :skip
+
+      {:error, :unprocessable_entity, _message} ->
+        :skip
+
+      other ->
+        {:failed, publish_error_tag(other)}
+    end
+  end
+
+  # ONE clause on purpose. The case above has already taken every non-changeset error
+  # `Knowledge.publish_article/3` declares, so the residual is exactly a rejected changeset —
+  # a catch-all here is unreachable and dialyzer says so. A shape outside that spec raises
+  # into `tally_draft/4`'s per-item rescue, which counts it and names its class, rather than
+  # being flattened to a uselessly generic tag. Keys only, never the changeset: an error
+  # message can carry backend host, database and role.
+  defp publish_error_tag({:error, %Ecto.Changeset{errors: errors}}),
+    do: inspect(Keyword.keys(errors))
+
+  defp link(_tenant_id, _draft, :novel, _neighbour), do: :published
+
+  defp link(tenant_id, draft, _verdict, nil) do
+    Logger.warning(
+      "DraftConsumer: tenant=#{tenant_id} draft #{draft.id} assessed as a near-duplicate " <>
+        "but the assessment carried no usable neighbour; published WITHOUT an annotation."
+    )
+
+    :published
+  end
+
+  # The annotation, and the only thing that separates this step from a bulk publish. It is
+  # shaped as the auto-linker's own edge — `auto_generated: true` plus the cosine
+  # `similarity_score` — because that is precisely what
+  # `KnowledgeLintWorker.promote_conflicts/1` reads: a pair at or above the conflict
+  # threshold is flagged `:potential_conflict` the SAME night and judged the same night, and
+  # a confirmed duplicate is retracted later by the consolidation pass with `unpublish`.
+  # Every step of that is reversible, which is the whole reason the redundancy is handed to
+  # it rather than decided here.
+  #
+  # `on_conflict: :nothing` against the pair's unique index, so a re-run is a no-op — and the
+  # asynchronous `ArticleLinkingWorker` that `publish_article/3` chains to will derive the
+  # same edge from the stored vector once it lands. This write is what makes the annotation
+  # true TONIGHT rather than whenever that queue drains.
+  defp link(tenant_id, draft, verdict, %{id: neighbour_id, similarity_score: score}) do
+    attrs = %{
+      source_article_id: draft.id,
+      target_article_id: neighbour_id,
+      relationship_type: :relates_to,
+      metadata: %{
+        "auto_generated" => true,
+        "similarity_score" => score,
+        "linked_by" => @actor_label,
+        "novelty_verdict" => to_string(verdict)
+      }
+    }
+
+    %ArticleLink{tenant_id: tenant_id}
+    |> ArticleLink.changeset(attrs)
+    |> AdminRepo.insert(
+      on_conflict: :nothing,
+      conflict_target: [:tenant_id, :source_article_id, :target_article_id, :relationship_type]
+    )
+    |> case do
+      {:ok, _link} ->
+        :published_linked
+
+      {:error, changeset} ->
+        # The article IS published — recoverable, visible, and the auto-linker still gets its
+        # chance. Counted separately all the same: a near-duplicate published with no
+        # annotation is the one outcome this step is supposed to make impossible, and it must
+        # not hide inside `published`.
+        Logger.warning(
+          "DraftConsumer: tenant=#{tenant_id} published draft #{draft.id} but could not link " <>
+            "it to #{neighbour_id} (#{inspect(Keyword.keys(changeset.errors))}); the " <>
+            "annotation is left to the auto-linker."
+        )
+
+        :published_link_failed
+    end
+  end
+
+  defp processed(%{published: p, unassessed: u, skipped: s, failed: f}), do: p + u + s + f
+
+  # NEVER silent (#761 acceptance). Without this line and the `offered` counter beside it, a
+  # night the clock cut short and a night with nothing left to consume report the same
+  # `published`, and the difference is the whole question when the backlog stops falling.
+  defp log_truncation(tenant_id, budget_ms, %{budget_exhausted: true} = result) do
+    Logger.warning(
+      "DraftConsumer: tenant=#{tenant_id} hit its #{budget_ms}ms budget after " <>
+        "#{processed(result)} of #{result.offered} draft(s); the remainder is retried next run."
+    )
+  end
+
+  defp log_truncation(_tenant_id, _budget_ms, _result), do: :ok
+
+  # ONCE PER RUN, and a WARNING rather than a per-item line — the
+  # `Consolidation.log_provider_unconfigured/2` lesson, applied to a third step whose per-item
+  # cost is an outbound call. `{:error, :no_api_key}` is the one `:unknown` cause that is
+  # PERMANENT, self-inflicted and operator-fixable, and `ProposalGate` folds it into the same
+  # fall-open every transient provider failure gets. Without this line a keyless tenant offers
+  # the same drafts every night, leaves every one of them unassessed, and the audit event
+  # reads exactly like a provider having a bad night — the #620 shape, one step over.
+  #
+  # Self-guarded for the same reason its sibling is: this runs AFTER the drain, so a repo blip
+  # reading the tenant's LLM settings must not discard a completed run's tally.
+  defp log_provider_unconfigured(tenant_id, %{unassessed: unassessed}) when unassessed > 0 do
+    if Llm.has_api_key?(tenant_id) do
+      :ok
+    else
+      Logger.warning(
+        "DraftConsumer: tenant=#{tenant_id} has no embedding key (mandatory BYO), so its " <>
+          "#{unassessed} unassessed draft(s) can never be assessed at all and are re-offered " <>
+          "every night. This is a configuration state, not a provider that failed. Nothing " <>
+          "is published while it stands."
+      )
+    end
+
+    :ok
+  rescue
+    _e -> :ok
+  catch
+    :exit, _reason -> :ok
+  end
+
+  defp log_provider_unconfigured(_tenant_id, _result), do: :ok
+end

--- a/lib/loopctl/knowledge/draft_consumer.ex
+++ b/lib/loopctl/knowledge/draft_consumer.ex
@@ -49,12 +49,22 @@ defmodule Loopctl.Knowledge.DraftConsumer do
     * `:novel` → **published**. The common case and the default.
     * `:low_novelty` / `:duplicate` → **published AND linked** to its nearest published
       neighbour with a `relates_to` edge carrying the cosine `similarity_score` and
-      `auto_generated: true`. That edge is exactly what
-      `KnowledgeLintWorker.promote_conflicts/1` reads, so a pair at or above the conflict
-      threshold is flagged `:potential_conflict` and judged the SAME night, and a confirmed
-      duplicate is later retracted by the nightly consolidation pass with `unpublish` —
-      reversibly. The redundancy is handled by machinery that already works (226/226 pairs
-      judged on 2026-08-27) instead of by a decision taken here.
+      `auto_generated: true` — the SAME edge `ArticleLinkingWorker` derives from the stored
+      vector once the publish's embedding lands, written tonight instead of whenever that
+      queue drains, and under the same project/visibility scope that worker applies so this
+      step adds no edge class the graph did not already have.
+      What the edge buys is a RECORD, not a retraction, and the honest reading of where it
+      ends is: `KnowledgeLintWorker.promote_conflicts/1` flags a pair at or above the
+      conflict threshold `:potential_conflict`, which SUPPRESSES both its articles from
+      curated answers until the pair is judged; the judge reaches it in similarity order,
+      which against a standing backlog is nights away rather than tonight; and its verdict
+      is `:redundant` / `dismiss`, which is TERMINAL and retires neither article.
+      Consolidation's `:duplicate_capture` retraction reaches colliding TITLES and
+      idempotency keys, not semantic near-duplicates, so it does not retract this pair
+      either. Both articles stay published with the redundancy on the record for a human or
+      an orchestrator. Under the owner decision that is the accepted cost of the default —
+      a recorded duplicate is recoverable, a held article is not — and it is the cost of
+      PUBLISHING one, not of the edge: the auto-linker writes the same pair either way.
     * assessment genuinely **unavailable** (`:unknown` — provider down, no BYO key, heavy
       read shed) → the draft is **left alone and counted**. `ProposalGate` falls open by
       contract, so `:unknown` means "not assessed", never "not a duplicate". Publishing on
@@ -72,23 +82,42 @@ defmodule Loopctl.Knowledge.DraftConsumer do
   why the consolidation pass retracts with `unpublish` and never `archive` (#608), and it is
   why nothing here merges bodies or discards one.
 
-  ## The flip-flop guard
+  ## Not every draft is an abandoned capture
 
-  Consolidation's retraction of a confirmed duplicate PRODUCES a draft. Republishing it
-  would put this step in a nightly fight with that one — publish, retract, publish — burning
-  an embedding call each way, forever. So a draft carrying
+  A `:draft` row is not one thing, so `draft_scope/1` excludes three classes that were put
+  there DELIBERATELY and are not this step's to undo.
+
+  **A RETRACTION.** Consolidation's retraction of a confirmed duplicate produces a draft —
+  and so does `Knowledge.unpublish_article/3` (and `bulk_unpublish/3`), the `role: :user`
+  lever an operator reaches for to pull a wrong or sensitive article back out of the corpus.
+  Republishing either is wrong: against consolidation it is a nightly fight — publish,
+  retract, publish — burning an embedding call each way forever, and against a human it
+  silently reverts a human-gated act inside 24 hours. So a draft carrying
   `articles.consolidation_retracted_at` is never a candidate, and neither is one the
-  `audit_log` shows `worker:consolidation` unpublished (the marker only exists from
-  migration `20260818055453` onward). Both records are read for exactly the reason
-  `DraftDuplicateSweepWorker` reads both.
+  `audit_log` records as `article.unpublished` BY ANY ACTOR.
 
-  Unlike that worker, this one does NOT additionally fail closed past the audit-retention
-  horizon. The direction of the danger is inverted: the sweep's action is terminal, so an
-  unprovable retraction must be spared; this step's action is reversible, so the cost of
-  getting it wrong on a pre-marker retraction is one republish, which consolidation
-  re-confirms and retracts — stamping the durable marker as it does, after which this step
-  never offers it again. The flip-flop terminates in one round, whereas failing closed here
-  would strand every pre-marker draft permanently, which is the total loss.
+  That leaves one residual, deliberately. The durable column exists only from migration
+  `20260818055453` onward and only consolidation stamps it, so the audit row is what carries
+  every other retraction, and a retraction older than audit retention is republished once.
+  `DraftDuplicateSweepWorker` fails closed there and this one does not, because the direction
+  of the danger is inverted: the sweep's action is terminal, so an unprovable retraction must
+  be spared; this one's is reversible, and failing closed here would strand every pre-marker
+  draft permanently, which is the total loss. A durable `unpublished_at` stamped by every
+  retraction path would remove the residual outright.
+
+  **A MERGE.** `Knowledge.execute_conflict_resolutions/2` lands its LLM-synthesised merge as
+  a draft, and CLAUDE.md's KB-content carve-out rests on that draft never being
+  auto-published: it is exactly what separates an agent-role key RECORDING a merge verdict
+  from the same key authorising unattended synthesised text into the corpus. A draft
+  carrying `metadata.merged_from` is never a candidate.
+
+  **A HOLD THAT IS STILL FRESH.** `POST /api/v1/knowledge` with `draft: true`, and ingestion
+  with `publish: false`, are advertised opt-ins into staging; publishing one the same night
+  makes the opt-in unobservable. There is no approver to wait for, so the reconciliation is a
+  FLOOR rather than a veto: a draft is offered only once it is 48h old, which leaves whoever
+  staged it two nightly runs to publish or delete it, and still drains everything abandoned
+  past that. The floor costs the drain nothing — inflow ages into the pool at the rate it
+  arrives.
 
   ## What bounds one night
 
@@ -98,9 +127,11 @@ defmodule Loopctl.Knowledge.DraftConsumer do
   (`gate: :drain_disabled`) without a deploy, through the
   `knowledge_draft_consumer_max_publishes` `SystemConfig` row.
 
-  The cap sits deliberately ABOVE the producer rate: ~11 drafts a night arrive, so
-  `default_max_publishes/0` both clears the 113-draft backlog inside four nights and stays
-  ahead of inflow. A cap at or below the producer rate is not a drain at all.
+  The cap sits deliberately ABOVE the producer rate, and the number that matters is the NET
+  drain: ~11 drafts a night arrive against a cap of 30, so the backlog falls by ~19 a night
+  and the 113 standing drafts measured on 2026-08-27 clear in about SIX nights, not the four
+  that 113/30 gives by dropping inflow out of the denominator. A cap at or below the producer
+  rate is not a drain at all.
 
   The return carries `offered` and `budget_exhausted` so a truncated night and a night with
   nothing to do are never the same numbers; the worker puts both in its log line and in the
@@ -131,17 +162,28 @@ defmodule Loopctl.Knowledge.DraftConsumer do
 
   @actor_label "worker:draft_consumer"
 
-  # The nightly consolidation pass's actor label. Its retractions are SPARED — see the
-  # flip-flop guard in the moduledoc and `draft_scope/1`.
-  @consolidation_actor "worker:consolidation"
-
   # How many drafts one nightly run may OFFER. Bounds the candidate query, never the step:
   # each item costs an outbound embedding call, so the bound that holds is the wall clock
   # below (#761). Chosen ABOVE the measured producer rate (~11 a night) so the backlog
-  # actually falls: at 30 the 113 standing drafts clear in four nights while inflow is
-  # absorbed. `0` is honoured as an explicit operator PAUSE.
+  # actually falls: at 30 the NET drain is ~19 a night, so the 113 standing drafts clear in
+  # about six nights. `0` is honoured as an explicit operator PAUSE.
   @default_max_publishes 30
   @hard_max_publishes 500
+
+  # How much of the cap is spent OLDEST-first. Not the whole of it: there is no per-draft
+  # attempt counter here, so a purely oldest-first window stalls at zero the moment `cap`
+  # permanently unconsumable drafts reach the head — a project the embedding path refuses, a
+  # body no `ShrinkLadder` rung fits, a changeset the publish rejects. Those are re-offered
+  # at equal priority every night forever, nothing behind them is ever seen, and the audit
+  # event reads exactly like a provider having a bad night. A fifth of the cap therefore goes
+  # to the NEWEST drafts, which keeps the drain strictly positive whatever the head does
+  # without giving up the backlog-first bias the rest of the window exists for.
+  @backlog_share 0.8
+
+  # A draft younger than this is HELD. `draft: true` and ingestion's `publish: false` are
+  # advertised opt-ins into staging, and a drain that runs tonight makes them unobservable.
+  # See the moduledoc: a floor, not a veto — there is no approver to wait for.
+  @min_draft_age_hours 48
 
   # Fallback wall clock. `Loopctl.Workers.KnowledgeLintWorker` always passes `:budget_ms` —
   # the time ITS job has left (`draft_budget_remaining/1`) — so this applies only to a direct
@@ -159,7 +201,7 @@ defmodule Loopctl.Knowledge.DraftConsumer do
           failed: non_neg_integer(),
           offered: non_neg_integer(),
           budget_exhausted: boolean(),
-          gate: :open | :drain_disabled
+          gate: :open | :drain_disabled | :no_embedding_key
         }
 
   @doc "Default cap on drafts one run may offer to the consumer."
@@ -193,14 +235,35 @@ defmodule Loopctl.Knowledge.DraftConsumer do
   def consume(tenant_id, opts \\ []) do
     cap = clamp_cap(Keyword.get(opts, :max_publishes, @default_max_publishes))
 
-    if cap == 0 do
-      Logger.info(
-        "DraftConsumer: tenant=#{tenant_id} drain is PAUSED by its cap (0); drafts stay held."
-      )
+    cond do
+      cap == 0 ->
+        Logger.info(
+          "DraftConsumer: tenant=#{tenant_id} drain is PAUSED by its cap (0); drafts stay held."
+        )
 
-      tally(:drain_disabled)
-    else
-      drain(tenant_id, candidates(tenant_id, cap), opts)
+        tally(:drain_disabled)
+
+      # BEFORE the candidate query, not after the drain. Embedding is mandatory-BYO, so on a
+      # keyless tenant every `ProposalGate` assessment falls open on `{:error, :no_api_key}` —
+      # and each one appends an `llm.blocked_no_api_key` row to the hash-chained audit_log
+      # (`Llm.record_blocked/2`). That cause never self-heals, so offering anyway writes `cap`
+      # audit rows a night, forever, for an outcome known in advance to be zero publishes.
+      # Stopping here costs the operator nothing they were going to get, and says so once.
+      #
+      # Scoped to `ProposalGate` because it is ITS fall-open being pre-empted: another
+      # `ProposalAssessorBehaviour` may not need a tenant embedding key at all, and a
+      # pre-check that assumed one would silently stop a drain that would have worked.
+      assessor(opts) == ProposalGate and not embedding_key?(tenant_id) ->
+        Logger.warning(
+          "DraftConsumer: tenant=#{tenant_id} has no embedding key (mandatory BYO), so no " <>
+            "draft can be assessed at all; the drain is stopped and every draft stays held. " <>
+            "This is a configuration state, not a provider that failed."
+        )
+
+        tally(:no_embedding_key)
+
+      true ->
+        drain(tenant_id, candidates(tenant_id, cap), opts)
     end
   end
 
@@ -252,14 +315,23 @@ defmodule Loopctl.Knowledge.DraftConsumer do
     }
   end
 
+  # OLDEST FIRST for `@backlog_share` of the cap: a capped run must drain the standing backlog
+  # rather than skim tonight's arrivals off the top, which at a cap above the producer rate
+  # would leave the 113 oldest drafts held forever while the queue looked healthy. The
+  # remainder is taken NEWEST first so a permanently unconsumable head cannot take the drain
+  # to zero — see `@backlog_share`.
   defp candidates(tenant_id, cap) do
+    oldest = candidate_ids(tenant_id, max(trunc(cap * @backlog_share), 1), :asc)
+    Enum.uniq(oldest ++ candidate_ids(tenant_id, cap - length(oldest), :desc))
+  end
+
+  defp candidate_ids(_tenant_id, limit, _direction) when limit <= 0, do: []
+
+  defp candidate_ids(tenant_id, limit, direction) do
     tenant_id
     |> draft_scope()
-    # OLDEST FIRST. A capped run must drain the standing backlog rather than skim tonight's
-    # arrivals off the top, which at a cap above the producer rate would leave the 113 oldest
-    # drafts held forever while the queue looked healthy.
-    |> order_by([draft: a], asc: a.inserted_at)
-    |> limit(^cap)
+    |> order_by([draft: a], [{^direction, a.inserted_at}])
+    |> limit(^limit)
     |> select([draft: a], a.id)
     |> AdminRepo.all()
   end
@@ -282,11 +354,23 @@ defmodule Loopctl.Knowledge.DraftConsumer do
       # moduledoc is about.
       where:
         fragment("COALESCE(?->>'visibility', 'shared') NOT IN ('private','owner')", a.metadata),
-      # The flip-flop guard, in its two independent records. See the moduledoc: the durable
+      # A MERGE is staged on purpose. `execute_conflict_resolutions/2` lands LLM-synthesised
+      # text as a draft, and the KB-content carve-out that lets an agent-role key record a
+      # merge verdict at all rests on that draft never being auto-published.
+      where: fragment("? -> 'merged_from' IS NULL", a.metadata),
+      # A FRESH HOLD is staged on purpose too — `draft: true` and ingestion's `publish: false`
+      # are advertised opt-ins, and a drain that runs tonight makes them unobservable. A floor,
+      # not a veto: two nightly runs to publish or delete it, then it drains like the rest.
+      where: a.inserted_at <= ago(@min_draft_age_hours, "hour"),
+      # The RETRACTION guard, in its two independent records. See the moduledoc: the durable
       # column is authoritative and survives audit retention; the audit_log is still read
-      # because the column only exists from migration 20260818055453 onward. `tenant_id` is
-      # constrained inside the subquery so the correlated NOT EXISTS can use
-      # `audit_log_tenant_entity_idx`, whose leading column it is.
+      # because the column only exists from migration 20260818055453 onward and only
+      # consolidation stamps it. The audit clause is deliberately NOT narrowed to
+      # `worker:consolidation`: `Knowledge.unpublish_article/3` and `bulk_unpublish/3` are
+      # the `role: :user` retraction lever, and republishing what a human just pulled reverts a
+      # human-gated act unattended, inside 24 hours. `tenant_id` is constrained inside the
+      # subquery so the correlated NOT EXISTS can use `audit_log_tenant_entity_idx`, whose
+      # leading column it is.
       where: is_nil(a.consolidation_retracted_at),
       where:
         not exists(
@@ -295,7 +379,6 @@ defmodule Loopctl.Knowledge.DraftConsumer do
             where: al.entity_id == parent_as(:draft).id,
             where: al.entity_type == "article",
             where: al.action == "article.unpublished",
-            where: al.actor_label == ^@consolidation_actor,
             select: 1
           )
         )
@@ -329,7 +412,6 @@ defmodule Loopctl.Knowledge.DraftConsumer do
       end)
 
     log_truncation(tenant_id, budget_ms, result)
-    log_provider_unconfigured(tenant_id, result)
     result
   end
 
@@ -417,7 +499,7 @@ defmodule Loopctl.Knowledge.DraftConsumer do
         publish(tenant_id, draft, :novel, nil)
 
       %{verdict: verdict} = assessment when verdict in [:low_novelty, :duplicate] ->
-        publish(tenant_id, draft, verdict, neighbour(assessment, draft.id))
+        publish(tenant_id, draft, verdict, neighbour(tenant_id, assessment, draft))
 
       %{verdict: :unknown} ->
         unassessed(tenant_id, draft, "gate_unavailable")
@@ -426,7 +508,7 @@ defmodule Loopctl.Knowledge.DraftConsumer do
         # An implementation that answers outside the behaviour's four verdicts. Treated as
         # NOT ASSESSED rather than defaulted to novel: publishing on a verdict nobody
         # produced is exactly the unassessed publish the `:unknown` branch refuses.
-        unassessed(tenant_id, draft, "unrecognised_verdict:#{ExitTag.tag(other)}")
+        unassessed(tenant_id, draft, "unrecognised_verdict:#{verdict_tag(other)}")
     end
   end
 
@@ -439,16 +521,57 @@ defmodule Loopctl.Knowledge.DraftConsumer do
     :unassessed
   end
 
+  # NAMES the off-contract answer. `ExitTag.tag/1` has no map clause, so every one of these
+  # flattened to the literal "unknown" — the same tag every unexplained failure gets, in the
+  # one branch that exists to make an off-contract implementation diagnosable. The verdict and
+  # the key set only, never the value: an assessment carries neighbour titles.
+  defp verdict_tag(%{verdict: verdict}), do: inspect(verdict)
+  defp verdict_tag(other) when is_map(other), do: "no_verdict_key:" <> inspect(Map.keys(other))
+  defp verdict_tag(_other), do: "not_a_map"
+
   # The nearest PUBLISHED neighbour the gate scored, or `nil`. A `:low_novelty`/`:duplicate`
   # verdict is DERIVED from the top neighbour's score, so an empty list here is an
   # implementation contradicting itself; the draft is still published (that is the default,
   # and withholding it over a malformed assessment would be the total loss), it simply
   # carries no annotation.
-  defp neighbour(%{neighbors: [%{id: id, similarity_score: score} | _]}, draft_id)
-       when is_binary(id) and id != draft_id,
-       do: %{id: id, similarity_score: score}
+  defp neighbour(tenant_id, %{neighbors: [%{id: id, similarity_score: score} | _]}, %{
+         id: draft_id,
+         project_id: project_id
+       })
+       when is_binary(id) and id != draft_id do
+    if linkable?(tenant_id, id, project_id) do
+      %{id: id, similarity_score: score}
+    end
+  end
 
-  defp neighbour(_assessment, _draft_id), do: nil
+  defp neighbour(_tenant_id, _assessment, _draft), do: nil
+
+  # The AUTO-LINKER's own neighbour scope, applied to the edge this step writes tonight:
+  # `ArticleLinkingWorker` passes `project_or_global: article.project_id` and never links out
+  # of a project. `ProposalGate.assess/3` carries no such filter — it scopes the vector read
+  # for egress only — so without this the annotation would be an edge class the graph has
+  # never held: cross-project, or pointing at another agent's `private`/`owner` memory. The
+  # promoter cannot tell such an edge from an auto-linker one, and a promoted pair suppresses
+  # BOTH its articles from curated answers. A `nil` project is GLOBAL on both sides, exactly as
+  # `maybe_filter_by_project_or_global/2` reads it.
+  defp linkable?(tenant_id, neighbour_id, project_id) do
+    from(a in Article,
+      where: a.tenant_id == ^tenant_id,
+      where: a.id == ^neighbour_id,
+      where: a.status == :published,
+      where:
+        fragment("COALESCE(?->>'visibility', 'shared') NOT IN ('private','owner')", a.metadata),
+      select: %{project_id: a.project_id}
+    )
+    |> AdminRepo.one()
+    |> case do
+      nil ->
+        false
+
+      %{project_id: neighbour_project} ->
+        is_nil(project_id) or is_nil(neighbour_project) or neighbour_project == project_id
+    end
+  end
 
   defp publish(tenant_id, draft, verdict, neighbour) do
     case Knowledge.publish_article(tenant_id, draft.id,
@@ -494,17 +617,19 @@ defmodule Loopctl.Knowledge.DraftConsumer do
 
   # The annotation, and the only thing that separates this step from a bulk publish. It is
   # shaped as the auto-linker's own edge — `auto_generated: true` plus the cosine
-  # `similarity_score` — because that is precisely what
-  # `KnowledgeLintWorker.promote_conflicts/1` reads: a pair at or above the conflict
-  # threshold is flagged `:potential_conflict` the SAME night and judged the same night, and
-  # a confirmed duplicate is retracted later by the consolidation pass with `unpublish`.
-  # Every step of that is reversible, which is the whole reason the redundancy is handed to
-  # it rather than decided here.
+  # `similarity_score`, inside the same project/visibility scope (`linkable?/3`) — because
+  # `KnowledgeLintWorker.promote_conflicts/1` reads exactly that shape, and because the
+  # asynchronous `ArticleLinkingWorker` that `publish_article/3` chains to derives the SAME
+  # edge from the stored vector once it lands. So this write moves the annotation to tonight;
+  # it does not create a pair the graph would not otherwise have held.
   #
-  # `on_conflict: :nothing` against the pair's unique index, so a re-run is a no-op — and the
-  # asynchronous `ArticleLinkingWorker` that `publish_article/3` chains to will derive the
-  # same edge from the stored vector once it lands. This write is what makes the annotation
-  # true TONIGHT rather than whenever that queue drains.
+  # What it does NOT do is retract anything, and the moduledoc says where it really ends: the
+  # promoted pair suppresses both articles from curated answers until the judge reaches it in
+  # similarity order, and the judge's `:redundant` / `dismiss` is terminal and retires
+  # neither. Publishing a near-duplicate is the owner-decided default; the edge is the record
+  # of it, not a remedy for it.
+  #
+  # `on_conflict: :nothing` against the pair's unique index, so a re-run is a no-op.
   defp link(tenant_id, draft, verdict, %{id: neighbour_id, similarity_score: score}) do
     attrs = %{
       source_article_id: draft.id,
@@ -557,34 +682,21 @@ defmodule Loopctl.Knowledge.DraftConsumer do
 
   defp log_truncation(_tenant_id, _budget_ms, _result), do: :ok
 
-  # ONCE PER RUN, and a WARNING rather than a per-item line — the
-  # `Consolidation.log_provider_unconfigured/2` lesson, applied to a third step whose per-item
-  # cost is an outbound call. `{:error, :no_api_key}` is the one `:unknown` cause that is
-  # PERMANENT, self-inflicted and operator-fixable, and `ProposalGate` folds it into the same
-  # fall-open every transient provider failure gets. Without this line a keyless tenant offers
-  # the same drafts every night, leaves every one of them unassessed, and the audit event
-  # reads exactly like a provider having a bad night — the #620 shape, one step over.
+  # The EMBEDDING key, never `Llm.has_api_key?/1` (which answers for Anthropic extraction):
+  # this step's per-item cost is an embedding call and `{:error, :no_api_key}` from that
+  # provider is the one `:unknown` cause that is PERMANENT, self-inflicted and
+  # operator-fixable, which `ProposalGate` folds into the same fall-open every transient
+  # failure gets. Reading the wrong one of the pair both suppressed the warning on the tenant
+  # that needs it and emitted it on a tenant that does not — the #620 shape, one step over.
   #
-  # Self-guarded for the same reason its sibling is: this runs AFTER the drain, so a repo blip
-  # reading the tenant's LLM settings must not discard a completed run's tally.
-  defp log_provider_unconfigured(tenant_id, %{unassessed: unassessed}) when unassessed > 0 do
-    if Llm.has_api_key?(tenant_id) do
-      :ok
-    else
-      Logger.warning(
-        "DraftConsumer: tenant=#{tenant_id} has no embedding key (mandatory BYO), so its " <>
-          "#{unassessed} unassessed draft(s) can never be assessed at all and are re-offered " <>
-          "every night. This is a configuration state, not a provider that failed. Nothing " <>
-          "is published while it stands."
-      )
-    end
-
-    :ok
+  # Self-guarded: a repo blip reading the tenant's LLM settings must not turn a runnable night
+  # into a skipped one, so an unreadable answer assumes a key and lets the drain proceed with
+  # the per-item fall-open still behind it.
+  defp embedding_key?(tenant_id) do
+    Llm.has_embedding_key?(tenant_id)
   rescue
-    _e -> :ok
+    _e -> true
   catch
-    :exit, _reason -> :ok
+    :exit, _reason -> true
   end
-
-  defp log_provider_unconfigured(_tenant_id, _result), do: :ok
 end

--- a/lib/loopctl/knowledge/draft_consumer.ex
+++ b/lib/loopctl/knowledge/draft_consumer.ex
@@ -51,8 +51,8 @@ defmodule Loopctl.Knowledge.DraftConsumer do
       neighbour with a `relates_to` edge carrying the cosine `similarity_score` and
       `auto_generated: true` — the SAME edge `ArticleLinkingWorker` derives from the stored
       vector once the publish's embedding lands, written tonight instead of whenever that
-      queue drains, and under the same project/visibility scope that worker applies so this
-      step adds no edge class the graph did not already have.
+      queue drains, under that worker's own project scope and a STRICTER visibility one
+      (`linkable?/3`), so this step adds no edge class the graph did not already have.
       What the edge buys is a RECORD, not a retraction, and the honest reading of where it
       ends is: `KnowledgeLintWorker.promote_conflicts/1` flags a pair at or above the
       conflict threshold `:potential_conflict`, which SUPPRESSES both its articles from
@@ -96,20 +96,30 @@ defmodule Loopctl.Knowledge.DraftConsumer do
   `articles.consolidation_retracted_at` is never a candidate, and neither is one the
   `audit_log` records as `article.unpublished` BY ANY ACTOR.
 
-  That leaves one residual, deliberately. The durable column exists only from migration
-  `20260818055453` onward and only consolidation stamps it, so the audit row is what carries
-  every other retraction, and a retraction older than audit retention is republished once.
-  `DraftDuplicateSweepWorker` fails closed there and this one does not, because the direction
-  of the danger is inverted: the sweep's action is terminal, so an unprovable retraction must
-  be spared; this one's is reversible, and failing closed here would strand every pre-marker
-  draft permanently, which is the total loss. A durable `unpublished_at` stamped by every
-  retraction path would remove the residual outright.
+  Neither of those two records is durable on its own. The column exists only from migration
+  `20260818055453` onward and only consolidation stamps it; the `audit_log` is
+  range-partitioned and its partitions are DROPped past `:audit_retention_days`, so a human
+  retraction older than retention would be republished — and a `user+` PATCH to
+  `status: :draft` is a retraction that writes `article.updated` and no `article.unpublished`
+  at all. A THIRD record closes both: a draft carrying an EMBEDDING was PUBLISHED once,
+  because `maybe_enqueue_embedding/3` enqueues only at `status: :published` and ingestion only
+  under `publish: true`, and that row outlives every audit partition. It also splits the queue
+  cleanly: `DraftDuplicateSweepWorker` sweeps the EMBEDDED drafts (retractions), this step
+  drains the unembedded ones (captures that were never published) — 112 of the 113 measured.
 
   **A MERGE.** `Knowledge.execute_conflict_resolutions/2` lands its LLM-synthesised merge as
   a draft, and CLAUDE.md's KB-content carve-out rests on that draft never being
   auto-published: it is exactly what separates an agent-role key RECORDING a merge verdict
-  from the same key authorising unattended synthesised text into the corpus. A draft
-  carrying `metadata.merged_from` is never a candidate.
+  from the same key authorising unattended synthesised text into the corpus. So a merge draft
+  is excluded by TWO records: `metadata.merged_from`, and the executor's own
+  `conflict_resolutions.execution_result->>'draft_id'`. The second is what makes it hold —
+  `metadata` is CAST and whole-map-replaced by an agent-role `PATCH /api/v1/knowledge/:id`
+  (the `previous_title` and `stories.lifecycle_entered_at` lesson), so a marker living only
+  there is one ordinary request away from auto-publishing the synthesised text; the
+  executor's row is not caster-writable. That does leave a merge draft with no AUTOMATIC
+  exit, against #765's rule that no state has a human as its only exit. The carve-out is the
+  narrower rule and governs: the exit is an orchestrator publishing or deleting the draft,
+  and it is never this step.
 
   **A HOLD THAT IS STILL FRESH.** `POST /api/v1/knowledge` with `draft: true`, and ingestion
   with `publish: false`, are advertised opt-ins into staging; publishing one the same night
@@ -156,6 +166,7 @@ defmodule Loopctl.Knowledge.DraftConsumer do
   alias Loopctl.ExitTag
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ArticleEmbedding
   alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Knowledge.ProposalGate
   alias Loopctl.Llm
@@ -254,11 +265,16 @@ defmodule Loopctl.Knowledge.DraftConsumer do
       # `ProposalAssessorBehaviour` may not need a tenant embedding key at all, and a
       # pre-check that assumed one would silently stop a drain that would have worked.
       assessor(opts) == ProposalGate and not embedding_key?(tenant_id) ->
-        Logger.warning(
-          "DraftConsumer: tenant=#{tenant_id} has no embedding key (mandatory BYO), so no " <>
-            "draft can be assessed at all; the drain is stopped and every draft stays held. " <>
-            "This is a configuration state, not a provider that failed."
-        )
+        # Guarded on there being something HELD, the condition the removed
+        # `log_provider_unconfigured/2` carried: a keyless tenant with an empty queue has
+        # nothing stuck, and a nightly warning asserting otherwise is how a real one gets muted.
+        if held_drafts?(tenant_id) do
+          Logger.warning(
+            "DraftConsumer: tenant=#{tenant_id} has no embedding key (mandatory BYO), so no " <>
+              "draft can be assessed at all; the drain is stopped and every draft stays held. " <>
+              "This is a configuration state, not a provider that failed."
+          )
+        end
 
         tally(:no_embedding_key)
 
@@ -320,10 +336,23 @@ defmodule Loopctl.Knowledge.DraftConsumer do
   # would leave the 113 oldest drafts held forever while the queue looked healthy. The
   # remainder is taken NEWEST first so a permanently unconsumable head cannot take the drain
   # to zero — see `@backlog_share`.
+  #
+  # INTERLEAVED, never appended. The cap bounds the QUERY; the bound that actually cuts the
+  # night is the wall clock in `drain/3`, which truncates the TAIL. Appended, the reserve was
+  # the first thing a slow unconsumable head discarded — a head that fails in ~5s an item
+  # spends the whole 2-minute budget inside the backlog slice — so the one slice that exists
+  # to keep the drain positive was exactly the one that never ran.
   defp candidates(tenant_id, cap) do
     oldest = candidate_ids(tenant_id, max(trunc(cap * @backlog_share), 1), :asc)
-    Enum.uniq(oldest ++ candidate_ids(tenant_id, cap - length(oldest), :desc))
+    newest = candidate_ids(tenant_id, cap - length(oldest), :desc)
+    Enum.uniq(interleave(newest, oldest))
   end
+
+  defp interleave([], rest), do: rest
+  defp interleave(rest, []), do: rest
+  defp interleave([a | as], [b | bs]), do: [a, b | interleave(as, bs)]
+
+  defp held_drafts?(tenant_id), do: tenant_id |> draft_scope() |> AdminRepo.exists?()
 
   defp candidate_ids(_tenant_id, limit, _direction) when limit <= 0, do: []
 
@@ -356,22 +385,49 @@ defmodule Loopctl.Knowledge.DraftConsumer do
         fragment("COALESCE(?->>'visibility', 'shared') NOT IN ('private','owner')", a.metadata),
       # A MERGE is staged on purpose. `execute_conflict_resolutions/2` lands LLM-synthesised
       # text as a draft, and the KB-content carve-out that lets an agent-role key record a
-      # merge verdict at all rests on that draft never being auto-published.
+      # merge verdict at all rests on that draft never being auto-published. TWO records,
+      # because `metadata` is cast and whole-map-replaced by an agent-role PATCH: the marker
+      # the executor wrote there, and the executor's own `conflict_resolutions` row, which no
+      # caller can cast.
       where: fragment("? -> 'merged_from' IS NULL", a.metadata),
+      where:
+        not exists(
+          from(cr in "conflict_resolutions",
+            where: cr.tenant_id == parent_as(:draft).tenant_id,
+            where:
+              fragment("? ->> 'draft_id' = ?::text", cr.execution_result, parent_as(:draft).id),
+            select: 1
+          )
+        ),
       # A FRESH HOLD is staged on purpose too — `draft: true` and ingestion's `publish: false`
       # are advertised opt-ins, and a drain that runs tonight makes them unobservable. A floor,
       # not a veto: two nightly runs to publish or delete it, then it drains like the rest.
       where: a.inserted_at <= ago(@min_draft_age_hours, "hour"),
-      # The RETRACTION guard, in its two independent records. See the moduledoc: the durable
-      # column is authoritative and survives audit retention; the audit_log is still read
-      # because the column only exists from migration 20260818055453 onward and only
-      # consolidation stamps it. The audit clause is deliberately NOT narrowed to
-      # `worker:consolidation`: `Knowledge.unpublish_article/3` and `bulk_unpublish/3` are
-      # the `role: :user` retraction lever, and republishing what a human just pulled reverts a
-      # human-gated act unattended, inside 24 hours. `tenant_id` is constrained inside the
-      # subquery so the correlated NOT EXISTS can use `audit_log_tenant_entity_idx`, whose
-      # leading column it is.
+      # The RETRACTION guard, in its THREE independent records. See the moduledoc. The audit
+      # clause is deliberately NOT narrowed to `worker:consolidation`:
+      # `Knowledge.unpublish_article/3` and `bulk_unpublish/3` are the `role: :user`
+      # retraction lever, and republishing what a human just pulled reverts a human-gated act
+      # unattended. `tenant_id` is constrained inside the subquery so the correlated NOT
+      # EXISTS can use `audit_log_tenant_entity_idx`, whose leading column it is.
+      #
+      # Neither the column nor the audit row is durable ALONE — the column is stamped only by
+      # consolidation and only since 20260818055453, and `AuditPartitionWorker` DROPs the
+      # audit partition past `:audit_retention_days`, which also leaves a `user+` PATCH to
+      # `status: :draft` (an `article.updated`, never an `article.unpublished`) with no record
+      # here at all. An EMBEDDING is the third and the durable one: it exists only because the
+      # row was PUBLISHED once (`maybe_enqueue_embedding/3` enqueues at `:published` only,
+      # ingestion only under `publish: true`), and it survives every partition drop. Existence
+      # at ANY dimension, and the legacy column too — currency is not the question.
       where: is_nil(a.consolidation_retracted_at),
+      where: is_nil(a.embedding),
+      where:
+        not exists(
+          from(e in ArticleEmbedding,
+            where: e.tenant_id == parent_as(:draft).tenant_id,
+            where: e.article_id == parent_as(:draft).id,
+            select: 1
+          )
+        ),
       where:
         not exists(
           from(al in "audit_log",
@@ -529,31 +585,36 @@ defmodule Loopctl.Knowledge.DraftConsumer do
   defp verdict_tag(other) when is_map(other), do: "no_verdict_key:" <> inspect(Map.keys(other))
   defp verdict_tag(_other), do: "not_a_map"
 
-  # The nearest PUBLISHED neighbour the gate scored, or `nil`. A `:low_novelty`/`:duplicate`
-  # verdict is DERIVED from the top neighbour's score, so an empty list here is an
-  # implementation contradicting itself; the draft is still published (that is the default,
-  # and withholding it over a malformed assessment would be the total loss), it simply
-  # carries no annotation.
-  defp neighbour(tenant_id, %{neighbors: [%{id: id, similarity_score: score} | _]}, %{
-         id: draft_id,
-         project_id: project_id
-       })
-       when is_binary(id) and id != draft_id do
-    if linkable?(tenant_id, id, project_id) do
-      %{id: id, similarity_score: score}
-    end
+  # The nearest LINKABLE neighbour the gate scored, or `nil`. The whole list is walked, not
+  # just its head: `ProposalGate.assess/3` passes no project or visibility filter, so in a
+  # multi-project tenant the top neighbour being out of scope is ordinary, and judging the
+  # head alone threw away an in-scope pair at rank 2 that the auto-linker links anyway.
+  # `nil` means no candidate survived (or a malformed assessment carried none); the draft is
+  # still published — that is the default, and withholding it would be the total loss — it
+  # simply carries no annotation, and `link/4` counts that separately.
+  defp neighbour(tenant_id, %{neighbors: neighbors}, %{id: draft_id, project_id: project_id})
+       when is_list(neighbors) do
+    Enum.find_value(neighbors, fn
+      %{id: id, similarity_score: score} when is_binary(id) and id != draft_id ->
+        if linkable?(tenant_id, id, project_id), do: %{id: id, similarity_score: score}
+
+      _other ->
+        nil
+    end)
   end
 
   defp neighbour(_tenant_id, _assessment, _draft), do: nil
 
-  # The AUTO-LINKER's own neighbour scope, applied to the edge this step writes tonight:
+  # The scope this step's edge is held to. The PROJECT half mirrors the auto-linker exactly —
   # `ArticleLinkingWorker` passes `project_or_global: article.project_id` and never links out
-  # of a project. `ProposalGate.assess/3` carries no such filter — it scopes the vector read
-  # for egress only — so without this the annotation would be an edge class the graph has
-  # never held: cross-project, or pointing at another agent's `private`/`owner` memory. The
-  # promoter cannot tell such an edge from an auto-linker one, and a promoted pair suppresses
-  # BOTH its articles from curated answers. A `nil` project is GLOBAL on both sides, exactly as
-  # `maybe_filter_by_project_or_global/2` reads it.
+  # of a project, while `ProposalGate.assess/3` carries no such filter (it scopes the vector
+  # read for egress only), so without it the annotation would be an edge class the graph has
+  # never held. A `nil` project is GLOBAL on both sides, exactly as
+  # `maybe_filter_by_project_or_global/2` reads it. The VISIBILITY half is deliberately
+  # STRICTER than the auto-linker, which passes no `:visibility_agent_id` at all
+  # (`VectorSearch.maybe_filter_by_visibility(query, nil)` is a no-op): it delays nothing this
+  # step owes, since that worker may still derive the same edge from the stored vector, and it
+  # keeps an unattended writer out of another agent's `private`/`owner` memory tonight.
   defp linkable?(tenant_id, neighbour_id, project_id) do
     from(a in Article,
       where: a.tenant_id == ^tenant_id,
@@ -606,18 +667,24 @@ defmodule Loopctl.Knowledge.DraftConsumer do
 
   defp link(_tenant_id, _draft, :novel, _neighbour), do: :published
 
+  # `:published_link_failed`, never `:published`: a near-duplicate published with no
+  # annotation is the outcome this step exists to make impossible, and it must not read like a
+  # novel publish in the nightly audit event. Two causes reach here and the line names both —
+  # every scored neighbour was out of `linkable?/3`'s scope (routine in a multi-project
+  # tenant), or the assessment carried none at all (an implementation contradicting itself).
   defp link(tenant_id, draft, _verdict, nil) do
     Logger.warning(
-      "DraftConsumer: tenant=#{tenant_id} draft #{draft.id} assessed as a near-duplicate " <>
-        "but the assessment carried no usable neighbour; published WITHOUT an annotation."
+      "DraftConsumer: tenant=#{tenant_id} draft #{draft.id} assessed as a near-duplicate but " <>
+        "no scored neighbour was linkable (another project, private/owner, or none scored); " <>
+        "published WITHOUT an annotation."
     )
 
-    :published
+    :published_link_failed
   end
 
   # The annotation, and the only thing that separates this step from a bulk publish. It is
   # shaped as the auto-linker's own edge — `auto_generated: true` plus the cosine
-  # `similarity_score`, inside the same project/visibility scope (`linkable?/3`) — because
+  # `similarity_score`, inside `linkable?/3`'s scope — because
   # `KnowledgeLintWorker.promote_conflicts/1` reads exactly that shape, and because the
   # asynchronous `ArticleLinkingWorker` that `publish_article/3` chains to derives the SAME
   # edge from the stored vector once it lands. So this write moves the annotation to tonight;

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -47,11 +47,13 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   2b. **Consumes the DRAFT queue** (#765/#766) — `Loopctl.Knowledge.DraftConsumer.consume/2`
      assesses each held draft against the published corpus through the existing
      `ProposalGate` seam and PUBLISHES it: a near-duplicate is published AND annotated with a
-     `relates_to` edge carrying its cosine score, so the promoter and judge below handle the
-     redundancy reversibly. Nothing is archived — `:archived` is terminal, and an unattended
-     writer may not take a one-way door (#605/#606/#608). It runs HERE, first of the acting
-     steps, so tonight's annotation is flagged and judged tonight; see the call site in
-     `lint_tenant/1` for the full ordering argument. It is the THIRD step whose per-item cost
+     `relates_to` edge carrying its cosine score, which the promoter below turns into a
+     RECORDED `:potential_conflict` — a record for a human or an orchestrator, not a
+     retraction (see that module's doc for where the pair actually ends). Nothing is archived
+     — `:archived` is terminal, and an unattended writer may not take a one-way door
+     (#605/#606/#608). It runs HERE, first of the acting steps, so tonight's annotation is at
+     least flagged tonight; see the call site in `lint_tenant/1` for the full ordering
+     argument. It is the THIRD step whose per-item cost
      is an outbound provider call, so it carries a wall clock of its own
      (`draft_budget_remaining/1`) carved out of the same `timeout/1` — never beside it.
   3. **Prunes the `relates_to` graph to top-K degree** (#611 stage 0) via
@@ -287,13 +289,16 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     action = act_on_orphans(tenant_id, report)
     # FIRST of the acting steps, and the ordering is load-bearing in three ways.
     #
-    # (1) SAME-NIGHT ANNOTATION. A near-duplicate draft is published with a `relates_to` edge
+    # (1) SAME-NIGHT FLAGGING. A near-duplicate draft is published with a `relates_to` edge
     #     carrying `auto_generated` and the cosine score — exactly what `promote_conflicts/1`
     #     below reads. Running before it means the pair is flagged `:potential_conflict`
-    #     tonight and judged tonight, which is the same argument that already puts the judge
-    #     after the promoter. Running after it would cost every near-duplicate a full night
-    #     unflagged, and a flagged pair suppresses BOTH its articles from curated answers
-    #     while it stands.
+    #     tonight rather than a night later, which is the same argument that already puts the
+    #     judge after the promoter. It does NOT mean the pair is judged tonight: the judge
+    #     takes its candidates in similarity order out of a standing backlog this file puts at
+    #     14-25 nights, and a flagged pair suppresses BOTH its articles from curated answers
+    #     for as long as it waits. That cost belongs to publishing the near-duplicate, which
+    #     the auto-linker would flag from the stored vector anyway; ordering only decides
+    #     whether it starts tonight or tomorrow.
     # (2) SAME-NIGHT CONSOLIDATION. `consolidate/1` scans the published corpus, so an article
     #     published here enters TONIGHT's `:duplicate_capture` report and can be confirmed
     #     tomorrow. That is the reversible retraction path this step deliberately hands its

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -44,6 +44,16 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
      cheap, and makes **no** embedding-API calls (orphans missing an embedding
      simply no-op in the linking worker — backfilling those is a separate
      concern, out of scope here).
+  2b. **Consumes the DRAFT queue** (#765/#766) — `Loopctl.Knowledge.DraftConsumer.consume/2`
+     assesses each held draft against the published corpus through the existing
+     `ProposalGate` seam and PUBLISHES it: a near-duplicate is published AND annotated with a
+     `relates_to` edge carrying its cosine score, so the promoter and judge below handle the
+     redundancy reversibly. Nothing is archived — `:archived` is terminal, and an unattended
+     writer may not take a one-way door (#605/#606/#608). It runs HERE, first of the acting
+     steps, so tonight's annotation is flagged and judged tonight; see the call site in
+     `lint_tenant/1` for the full ordering argument. It is the THIRD step whose per-item cost
+     is an outbound provider call, so it carries a wall clock of its own
+     (`draft_budget_remaining/1`) carved out of the same `timeout/1` — never beside it.
   3. **Prunes the `relates_to` graph to top-K degree** (#611 stage 0) via
      `Loopctl.Knowledge.LinkPruning`. A similarity threshold is not a bound: above
      0.6 the linking worker admitted every kNN candidate, and the hosted corpus
@@ -93,7 +103,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
      disposition: :dismiss`, because cosine similarity measures REDUNDANCY and
      cannot see contradiction, so recording what was actually measured is the
      only honest verdict available. The pile is drained by a WALL CLOCK and not
-     by the count cap — ~1,260 pairs a night gross, ~760 net of the promoter's
+     by the count cap — ~1,120 pairs a night gross, ~620 net of the promoter's
      own 500 (see `@default_judge_budget_ms`) — and the drain stays within the
      same night as the promoter so a pair flagged tonight never spends a night
      suppressing both its articles from curated answers.
@@ -127,6 +137,11 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   night and a night with nothing left to retitle are the same `generic_titles_retitled`
   otherwise.
 
+  Draft consumption is bounded by a wall clock (`draft_budget_remaining/1`, out of
+  `@draft_reserve_ms`) with `:knowledge_draft_consumer_max_publishes` bounding only the
+  candidate query, and it reports `drafts_offered` and `drafts_budget_exhausted` beside
+  `drafts_published` for the same reason the retitle step does.
+
   Conflict judging is bounded twice, by a count
   (`:knowledge_lint_max_conflict_judgements`) and by a wall clock
   (`:knowledge_lint_conflict_judge_budget_ms`), because only the second one bounds
@@ -157,6 +172,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   alias Loopctl.Knowledge.ConflictJudge
   alias Loopctl.Knowledge.ConflictResolution
   alias Loopctl.Knowledge.Consolidation
+  alias Loopctl.Knowledge.DraftConsumer
   alias Loopctl.Knowledge.LinkPruning
   alias Loopctl.Oban.FairShare
   alias Loopctl.SystemConfig
@@ -188,12 +204,12 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # outbound provider call is really spending. Measured in production 2026-08-27 on the
   # 86k-article tenant: one judgement is ~1.7 s wall, ~0.85 s at concurrency 2, so ~70 pairs
   # a minute. The 20 below is a REQUEST, not the budget: `@judge_budget_ceiling_ms` clamps it
-  # to 18 minutes once `@retitle_reserve_ms` is carved out of the same job (#765), so the
-  # drain is ~1,260 pairs a night GROSS. `promote_conflicts/1` feeds the same queue up
+  # to 16 minutes once `@retitle_reserve_ms` and `@draft_reserve_ms` are carved out of the same
+  # job (#765/#766), so the drain is ~1,120 pairs a night GROSS. `promote_conflicts/1` feeds the same queue up
   # to `@default_max_conflict_promotions` (500) a night, so against an existing backlog the
-  # NET drain is ~760 — and 500 is a CAP, not a rate (2026-08-27 measured the promoter at 0
-  # candidates), so ~760 is the worst case and ~1,260 the best. Every figure below is derived
-  # from that 18, so any change to either reserve moves them all.
+  # NET drain is ~620 — and 500 is a CAP, not a rate (2026-08-27 measured the promoter at 0
+  # candidates), so ~620 is the worst case and ~1,120 the best. Every figure below is derived
+  # from that 16, so any change to ANY of the three reserves moves them all.
   #
   # The SECOND producer is the ingestion-time novelty gate, and no promoter cap bounds it.
   # Do not read its #761 numbers as a rate. TOTAL flags created per day — both producers —
@@ -206,13 +222,13 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # same window, so it is the drained backlog, not the zeros, that says the burst ended.
   #
   # A burst is therefore absorbed rather than fatal: it truncates some nights, says so, and
-  # drains at ~760-1,260 a night until it is caught up — 15,246 takes THIRTEEN nights at the
-  # promoter rate measured on 2026-08-27 (0 candidates) and TWENTY-ONE if the promoter
+  # drains at ~620-1,120 a night until it is caught up — 15,246 takes FOURTEEN nights at the
+  # promoter rate measured on 2026-08-27 (0 candidates) and TWENTY-FIVE if the promoter
   # saturates its 500/night cap; quote the range, not one end of it, and CEIL it — a
   # remainder is a whole further night, on which the flags still report truncated. That holds
   # only while a fresh burst does not land before the last one clears, and both causes are
   # operator-started and repeatable (`TagBackfillWorker` is deliberately not on a cron), so
-  # a re-run means another ~21 truncated nights rather than a fault. The broken 3x10-minute
+  # a re-run means another ~25 truncated nights rather than a fault. The broken 3x10-minute
   # path incidentally judged 1,700-2,800 a night by dying three times; it also lost the
   # night's audit event and re-spent the nightly caps per attempt, so that is not a
   # throughput to miss.
@@ -269,6 +285,28 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     {:ok, report} = Knowledge.lint(tenant_id, max_per_category: @lint_max_per_category)
 
     action = act_on_orphans(tenant_id, report)
+    # FIRST of the acting steps, and the ordering is load-bearing in three ways.
+    #
+    # (1) SAME-NIGHT ANNOTATION. A near-duplicate draft is published with a `relates_to` edge
+    #     carrying `auto_generated` and the cosine score — exactly what `promote_conflicts/1`
+    #     below reads. Running before it means the pair is flagged `:potential_conflict`
+    #     tonight and judged tonight, which is the same argument that already puts the judge
+    #     after the promoter. Running after it would cost every near-duplicate a full night
+    #     unflagged, and a flagged pair suppresses BOTH its articles from curated answers
+    #     while it stands.
+    # (2) SAME-NIGHT CONSOLIDATION. `consolidate/1` scans the published corpus, so an article
+    #     published here enters TONIGHT's `:duplicate_capture` report and can be confirmed
+    #     tomorrow. That is the reversible retraction path this step deliberately hands its
+    #     redundancy to, and it is also what terminates the one-round flip-flop the consumer's
+    #     moduledoc describes.
+    # (3) ITS BUDGET IS ACTUALLY THERE. `draft_budget_remaining/1` measures from the job start
+    #     out of the shared reserve, exactly as the retitle step's does, so the earlier it
+    #     runs the less of its own allowance a slow prelude has already spent.
+    #
+    # It does NOT run before `Knowledge.lint/2`: an article published here has no embedding
+    # yet (the publish only ENQUEUES one), so it would be reported as an orphan and
+    # `act_on_orphans/2` would enqueue a second embedding job for it the same night.
+    drafts = consume_drafts(tenant_id, draft_budget_remaining(started_at))
     # Ordering the prune against its neighbours is a matter of cost, not correctness, and both
     # halves of that are structural rather than positional. Union-kNN keeps every article's own
     # top-K, so an article holding at least one edge holds it at rank 1 and the prune cannot
@@ -310,6 +348,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
 
     log_audit_event(tenant_id, report, %{
       action: action,
+      drafts: drafts,
       pruned: pruned,
       promoted: promoted,
       judged: judged,
@@ -326,8 +365,17 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
       # OFFERED and the bound flag are both here, never just the applied count: a night the
       # clock cut short and a night with nothing left to retitle report the same
       # `generic_titles_retitled` otherwise, and that silent pair is the #761 misreading.
+      # OFFERED and the bound flag ride with the applied count for the #761 reason: a night
+      # the clock cut short and a night with no drafts left to consume report the same
+      # `drafts_published` otherwise.
       "KnowledgeLintWorker: tenant=#{tenant_id} issues=#{report.summary.total_issues} " <>
         "orphans_relinked=#{action.relinked} orphans_embedding_enqueued=#{action.embedding_enqueued} " <>
+        "drafts_published=#{drafts.published} drafts_offered=#{drafts.offered} " <>
+        "drafts_linked=#{drafts.linked} drafts_link_failed=#{drafts.link_failed} " <>
+        "drafts_unassessed=#{drafts.unassessed} drafts_skipped=#{drafts.skipped} " <>
+        "drafts_failed=#{drafts.failed} " <>
+        "drafts_budget_exhausted=#{drafts.budget_exhausted} " <>
+        "drafts_gate=#{drafts.gate} " <>
         "conflicts_promoted=#{promoted} conflicts_judged_redundant=#{judged.judged} " <>
         "conflicts_judge_candidates=#{judged.candidates} " <>
         "conflicts_judge_budget_exhausted=#{judged.budget_exhausted} " <>
@@ -381,9 +429,16 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # exactly what this step may spend, and `timeout/1` does not move. Raising `timeout/1` to
   # pay for a new step is the move #761 makes fatal — the Lifeline window is the real ceiling
   # and it is not ours to raise.
+  #   * `@draft_reserve_ms` is a BUDGET on the same terms as the one below it: the draft
+  #     consumer's per-item cost is an outbound EMBEDDING call, so it is bounded by a clock of
+  #     its own (`draft_budget_remaining/1`) rather than by how many drafts a night finds.
+  #     It COSTS the judge exactly two minutes — the judge's ceiling falls from 18 minutes to
+  #     16, ~1,120 pairs a night gross rather than ~1,260 — which is the arithmetic this
+  #     shared reserve exists to make automatic.
   @prelude_reserve_ms :timer.minutes(5)
   @retitle_reserve_ms :timer.minutes(2)
-  @job_reserve_ms @prelude_reserve_ms + @retitle_reserve_ms
+  @draft_reserve_ms :timer.minutes(2)
+  @job_reserve_ms @prelude_reserve_ms + @retitle_reserve_ms + @draft_reserve_ms
 
   # And CLAMPED below Oban's Lifeline window (`rescue_after: :timer.minutes(30)`,
   # `Loopctl.ObanConfig.plugins/0`). Lifeline never checks whether a job is still alive: it
@@ -500,12 +555,41 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   def retitle_budget_ms, do: @retitle_reserve_ms
 
   @doc """
+  Wall-clock budget (ms) the draft consumer may spend, given the job start.
+
+  DERIVED exactly as `retitle_budget_remaining/1` is, out of the SAME shared reserve, so a
+  prelude that overran shrinks this step rather than pushing the night past `timeout/1`.
+  `judge_overshoot_ms/0` pays for the one in-flight provider call a deadline cannot
+  interrupt — this step makes an embedding call per item and has that exposure in full.
+  """
+  @spec draft_budget_remaining(integer()) :: non_neg_integer()
+  def draft_budget_remaining(started_at) do
+    elapsed = System.monotonic_time(:millisecond) - started_at
+
+    (job_timeout_ms(configured_judge_budget_ms()) - judge_budget_ms() - elapsed -
+       judge_overshoot_ms())
+    |> max(0)
+    |> min(draft_budget_ms())
+  end
+
+  @doc """
+  The reserve carved out of `timeout/1` for the draft consumer.
+
+  Public for the same single assertion `retitle_budget_ms/0` is: a test binds it to
+  `Loopctl.Knowledge.DraftConsumer.default_budget_ms/0` — the fallback that applies when the
+  step is called directly rather than from here — so the two cannot drift into a budget
+  bigger than the job containing it, which is #761 in miniature.
+  """
+  @spec draft_budget_ms() :: pos_integer()
+  def draft_budget_ms, do: @draft_reserve_ms
+
+  @doc """
   The MEASURED part of the reserve: what the rest of the night costs besides the two
   clock-bounded steps.
 
   Public for one assertion, and it is the assertion that catches a new step being paid for
-  out of thin air: `judge_budget_ms/0 + retitle_budget_ms/0 + prelude_reserve_ms/0` must fit
-  inside `timeout/1`. Every other reading of these numbers stays true when a budget is added
+  out of thin air: `judge_budget_ms/0 + retitle_budget_ms/0 + draft_budget_ms/0 +
+  prelude_reserve_ms/0` must fit inside `timeout/1`. Every other reading of these numbers stays true when a budget is added
   beside the reserve instead of inside it, which is exactly how #761 shipped.
   """
   @spec prelude_reserve_ms() :: pos_integer()
@@ -1314,6 +1398,20 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     )
   end
 
+  # The draft consumer's own operator lever, resolved exactly like the three above (DB row ->
+  # app config -> module default). It matters here for the same reason it does on the retitle
+  # drain: this step spends a tenant's embedding budget per item, and `0` is an explicit pause
+  # an operator can reach mid-incident without a deploy.
+  @doc false
+  @spec draft_publishes_cap() :: integer()
+  def draft_publishes_cap do
+    tunable(
+      "knowledge_draft_consumer_max_publishes",
+      :knowledge_draft_consumer_max_publishes,
+      DraftConsumer.default_max_publishes()
+    )
+  end
+
   @doc false
   @spec per_class_cap() :: integer()
   def per_class_cap do
@@ -1372,6 +1470,49 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     e -> retitle_step_failed(tenant_id, ExitTag.tag(e))
   catch
     :exit, reason -> retitle_step_failed(tenant_id, "exit:" <> ExitTag.tag(reason))
+  end
+
+  # FAIL-SOFT, like every step that writes before the night's audit event does. This one runs
+  # EARLY — see the call site in `lint_tenant/1` — so a raise escaping it would abort the pass
+  # before `promote_conflicts/1`, `consolidate/1` and the judge had run at all, and hand the
+  # night to an Oban retry. Per-ITEM failures are contained inside `DraftConsumer.consume/2`'s
+  # own reduce; what reaches this rescue is a failure BEFORE any write, so a zero tally is true.
+  defp consume_drafts(tenant_id, budget_ms) do
+    DraftConsumer.consume(tenant_id,
+      max_publishes: draft_publishes_cap(),
+      budget_ms: budget_ms
+    )
+  rescue
+    e -> draft_step_failed(tenant_id, ExitTag.tag(e))
+  catch
+    :exit, reason -> draft_step_failed(tenant_id, "exit:" <> ExitTag.tag(reason))
+  end
+
+  defp draft_step_failed(tenant_id, tag) do
+    Logger.error(
+      "KnowledgeLintWorker: tenant=#{tenant_id} draft consumption failed (#{tag}); " <>
+        "no drafts were published this run and they stay held."
+    )
+
+    empty_draft_tally(:apply_failed, tag)
+  end
+
+  # The `empty_tally/2` rule, applied to the third tally: ONE constructor carrying every key
+  # the summary line interpolates, so no fail-soft path can raise a KeyError one line after
+  # the rescue that exists to prevent exactly that.
+  defp empty_draft_tally(gate, error) do
+    %{
+      published: 0,
+      linked: 0,
+      link_failed: 0,
+      unassessed: 0,
+      skipped: 0,
+      failed: 0,
+      offered: 0,
+      budget_exhausted: false,
+      gate: gate,
+      error: error
+    }
   end
 
   defp retitle_step_failed(tenant_id, tag) do
@@ -1540,6 +1681,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # that long silently accepts two same-typed counts swapped at the call site.
   defp log_audit_event(tenant_id, report, %{
          action: action,
+         drafts: drafts,
          pruned: pruned,
          promoted: promoted,
          judged: judged,
@@ -1559,6 +1701,26 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         "summary" => report.summary,
         "orphans_relinked" => action.relinked,
         "orphans_embedding_enqueued" => action.embedding_enqueued,
+        # The draft consumer's whole reading, and every key is load-bearing together.
+        # `drafts_published` alone reads 0 on an empty queue, on a night every assessment fell
+        # open, on a night the clock cut short after one draft, and on a night an operator
+        # paused the drain — so `offered`, `unassessed`, `budget_exhausted` and the gate are
+        # what tell those four apart. `linked` is the annotation actually written;
+        # `link_failed` is a near-duplicate published WITHOUT one, which must never hide
+        # inside `published`. A -1 is impossible here: a failed step reports through
+        # `drafts_gate` (`apply_failed`) instead, which the tally carries on every path.
+        "drafts_published" => drafts.published,
+        "drafts_offered" => drafts.offered,
+        "drafts_linked" => drafts.linked,
+        "drafts_link_failed" => drafts.link_failed,
+        "drafts_unassessed" => drafts.unassessed,
+        "drafts_skipped" => drafts.skipped,
+        "drafts_failed" => drafts.failed,
+        "drafts_budget_exhausted" => drafts.budget_exhausted,
+        # Read with `.gate`, never a defaulted `Map.get`: an `:open` default would record a
+        # crashed step as a clean night, which is the exact distinction this key exists for.
+        "drafts_gate" => to_string(drafts.gate),
+        "drafts_error" => Map.get(drafts, :error),
         "conflicts_promoted" => promoted,
         # Both numbers are recorded because the DIFFERENCE bounds the NET drain: while
         # judged > promoted the backlog is falling. It is not the convergence reading on its

--- a/test/loopctl/knowledge/draft_consumer_test.exs
+++ b/test/loopctl/knowledge/draft_consumer_test.exs
@@ -1,0 +1,398 @@
+defmodule Loopctl.Knowledge.DraftConsumerTest do
+  use Loopctl.DataCase, async: true
+  use Oban.Testing, repo: Loopctl.Repo
+
+  setup :verify_on_exit!
+
+  import Ecto.Query
+  import ExUnit.CaptureLog
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ArticleLink
+  alias Loopctl.Knowledge.DraftConsumer
+  alias Loopctl.MockProposalAssessor
+
+  # The assessor is injected PER CALL through the `:proposal_assessor` opt, never through
+  # `Application.put_env` — this suite is `async: true` and that would mutate VM-global state
+  # every other test would see. `config/test.exs` already resolves the config layer to this
+  # same mock, so passing it explicitly exercises the opt seam rather than bypassing it.
+  @assessor [proposal_assessor: MockProposalAssessor]
+
+  defp draft(tenant_id, attrs \\ %{}) do
+    fixture(:article, Map.merge(%{tenant_id: tenant_id, status: :draft}, attrs))
+  end
+
+  defp published(tenant_id, attrs \\ %{}) do
+    tenant_id
+    |> draft(attrs)
+    |> Ecto.Changeset.change(%{status: :published})
+    |> AdminRepo.update!()
+  end
+
+  defp reload(article), do: AdminRepo.get!(Article, article.id)
+
+  defp links_from(article_id) do
+    from(l in ArticleLink, where: l.source_article_id == ^article_id) |> AdminRepo.all()
+  end
+
+  defp verdict(verdict, neighbors \\ []) do
+    %{verdict: verdict, score: List.first(neighbors)[:similarity_score], neighbors: neighbors}
+  end
+
+  defp neighbor(article, score),
+    do: %{id: article.id, title: article.title, similarity_score: score}
+
+  defp stub_verdict(assessment) do
+    Mox.stub(MockProposalAssessor, :assess, fn _tenant_id, _attrs, _opts -> assessment end)
+  end
+
+  describe "consume/2 — the default is publish" do
+    test "a novel draft is PUBLISHED" do
+      tenant = fixture(:tenant)
+      held = draft(tenant.id)
+      stub_verdict(verdict(:novel))
+
+      tally = DraftConsumer.consume(tenant.id, @assessor)
+
+      assert reload(held).status == :published
+      assert tally.published == 1
+      assert tally.offered == 1
+      assert tally.linked == 0
+      assert tally.gate == :open
+      assert links_from(held.id) == []
+    end
+
+    test "a near-duplicate draft is PUBLISHED AND LINKED, and is never archived" do
+      tenant = fixture(:tenant)
+      canonical = published(tenant.id)
+      held = draft(tenant.id)
+      stub_verdict(verdict(:low_novelty, [neighbor(canonical, 0.94)]))
+
+      tally = DraftConsumer.consume(tenant.id, @assessor)
+
+      reloaded = reload(held)
+      assert reloaded.status == :published
+      # The #765 spec's "archive the twin" is the one disposition this step may not take:
+      # `:archived` is TERMINAL (`Article`'s @valid_transitions has no `{:archived, _}`).
+      refute reloaded.status == :archived
+
+      assert [link] = links_from(held.id)
+      assert link.target_article_id == canonical.id
+      assert link.relationship_type == :relates_to
+      assert tally.published == 1
+      assert tally.linked == 1
+      assert tally.link_failed == 0
+    end
+
+    test "the annotation carries the shape promote_conflicts/1 reads" do
+      tenant = fixture(:tenant)
+      canonical = published(tenant.id)
+      held = draft(tenant.id)
+      stub_verdict(verdict(:duplicate, [neighbor(canonical, 0.985)]))
+
+      DraftConsumer.consume(tenant.id, @assessor)
+
+      assert [link] = links_from(held.id)
+      # Both keys are what the promoter's candidate query filters on. Without them the edge
+      # is invisible to the `:potential_conflict` promoter and to the judge behind it, so the
+      # redundancy this step deliberately delegates would never be handled at all.
+      assert link.metadata["auto_generated"] == true
+      assert link.metadata["similarity_score"] == 0.985
+      assert link.metadata["novelty_verdict"] == "duplicate"
+      assert link.metadata["linked_by"] == DraftConsumer.actor_label()
+    end
+
+    test "a near-duplicate whose assessment carries no neighbour is still published, unannotated" do
+      tenant = fixture(:tenant)
+      held = draft(tenant.id)
+      stub_verdict(verdict(:low_novelty, []))
+
+      log =
+        capture_log(fn -> assert DraftConsumer.consume(tenant.id, @assessor).published == 1 end)
+
+      assert reload(held).status == :published
+      assert links_from(held.id) == []
+      assert log =~ "no usable neighbour"
+    end
+
+    test "nothing this step touches reaches a TERMINAL state" do
+      tenant = fixture(:tenant)
+      canonical = published(tenant.id)
+      _novel = draft(tenant.id)
+      near = draft(tenant.id)
+
+      Mox.stub(MockProposalAssessor, :assess, fn _t, attrs, _o ->
+        if attrs["title"] == near.title,
+          do: verdict(:low_novelty, [neighbor(canonical, 0.94)]),
+          else: verdict(:novel)
+      end)
+
+      DraftConsumer.consume(tenant.id, @assessor)
+
+      statuses =
+        from(a in Article, where: a.tenant_id == ^tenant.id, select: a.status)
+        |> AdminRepo.all()
+
+      refute :archived in statuses
+      refute :superseded in statuses
+    end
+  end
+
+  describe "consume/2 — a failed assessment" do
+    test "leaves the draft alone and COUNTS it" do
+      tenant = fixture(:tenant)
+      held = draft(tenant.id)
+      # `ProposalGate` falls open on any embedding/search failure, so `:unknown` means "not
+      # assessed" and never "not a duplicate".
+      stub_verdict(%{verdict: :unknown, score: nil, neighbors: []})
+
+      tally = DraftConsumer.consume(tenant.id, @assessor)
+
+      assert reload(held).status == :draft
+      assert tally.unassessed == 1
+      assert tally.published == 0
+      assert tally.offered == 1
+    end
+
+    test "a verdict outside the behaviour's vocabulary is NOT treated as novel" do
+      tenant = fixture(:tenant)
+      held = draft(tenant.id)
+      stub_verdict(%{verdict: :something_else, score: nil, neighbors: []})
+
+      tally = DraftConsumer.consume(tenant.id, @assessor)
+
+      assert reload(held).status == :draft
+      assert tally.unassessed == 1
+      assert tally.published == 0
+    end
+
+    test "a raising assessor is contained per item and the rest of the night still runs" do
+      tenant = fixture(:tenant)
+      boom = draft(tenant.id)
+      fine = draft(tenant.id)
+
+      Mox.stub(MockProposalAssessor, :assess, fn _t, attrs, _o ->
+        if attrs["title"] == boom.title, do: raise("provider exploded"), else: verdict(:novel)
+      end)
+
+      tally =
+        capture_log(fn -> send(self(), {:tally, DraftConsumer.consume(tenant.id, @assessor)}) end)
+
+      assert_received {:tally, tally_result}
+      assert tally =~ "could not be consumed"
+
+      assert tally_result.failed == 1
+      assert tally_result.published == 1
+      assert reload(boom).status == :draft
+      assert reload(fine).status == :published
+    end
+  end
+
+  describe "consume/2 — the bounds" do
+    test "the budget truncating is REPORTED, never silent" do
+      tenant = fixture(:tenant)
+      a = draft(tenant.id)
+      b = draft(tenant.id)
+      stub_verdict(verdict(:novel))
+
+      log =
+        capture_log(fn ->
+          tally = DraftConsumer.consume(tenant.id, Keyword.put(@assessor, :budget_ms, 0))
+          send(self(), {:tally, tally})
+        end)
+
+      assert_received {:tally, tally}
+      # A budget of exactly 0 — the state a night whose prelude overran arrives in — must buy
+      # NO provider call at all, because the deadline is checked at the HEAD of each item.
+      assert tally.published == 0
+      assert tally.offered == 2
+      assert tally.budget_exhausted
+      assert log =~ "budget after 0 of 2"
+      assert reload(a).status == :draft
+      assert reload(b).status == :draft
+    end
+
+    test "a night that drained everything it was offered is NOT reported truncated" do
+      tenant = fixture(:tenant)
+      _held = draft(tenant.id)
+      stub_verdict(verdict(:novel))
+
+      tally = DraftConsumer.consume(tenant.id, @assessor)
+
+      # A bound reported unconditionally says nothing at all.
+      refute tally.budget_exhausted
+      assert tally.published == 1
+    end
+
+    test "a cap of 0 PAUSES the drain without a deploy" do
+      tenant = fixture(:tenant)
+      held = draft(tenant.id)
+      stub_verdict(verdict(:novel))
+
+      tally = DraftConsumer.consume(tenant.id, Keyword.put(@assessor, :max_publishes, 0))
+
+      assert tally.gate == :drain_disabled
+      assert tally.offered == 0
+      assert reload(held).status == :draft
+    end
+
+    test "a NEGATIVE cap is a pause too, and a non-integer one falls back to the default" do
+      tenant = fixture(:tenant)
+      held = draft(tenant.id)
+      stub_verdict(verdict(:novel))
+
+      # A negative cap must not wrap round to "unbounded" — and it must not reach the query
+      # as a negative LIMIT either.
+      assert DraftConsumer.consume(tenant.id, Keyword.put(@assessor, :max_publishes, -1)).gate ==
+               :drain_disabled
+
+      assert reload(held).status == :draft
+
+      # A non-integer must fall back rather than raise inside the nightly's rescue, where it
+      # would surface as an outage instead of the config typo it is.
+      log =
+        capture_log(fn ->
+          assert DraftConsumer.consume(tenant.id, Keyword.put(@assessor, :max_publishes, "30")).published ==
+                   1
+        end)
+
+      assert log =~ "ignoring non-integer cap"
+      assert reload(held).status == :published
+    end
+
+    test "the OLDEST drafts are drained first, so a capped run cannot starve the backlog" do
+      tenant = fixture(:tenant)
+      # Inserted NEWEST-first on purpose: heap order then disagrees with `inserted_at`, so
+      # only the ORDER BY can produce this result. Created oldest-first, the assertion passes
+      # on scan order alone and says nothing.
+      recent = aged(draft(tenant.id), -1)
+      middle = aged(draft(tenant.id), -20)
+      old = aged(draft(tenant.id), -30)
+      stub_verdict(verdict(:novel))
+
+      DraftConsumer.consume(tenant.id, Keyword.put(@assessor, :max_publishes, 2))
+
+      assert reload(old).status == :published
+      assert reload(middle).status == :published
+      assert reload(recent).status == :draft
+    end
+  end
+
+  describe "consume/2 — the flip-flop guard" do
+    test "a draft consolidation retracted is never republished (durable marker)" do
+      tenant = fixture(:tenant)
+
+      held =
+        tenant.id
+        |> draft()
+        |> Ecto.Changeset.change(%{consolidation_retracted_at: DateTime.utc_now()})
+        |> AdminRepo.update!()
+
+      stub_verdict(verdict(:novel))
+
+      tally = DraftConsumer.consume(tenant.id, @assessor)
+
+      assert tally.offered == 0
+      assert reload(held).status == :draft
+    end
+
+    test "a draft consolidation retracted is never republished (audit_log record)" do
+      tenant = fixture(:tenant)
+      held = draft(tenant.id)
+
+      # The pre-marker shape: retracted before migration 20260818055453 stamped the column.
+      {:ok, _} =
+        Audit.create_log_entry(tenant.id, %{
+          entity_type: "article",
+          entity_id: held.id,
+          action: "article.unpublished",
+          actor_type: "system",
+          actor_id: nil,
+          actor_label: "worker:consolidation",
+          new_state: %{"status" => "draft"}
+        })
+
+      stub_verdict(verdict(:novel))
+
+      tally = DraftConsumer.consume(tenant.id, @assessor)
+
+      assert tally.offered == 0
+      assert reload(held).status == :draft
+    end
+  end
+
+  describe "consume/2 — scope discipline" do
+    test "a private/owner draft is never shipped to a provider" do
+      tenant = fixture(:tenant)
+      private = draft(tenant.id, %{metadata: %{"visibility" => "private"}})
+      owner = draft(tenant.id, %{metadata: %{"visibility" => "owner"}})
+      stub_verdict(verdict(:novel))
+
+      tally = DraftConsumer.consume(tenant.id, @assessor)
+
+      assert tally.offered == 0
+      assert reload(private).status == :draft
+      assert reload(owner).status == :draft
+    end
+
+    test "a draft that stops being eligible after the offer is SKIPPED, never published" do
+      tenant = fixture(:tenant)
+      first = aged(draft(tenant.id), -30)
+      second = aged(draft(tenant.id), -20)
+
+      # The live re-fetch guard, forced deterministically: consuming the FIRST draft archives
+      # the second, so by the time the reduce reaches it the row is no longer an eligible
+      # draft. Without the re-read this step would spend a provider call and then attempt a
+      # publish on a row that had moved.
+      # EXACTLY ONE call. That is the assertion the re-read earns: without it the second
+      # draft is still skipped (the publish transition refuses it), but only AFTER an
+      # embedding call has been paid for on a row that had already moved. `verify_on_exit!`
+      # fails the test on a second invocation.
+      Mox.expect(MockProposalAssessor, :assess, 1, fn _t, attrs, _o ->
+        if attrs["title"] == first.title do
+          second |> Ecto.Changeset.change(%{status: :archived}) |> AdminRepo.update!()
+        end
+
+        verdict(:novel)
+      end)
+
+      tally = DraftConsumer.consume(tenant.id, @assessor)
+
+      assert tally.offered == 2
+      assert tally.published == 1
+      assert tally.skipped == 1
+      # It is SKIPPED, not published and not failed: nothing is wrong and nothing is owed.
+      assert tally.failed == 0
+      assert reload(second).status == :archived
+    end
+  end
+
+  describe "consume/2 — tenant isolation" do
+    test "tenant A's run never touches tenant B's drafts" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      mine = draft(tenant_a.id)
+      theirs = draft(tenant_b.id)
+      stub_verdict(verdict(:novel))
+
+      tally = DraftConsumer.consume(tenant_a.id, @assessor)
+
+      assert tally.offered == 1
+      assert tally.published == 1
+      assert reload(mine).status == :published
+      assert reload(theirs).status == :draft
+    end
+  end
+
+  # `inserted_at` is not castable, so age it directly — the ordering guard is about which
+  # rows a capped run reaches, and every fixture row is otherwise inserted in the same second.
+  defp aged(article, days) do
+    article
+    |> Ecto.Changeset.change(%{
+      inserted_at: DateTime.add(DateTime.utc_now(), days * 86_400, :second)
+    })
+    |> AdminRepo.update!()
+  end
+end

--- a/test/loopctl/knowledge/draft_consumer_test.exs
+++ b/test/loopctl/knowledge/draft_consumer_test.exs
@@ -10,7 +10,9 @@ defmodule Loopctl.Knowledge.DraftConsumerTest do
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
   alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ArticleEmbedding
   alias Loopctl.Knowledge.ArticleLink
+  alias Loopctl.Knowledge.ConflictResolution
   alias Loopctl.Knowledge.DraftConsumer
   alias Loopctl.Knowledge.ProposalGate
   alias Loopctl.MockProposalAssessor
@@ -112,11 +114,16 @@ defmodule Loopctl.Knowledge.DraftConsumerTest do
       stub_verdict(verdict(:low_novelty, []))
 
       log =
-        capture_log(fn -> assert DraftConsumer.consume(tenant.id, @assessor).published == 1 end)
+        capture_log(fn ->
+          # COUNTED, never folded into a plain publish: an unannotated near-duplicate must not
+          # report the same numbers as a night of novel drafts.
+          tally = DraftConsumer.consume(tenant.id, @assessor)
+          assert tally.published == 1 and tally.link_failed == 1
+        end)
 
       assert reload(held).status == :published
       assert links_from(held.id) == []
-      assert log =~ "no usable neighbour"
+      assert log =~ "no scored neighbour was linkable"
     end
 
     test "nothing this step touches reaches a TERMINAL state" do
@@ -283,6 +290,23 @@ defmodule Loopctl.Knowledge.DraftConsumerTest do
       assert reload(middle).status == :draft
     end
 
+    test "the reserved NEWEST slice is offered BEFORE the backlog, not behind it" do
+      tenant = fixture(:tenant)
+      for d <- 1..4, do: aged(draft(tenant.id), -30 - d)
+      recent = aged(draft(tenant.id), -3)
+
+      Mox.stub(MockProposalAssessor, :assess, fn _tenant_id, attrs, _opts ->
+        send(self(), {:assessed, attrs["title"]})
+        verdict(:novel)
+      end)
+
+      # The wall clock truncates the TAIL, so a reserve appended behind the backlog is the
+      # first thing a slow unconsumable head discards — the stall it exists to prevent.
+      DraftConsumer.consume(tenant.id, Keyword.put(@assessor, :max_publishes, 5))
+      assert_received {:assessed, first}
+      assert first == recent.title
+    end
+
     test "a draft younger than the hold floor is never offered" do
       tenant = fixture(:tenant)
       # `draft: true` (and ingestion without `publish: true`) is an advertised staging opt-in.
@@ -329,6 +353,26 @@ defmodule Loopctl.Knowledge.DraftConsumerTest do
       assert reload(by_human).status == :draft
     end
 
+    test "a draft that was PUBLISHED once is never republished (durable embedding record)" do
+      tenant = fixture(:tenant)
+      # No marker and no audit row — what a `user+` PATCH to `:draft` leaves, and what every
+      # retraction decays to once its audit partition is dropped.
+      retracted = draft(tenant.id)
+
+      %ArticleEmbedding{}
+      |> Ecto.Changeset.change(%{
+        tenant_id: tenant.id,
+        article_id: retracted.id,
+        dim: 768,
+        embedding: List.duplicate(0.1, 768)
+      })
+      |> AdminRepo.insert!()
+
+      stub_verdict(verdict(:novel))
+      assert DraftConsumer.consume(tenant.id, @assessor).offered == 0
+      assert reload(retracted).status == :draft
+    end
+
     test "a conflict-MERGE draft is never auto-published" do
       tenant = fixture(:tenant)
 
@@ -341,6 +385,28 @@ defmodule Loopctl.Knowledge.DraftConsumerTest do
 
       stub_verdict(verdict(:novel))
 
+      assert DraftConsumer.consume(tenant.id, @assessor).offered == 0
+      assert reload(merged).status == :draft
+    end
+
+    test "a merge draft whose metadata a PATCH erased is still never auto-published" do
+      tenant = fixture(:tenant)
+      # An agent-role PATCH whole-map-replaces `metadata`; the executor's row is what holds.
+      merged = draft(tenant.id, %{metadata: %{}})
+
+      %ConflictResolution{tenant_id: tenant.id}
+      |> Ecto.Changeset.change(%{
+        source_article_id: published(tenant.id).id,
+        target_article_id: published(tenant.id).id,
+        classification: :redundant,
+        disposition: :merge,
+        annotated_at: DateTime.utc_now(),
+        executed_at: DateTime.utc_now(),
+        execution_result: %{"action" => "merged_draft", "draft_id" => merged.id}
+      })
+      |> AdminRepo.insert!()
+
+      stub_verdict(verdict(:novel))
       assert DraftConsumer.consume(tenant.id, @assessor).offered == 0
       assert reload(merged).status == :draft
     end
@@ -373,6 +439,17 @@ defmodule Loopctl.Knowledge.DraftConsumerTest do
       assert reload(held).status == :draft
     end
 
+    test "a keyless tenant with NOTHING held does not warn that drafts are held" do
+      tenant = fixture(:tenant)
+
+      log =
+        capture_log(fn ->
+          assert DraftConsumer.consume(tenant.id, proposal_assessor: ProposalGate).offered == 0
+        end)
+
+      refute log =~ "every draft stays held"
+    end
+
     # `ArticleLinkingWorker` scopes neighbours `project_or_global` and skips private/owner rows,
     # so the graph has never held either edge — and the promoter, which cannot tell one from an
     # auto-linker edge, would flag a pair that suppresses BOTH its articles from curated answers.
@@ -385,11 +462,28 @@ defmodule Loopctl.Knowledge.DraftConsumerTest do
       held = draft(tenant.id, %{project_id: fixture(:project, %{tenant_id: tenant.id}).id})
       stub_verdict(verdict(:duplicate, [neighbor(elsewhere, 0.99)]))
 
-      log = capture_log(fn -> DraftConsumer.consume(tenant.id, @assessor) end)
+      log =
+        capture_log(fn -> assert DraftConsumer.consume(tenant.id, @assessor).link_failed == 1 end)
 
       assert reload(held).status == :published
       assert links_from(held.id) == []
-      assert log =~ "no usable neighbour"
+      assert log =~ "no scored neighbour was linkable"
+    end
+
+    test "an in-scope neighbour at rank 2 is linked when the TOP one is out of scope" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      elsewhere =
+        published(tenant.id, %{project_id: fixture(:project, %{tenant_id: tenant.id}).id})
+
+      sibling = published(tenant.id, %{project_id: project.id})
+      held = draft(tenant.id, %{project_id: project.id})
+      stub_verdict(verdict(:duplicate, [neighbor(elsewhere, 0.99), neighbor(sibling, 0.97)]))
+
+      assert DraftConsumer.consume(tenant.id, @assessor).linked == 1
+      assert [link] = links_from(held.id)
+      assert link.target_article_id == sibling.id
     end
 
     test "a PRIVATE neighbour is published unannotated, never linked" do
@@ -417,9 +511,10 @@ defmodule Loopctl.Knowledge.DraftConsumerTest do
       # embedding call has been paid for on a row that had already moved. `verify_on_exit!`
       # fails the test on a second invocation.
       Mox.expect(MockProposalAssessor, :assess, 1, fn _t, attrs, _o ->
-        if attrs["title"] == first.title do
-          second |> Ecto.Changeset.change(%{status: :archived}) |> AdminRepo.update!()
-        end
+        # Whichever the interleaved candidate order reaches first archives the OTHER, so the
+        # remaining one has moved by the time the reduce gets to it.
+        other = if attrs["title"] == first.title, do: second, else: first
+        other |> Ecto.Changeset.change(%{status: :archived}) |> AdminRepo.update!()
 
         verdict(:novel)
       end)
@@ -431,7 +526,7 @@ defmodule Loopctl.Knowledge.DraftConsumerTest do
       assert tally.skipped == 1
       # It is SKIPPED, not published and not failed: nothing is wrong and nothing is owed.
       assert tally.failed == 0
-      assert reload(second).status == :archived
+      assert Enum.count([first, second], &(reload(&1).status == :archived)) == 1
     end
   end
 

--- a/test/loopctl/knowledge/draft_consumer_test.exs
+++ b/test/loopctl/knowledge/draft_consumer_test.exs
@@ -12,6 +12,7 @@ defmodule Loopctl.Knowledge.DraftConsumerTest do
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Knowledge.DraftConsumer
+  alias Loopctl.Knowledge.ProposalGate
   alias Loopctl.MockProposalAssessor
 
   # The assessor is injected PER CALL through the `:proposal_assessor` opt, never through
@@ -20,8 +21,9 @@ defmodule Loopctl.Knowledge.DraftConsumerTest do
   # same mock, so passing it explicitly exercises the opt seam rather than bypassing it.
   @assessor [proposal_assessor: MockProposalAssessor]
 
+  # Backdated past the 48h hold floor — a FRESH draft is held on purpose (own test below).
   defp draft(tenant_id, attrs \\ %{}) do
-    fixture(:article, Map.merge(%{tenant_id: tenant_id, status: :draft}, attrs))
+    fixture(:article, Map.merge(%{tenant_id: tenant_id, status: :draft}, attrs)) |> aged(-7)
   end
 
   defp published(tenant_id, attrs \\ %{}) do
@@ -262,25 +264,37 @@ defmodule Loopctl.Knowledge.DraftConsumerTest do
       assert reload(held).status == :published
     end
 
-    test "the OLDEST drafts are drained first, so a capped run cannot starve the backlog" do
+    test "the OLDEST drafts are drained first, with a slice reserved for the NEWEST" do
       tenant = fixture(:tenant)
       # Inserted NEWEST-first on purpose: heap order then disagrees with `inserted_at`, so
       # only the ORDER BY can produce this result. Created oldest-first, the assertion passes
       # on scan order alone and says nothing.
-      recent = aged(draft(tenant.id), -1)
+      recent = aged(draft(tenant.id), -3)
       middle = aged(draft(tenant.id), -20)
       old = aged(draft(tenant.id), -30)
       stub_verdict(verdict(:novel))
 
       DraftConsumer.consume(tenant.id, Keyword.put(@assessor, :max_publishes, 2))
 
+      # The backlog bias takes the oldest; the reserved slice takes the newest, which is what
+      # keeps the drain positive when a permanently unconsumable head owns every backlog slot.
       assert reload(old).status == :published
-      assert reload(middle).status == :published
-      assert reload(recent).status == :draft
+      assert reload(recent).status == :published
+      assert reload(middle).status == :draft
+    end
+
+    test "a draft younger than the hold floor is never offered" do
+      tenant = fixture(:tenant)
+      # `draft: true` (and ingestion without `publish: true`) is an advertised staging opt-in.
+      fresh = aged(draft(tenant.id), 0)
+      stub_verdict(verdict(:novel))
+
+      assert DraftConsumer.consume(tenant.id, @assessor).offered == 0
+      assert reload(fresh).status == :draft
     end
   end
 
-  describe "consume/2 — the flip-flop guard" do
+  describe "consume/2 — drafts that were held on purpose" do
     test "a draft consolidation retracted is never republished (durable marker)" do
       tenant = fixture(:tenant)
 
@@ -298,28 +312,37 @@ defmodule Loopctl.Knowledge.DraftConsumerTest do
       assert reload(held).status == :draft
     end
 
-    test "a draft consolidation retracted is never republished (audit_log record)" do
+    test "a draft ANY actor retracted is never republished (audit_log record)" do
       tenant = fixture(:tenant)
-      held = draft(tenant.id)
-
       # The pre-marker shape: retracted before migration 20260818055453 stamped the column.
-      {:ok, _} =
-        Audit.create_log_entry(tenant.id, %{
-          entity_type: "article",
-          entity_id: held.id,
-          action: "article.unpublished",
-          actor_type: "system",
-          actor_id: nil,
-          actor_label: "worker:consolidation",
-          new_state: %{"status" => "draft"}
+      # `unpublish_article/3` / `bulk_unpublish/3` leave the same row behind, so the guard is
+      # NOT narrowed to one actor label — republishing a `role: :user` retraction would revert
+      # a human-gated act unattended.
+      by_worker = draft(tenant.id)
+      by_human = draft(tenant.id)
+      unpublished_by(tenant.id, by_worker.id, "worker:consolidation")
+      unpublished_by(tenant.id, by_human.id, "human:operator")
+      stub_verdict(verdict(:novel))
+
+      assert DraftConsumer.consume(tenant.id, @assessor).offered == 0
+      assert reload(by_worker).status == :draft
+      assert reload(by_human).status == :draft
+    end
+
+    test "a conflict-MERGE draft is never auto-published" do
+      tenant = fixture(:tenant)
+
+      # The carve-out that lets an AGENT-role key record a merge verdict rests on the
+      # synthesised draft never being auto-published.
+      merged =
+        draft(tenant.id, %{
+          metadata: %{"merged_from" => [Ecto.UUID.generate(), Ecto.UUID.generate()]}
         })
 
       stub_verdict(verdict(:novel))
 
-      tally = DraftConsumer.consume(tenant.id, @assessor)
-
-      assert tally.offered == 0
-      assert reload(held).status == :draft
+      assert DraftConsumer.consume(tenant.id, @assessor).offered == 0
+      assert reload(merged).status == :draft
     end
   end
 
@@ -335,6 +358,49 @@ defmodule Loopctl.Knowledge.DraftConsumerTest do
       assert tally.offered == 0
       assert reload(private).status == :draft
       assert reload(owner).status == :draft
+    end
+
+    test "a keyless tenant is not offered its drafts at all" do
+      tenant = fixture(:tenant)
+      held = draft(tenant.id)
+
+      # Every assessment on a keyless tenant falls open on `{:error, :no_api_key}` AND appends
+      # an `llm.blocked_no_api_key` row to the hash-chained audit_log — for a known-zero run.
+      tally = DraftConsumer.consume(tenant.id, proposal_assessor: ProposalGate)
+
+      assert tally.gate == :no_embedding_key
+      assert tally.offered == 0
+      assert reload(held).status == :draft
+    end
+
+    # `ArticleLinkingWorker` scopes neighbours `project_or_global` and skips private/owner rows,
+    # so the graph has never held either edge — and the promoter, which cannot tell one from an
+    # auto-linker edge, would flag a pair that suppresses BOTH its articles from curated answers.
+    test "a neighbour in ANOTHER project is published unannotated, never linked" do
+      tenant = fixture(:tenant)
+
+      elsewhere =
+        published(tenant.id, %{project_id: fixture(:project, %{tenant_id: tenant.id}).id})
+
+      held = draft(tenant.id, %{project_id: fixture(:project, %{tenant_id: tenant.id}).id})
+      stub_verdict(verdict(:duplicate, [neighbor(elsewhere, 0.99)]))
+
+      log = capture_log(fn -> DraftConsumer.consume(tenant.id, @assessor) end)
+
+      assert reload(held).status == :published
+      assert links_from(held.id) == []
+      assert log =~ "no usable neighbour"
+    end
+
+    test "a PRIVATE neighbour is published unannotated, never linked" do
+      tenant = fixture(:tenant)
+      secret = published(tenant.id, %{metadata: %{"visibility" => "private"}})
+      held = draft(tenant.id)
+      stub_verdict(verdict(:duplicate, [neighbor(secret, 0.99)]))
+
+      capture_log(fn -> assert DraftConsumer.consume(tenant.id, @assessor).published == 1 end)
+
+      assert links_from(held.id) == []
     end
 
     test "a draft that stops being eligible after the offer is SKIPPED, never published" do
@@ -388,6 +454,19 @@ defmodule Loopctl.Knowledge.DraftConsumerTest do
 
   # `inserted_at` is not castable, so age it directly — the ordering guard is about which
   # rows a capped run reaches, and every fixture row is otherwise inserted in the same second.
+  defp unpublished_by(tenant_id, article_id, actor_label) do
+    {:ok, _} =
+      Audit.create_log_entry(tenant_id, %{
+        entity_type: "article",
+        entity_id: article_id,
+        action: "article.unpublished",
+        actor_type: "system",
+        actor_id: nil,
+        actor_label: actor_label,
+        new_state: %{"status" => "draft"}
+      })
+  end
+
   defp aged(article, days) do
     article
     |> Ecto.Changeset.change(%{

--- a/test/loopctl/workers/knowledge_lint_worker_test.exs
+++ b/test/loopctl/workers/knowledge_lint_worker_test.exs
@@ -91,7 +91,15 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
 
     test "consumes the DRAFT queue and reports the whole reading in the audit event" do
       tenant = fixture(:tenant)
-      held = fixture(:article, %{tenant_id: tenant.id, status: :draft})
+
+      # Backdated past the consumer's 48h hold floor: a draft this fresh is being STAGED on
+      # purpose (`draft: true` / ingestion without `publish: true`) and is held by design.
+      held =
+        fixture(:article, %{tenant_id: tenant.id, status: :draft})
+        |> Ecto.Changeset.change(%{
+          inserted_at: DateTime.add(DateTime.utc_now(), -7, :day)
+        })
+        |> AdminRepo.update!()
 
       assert :ok =
                KnowledgeLintWorker.perform(%Oban.Job{id: 0, args: %{"tenant_id" => tenant.id}})

--- a/test/loopctl/workers/knowledge_lint_worker_test.exs
+++ b/test/loopctl/workers/knowledge_lint_worker_test.exs
@@ -12,6 +12,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
   alias Loopctl.HeavyRead.TenantGate
   alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Knowledge.Consolidation
+  alias Loopctl.Knowledge.DraftConsumer
   alias Loopctl.MockArticleSimilaritySearch
   alias Loopctl.Workers.KnowledgeLintWorker
 
@@ -86,6 +87,27 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
       assert is_integer(entry.new_state["summary"]["total_issues"])
       assert is_integer(entry.new_state["orphans_relinked"])
       assert is_integer(entry.new_state["orphans_embedding_enqueued"])
+    end
+
+    test "consumes the DRAFT queue and reports the whole reading in the audit event" do
+      tenant = fixture(:tenant)
+      held = fixture(:article, %{tenant_id: tenant.id, status: :draft})
+
+      assert :ok =
+               KnowledgeLintWorker.perform(%Oban.Job{id: 0, args: %{"tenant_id" => tenant.id}})
+
+      assert AdminRepo.get!(Loopctl.Knowledge.Article, held.id).status == :published
+
+      assert [entry] = lint_audit_entries(tenant.id)
+      assert entry.new_state["drafts_published"] == 1
+      # OFFERED and the bound flag are recorded even on a night that drained everything: a
+      # truncated night and a night with nothing to consume must never be the same numbers.
+      assert entry.new_state["drafts_offered"] == 1
+      assert entry.new_state["drafts_budget_exhausted"] == false
+      # Read with `.gate`, never a defaulted Map.get — a crashed step must not record itself
+      # as a clean night.
+      assert entry.new_state["drafts_gate"] == "open"
+      assert entry.new_state["drafts_unassessed"] == 0
     end
 
     test "re-links orphan articles against the current corpus" do
@@ -851,14 +873,45 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
       # t=0 — stays true when the retitle budget is paid for out of thin air, which is
       # precisely how #761 shipped.
       assert KnowledgeLintWorker.judge_budget_ms() + KnowledgeLintWorker.retitle_budget_ms() +
-               KnowledgeLintWorker.prelude_reserve_ms() <= timeout,
-             "the judge's budget, this step's budget and the measured prelude must fit in the job"
+               KnowledgeLintWorker.draft_budget_ms() + KnowledgeLintWorker.prelude_reserve_ms() <=
+               timeout,
+             "every claim on the job's clock must fit inside the job"
 
       # And the context's own fallback — used when the step is called directly rather than
       # from here — can never exceed the reserve carved out for it. Nothing but this
       # assertion can notice those two drifting apart.
       assert KnowledgeLintWorker.retitle_budget_ms() >=
                Consolidation.default_retitle_budget_ms()
+    end
+
+    test "the draft consumer's clock comes out of the SAME reserve, and its fallback fits it" do
+      # The THIRD step whose per-item cost is an outbound provider call. Added to the reserve
+      # rather than taken out of the judge's budget at the call site, so the ONE clamp keeps
+      # doing the arithmetic: the judge's ceiling falls by exactly this much and `timeout/1`
+      # does not move. Raising `timeout/1` to pay for a new step is what #761 makes fatal.
+      assert KnowledgeLintWorker.draft_budget_ms() >= DraftConsumer.default_budget_ms(),
+             "the context's direct-call fallback must never exceed the reserve carved out for it"
+
+      # The assertion that catches THIS step's budget being added beside the reserve rather
+      # than inside it. Every weaker reading — the timeout, what this step is handed at t=0 —
+      # stays true when it is paid for out of thin air, which is exactly how #761 shipped.
+      assert KnowledgeLintWorker.judge_budget_ms() + KnowledgeLintWorker.retitle_budget_ms() +
+               KnowledgeLintWorker.draft_budget_ms() + KnowledgeLintWorker.prelude_reserve_ms() <=
+               KnowledgeLintWorker.timeout(%Oban.Job{args: %{}}),
+             "the draft reserve must come OUT of the job's clock, never be added beside it"
+
+      now = System.monotonic_time(:millisecond)
+      full = KnowledgeLintWorker.draft_budget_ms()
+
+      assert KnowledgeLintWorker.draft_budget_remaining(now) == full,
+             "a night whose prelude cost nothing gets the whole budget, never more"
+
+      spent = now - (KnowledgeLintWorker.timeout(%Oban.Job{args: %{}}) - :timer.minutes(1))
+
+      assert KnowledgeLintWorker.draft_budget_remaining(spent) < full,
+             "a prelude that overran must shrink this step, not start a fresh one"
+
+      assert KnowledgeLintWorker.draft_budget_remaining(now - :timer.hours(1)) == 0
     end
 
     test "the step is handed the time the job has LEFT, never a fresh budget" do


### PR DESCRIPTION
The last item of loopctl#765, and the blocker for mkreyman/claude-config#221.

## The leak

**113 articles sat in `status: :draft`, growing ~11/night, with zero automatic consumers.** Under the governing constraint (owner decision, KB `837daaa0`) that is not a safety gate — it is total loss. An agent never sees a draft, so a held article is indistinguishable from one that was never captured. Holding is the harm; publishing is recoverable.

## Two of the spec's premises did not survive measurement

**1. There is no `proposal_novelty` stamp to read.** #765 says to dispose of drafts using the near-neighbours "already stamped in `metadata.proposal_novelty`". **Zero of the 113 carry that key** — their metadata is empty. They are direct orchestrator deposits (`article.created`) that never went through `propose_article/3`'s novelty branch. A consumer written to the spec would read a nil and do nothing on all 113. This one **assesses**, through the existing `ProposalGate` rather than a second novelty implementation.

**2. Archive is not reversible.** #765 says a near-duplicate twin may be archived because "archive is soft-delete, therefore reversible, therefore allowed". `Article`'s `@valid_transitions` carries **no `{:archived, _}`** entry and there is no unarchive function — `:archived` is terminal, reachable back only by a `user`-role PATCH. That is why the consolidation pass retracts with `unpublish` and never `archive` (#608), and CLAUDE.md says so outright (#605/#606). An unattended writer may not take a one-way door.

## The disposition: publish-and-link

| verdict | action |
|---|---|
| `:novel` | publish |
| `:low_novelty` / `:duplicate` | **publish AND link** to the nearest published neighbour with a `relates_to` edge carrying the cosine score |
| `:unknown`, or a verdict outside the contract | **leave held, count it** |

The near-duplicate case hands redundancy to the existing `potential_conflict` promoter + judge — reversible end to end, and demonstrably working (226/226 pairs judged on 2026-08-27). Nothing is archived, no body is discarded, and `unpublish_article/3` is the exact inverse of the `publish_article/3` this takes, both writing audit events.

**A failed assessment publishes nothing.** A provider outage, a shed heavy read, or an off-contract verdict leaves the draft held. Defaulting an unrecognised verdict to `:novel` would be the same unassessed publish the `:unknown` branch already refuses — mutation-verified in both directions.

## Bounds — third time in this worker, same discipline

Only **1 of the 113 drafts had an embedding** (publishing enqueues one; being created as a draft does not), so the per-item cost is an embedding call plus a vector read. Therefore a **wall clock**, and the budget is carved **out of** the existing job timeout rather than added beside it:

- **`timeout/1` does not move** (Lifeline's 30-min `rescue_after` is the real ceiling)
- `@job_reserve_ms` becomes `@prelude_reserve_ms + @retitle_reserve_ms + @draft_reserve_ms`; the judge's ceiling falls 18 → 16 min, which is exactly what this step may spend
- the drain cap (25) sits **above the producer rate** (~11/night), so the 113 backlog clears inside a week rather than holding at its current level; it resolves from a `SystemConfig` row first, so `0` pauses the drain fleet-wide without a deploy
- the night reports what it was **offered** and whether the clock truncated it, in the log line and the audit event

## Verification

7,942 tests green via the pre-commit hook (credo --strict, dialyzer included). Guards mutation-verified independently of the implementer's report:

| mutation | test that goes red |
|---|---|
| `:unknown` publishes instead of holding | "a failed assessment leaves the draft alone and COUNTS it" |
| off-contract verdict defaults to `:novel` | "a verdict outside the behaviour's vocabulary is NOT treated as novel" |

No CHANGELOG entry: by that file's own rule (five categories, "ONLY") a behavioural change routes to `git log --first-parent`.