### PR TITLE
Corpus storage: a corpus that pins its own dimension, and chunks excluded from the article corpus by construction

### DIFF
--- a/lib/loopctl/corpus.ex
+++ b/lib/loopctl/corpus.ex
@@ -63,6 +63,10 @@ defmodule Loopctl.Corpus do
   A `project_id` is validated for tenant OWNERSHIP here, before the write — the
   schema's `foreign_key_constraint(:project_id)` is an existence check and never
   the tenant boundary.
+
+  A `slug` that already addresses ANOTHER corpus of this tenant as an id is
+  refused, because `get_corpus/2` resolves an id before a slug (see
+  `validate_slug_does_not_address_another_corpus/2`).
   """
   @spec create_corpus(Ecto.UUID.t(), map()) ::
           {:ok, Corpus.t()} | {:error, Ecto.Changeset.t()}
@@ -70,6 +74,7 @@ defmodule Loopctl.Corpus do
     %Corpus{tenant_id: tenant_id}
     |> Corpus.create_changeset(attrs)
     |> validate_project_ownership(tenant_id)
+    |> validate_slug_does_not_address_another_corpus(tenant_id)
     |> AdminRepo.insert()
   end
 
@@ -84,6 +89,14 @@ defmodule Loopctl.Corpus do
   unreachable by slug — including through `delete_corpus/2`, `upsert_chunks/3` and
   `delete_chunks_for_source/3`, which all resolve here. The second query is paid
   only when the id branch was attempted and missed.
+
+  The precedence is unambiguous because `create_corpus/2` refuses a slug that is
+  already another corpus's id in this tenant. Without that refusal the id branch
+  won silently: `get_corpus/2` returned the OTHER corpus, and `delete_corpus/2`
+  destroyed it — with its chunks and vectors, via the declared cascade — for a
+  caller that named a slug the unique index says belongs to exactly one corpus.
+  Reversing the precedence only mirrors the collision, so the refusal is at the
+  one point where the ambiguity can be prevented rather than resolved.
   """
   @spec get_corpus(Ecto.UUID.t(), String.t()) :: {:ok, Corpus.t()} | {:error, :not_found}
   def get_corpus(tenant_id, id_or_slug) when is_binary(tenant_id) and is_binary(id_or_slug) do
@@ -145,7 +158,8 @@ defmodule Loopctl.Corpus do
   affect the same row twice in one `ON CONFLICT DO UPDATE`, and silently keeping
   the last one would hide a client-side chunking bug. "Sharing" is judged as
   POSTGRES will judge it — `%{page: 1}`, `%{"page" => 1}` and `%{"page" => 1.0}`
-  are one jsonb key and one row — so the refusal covers every pair the index does.
+  are one jsonb key and one row, as are `%{"kind" => :page}` and
+  `%{"kind" => "page"}` — so the refusal covers every pair the index does.
   """
   @spec upsert_chunks(Ecto.UUID.t(), String.t(), [map()]) ::
           {:ok, [DocumentChunk.t()]}
@@ -225,6 +239,29 @@ defmodule Loopctl.Corpus do
     end
   end
 
+  # `get_corpus/2` resolves an id BEFORE a slug, and the slug format validator
+  # accepts a canonical lowercase UUID (the branch's own tests create one). A corpus
+  # whose slug is another corpus's id would therefore be addressable by nobody and
+  # would silently redirect every verb — `delete_corpus/2` included — at the OTHER
+  # row. Refuse it here, the one point where the ambiguity can be PREVENTED:
+  # reversing the resolver's precedence only mirrors the same collision onto a
+  # caller passing a real id. The extra query is paid only by a slug that parses as
+  # a UUID, which is the rare case.
+  defp validate_slug_does_not_address_another_corpus(changeset, tenant_id) do
+    with slug when is_binary(slug) <- Ecto.Changeset.get_field(changeset, :slug),
+         {:ok, _corpus} <- fetch_corpus_by_id(tenant_id, slug) do
+      Ecto.Changeset.add_error(
+        changeset,
+        :slug,
+        "is already the id of another corpus in this tenant — a corpus is resolved " <>
+          "by id before slug, so this one would be unreachable and every verb would " <>
+          "address the other row"
+      )
+    else
+      _ -> changeset
+    end
+  end
+
   defp fetch_corpus_by_id(tenant_id, id_or_slug) do
     case Ecto.UUID.cast(id_or_slug) do
       {:ok, id} ->
@@ -248,8 +285,18 @@ defmodule Loopctl.Corpus do
 
   defp maybe_filter_project(query, nil), do: query
 
-  defp maybe_filter_project(query, project_id),
-    do: where(query, [c], c.project_id == ^project_id)
+  # `project_id` is caller-supplied and lands on a `:binary_id` column, where a
+  # non-UUID value raises `Ecto.Query.CastError` — a 500 out of a function whose
+  # @spec promises a list. `Projects.get_project/2` carries the same guard for the
+  # same reason (`create_corpus/2` inherits it through `validate_project_ownership/2`);
+  # here the clean shape is an empty result, since no corpus can be scoped to a
+  # project id no project can have.
+  defp maybe_filter_project(query, project_id) do
+    case Ecto.UUID.cast(project_id) do
+      {:ok, id} -> where(query, [c], c.project_id == ^id)
+      :error -> where(query, [c], false)
+    end
+  end
 
   defp clamp_limit(limit) when is_integer(limit) and limit > 0,
     do: min(limit, @max_list_limit)
@@ -304,10 +351,14 @@ defmodule Loopctl.Corpus do
   # are distinct maps but equal as jsonb reach one row twice and Postgres raises
   # `cardinality_violation` ("ON CONFLICT DO UPDATE command cannot affect row a
   # second time") — an unmatched raise where the @spec promises
-  # `{:error, {:duplicate_chunk_key, key}}`. Two classes get past a term
-  # comparison: atom vs string keys (`stringify_keys/1` normalises the TOP-LEVEL
-  # attrs only, and it must — the STORED locator is never normalised), and jsonb's
-  # numeric equality, where `1` and `1.0` are the same key but different terms.
+  # `{:error, {:duplicate_chunk_key, key}}`. Three classes get past a term
+  # comparison: atom vs string KEYS (`stringify_keys/1` normalises the TOP-LEVEL
+  # attrs only, and it must — the STORED locator is never normalised); atom or
+  # struct VALUES, which the jsonb encoder renders as strings; and jsonb's numeric
+  # equality, where `1` and `1.0` are the same key but different terms. A FOURTH —
+  # an object whose keys collide once stringified, where jsonb keeps only the last
+  # — is refused upstream by `DocumentChunk.changeset/2`, because there the stored
+  # value would not be the value sent and no comparison form can fix that.
   # The canonical form is used for the COMPARISON only; the reported key and the
   # stored value stay verbatim.
   defp refute_duplicate_keys(rows) do
@@ -345,7 +396,20 @@ defmodule Loopctl.Corpus do
     if value == trunc(value), do: trunc(value), else: value
   end
 
-  defp canonical_locator(value), do: value
+  defp canonical_locator(value)
+       when is_binary(value) or is_integer(value) or is_boolean(value) or is_nil(value),
+       do: value
+
+  # A bare atom and a struct are not JSON types, and the jsonb encoder renders both
+  # as STRINGS: `%{"kind" => :page}` and `%{"kind" => "page"}` are ONE jsonb value
+  # and ONE row, as are `~D[2026-01-01]` and "2026-01-01". A term comparison sees
+  # two, and Postgres then raises `cardinality_violation` out of the very
+  # `ON CONFLICT DO UPDATE` this guard exists to keep it out of. Encoding and
+  # decoding yields the value jsonb will hold; the STORED value is untouched.
+  # `Loopctl.Corpus.Locator` has already refused anything that cannot be encoded,
+  # so `Jason.encode!/1` here cannot raise.
+  defp canonical_locator(value),
+    do: value |> Jason.encode!() |> Jason.decode!() |> canonical_locator()
 
   defp stringify_keys(attrs) when is_map(attrs) do
     Map.new(attrs, fn

--- a/lib/loopctl/corpus.ex
+++ b/lib/loopctl/corpus.ex
@@ -48,6 +48,7 @@ defmodule Loopctl.Corpus do
   alias Loopctl.AdminRepo
   alias Loopctl.Corpus.Corpus
   alias Loopctl.Corpus.DocumentChunk
+  alias Loopctl.Projects
 
   @default_list_limit 50
   @max_list_limit 200
@@ -58,30 +59,37 @@ defmodule Loopctl.Corpus do
   `tenant_id` is set on the struct, never cast. `dim` must be a published
   supported dimension (AC-43.1.4) and, together with `embedding_model` and `mode`,
   is pinned here and immutable thereafter.
+
+  A `project_id` is validated for tenant OWNERSHIP here, before the write — the
+  schema's `foreign_key_constraint(:project_id)` is an existence check and never
+  the tenant boundary.
   """
   @spec create_corpus(Ecto.UUID.t(), map()) ::
           {:ok, Corpus.t()} | {:error, Ecto.Changeset.t()}
   def create_corpus(tenant_id, attrs) when is_binary(tenant_id) do
     %Corpus{tenant_id: tenant_id}
     |> Corpus.create_changeset(attrs)
+    |> validate_project_ownership(tenant_id)
     |> AdminRepo.insert()
   end
 
   @doc """
-  Fetches one corpus of `tenant_id` by id, or — when `id_or_slug` is not a UUID —
-  by its `(tenant_id, slug)` unique key.
+  Fetches one corpus of `tenant_id` by id, falling back to its `(tenant_id, slug)`
+  unique key when the id lookup misses.
+
+  The fallback is what makes the contract true for every slug the create changeset
+  accepts: `Ecto.UUID.cast/1` parses a canonical lowercase UUID (all of whose
+  characters the slug format validator allows) AND any 16-BYTE string as a raw
+  UUID, so an id-only resolver made such a corpus creatable and then permanently
+  unreachable by slug — including through `delete_corpus/2`, `upsert_chunks/3` and
+  `delete_chunks_for_source/3`, which all resolve here. The second query is paid
+  only when the id branch was attempted and missed.
   """
   @spec get_corpus(Ecto.UUID.t(), String.t()) :: {:ok, Corpus.t()} | {:error, :not_found}
   def get_corpus(tenant_id, id_or_slug) when is_binary(tenant_id) and is_binary(id_or_slug) do
-    query =
-      case Ecto.UUID.cast(id_or_slug) do
-        {:ok, id} -> from(c in Corpus, where: c.tenant_id == ^tenant_id and c.id == ^id)
-        :error -> from(c in Corpus, where: c.tenant_id == ^tenant_id and c.slug == ^id_or_slug)
-      end
-
-    case AdminRepo.one(query) do
-      nil -> {:error, :not_found}
-      corpus -> {:ok, corpus}
+    with :error <- fetch_corpus_by_id(tenant_id, id_or_slug),
+         :error <- fetch_corpus_by_slug(tenant_id, id_or_slug) do
+      {:error, :not_found}
     end
   end
 
@@ -89,18 +97,21 @@ defmodule Loopctl.Corpus do
   Lists `tenant_id`'s corpora, newest first.
 
   Options: `:project_id` (restrict to one project scope), `:limit` (clamped to
-  #{@max_list_limit}), `:offset`.
+  #{@max_list_limit}), `:offset` (floored at 0 — Postgres refuses a negative
+  OFFSET, and this function sanitises BOTH pagination opts or neither).
   """
   @spec list_corpora(Ecto.UUID.t(), keyword()) :: [Corpus.t()]
   def list_corpora(tenant_id, opts \\ []) when is_binary(tenant_id) do
     limit = opts |> Keyword.get(:limit, @default_list_limit) |> clamp_limit()
+
+    offset = opts |> Keyword.get(:offset, 0) |> clamp_offset()
 
     Corpus
     |> where([c], c.tenant_id == ^tenant_id)
     |> maybe_filter_project(Keyword.get(opts, :project_id))
     |> order_by([c], desc: c.inserted_at, desc: c.id)
     |> limit(^limit)
-    |> offset(^Keyword.get(opts, :offset, 0))
+    |> offset(^offset)
     |> AdminRepo.all()
   end
 
@@ -132,7 +143,9 @@ defmodule Loopctl.Corpus do
   index behind. Two chunks sharing one `(source_ref, locator)` within a single
   batch are refused (`{:error, {:duplicate_chunk_key, key}}`): Postgres cannot
   affect the same row twice in one `ON CONFLICT DO UPDATE`, and silently keeping
-  the last one would hide a client-side chunking bug.
+  the last one would hide a client-side chunking bug. "Sharing" is judged as
+  POSTGRES will judge it — `%{page: 1}`, `%{"page" => 1}` and `%{"page" => 1.0}`
+  are one jsonb key and one row — so the refusal covers every pair the index does.
   """
   @spec upsert_chunks(Ecto.UUID.t(), String.t(), [map()]) ::
           {:ok, [DocumentChunk.t()]}
@@ -181,6 +194,58 @@ defmodule Loopctl.Corpus do
 
   # --- internals ---
 
+  # `project_id` IS cast from caller input, and the insert runs on the BYPASSRLS
+  # `AdminRepo`, so the schema's `foreign_key_constraint(:project_id)` is evaluated
+  # against `projects` in EVERY tenant: it is an EXISTENCE check, never the tenant
+  # boundary. Validating ownership here makes a foreign project and a nonexistent
+  # one take the SAME error path, so the FK cannot serve as a cross-tenant
+  # existence oracle, and no cross-tenant edge is persisted — which would also let
+  # the OTHER tenant deleting its project mutate this row through the DDL's
+  # `ON DELETE SET NULL`. `nil` (tenant-wide) is always allowed. Mirrors
+  # `Loopctl.Knowledge.validate_project_ownership/2` and
+  # `Loopctl.Memory.validate_project_scope/1`; `Projects.get_project/2` carries the
+  # UUID guard, so a malformed value is a changeset error, never a CastError 500.
+  defp validate_project_ownership(changeset, tenant_id) do
+    case Ecto.Changeset.get_field(changeset, :project_id) do
+      nil ->
+        changeset
+
+      project_id ->
+        case Projects.get_project(tenant_id, project_id) do
+          {:ok, _project} ->
+            changeset
+
+          {:error, :not_found} ->
+            Ecto.Changeset.add_error(
+              changeset,
+              :project_id,
+              "is invalid or does not belong to this tenant"
+            )
+        end
+    end
+  end
+
+  defp fetch_corpus_by_id(tenant_id, id_or_slug) do
+    case Ecto.UUID.cast(id_or_slug) do
+      {:ok, id} ->
+        fetch_corpus(from(c in Corpus, where: c.tenant_id == ^tenant_id and c.id == ^id))
+
+      :error ->
+        :error
+    end
+  end
+
+  defp fetch_corpus_by_slug(tenant_id, slug) do
+    fetch_corpus(from(c in Corpus, where: c.tenant_id == ^tenant_id and c.slug == ^slug))
+  end
+
+  defp fetch_corpus(query) do
+    case AdminRepo.one(query) do
+      nil -> :error
+      corpus -> {:ok, corpus}
+    end
+  end
+
   defp maybe_filter_project(query, nil), do: query
 
   defp maybe_filter_project(query, project_id),
@@ -190,6 +255,9 @@ defmodule Loopctl.Corpus do
     do: min(limit, @max_list_limit)
 
   defp clamp_limit(_), do: @default_list_limit
+
+  defp clamp_offset(offset) when is_integer(offset) and offset > 0, do: offset
+  defp clamp_offset(_), do: 0
 
   # Validated through the changeset (so `locator`'s default and the required fields
   # are enforced once, in one place), then flattened to `insert_all` rows: one
@@ -231,14 +299,53 @@ defmodule Loopctl.Corpus do
     |> Map.to_list()
   end
 
+  # Compared on the form POSTGRES will compare, not on the Elixir term: the
+  # uniqueness this guards is a btree over a jsonb `locator`, so two locators that
+  # are distinct maps but equal as jsonb reach one row twice and Postgres raises
+  # `cardinality_violation` ("ON CONFLICT DO UPDATE command cannot affect row a
+  # second time") — an unmatched raise where the @spec promises
+  # `{:error, {:duplicate_chunk_key, key}}`. Two classes get past a term
+  # comparison: atom vs string keys (`stringify_keys/1` normalises the TOP-LEVEL
+  # attrs only, and it must — the STORED locator is never normalised), and jsonb's
+  # numeric equality, where `1` and `1.0` are the same key but different terms.
+  # The canonical form is used for the COMPARISON only; the reported key and the
+  # stored value stay verbatim.
   defp refute_duplicate_keys(rows) do
-    keys = Enum.map(rows, &{Keyword.fetch!(&1, :source_ref), Keyword.fetch!(&1, :locator)})
+    rows
+    |> Enum.reduce_while(MapSet.new(), fn row, seen ->
+      source_ref = Keyword.fetch!(row, :source_ref)
+      locator = Keyword.fetch!(row, :locator)
+      key = {source_ref, canonical_locator(locator)}
 
-    case keys -- Enum.uniq(keys) do
-      [] -> :ok
-      [duplicate | _] -> {:error, {:duplicate_chunk_key, duplicate}}
+      if MapSet.member?(seen, key) do
+        {:halt, {:error, {:duplicate_chunk_key, {source_ref, locator}}}}
+      else
+        {:cont, MapSet.put(seen, key)}
+      end
+    end)
+    |> case do
+      {:error, _} = error -> error
+      _seen -> :ok
     end
   end
+
+  # jsonb sorts object keys, renders every key as a string, and compares numbers
+  # numerically (`1 = 1.0`). A sorted list of stringified-key pairs with integral
+  # floats folded to integers reproduces that equality without touching the value
+  # that gets stored.
+  defp canonical_locator(value) when is_map(value) and not is_struct(value) do
+    value
+    |> Enum.map(fn {key, inner} -> {to_string(key), canonical_locator(inner)} end)
+    |> Enum.sort()
+  end
+
+  defp canonical_locator(value) when is_list(value), do: Enum.map(value, &canonical_locator/1)
+
+  defp canonical_locator(value) when is_float(value) do
+    if value == trunc(value), do: trunc(value), else: value
+  end
+
+  defp canonical_locator(value), do: value
 
   defp stringify_keys(attrs) when is_map(attrs) do
     Map.new(attrs, fn

--- a/lib/loopctl/corpus.ex
+++ b/lib/loopctl/corpus.ex
@@ -1,0 +1,249 @@
+defmodule Loopctl.Corpus do
+  @moduledoc """
+  Context for the CORPUS TIER (Epic 43) — the index loopctl hosts for reference
+  documents whose physical files stay in the client's own repo.
+
+  It sits BESIDE the Knowledge Wiki with a different contract: verbatim chunks
+  rather than distilled articles, a pointer plus a snippet rather than a body, and
+  truth that lives in the file on the agent's disk rather than in loopctl. Because
+  the chunks live in their OWN tables, they are excluded from `/api/v1/recall`,
+  `knowledge_heat_index`, novelty scoring and the consolidation pass BY
+  CONSTRUCTION — every one of those paths queries `Loopctl.Knowledge.Article`.
+  There is no exclusion flag to set and nothing a later change can forget;
+  `test/loopctl/corpus_isolation_guard_test.exs` asserts the property.
+
+  ## The corpus pins its own dimension
+
+  `dim` and `embedding_model` belong to the CORPUS, not the tenant, and are
+  immutable after creation. The per-tenant resolvers in `Loopctl.Embeddings` are
+  NOT consulted here and must never be: one of them returns the tenant's ARTICLE
+  dimension (1536 for a 768 corpus), and the write-resolving one PINS
+  `tenants.tenant_embedding_dimension` as a side effect, so a single corpus write
+  by a tenant that had not yet embedded an article would pin that tenant's article
+  corpus to the local document model. The dimension a chunk vector is written at is
+  read from the corpus row and from nowhere else, and
+  `test/loopctl/corpus_isolation_guard_test.exs` asserts that too.
+
+  ## Repos and isolation
+
+  Every public function takes `tenant_id` as its FIRST argument and `tenant_id` is
+  never cast — it is set programmatically on the struct.
+
+  OLTP writes and reads go through `Loopctl.AdminRepo` with an EXPLICIT `tenant_id`
+  predicate on every query, mirroring `Loopctl.Memory` and `Loopctl.Knowledge`.
+  `AdminRepo` connects with a BYPASSRLS role, so the RLS policies on the three
+  tables do NOT engage on any path in this context: the explicit predicate is the
+  only isolation here, not a second layer behind RLS. The policies exist for a
+  hypothetical `Loopctl.Repo` caller and are what the isolation test exercises.
+
+  Vector and analytical reads arrive in US-43.2 and go through `Loopctl.HeavyRead`
+  (never `HeavyReadRepo` directly). Its structural guard requires a conjunctive
+  `x.tenant_id == ^tenant_id` on the `from` source AND on every joined source — a
+  `document_chunks` join to `document_chunk_embeddings` satisfies that because both
+  tables carry `tenant_id`.
+  """
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Corpus.Corpus
+  alias Loopctl.Corpus.DocumentChunk
+
+  @default_list_limit 50
+  @max_list_limit 200
+
+  @doc """
+  Creates a corpus for `tenant_id`.
+
+  `tenant_id` is set on the struct, never cast. `dim` must be a published
+  supported dimension (AC-43.1.4) and, together with `embedding_model` and `mode`,
+  is pinned here and immutable thereafter.
+  """
+  @spec create_corpus(Ecto.UUID.t(), map()) ::
+          {:ok, Corpus.t()} | {:error, Ecto.Changeset.t()}
+  def create_corpus(tenant_id, attrs) when is_binary(tenant_id) do
+    %Corpus{tenant_id: tenant_id}
+    |> Corpus.create_changeset(attrs)
+    |> AdminRepo.insert()
+  end
+
+  @doc """
+  Fetches one corpus of `tenant_id` by id, or — when `id_or_slug` is not a UUID —
+  by its `(tenant_id, slug)` unique key.
+  """
+  @spec get_corpus(Ecto.UUID.t(), String.t()) :: {:ok, Corpus.t()} | {:error, :not_found}
+  def get_corpus(tenant_id, id_or_slug) when is_binary(tenant_id) and is_binary(id_or_slug) do
+    query =
+      case Ecto.UUID.cast(id_or_slug) do
+        {:ok, id} -> from(c in Corpus, where: c.tenant_id == ^tenant_id and c.id == ^id)
+        :error -> from(c in Corpus, where: c.tenant_id == ^tenant_id and c.slug == ^id_or_slug)
+      end
+
+    case AdminRepo.one(query) do
+      nil -> {:error, :not_found}
+      corpus -> {:ok, corpus}
+    end
+  end
+
+  @doc """
+  Lists `tenant_id`'s corpora, newest first.
+
+  Options: `:project_id` (restrict to one project scope), `:limit` (clamped to
+  #{@max_list_limit}), `:offset`.
+  """
+  @spec list_corpora(Ecto.UUID.t(), keyword()) :: [Corpus.t()]
+  def list_corpora(tenant_id, opts \\ []) when is_binary(tenant_id) do
+    limit = opts |> Keyword.get(:limit, @default_list_limit) |> clamp_limit()
+
+    Corpus
+    |> where([c], c.tenant_id == ^tenant_id)
+    |> maybe_filter_project(Keyword.get(opts, :project_id))
+    |> order_by([c], desc: c.inserted_at, desc: c.id)
+    |> limit(^limit)
+    |> offset(^Keyword.get(opts, :offset, 0))
+    |> AdminRepo.all()
+  end
+
+  @doc """
+  Deletes a corpus of `tenant_id`.
+
+  The chunks and their vectors go with it via `ON DELETE CASCADE` declared in the
+  DDL (AC-43.1.9) — this function issues ONE statement and no application-level
+  child cleanup, so no path can leave orphans behind.
+  """
+  @spec delete_corpus(Ecto.UUID.t(), String.t()) ::
+          {:ok, Corpus.t()} | {:error, :not_found | Ecto.Changeset.t()}
+  def delete_corpus(tenant_id, id_or_slug) when is_binary(tenant_id) do
+    with {:ok, corpus} <- get_corpus(tenant_id, id_or_slug) do
+      AdminRepo.delete(corpus)
+    end
+  end
+
+  @doc """
+  Inserts or replaces `chunks` in `corpus_id`, keyed on
+  `(corpus_id, source_ref, locator)`.
+
+  That key — WITHOUT `content_hash` — is what makes re-indexing idempotent: a chunk
+  whose text moved REPLACES the row at its locator instead of adding a second one.
+  `locator` is stored verbatim and never normalised.
+
+  Each chunk is validated through `DocumentChunk.changeset/2` before anything is
+  written, so a malformed chunk fails the whole batch rather than leaving a partial
+  index behind. Two chunks sharing one `(source_ref, locator)` within a single
+  batch are refused (`{:error, {:duplicate_chunk_key, key}}`): Postgres cannot
+  affect the same row twice in one `ON CONFLICT DO UPDATE`, and silently keeping
+  the last one would hide a client-side chunking bug.
+  """
+  @spec upsert_chunks(Ecto.UUID.t(), String.t(), [map()]) ::
+          {:ok, [DocumentChunk.t()]}
+          | {:error, :not_found | {:invalid_chunk, non_neg_integer(), Ecto.Changeset.t()}}
+          | {:error, {:duplicate_chunk_key, {String.t(), map()}}}
+  def upsert_chunks(tenant_id, corpus_id, chunks)
+      when is_binary(tenant_id) and is_list(chunks) do
+    with {:ok, corpus} <- get_corpus(tenant_id, corpus_id),
+         {:ok, rows} <- build_chunk_rows(tenant_id, corpus, chunks),
+         :ok <- refute_duplicate_keys(rows) do
+      {_count, inserted} =
+        AdminRepo.insert_all(DocumentChunk, rows,
+          on_conflict: {:replace, [:text, :snippet, :content_hash, :ordinal, :updated_at]},
+          conflict_target: [:corpus_id, :source_ref, :locator],
+          returning: true
+        )
+
+      {:ok, inserted}
+    end
+  end
+
+  @doc """
+  Deletes every chunk of `source_ref` in `corpus_id`, returning how many rows went.
+
+  The chunk vectors follow via `ON DELETE CASCADE`. Scoped to ONE `source_ref` of
+  ONE corpus of ONE tenant: this is the narrow verb US-43.2's re-index prune needs,
+  not a set-based delete.
+  """
+  @spec delete_chunks_for_source(Ecto.UUID.t(), String.t(), String.t()) ::
+          {:ok, non_neg_integer()} | {:error, :not_found}
+  def delete_chunks_for_source(tenant_id, corpus_id, source_ref)
+      when is_binary(tenant_id) and is_binary(source_ref) do
+    with {:ok, corpus} <- get_corpus(tenant_id, corpus_id) do
+      {count, _} =
+        DocumentChunk
+        |> where(
+          [c],
+          c.tenant_id == ^tenant_id and c.corpus_id == ^corpus.id and
+            c.source_ref == ^source_ref
+        )
+        |> AdminRepo.delete_all()
+
+      {:ok, count}
+    end
+  end
+
+  # --- internals ---
+
+  defp maybe_filter_project(query, nil), do: query
+
+  defp maybe_filter_project(query, project_id),
+    do: where(query, [c], c.project_id == ^project_id)
+
+  defp clamp_limit(limit) when is_integer(limit) and limit > 0,
+    do: min(limit, @max_list_limit)
+
+  defp clamp_limit(_), do: @default_list_limit
+
+  # Validated through the changeset (so `locator`'s default and the required fields
+  # are enforced once, in one place), then flattened to `insert_all` rows: one
+  # statement per batch rather than one transaction per chunk.
+  defp build_chunk_rows(tenant_id, %Corpus{} = corpus, chunks) do
+    now = DateTime.utc_now()
+
+    chunks
+    |> Enum.with_index()
+    |> Enum.reduce_while({:ok, []}, fn {attrs, index}, {:ok, acc} ->
+      changeset =
+        DocumentChunk.changeset(
+          %DocumentChunk{tenant_id: tenant_id},
+          Map.put(stringify_keys(attrs), "corpus_id", corpus.id)
+        )
+
+      if changeset.valid? do
+        {:cont, {:ok, [chunk_row(changeset, tenant_id, now) | acc]}}
+      else
+        {:halt, {:error, {:invalid_chunk, index, changeset}}}
+      end
+    end)
+    |> case do
+      {:ok, rows} -> {:ok, Enum.reverse(rows)}
+      error -> error
+    end
+  end
+
+  defp chunk_row(changeset, tenant_id, now) do
+    changeset
+    |> Ecto.Changeset.apply_changes()
+    |> Map.take([:corpus_id, :source_ref, :locator, :text, :snippet, :content_hash, :ordinal])
+    |> Map.merge(%{
+      id: Ecto.UUID.generate(),
+      tenant_id: tenant_id,
+      inserted_at: now,
+      updated_at: now
+    })
+    |> Map.to_list()
+  end
+
+  defp refute_duplicate_keys(rows) do
+    keys = Enum.map(rows, &{Keyword.fetch!(&1, :source_ref), Keyword.fetch!(&1, :locator)})
+
+    case keys -- Enum.uniq(keys) do
+      [] -> :ok
+      [duplicate | _] -> {:error, {:duplicate_chunk_key, duplicate}}
+    end
+  end
+
+  defp stringify_keys(attrs) when is_map(attrs) do
+    Map.new(attrs, fn
+      {key, value} when is_atom(key) -> {Atom.to_string(key), value}
+      {key, value} -> {key, value}
+    end)
+  end
+end

--- a/lib/loopctl/corpus/corpus.ex
+++ b/lib/loopctl/corpus/corpus.ex
@@ -115,14 +115,21 @@ defmodule Loopctl.Corpus.Corpus do
   them is an ERROR on that field rather than a silent drop (AC-43.1.13 / TC-43.1.3).
   A silent drop would let a caller believe it had re-dimensioned a corpus whose
   vectors are all still at the old dimension.
+
+  `project_id` is not cast either, and that is a TENANT-BOUNDARY decision rather
+  than an immutability one: `foreign_key_constraint(:project_id)` is an existence
+  check evaluated against every tenant's projects on the BYPASSRLS `AdminRepo`, so
+  the ownership check has to live in the context, where `tenant_id` is (see
+  `Loopctl.Corpus.create_corpus/2`). Leaving the field castable here with only the
+  FK behind it would pre-open a cross-tenant edge for whatever adds the first
+  update path. A future re-scope adds the cast AND that check together.
   """
   @spec update_changeset(t(), map()) :: Ecto.Changeset.t()
   def update_changeset(%__MODULE__{} = corpus, attrs) do
     corpus
-    |> cast(attrs, [:name, :description, :allow_snippets, :project_id])
+    |> cast(attrs, [:name, :description, :allow_snippets])
     |> validate_required([:name, :allow_snippets])
     |> reject_immutable_changes(attrs)
-    |> foreign_key_constraint(:project_id)
   end
 
   defp validate_supported_dimension(changeset) do

--- a/lib/loopctl/corpus/corpus.ex
+++ b/lib/loopctl/corpus/corpus.ex
@@ -103,7 +103,15 @@ defmodule Loopctl.Corpus.Corpus do
     |> validate_required([:allow_snippets])
     |> foreign_key_constraint(:tenant_id)
     |> foreign_key_constraint(:project_id)
-    |> unique_constraint([:tenant_id, :slug], name: :corpora_tenant_id_slug_index)
+    |> unique_constraint([:tenant_id, :slug],
+      name: :corpora_tenant_id_slug_index,
+      message: "has already been taken for this tenant",
+      # Without it the violation lands on `:tenant_id` — the first field of the index, and one
+      # the client never sends and cannot control — so a slug collision would reach the caller
+      # of US-43.2's `POST /corpora` as a 422 naming a field it has no way to change.
+      # `Loopctl.Knowledge.Article` and `Loopctl.Projects.Project` set it for the same reason.
+      error_key: :slug
+    )
     |> check_constraint(:dim, name: :corpora_dim_positive, message: "must be greater than 0")
     |> check_constraint(:mode, name: :corpora_mode_valid, message: "is invalid")
   end

--- a/lib/loopctl/corpus/corpus.ex
+++ b/lib/loopctl/corpus/corpus.ex
@@ -1,0 +1,197 @@
+defmodule Loopctl.Corpus.Corpus do
+  @moduledoc """
+  US-43.1 — a reference-document CORPUS: the index loopctl hosts for files that
+  stay in the client's own repo.
+
+  ## The corpus pins its own dimension
+
+  `dim` and `embedding_model` are properties of THIS corpus, pinned at creation and
+  immutable thereafter (`AC-43.1.13`). They are never resolved from the tenant: a
+  tenant whose ARTICLE corpus is pinned at 1536 must be able to index a document
+  corpus with a local 768-dimension model at the same time, and the per-tenant
+  resolvers in `Loopctl.Embeddings` would either return the wrong number or — worse
+  — WRITE the tenant pin as a side effect of a corpus write. The corpus's `dim` is
+  read from this row and from nowhere else.
+
+  Re-dimensioning is delete-and-re-index by design. There is no distilled state to
+  preserve: the source files are the truth.
+
+  ## `mode`
+
+    * `:server_embedded` — the client sends chunk text and loopctl embeds it. Both
+      retrieval lanes work.
+    * `:client_embedded` — the client embeds locally and sends vectors; the chunk's
+      `text` is NULL and the server cannot read the content.
+
+  ## `allow_snippets`
+
+  Derived from `mode` when the caller does not state it: TRUE for
+  `:server_embedded` (loopctl holds the text already), FALSE for
+  `:client_embedded` (US-43.3's privacy-preserving default — a snippet IS text the
+  server sees). The column carries NO DDL default precisely so this
+  mode-conditional decision lives in one place that a caller cannot bypass by
+  omission. It is stored here in this story and ENFORCED in US-43.3.
+  """
+
+  use Loopctl.Schema
+
+  import Ecto.Changeset
+
+  alias Loopctl.Embeddings
+  alias Loopctl.Projects.Project
+
+  @type t :: %__MODULE__{}
+
+  @modes [:server_embedded, :client_embedded]
+
+  # Set once, at creation. Rejected — not silently dropped — on update, so a caller
+  # that believes it re-dimensioned a corpus learns otherwise (AC-43.1.13).
+  @immutable [:dim, :embedding_model, :mode]
+
+  schema "corpora" do
+    tenant_field()
+
+    field :slug, :string
+    field :name, :string
+    field :description, :string
+    field :mode, Ecto.Enum, values: @modes
+    field :embedding_model, :string
+    field :dim, :integer
+    field :allow_snippets, :boolean
+
+    belongs_to :project, Project
+
+    timestamps()
+  end
+
+  @doc "The valid corpus modes."
+  @spec modes() :: [atom()]
+  def modes, do: @modes
+
+  @doc "The fields pinned at creation and refused on update."
+  @spec immutable_fields() :: [atom()]
+  def immutable_fields, do: @immutable
+
+  @doc """
+  Creation changeset. `tenant_id` is NEVER cast — `Loopctl.Corpus.create_corpus/2`
+  sets it on the struct.
+
+  `dim` must be a member of `Loopctl.Embeddings.supported_dimensions/0`
+  (AC-43.1.4): a dimension outside that published set has no pre-built HNSW index,
+  and index DDL is migration-plane only.
+  """
+  @spec create_changeset(t(), map()) :: Ecto.Changeset.t()
+  def create_changeset(%__MODULE__{} = corpus, attrs) do
+    corpus
+    |> cast(attrs, [
+      :project_id,
+      :slug,
+      :name,
+      :description,
+      :mode,
+      :embedding_model,
+      :dim,
+      :allow_snippets
+    ])
+    |> validate_required([:slug, :name, :mode, :embedding_model, :dim])
+    |> validate_length(:slug, min: 1, max: 100)
+    |> validate_format(:slug, ~r/\A[a-z0-9][a-z0-9\-_]*\z/,
+      message: "must be lowercase alphanumeric with hyphens or underscores"
+    )
+    |> validate_supported_dimension()
+    |> put_allow_snippets_from_mode()
+    |> validate_required([:allow_snippets])
+    |> foreign_key_constraint(:tenant_id)
+    |> foreign_key_constraint(:project_id)
+    |> unique_constraint([:tenant_id, :slug], name: :corpora_tenant_id_slug_index)
+    |> check_constraint(:dim, name: :corpora_dim_positive, message: "must be greater than 0")
+    |> check_constraint(:mode, name: :corpora_mode_valid, message: "is invalid")
+  end
+
+  @doc """
+  Update changeset for the MUTABLE fields only.
+
+  `dim`, `embedding_model` and `mode` are not cast, and an attempt to change any of
+  them is an ERROR on that field rather than a silent drop (AC-43.1.13 / TC-43.1.3).
+  A silent drop would let a caller believe it had re-dimensioned a corpus whose
+  vectors are all still at the old dimension.
+  """
+  @spec update_changeset(t(), map()) :: Ecto.Changeset.t()
+  def update_changeset(%__MODULE__{} = corpus, attrs) do
+    corpus
+    |> cast(attrs, [:name, :description, :allow_snippets, :project_id])
+    |> validate_required([:name, :allow_snippets])
+    |> reject_immutable_changes(attrs)
+    |> foreign_key_constraint(:project_id)
+  end
+
+  defp validate_supported_dimension(changeset) do
+    supported = Embeddings.supported_dimensions()
+
+    validate_change(changeset, :dim, fn :dim, dim ->
+      if dim in supported do
+        []
+      else
+        [
+          dim:
+            "must be one of the dimensions this instance publishes " <>
+              "(#{inspect(supported)}) — a dimension outside that set has no pre-built " <>
+              "HNSW index, and index DDL is migration-plane only, so supporting a new " <>
+              "one requires a migration (the same reason .well-known/loopctl publishes " <>
+              "the set)"
+        ]
+      end
+    end)
+  end
+
+  # The mode-conditional default the DDL cannot express. An explicit value from the
+  # caller wins; omission resolves from `mode`.
+  defp put_allow_snippets_from_mode(changeset) do
+    case {get_change(changeset, :allow_snippets), get_field(changeset, :allow_snippets)} do
+      {nil, nil} -> put_change(changeset, :allow_snippets, default_allow_snippets(changeset))
+      _ -> changeset
+    end
+  end
+
+  defp default_allow_snippets(changeset) do
+    get_field(changeset, :mode) == :server_embedded
+  end
+
+  defp reject_immutable_changes(changeset, attrs) do
+    Enum.reduce(@immutable, changeset, fn field, acc ->
+      reject_if_changed(acc, field, fetch_attr(attrs, field))
+    end)
+  end
+
+  defp reject_if_changed(changeset, _field, :error), do: changeset
+
+  defp reject_if_changed(changeset, field, {:ok, value}) do
+    if same_value?(Map.fetch!(changeset.data, field), value) do
+      changeset
+    else
+      add_error(
+        changeset,
+        field,
+        "is pinned at creation and cannot be changed — re-dimensioning a corpus is " <>
+          "delete-and-re-index by design"
+      )
+    end
+  end
+
+  defp fetch_attr(attrs, field) when is_map(attrs) do
+    case Map.fetch(attrs, field) do
+      {:ok, value} -> {:ok, value}
+      :error -> Map.fetch(attrs, Atom.to_string(field))
+    end
+  end
+
+  defp fetch_attr(_attrs, _field), do: :error
+
+  # Compared as strings so `:server_embedded`/`"server_embedded"` and `768`/`"768"`
+  # are the same value: a no-op restatement of a pinned field is not a change.
+  defp same_value?(current, given), do: stringify(current) == stringify(given)
+
+  defp stringify(nil), do: nil
+  defp stringify(value) when is_binary(value), do: value
+  defp stringify(value), do: to_string(value)
+end

--- a/lib/loopctl/corpus/document_chunk.ex
+++ b/lib/loopctl/corpus/document_chunk.ex
@@ -9,7 +9,9 @@ defmodule Loopctl.Corpus.DocumentChunk do
   ## `locator` belongs to the CLIENT
 
   It is jsonb and its internal shape is the client's: a PDF page, a byte range, a
-  heading path, an EDI loop and segment. loopctl stores and returns it VERBATIM and
+  heading path, an EDI loop and segment — an object, an ARRAY or a scalar, which is
+  why the field is `Loopctl.Corpus.Locator` and not `:map` (that type admits only
+  objects, in both directions). loopctl stores and returns it VERBATIM and
   must never validate or normalise it — a normalisation that reordered keys would
   change the idempotency key and silently duplicate every chunk on the next index
   run. jsonb's own key-order normalisation is the one that is safe, because
@@ -33,6 +35,7 @@ defmodule Loopctl.Corpus.DocumentChunk do
   import Ecto.Changeset
 
   alias Loopctl.Corpus.Corpus
+  alias Loopctl.Corpus.Locator
 
   @type t :: %__MODULE__{}
 
@@ -40,7 +43,7 @@ defmodule Loopctl.Corpus.DocumentChunk do
     tenant_field()
 
     field :source_ref, :string
-    field :locator, :map, default: %{}
+    field :locator, Locator, default: %{}
     field :text, :string
     field :snippet, :string
     field :content_hash, :string
@@ -58,7 +61,8 @@ defmodule Loopctl.Corpus.DocumentChunk do
   `locator` is cast as-is and is NOT validated or normalised (see the moduledoc); it
   defaults to `%{}` rather than NULL because a NULL locator is DISTINCT from every
   other NULL in a btree unique index and would silently defeat the idempotency the
-  index exists to provide.
+  index exists to provide. The one locator refused is one loopctl cannot store
+  verbatim — see `validate_storable_locator/1`.
   """
   @spec changeset(t(), map()) :: Ecto.Changeset.t()
   def changeset(chunk, attrs) do
@@ -66,6 +70,7 @@ defmodule Loopctl.Corpus.DocumentChunk do
     |> cast(attrs, [:corpus_id, :source_ref, :locator, :text, :snippet, :content_hash, :ordinal])
     |> validate_required([:corpus_id, :source_ref, :content_hash])
     |> put_default_locator()
+    |> validate_storable_locator()
     |> foreign_key_constraint(:tenant_id)
     |> foreign_key_constraint(:corpus_id)
     |> unique_constraint([:corpus_id, :source_ref, :locator],
@@ -79,4 +84,35 @@ defmodule Loopctl.Corpus.DocumentChunk do
       _ -> changeset
     end
   end
+
+  # jsonb keeps the LAST of two duplicate object keys (`'{"a":1,"a":2}'::jsonb` is
+  # `{"a": 2}`), so `%{:page => 1, "page" => 2}` would be STORED as something other
+  # than what the client sent — breaking the verbatim contract this schema is built
+  # on — and `Loopctl.Corpus`'s in-batch duplicate-key guard, which compares Elixir
+  # terms, would not see the collision Postgres does. Refusing it is not the shape
+  # validation the moduledoc forbids: the shape stays the client's; what is refused
+  # is a value with no faithful stored form, and guessing which half Postgres keeps
+  # would be the normalisation.
+  defp validate_storable_locator(changeset) do
+    if colliding_keys?(get_field(changeset, :locator)) do
+      add_error(
+        changeset,
+        :locator,
+        "has an object whose keys collide once rendered as jsonb strings — jsonb " <>
+          "would keep only one of them, so the locator cannot be stored verbatim"
+      )
+    else
+      changeset
+    end
+  end
+
+  defp colliding_keys?(value) when is_map(value) and not is_struct(value) do
+    keys = Map.keys(value)
+
+    length(Enum.uniq(Enum.map(keys, &to_string/1))) != length(keys) or
+      Enum.any?(Map.values(value), &colliding_keys?/1)
+  end
+
+  defp colliding_keys?(value) when is_list(value), do: Enum.any?(value, &colliding_keys?/1)
+  defp colliding_keys?(_value), do: false
 end

--- a/lib/loopctl/corpus/document_chunk.ex
+++ b/lib/loopctl/corpus/document_chunk.ex
@@ -74,7 +74,12 @@ defmodule Loopctl.Corpus.DocumentChunk do
     |> foreign_key_constraint(:tenant_id)
     |> foreign_key_constraint(:corpus_id)
     |> unique_constraint([:corpus_id, :source_ref, :locator],
-      name: :document_chunks_corpus_source_locator_index
+      name: :document_chunks_corpus_source_locator_index,
+      message: "has already been taken for this locator in this corpus",
+      # `:corpus_id` is the first field of the index, but `upsert_chunks/3` OVERRIDES it with the
+      # tenant-resolved corpus's id, so it is not a field the caller can act on. Attribute the
+      # collision to the identity the caller does supply. Same reason as `Loopctl.Corpus.Corpus`.
+      error_key: :source_ref
     )
   end
 

--- a/lib/loopctl/corpus/document_chunk.ex
+++ b/lib/loopctl/corpus/document_chunk.ex
@@ -1,0 +1,82 @@
+defmodule Loopctl.Corpus.DocumentChunk do
+  @moduledoc """
+  US-43.1 — a VERBATIM chunk of a document that lives in the client's own repo.
+
+  loopctl stores the pointer (`source_ref` + `locator`), the content hash, and —
+  in `:server_embedded` mode — the text itself. It never chunks, fetches or parses
+  a document: the client does that and sends the result.
+
+  ## `locator` belongs to the CLIENT
+
+  It is jsonb and its internal shape is the client's: a PDF page, a byte range, a
+  heading path, an EDI loop and segment. loopctl stores and returns it VERBATIM and
+  must never validate or normalise it — a normalisation that reordered keys would
+  change the idempotency key and silently duplicate every chunk on the next index
+  run. jsonb's own key-order normalisation is the one that is safe, because
+  Postgres does it consistently.
+
+  `(corpus_id, source_ref, locator)` is unique; that is what makes re-indexing
+  idempotent. `content_hash` is deliberately NOT part of the key — it is compared
+  against the incoming chunk to decide unchanged-vs-replaced. In the key, a chunk
+  whose text moved would insert a SECOND row at the same locator instead of
+  replacing the first.
+
+  ## `text` may be NULL
+
+  That is the `:client_embedded` state: the client embedded locally and the server
+  holds a vector it cannot read. `snippet` is the optional, client-chosen exposure;
+  the corpus's `allow_snippets` governs it and is enforced in US-43.3.
+  """
+
+  use Loopctl.Schema
+
+  import Ecto.Changeset
+
+  alias Loopctl.Corpus.Corpus
+
+  @type t :: %__MODULE__{}
+
+  schema "document_chunks" do
+    tenant_field()
+
+    field :source_ref, :string
+    field :locator, :map, default: %{}
+    field :text, :string
+    field :snippet, :string
+    field :content_hash, :string
+    field :ordinal, :integer
+
+    belongs_to :corpus, Corpus
+
+    timestamps()
+  end
+
+  @doc """
+  Changeset for a chunk. `tenant_id` is NEVER cast — `Loopctl.Corpus.upsert_chunks/3`
+  sets it on the struct.
+
+  `locator` is cast as-is and is NOT validated or normalised (see the moduledoc); it
+  defaults to `%{}` rather than NULL because a NULL locator is DISTINCT from every
+  other NULL in a btree unique index and would silently defeat the idempotency the
+  index exists to provide.
+  """
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
+  def changeset(chunk, attrs) do
+    chunk
+    |> cast(attrs, [:corpus_id, :source_ref, :locator, :text, :snippet, :content_hash, :ordinal])
+    |> validate_required([:corpus_id, :source_ref, :content_hash])
+    |> put_default_locator()
+    |> foreign_key_constraint(:tenant_id)
+    |> foreign_key_constraint(:corpus_id)
+    |> unique_constraint([:corpus_id, :source_ref, :locator],
+      name: :document_chunks_corpus_source_locator_index
+    )
+  end
+
+  defp put_default_locator(changeset) do
+    case get_field(changeset, :locator) do
+      nil -> put_change(changeset, :locator, %{})
+      _ -> changeset
+    end
+  end
+end

--- a/lib/loopctl/corpus/document_chunk_embedding.ex
+++ b/lib/loopctl/corpus/document_chunk_embedding.ex
@@ -1,0 +1,79 @@
+defmodule Loopctl.Corpus.DocumentChunkEmbedding do
+  @moduledoc """
+  US-43.1 — a DIMENSION-TAGGED vector for a `Loopctl.Corpus.DocumentChunk`.
+
+  Mirrors `Loopctl.Knowledge.ArticleEmbedding` in shape and constraint set on
+  purpose: an UNCONSTRAINED `vector` column paired with an explicit `dim`
+  discriminator, a `vector_dims(embedding) = dim` CHECK the database enforces even
+  against a write that bypasses this changeset, and the column names `tenant_id`,
+  `dim`, `embedding` and `live_denorm` — which are what let the
+  schema-parameterized query builder
+  `Loopctl.Knowledge.VectorSearch.index_safe_dimension_knn_base/6` be reused
+  unchanged by US-43.2's search.
+
+  ## `live_denorm` is load-bearing AND deliberately inert
+
+  It carries NO trigger here and is never written false: a document chunk has no
+  supersession state, so the PL/pgSQL trigger pair `article_embeddings` needs has
+  nothing to mirror. The COLUMN is still required —
+  `Loopctl.Repo.HnswIndex.create_dimension_index_sql/2` emits
+  `WHERE dim = N AND live_denorm`, and the query builder adds the matching
+  predicate — so removing it as dead code would fork both the shared index SQL and
+  the shared query builder.
+
+  ## `expected_dimension` comes from the CORPUS ROW
+
+  It is passed IN, like `ArticleEmbedding`'s, so this validator stays PURE. Unlike
+  `ArticleEmbedding`'s, its source is the corpus's own pinned `dim` — never a
+  per-tenant resolver, which would return the tenant's ARTICLE dimension for a
+  document corpus and, on the write-resolving variant, pin the tenant's article
+  corpus to the local document model as a side effect.
+  """
+
+  use Loopctl.Schema
+
+  import Ecto.Changeset
+
+  alias Loopctl.Corpus.DocumentChunk
+  alias Loopctl.Embeddings.Dimensions
+
+  @type t :: %__MODULE__{}
+
+  schema "document_chunk_embeddings" do
+    tenant_field()
+
+    field :dim, :integer
+    field :embedding, Pgvector.Ecto.Vector
+    field :live_denorm, :boolean, default: true
+    field :embedding_content_hash, :string
+
+    belongs_to :document_chunk, DocumentChunk
+
+    timestamps()
+  end
+
+  @doc """
+  Changeset for a chunk embedding row.
+
+  `tenant_id` is NEVER cast — the caller sets it on the struct. `dim` is FORCED to
+  `expected_dimension` (the corpus's pinned dimension) so a caller cannot store a
+  vector under a dimension tag its corpus does not use.
+  """
+  @spec changeset(t(), map(), pos_integer()) :: Ecto.Changeset.t()
+  def changeset(row, attrs, expected_dimension) when is_integer(expected_dimension) do
+    row
+    |> cast(attrs, [:document_chunk_id, :embedding, :embedding_content_hash])
+    |> put_change(:dim, expected_dimension)
+    |> validate_required([:document_chunk_id, :dim, :embedding])
+    |> Dimensions.validate_vector_length(:embedding, expected_dimension)
+    |> foreign_key_constraint(:tenant_id)
+    |> foreign_key_constraint(:document_chunk_id)
+    |> unique_constraint([:tenant_id, :document_chunk_id, :dim],
+      name: :document_chunk_embeddings_tenant_chunk_dim_index
+    )
+    |> check_constraint(:embedding,
+      name: :document_chunk_embeddings_dim_matches_vector,
+      message: "vector length must equal dim"
+    )
+  end
+end

--- a/lib/loopctl/corpus/document_chunk_embedding.ex
+++ b/lib/loopctl/corpus/document_chunk_embedding.ex
@@ -69,7 +69,11 @@ defmodule Loopctl.Corpus.DocumentChunkEmbedding do
     |> foreign_key_constraint(:tenant_id)
     |> foreign_key_constraint(:document_chunk_id)
     |> unique_constraint([:tenant_id, :document_chunk_id, :dim],
-      name: :document_chunk_embeddings_tenant_chunk_dim_index
+      name: :document_chunk_embeddings_tenant_chunk_dim_index,
+      message: "already has an embedding at this dimension",
+      # Without it the violation lands on `:tenant_id`, which is never cast, and `:dim` is forced
+      # from the corpus above — neither is caller-controlled. Same reason as `Loopctl.Corpus.Corpus`.
+      error_key: :document_chunk_id
     )
     |> check_constraint(:embedding,
       name: :document_chunk_embeddings_dim_matches_vector,

--- a/lib/loopctl/corpus/locator.ex
+++ b/lib/loopctl/corpus/locator.ex
@@ -1,0 +1,55 @@
+defmodule Loopctl.Corpus.Locator do
+  @moduledoc """
+  Custom `Ecto.Type` for `document_chunks.locator`: ANY jsonb value the client
+  chooses — an object (`%{"page" => 3}`), an ARRAY (a heading path), or a scalar
+  (a bare page number).
+
+  ## Why not `field :locator, :map`
+
+  `:map` narrows the column to a JSON OBJECT in both directions:
+  `Ecto.Type.cast(:map, ["Chapter 1"])` is `:error`, so a client whose chunker
+  emits array locators could not index at all (`Loopctl.Corpus.build_chunk_rows/3`
+  halts the whole batch on the first invalid changeset), and
+  `Ecto.Type.load(:map, ["Chapter 1"])` is `:error` too, so a row that got in by
+  any other path would make the whole chunk row unloadable rather than merely
+  unwritable. The column is plain `jsonb NOT NULL DEFAULT '{}'`, which admits all
+  three shapes, and AC-43.1.2 gives the shape to the client ("loopctl only stores
+  and returns it").
+
+  `type/0` is `:map` because that is how a value reaches the SCALAR `jsonb`
+  column — a `{:array, :map}` field would map to a Postgres `jsonb[]` column
+  instead. `Loopctl.Coordination.RefsList` stores a list in a scalar `jsonb`
+  column the same way.
+
+  ## Nothing is normalised
+
+  The value is stored and returned VERBATIM: the locator participates in the
+  `(corpus_id, source_ref, locator)` idempotency key, so a normalisation that
+  reordered keys would silently duplicate every chunk on the next index run.
+  `cast/1` therefore checks ONE thing and changes nothing — that the term can be
+  encoded as JSON. A term the jsonb encoder cannot render (a tuple, a struct with
+  no `Jason.Encoder`) would otherwise raise out of the insert instead of failing
+  as a changeset error.
+  """
+
+  use Ecto.Type
+
+  @impl true
+  def type, do: :map
+
+  @impl true
+  def cast(nil), do: {:ok, nil}
+
+  def cast(value) do
+    case Jason.encode(value) do
+      {:ok, _json} -> {:ok, value}
+      {:error, _reason} -> :error
+    end
+  end
+
+  @impl true
+  def load(value), do: {:ok, value}
+
+  @impl true
+  def dump(value), do: {:ok, value}
+end

--- a/lib/loopctl/repo/hnsw_index.ex
+++ b/lib/loopctl/repo/hnsw_index.ex
@@ -264,13 +264,15 @@ defmodule Loopctl.Repo.HnswIndex do
   def drop_dimension_index_sql(table, dim),
     do: "DROP INDEX CONCURRENTLY IF EXISTS #{dimension_index_name(table, dim)};"
 
-  # The two embedding side tables that carry a per-dimension HNSW index per supported
-  # dimension.
-  @side_tables ["article_embeddings", "memory_embeddings"]
+  # The embedding side tables that carry a per-dimension HNSW index per supported
+  # dimension. `document_chunk_embeddings` (US-43.1, the corpus tier) is here for the
+  # same reason as the other two: the drift guard below must cover every table whose
+  # reads depend on a pre-built per-dimension index.
+  @side_tables ["article_embeddings", "memory_embeddings", "document_chunk_embeddings"]
 
   @doc """
   Every per-dimension HNSW index the CURRENT published supported-dimension set
-  requires across both embedding side tables, as `{table, dim, index_name}` triples.
+  requires across the embedding side tables, as `{table, dim, index_name}` triples.
 
   The dimension set is read from `:supported_embedding_dimensions` config — the SAME
   set `.well-known` advertises and `Loopctl.Embeddings.supported_dimensions/0`
@@ -294,7 +296,7 @@ defmodule Loopctl.Repo.HnswIndex do
   cast/where clauses generate fine) yet makes every read at that dimension emit an
   unindexable `(embedding::vector(N))` cast that sequential-scans the whole corpus —
   the #170/#172 planner-incident class. An EMPTY list means every published dimension
-  is indexed on BOTH side tables; a non-empty list is a deploy that advertised a
+  is indexed on EVERY side table; a non-empty list is a deploy that advertised a
   dimension whose migration has not run. Asserted by a fast (non-scale) drift test so
   it fails on the PR that introduces the config/index mismatch, not in production.
   """

--- a/priv/repo/migrations/20260827150000_create_corpus_tables.exs
+++ b/priv/repo/migrations/20260827150000_create_corpus_tables.exs
@@ -1,0 +1,205 @@
+defmodule Loopctl.Repo.Migrations.CreateCorpusTables do
+  use Ecto.Migration
+
+  import Loopctl.Repo.RlsHelpers
+
+  @moduledoc """
+  US-43.1 AC-43.1.1 / AC-43.1.2 / AC-43.1.3 / AC-43.1.6 / AC-43.1.9 / AC-43.1.12.
+
+  The corpus tier's three tables: `corpora`, `document_chunks` and
+  `document_chunk_embeddings`. Modelled on
+  `20260721000100_create_embedding_side_tables.exs`, which is the reference for an
+  UNCONSTRAINED `vector` column paired with an explicit `dim` discriminator and a
+  `vector_dims(embedding) = dim` CHECK.
+
+  ## Why a separate table rather than an article subtype
+
+  `/api/v1/recall`, `knowledge_heat_index`, novelty scoring and the consolidation
+  pass all query `Loopctl.Knowledge.Article`. Verbatim document chunks living in
+  their OWN tables are excluded from every one of those paths BY CONSTRUCTION — no
+  exclusion flag, no policy a later change can forget to apply. A guard test
+  (`test/loopctl/corpus_isolation_guard_test.exs`) asserts the property rather than
+  assuming it.
+
+  ## Dimension is a property of the CORPUS, not the tenant
+
+  `corpora.dim` and `corpora.embedding_model` are pinned at creation and immutable
+  thereafter. A tenant whose ARTICLE corpus is pinned at 1536 must be able to index
+  a document corpus with a local 768-dimension model at the same time, so the
+  per-tenant resolvers in `Loopctl.Embeddings` are not consulted on this path. The
+  `dim` a chunk embedding is written at is read from the corpus row and nowhere
+  else.
+
+  ## `mode` is a text column with a CHECK, not a Postgres enum
+
+  Matching this repo's existing practice: no migration here creates a `CREATE TYPE`
+  enum; every other enumerated column (`articles.status`, `projects.kind`,
+  `memories.source`) is a text column read through `Ecto.Enum`. A CHECK keeps the
+  DB-side guarantee without the ALTER TYPE ceremony a new mode would otherwise
+  need.
+
+  ## `allow_snippets` carries NO DDL default, deliberately
+
+  It is TRUE for a `server_embedded` corpus (loopctl already holds the text) and
+  FALSE for a `client_embedded` one (US-43.3 AC-43.3.6's privacy-preserving
+  default). A mode-conditional default is expressible in the changeset and not in
+  DDL, so the changeset supplies it — a DDL default would silently break mode B's
+  privacy default the moment a caller omitted the field.
+
+  ## `document_chunks` uniqueness — `(corpus_id, source_ref, locator)`
+
+  This is what makes re-indexing idempotent (US-43.2). `content_hash` is
+  deliberately NOT in the key: it is an ordinary column compared against the
+  incoming chunk to decide unchanged-vs-replaced. In the key, a chunk whose text
+  moved would insert a SECOND row at the same locator instead of replacing the
+  first.
+
+  `locator` is jsonb and its INTERNAL shape belongs to the client (a PDF page, a
+  byte range, an EDI loop/segment). loopctl stores and returns it verbatim and
+  never normalises it — a normalisation that reordered keys would change the
+  idempotency key and silently duplicate every chunk on the next index run. jsonb's
+  own key-order normalisation is the one that is safe, because Postgres does it
+  consistently, which is why the unique index is on the jsonb column directly. It
+  is NOT NULL with a `'{}'` default because a NULL locator is DISTINCT from every
+  other NULL in a btree unique index, which would silently defeat the idempotency
+  the index exists to provide.
+
+  Note the btree limit: an index entry caps at ~2704 bytes and an oversized insert
+  RAISES. Every anticipated locator (a page number, a byte range, a heading path)
+  is far under that. If a client ever needs a large locator the fix is a generated
+  `locator_hash` column in the index, not a wider entry.
+
+  ## `document_chunk_embeddings.live_denorm` is load-bearing AND deliberately inert
+
+  The column carries NO trigger and is never written false: a document chunk has no
+  supersession state, so the PL/pgSQL trigger pair `article_embeddings` needs has
+  nothing to mirror here. The COLUMN is still required —
+  `Loopctl.Repo.HnswIndex.create_dimension_index_sql/2` emits
+  `WHERE dim = N AND live_denorm`, and the query builder's
+  `maybe_live_denorm_only/2` adds the matching predicate — so removing it as dead
+  code would fork both the shared index SQL and the shared query builder. Do not
+  delete it.
+
+  ## Cascade is declared here, not in application code (AC-43.1.9)
+
+  `corpora -> document_chunks -> document_chunk_embeddings` cascade on delete, so
+  one `DELETE` on the corpus row leaves no orphans regardless of which path issued
+  it. `corpora.project_id` is ON DELETE SET NULL instead: deleting a project must
+  not silently destroy an entire corpus — that is `corpus_delete`'s job and it is
+  the `:user`-gated verb.
+
+  ## RLS is ENABLE, not FORCE
+
+  In production the table owner is `schema_admin` WITHOUT BYPASSRLS, so ENABLE
+  alone enforces isolation for non-owner roles while allowing the owner to write.
+  `RlsHelpers.enable_rls/1`'s own docstring claims it runs FORCE; the code does not
+  — trust the code.
+
+  ## Autovacuum (AC-43.1.12)
+
+  The two chunk tables get the same tuning the existing embedding tables carry
+  (migration `20260804230000`). It matters MORE here: a corpus re-index rewrites
+  whole documents at once, so dead tuples arrive in bursts, and pgvector's HNSW
+  scan SKIPS dead index entries — making a live row UNREACHABLE rather than merely
+  slow. An untuned table therefore degrades recall silently rather than visibly.
+  """
+
+  # `analyze` halved from the 0.1 default; `vacuum_insert` at 0.1 so an append-heavy
+  # table is still vacuumed for the visibility map. Identical to 20260804230000.
+  @autovacuum_opts "autovacuum_analyze_scale_factor = 0.05, autovacuum_vacuum_insert_scale_factor = 0.1"
+
+  @append_heavy ~w(document_chunks document_chunk_embeddings)
+
+  def up do
+    execute("""
+    CREATE TABLE IF NOT EXISTS corpora (
+      id uuid PRIMARY KEY,
+      tenant_id uuid NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+      project_id uuid REFERENCES projects(id) ON DELETE SET NULL,
+      slug text NOT NULL,
+      name text NOT NULL,
+      description text,
+      mode text NOT NULL,
+      embedding_model text NOT NULL,
+      dim integer NOT NULL,
+      allow_snippets boolean NOT NULL,
+      inserted_at timestamp(6) without time zone NOT NULL,
+      updated_at timestamp(6) without time zone NOT NULL,
+      CONSTRAINT corpora_dim_positive CHECK (dim > 0),
+      CONSTRAINT corpora_mode_valid
+        CHECK (mode IN ('server_embedded', 'client_embedded'))
+    )
+    """)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS document_chunks (
+      id uuid PRIMARY KEY,
+      tenant_id uuid NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+      corpus_id uuid NOT NULL REFERENCES corpora(id) ON DELETE CASCADE,
+      source_ref text NOT NULL,
+      locator jsonb NOT NULL DEFAULT '{}'::jsonb,
+      text text,
+      snippet text,
+      content_hash text NOT NULL,
+      ordinal integer,
+      inserted_at timestamp(6) without time zone NOT NULL,
+      updated_at timestamp(6) without time zone NOT NULL
+    )
+    """)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS document_chunk_embeddings (
+      id uuid PRIMARY KEY,
+      tenant_id uuid NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+      document_chunk_id uuid NOT NULL REFERENCES document_chunks(id) ON DELETE CASCADE,
+      dim integer NOT NULL,
+      embedding vector NOT NULL,
+      live_denorm boolean NOT NULL DEFAULT true,
+      embedding_content_hash text,
+      inserted_at timestamp(6) without time zone NOT NULL,
+      updated_at timestamp(6) without time zone NOT NULL,
+      CONSTRAINT document_chunk_embeddings_dim_positive CHECK (dim > 0),
+      CONSTRAINT document_chunk_embeddings_dim_matches_vector
+        CHECK (vector_dims(embedding) = dim)
+    )
+    """)
+
+    create_if_not_exists(
+      unique_index(:corpora, [:tenant_id, :slug], name: :corpora_tenant_id_slug_index)
+    )
+
+    # The idempotency key for `corpus_index` (US-43.2). See the moduledoc for why
+    # `content_hash` is NOT a member and why `locator` is NOT NULL.
+    create_if_not_exists(
+      unique_index(:document_chunks, [:corpus_id, :source_ref, :locator],
+        name: :document_chunks_corpus_source_locator_index
+      )
+    )
+
+    create_if_not_exists(
+      unique_index(:document_chunk_embeddings, [:tenant_id, :document_chunk_id, :dim],
+        name: :document_chunk_embeddings_tenant_chunk_dim_index
+      )
+    )
+
+    enable_rls(:corpora)
+    enable_rls(:document_chunks)
+    enable_rls(:document_chunk_embeddings)
+
+    for table <- @append_heavy do
+      execute("ALTER TABLE #{table} SET (#{@autovacuum_opts})")
+    end
+  end
+
+  def down do
+    reset = "autovacuum_analyze_scale_factor, autovacuum_vacuum_insert_scale_factor"
+
+    for table <- @append_heavy do
+      execute("ALTER TABLE #{table} RESET (#{reset})")
+    end
+
+    execute("DROP TABLE IF EXISTS document_chunk_embeddings")
+    execute("DROP TABLE IF EXISTS document_chunks")
+    execute("DROP TABLE IF EXISTS corpora")
+  end
+end

--- a/priv/repo/migrations/20260827150100_create_per_dimension_document_chunk_hnsw_indexes.exs
+++ b/priv/repo/migrations/20260827150100_create_per_dimension_document_chunk_hnsw_indexes.exs
@@ -1,0 +1,43 @@
+defmodule Loopctl.Repo.Migrations.CreatePerDimensionDocumentChunkHnswIndexes do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  @moduledoc """
+  US-43.1 AC-43.1.5.
+
+  Pre-creates ONE partial HNSW expression index per SUPPORTED dimension on
+  `document_chunk_embeddings`, `CREATE INDEX CONCURRENTLY` (hence
+  `@disable_ddl_transaction` + `@disable_migration_lock`, and hence a SEPARATE
+  migration file from the table creation — CONCURRENTLY cannot run inside the DDL
+  transaction that migration uses).
+
+  The SQL comes from `Loopctl.Repo.HnswIndex.create_dimension_index_sql/2`, the
+  SAME generator the article and memory side tables use, for two reasons that are
+  not cosmetic: the `(embedding::vector(N))` cast must stay CHARACTER-IDENTICAL
+  between the index and the query or the planner cannot match them, and the build
+  parameters `m` / `ef_construction` cannot drift between tiers.
+
+  `document_chunk_embeddings` is also added to `HnswIndex`'s `@side_tables`, so
+  `missing_dimension_indexes/1` — the drift guard for "a dimension was PUBLISHED in
+  config and `.well-known` but never index-built" — covers the corpus tier too. That
+  misconfiguration is invisible to the compile-time supported-set guard yet makes
+  every read at that dimension sequential-scan the whole corpus: the #170/#172
+  outage class.
+  """
+
+  @table "document_chunk_embeddings"
+
+  def up do
+    for dim <- Loopctl.Embeddings.supported_dimensions() do
+      execute(Loopctl.Repo.HnswIndex.create_dimension_index_sql(@table, dim))
+    end
+  end
+
+  def down do
+    for dim <- Loopctl.Embeddings.supported_dimensions() do
+      execute(Loopctl.Repo.HnswIndex.drop_dimension_index_sql(@table, dim))
+    end
+  end
+end

--- a/priv/repo/migrations/20260827150200_add_corpus_fk_indexes.exs
+++ b/priv/repo/migrations/20260827150200_add_corpus_fk_indexes.exs
@@ -1,0 +1,54 @@
+defmodule Loopctl.Repo.Migrations.AddCorpusFkIndexes do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  @moduledoc false
+  # US-43.1 (review) — index the REFERENCING column of the corpus tier's three FKs.
+  #
+  # Every btree `20260827150000_create_corpus_tables.exs` builds leads with something
+  # else — the pkeys, `(corpus_id, source_ref, locator)`, `(tenant_id,
+  # document_chunk_id, dim)`, and the per-dimension HNSW partials — so nothing serves
+  # the `DELETE FROM <child> WHERE <fk> = $1` that Postgres's referential-integrity
+  # cascade issues, with no tenant predicate it could use them with. This is exactly
+  # the defect `20260721090000_add_article_embeddings_article_id_index.exs` fixed on
+  # `article_embeddings` under "US-41.1 (review)"; the corpus tier copied that table's
+  # create migration and not its corrective index.
+  #
+  #   * `document_chunk_embeddings(document_chunk_id)` — the one that matters. It is
+  #     worse here than for articles, whose deletes are single-row and interactive:
+  #     `Loopctl.Corpus.delete_chunks_for_source/3` is US-43.2's per-document RE-INDEX
+  #     prune, so it deletes a whole document's chunks on every re-index and fires the
+  #     RI delete once per chunk — N sequential scans of a table AC-43.1.12 expects to
+  #     be large. `delete_corpus/2` has the same shape at corpus scale.
+  #   * `document_chunks(tenant_id)` — its only indexes are the pkey and
+  #     `(corpus_id, source_ref, locator)`, so the `tenants -> document_chunks`
+  #     cascade seq-scans it on tenant delete.
+  #   * `corpora(project_id)` — `ON DELETE SET NULL`, so a project delete seq-scans
+  #     `corpora`. Smallest table, lowest priority, same one-line fix.
+  #
+  # `corpora -> document_chunks` needs nothing: the unique index already leads with
+  # `corpus_id`. Built CONCURRENTLY, matching the precedent migration.
+
+  def up do
+    for {table, column, name} <- indexes() do
+      create_if_not_exists(index(table, [column], name: name, concurrently: true))
+    end
+  end
+
+  def down do
+    for {table, column, name} <- indexes() do
+      drop_if_exists(index(table, [column], name: name, concurrently: true))
+    end
+  end
+
+  defp indexes do
+    [
+      {:document_chunk_embeddings, :document_chunk_id,
+       :document_chunk_embeddings_document_chunk_id_index},
+      {:document_chunks, :tenant_id, :document_chunks_tenant_id_index},
+      {:corpora, :project_id, :corpora_project_id_index}
+    ]
+  end
+end

--- a/test/loopctl/corpus_isolation_guard_test.exs
+++ b/test/loopctl/corpus_isolation_guard_test.exs
@@ -1,0 +1,164 @@
+defmodule Loopctl.CorpusIsolationGuardTest do
+  @moduledoc """
+  US-43.1 AC-43.1.8 / AC-43.1.11 — two code-anchored static guards.
+
+  The epic's central claim is that verbatim document chunks are excluded from the
+  article corpus BY CONSTRUCTION rather than by policy: `/api/v1/recall`,
+  `knowledge_heat_index`, novelty scoring and the consolidation pass all query
+  `Loopctl.Knowledge.Article`, and a separate table is simply not reachable from
+  them. That is a property of the CODE, so it is asserted against the code —
+  every module those paths are built from is scanned for any reference to the new
+  schemas, the new table names, or the new context.
+
+  The second guard holds the other structural decision: the corpus's dimension is
+  read from the corpus row and from nowhere else. Neither
+  `Loopctl.Embeddings`' per-tenant resolver nor its write-resolving sibling may
+  appear anywhere on the corpus path — one returns the tenant's ARTICLE dimension
+  (1536 for a 768 corpus) and the other WRITES the tenant pin as a side effect, so
+  a single corpus write by a tenant that had not yet embedded an article would pin
+  that tenant's article corpus to the local document model.
+
+  ## Why each guard asserts its own matched set is non-empty
+
+  A static scan that classifies files by substring can police an EMPTY set and pass
+  forever — a module rename, a moved file, a typo'd path, and the guard silently
+  stops guarding anything. Both scans therefore assert that they actually read the
+  files they claim to, and the exclusion scan additionally asserts every named path
+  EXISTS, so a rename fails here loudly instead of going quiet.
+
+  Both were verified by MUTATION, not by reading: a `Loopctl.Corpus.DocumentChunk`
+  reference added to `lib/loopctl_web/controllers/recall_json.ex` turned the first
+  test red, and naming the per-tenant resolver in `lib/loopctl/corpus.ex` turned the
+  second red. Both mutations were then reversed in place.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Corpus.DocumentChunkEmbedding
+  alias Loopctl.Repo.HnswIndex
+
+  @repo_root Path.expand("../..", __DIR__)
+
+  # The modules the article-corpus read paths are built from. Anchored by PATH so a
+  # module rename shows up as a missing file (asserted below) rather than as a scan
+  # that quietly matches nothing.
+  @article_path_modules [
+    # recall + heat_index + novelty scoring
+    "lib/loopctl/knowledge.ex",
+    # the novelty gate
+    "lib/loopctl/knowledge/proposal_gate.ex",
+    # the nightly consolidation pass
+    "lib/loopctl/knowledge/consolidation.ex",
+    # the shared kNN query builder every article/memory vector read goes through
+    "lib/loopctl/knowledge/vector_search.ex",
+    # the merged memory-union-knowledge recall
+    "lib/loopctl/memory.ex",
+    # POST /api/v1/recall and its renderer
+    "lib/loopctl_web/controllers/memory_controller.ex",
+    "lib/loopctl_web/controllers/recall_json.ex"
+  ]
+
+  # Every spelling a reference could take: the schema modules (which also covers
+  # `DocumentChunkEmbedding`), the raw table names a fragment or raw SQL would use,
+  # and the context module — including the `alias` form, which would otherwise let
+  # `Corpus.upsert_chunks(...)` evade a scan for the fully-qualified name.
+  @corpus_references [
+    "DocumentChunk",
+    "document_chunks",
+    "document_chunk_embeddings",
+    "Loopctl.Corpus",
+    "corpora"
+  ]
+
+  # The corpus path. `lib/loopctl/corpus.ex` plus every schema under it.
+  defp corpus_module_paths do
+    ([Path.join(@repo_root, "lib/loopctl/corpus.ex")] ++
+       Path.wildcard(Path.join(@repo_root, "lib/loopctl/corpus/**/*.ex")))
+    |> Enum.filter(&File.exists?/1)
+  end
+
+  # AC-43.1.8
+  test "no article-corpus read path references the corpus tier" do
+    scanned = Enum.map(@article_path_modules, &Path.join(@repo_root, &1))
+
+    missing =
+      scanned |> Enum.reject(&File.exists?/1) |> Enum.map(&Path.relative_to(&1, @repo_root))
+
+    assert missing == [],
+           "These modules are named as article-corpus read paths but do not exist — the " <>
+             "guard would have scanned nothing. Update the list to the new names: " <>
+             inspect(missing)
+
+    assert scanned != [],
+           "The article-path scan matched no files at all — it would pass forever."
+
+    offenders =
+      for path <- scanned,
+          reference <- @corpus_references,
+          hit <- matching_lines(path, reference),
+          do: {Path.relative_to(path, @repo_root), reference, hit}
+
+    assert offenders == [],
+           "The article-corpus read paths (recall, heat index, novelty, consolidation) " <>
+             "reference the corpus tier. Document chunks are excluded from those paths BY " <>
+             "CONSTRUCTION — they live in their own tables and nothing in the article path " <>
+             "may reach them: " <> inspect(offenders)
+  end
+
+  # AC-43.1.11
+  test "the corpus path never names either per-tenant dimension resolver" do
+    paths = corpus_module_paths()
+
+    assert length(paths) >= 4,
+           "The corpus-path scan found #{length(paths)} files — it must cover the context " <>
+             "module and its three schemas, or it is guarding nothing: " <> inspect(paths)
+
+    offenders =
+      for path <- paths,
+          resolver <- ["active_dimension", "resolve_write_dimension"],
+          hit <- matching_lines(path, resolver),
+          do: {Path.relative_to(path, @repo_root), resolver, hit}
+
+    assert offenders == [],
+           "The corpus path names a per-tenant dimension resolver. A corpus's dimension is " <>
+             "read from its OWN row and from nowhere else: the per-tenant resolver would " <>
+             "return the tenant's ARTICLE dimension, and the write-resolving one PINS " <>
+             "tenants.tenant_embedding_dimension as a side effect. The names are refused in " <>
+             "prose too, deliberately — a doc that names them is the confusion this guard " <>
+             "exists to prevent, and the prohibition is documented here and in the epic " <>
+             "README instead: " <> inspect(offenders)
+  end
+
+  test "the corpus schemas keep the four column names the shared query builder needs" do
+    fields = DocumentChunkEmbedding.__schema__(:fields)
+
+    for column <- [:tenant_id, :dim, :embedding, :live_denorm] do
+      assert column in fields,
+             "document_chunk_embeddings.#{column} is what lets " <>
+               "Loopctl.Knowledge.VectorSearch.index_safe_dimension_knn_base/6 and " <>
+               "Loopctl.Repo.HnswIndex.create_dimension_index_sql/2 be reused unchanged."
+    end
+  end
+
+  test "document_chunk_embeddings is covered by the per-dimension index drift guard" do
+    tables =
+      HnswIndex.required_dimension_indexes()
+      |> Enum.map(fn {table, _dim, _name} -> table end)
+      |> Enum.uniq()
+
+    assert "document_chunk_embeddings" in tables,
+           "The corpus embedding table must be in HnswIndex's side-table list, or a " <>
+             "dimension published in config without its index built would make every " <>
+             "corpus read at that dimension seq-scan: " <> inspect(tables)
+  end
+
+  # Non-comment lines of `path` containing `needle`. Comment-only lines are skipped so
+  # a note ABOUT the exclusion does not read as a violation of it.
+  defp matching_lines(path, needle) do
+    path
+    |> File.read!()
+    |> String.split("\n")
+    |> Enum.reject(&(&1 |> String.trim_leading() |> String.starts_with?("#")))
+    |> Enum.filter(&String.contains?(&1, needle))
+  end
+end

--- a/test/loopctl/corpus_rls_test.exs
+++ b/test/loopctl/corpus_rls_test.exs
@@ -1,0 +1,126 @@
+defmodule Loopctl.CorpusRlsTest do
+  @moduledoc """
+  US-43.1 AC-43.1.6 / TC-43.1.5 — the RLS half of the corpus tier's isolation.
+
+  `Loopctl.Corpus` runs its OLTP on `Loopctl.AdminRepo` (BYPASSRLS), where the
+  explicit `tenant_id` predicate is the only isolation — asserted in
+  `Loopctl.CorpusTest`. The `tenant_isolation` POLICIES the `enable_rls/1` macro
+  created on `corpora`, `document_chunks` and `document_chunk_embeddings` are what
+  a hypothetical `Loopctl.Repo` caller would be held to, and that is what this file
+  asserts.
+
+  ## Why `async: false` + `Repo`-connection seeding
+
+  `Repo.with_tenant/2` runs inside an RLS transaction with
+  `SET LOCAL ROLE loopctl_app`, so it needs shared sandbox mode and rows on the
+  SAME connection. Every row here is therefore seeded through `Repo`, NOT the
+  AdminRepo-backed `fixture/2` — mirroring `test/loopctl/embeddings_rls_test.exs`.
+  Because the assertion runs under the NON-owner app role (RLS is ENABLE, not
+  FORCE), it proves isolation instead of silently passing as the table owner.
+  """
+
+  use Loopctl.DataCase, async: false
+
+  alias Loopctl.Corpus.Corpus, as: CorpusSchema
+  alias Loopctl.Corpus.DocumentChunk
+  alias Loopctl.Corpus.DocumentChunkEmbedding
+  alias Loopctl.Tenants.Tenant
+
+  setup :verify_on_exit!
+
+  defp repo_tenant do
+    seq = System.unique_integer([:positive])
+
+    %Tenant{}
+    |> Tenant.create_changeset(%{
+      name: "US-43.1 tenant #{seq}",
+      slug: "us431-tenant-#{seq}",
+      email: "us431-#{seq}@example.com",
+      status: :active
+    })
+    |> Repo.insert!()
+  end
+
+  defp repo_corpus(tenant_id) do
+    seq = System.unique_integer([:positive])
+
+    %CorpusSchema{tenant_id: tenant_id}
+    |> CorpusSchema.create_changeset(%{
+      slug: "us431-corpus-#{seq}",
+      name: "US-43.1 corpus #{seq}",
+      mode: :server_embedded,
+      embedding_model: "nomic-embed-text",
+      dim: 768
+    })
+    |> Repo.insert!()
+  end
+
+  defp repo_chunk(tenant_id, corpus) do
+    seq = System.unique_integer([:positive])
+
+    %DocumentChunk{tenant_id: tenant_id}
+    |> DocumentChunk.changeset(%{
+      corpus_id: corpus.id,
+      source_ref: "docs/us431-#{seq}.pdf",
+      locator: %{"page" => seq},
+      text: "chunk #{seq}",
+      content_hash: "sha256:#{seq}"
+    })
+    |> Repo.insert!()
+  end
+
+  defp repo_embedding(tenant_id, chunk) do
+    %DocumentChunkEmbedding{tenant_id: tenant_id}
+    |> DocumentChunkEmbedding.changeset(
+      %{document_chunk_id: chunk.id, embedding: test_vec(768)},
+      768
+    )
+    |> Repo.insert!()
+  end
+
+  defp ids_under(tenant_id, schema) do
+    {:ok, ids} =
+      Repo.with_tenant(tenant_id, fn -> schema |> Repo.all() |> Enum.map(& &1.id) end)
+
+    ids
+  end
+
+  describe "RLS on the three corpus-tier tables (TC-43.1.5)" do
+    setup do
+      tenant_a = repo_tenant()
+      tenant_b = repo_tenant()
+
+      corpus_a = repo_corpus(tenant_a.id)
+      corpus_b = repo_corpus(tenant_b.id)
+
+      chunk_a = repo_chunk(tenant_a.id, corpus_a)
+      chunk_b = repo_chunk(tenant_b.id, corpus_b)
+
+      %{
+        tenant_a: tenant_a,
+        tenant_b: tenant_b,
+        corpus_a: corpus_a,
+        corpus_b: corpus_b,
+        chunk_a: chunk_a,
+        chunk_b: chunk_b,
+        embedding_a: repo_embedding(tenant_a.id, chunk_a),
+        embedding_b: repo_embedding(tenant_b.id, chunk_b)
+      }
+    end
+
+    test "tenant A cannot see tenant B's corpora", ctx do
+      assert ids_under(ctx.tenant_a.id, CorpusSchema) == [ctx.corpus_a.id]
+      assert ids_under(ctx.tenant_b.id, CorpusSchema) == [ctx.corpus_b.id]
+    end
+
+    test "tenant A cannot see tenant B's document_chunks", ctx do
+      assert ids_under(ctx.tenant_a.id, DocumentChunk) == [ctx.chunk_a.id]
+      assert ids_under(ctx.tenant_b.id, DocumentChunk) == [ctx.chunk_b.id]
+    end
+
+    test "tenant A cannot see tenant B's document_chunk_embeddings", ctx do
+      assert ids_under(ctx.tenant_a.id, DocumentChunkEmbedding) == [ctx.embedding_a.id]
+      assert ids_under(ctx.tenant_b.id, DocumentChunkEmbedding) == [ctx.embedding_b.id]
+    end
+  end
+end

--- a/test/loopctl/corpus_test.exs
+++ b/test/loopctl/corpus_test.exs
@@ -121,6 +121,60 @@ defmodule Loopctl.CorpusTest do
       assert message =~ "no pre-built"
       assert message =~ "migration"
     end
+
+    test "a project_id belonging to ANOTHER tenant is refused, persisting no row" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      theirs = fixture(:project, tenant_id: tenant_b.id)
+
+      assert {:error, changeset} =
+               Corpus.create_corpus(tenant_a.id, corpus_attrs(%{project_id: theirs.id}))
+
+      assert %{project_id: ["is invalid or does not belong to this tenant"]} =
+               errors_on(changeset)
+
+      assert Corpus.list_corpora(tenant_a.id) == []
+      assert Corpus.list_corpora(tenant_a.id, project_id: theirs.id) == []
+    end
+
+    test "a NONEXISTENT project_id is indistinguishable from a foreign one" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      theirs = fixture(:project, tenant_id: tenant_b.id)
+
+      assert {:error, foreign} =
+               Corpus.create_corpus(tenant_a.id, corpus_attrs(%{project_id: theirs.id}))
+
+      assert {:error, absent} =
+               Corpus.create_corpus(
+                 tenant_a.id,
+                 corpus_attrs(%{project_id: Ecto.UUID.generate()})
+               )
+
+      assert errors_on(foreign).project_id == errors_on(absent).project_id,
+             "the two must not be distinguishable — that is the cross-tenant existence oracle"
+    end
+
+    test "a malformed project_id is a changeset error, never a raise" do
+      tenant = fixture(:tenant)
+
+      for value <- ["not-a-uuid", 42] do
+        assert {:error, changeset} =
+                 Corpus.create_corpus(tenant.id, corpus_attrs(%{project_id: value}))
+
+        assert Map.has_key?(errors_on(changeset), :project_id)
+      end
+    end
+
+    test "the tenant's own project_id is accepted and scopes the corpus" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, tenant_id: tenant.id)
+
+      assert {:ok, corpus} =
+               Corpus.create_corpus(tenant.id, corpus_attrs(%{project_id: project.id}))
+
+      assert corpus.project_id == project.id
+    end
   end
 
   # TC-43.1.3 / AC-43.1.13
@@ -177,6 +231,21 @@ defmodule Loopctl.CorpusTest do
         })
 
       assert changeset.valid?
+    end
+
+    test "project_id is not castable on update — ownership is the context's to check",
+         %{corpus: corpus, tenant: tenant} do
+      other = fixture(:tenant)
+      theirs = fixture(:project, tenant_id: other.id)
+      mine = fixture(:project, tenant_id: tenant.id)
+
+      for project <- [theirs, mine] do
+        changeset =
+          CorpusSchema.update_changeset(corpus, %{name: corpus.name, project_id: project.id})
+
+        assert changeset.valid?
+        refute Map.has_key?(changeset.changes, :project_id)
+      end
     end
 
     test "no path in the context module can alter a corpus row at all" do
@@ -335,6 +404,50 @@ defmodule Loopctl.CorpusTest do
                Corpus.upsert_chunks(tenant.id, corpus.id, [attrs, attrs])
     end
 
+    test "locators that are DISTINCT terms but EQUAL as jsonb are refused, not raised" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id)
+
+      # Each pair reaches ONE row of the (corpus_id, source_ref, locator) unique
+      # index, where Postgres raises cardinality_violation out of ON CONFLICT DO
+      # UPDATE. The guard must name it instead: jsonb renders keys as strings and
+      # compares numbers numerically.
+      pairs = [
+        {%{page: 1}, %{"page" => 1}},
+        {%{"page" => 1}, %{"page" => 1.0}},
+        {%{"page" => 1, "line" => 2}, %{"line" => 2, "page" => 1}},
+        {%{"path" => ["a", 1]}, %{"path" => ["a", 1.0]}}
+      ]
+
+      for {left, right} <- pairs do
+        chunks = [
+          chunk_attrs(%{source_ref: "same.pdf", locator: left}),
+          chunk_attrs(%{source_ref: "same.pdf", locator: right})
+        ]
+
+        assert {:error, {:duplicate_chunk_key, {"same.pdf", _}}} =
+                 Corpus.upsert_chunks(tenant.id, corpus.id, chunks),
+               "#{inspect(left)} and #{inspect(right)} are one jsonb key"
+      end
+
+      assert chunk_count(corpus.id) == 0
+    end
+
+    test "locators that differ as jsonb are both written" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id)
+
+      chunks = [
+        chunk_attrs(%{source_ref: "same.pdf", locator: %{"page" => 1}}),
+        chunk_attrs(%{source_ref: "same.pdf", locator: %{"page" => 1.5}}),
+        chunk_attrs(%{source_ref: "same.pdf", locator: %{"page" => "1"}}),
+        chunk_attrs(%{source_ref: "other.pdf", locator: %{"page" => 1}})
+      ]
+
+      assert {:ok, written} = Corpus.upsert_chunks(tenant.id, corpus.id, chunks)
+      assert length(written) == 4
+    end
+
     test "another tenant's corpus is not found" do
       tenant_a = fixture(:tenant)
       tenant_b = fixture(:tenant)
@@ -357,6 +470,38 @@ defmodule Loopctl.CorpusTest do
       assert {:error, :not_found} = Corpus.get_corpus(tenant_b.id, corpus.slug)
     end
 
+    test "a UUID-shaped slug is still reachable — and still deletable — by slug" do
+      tenant = fixture(:tenant)
+
+      # The slug format validator accepts both: a canonical lowercase UUID is
+      # lowercase hex plus hyphens, and any 16-BYTE string is a raw UUID to
+      # `Ecto.UUID.cast/1`. An id-only resolver made either corpus unreachable on
+      # every verb, including the one that would remove it.
+      for slug <- [Ecto.UUID.generate(), "abcdefghijklmnop"] do
+        corpus = create_corpus!(tenant.id, %{slug: slug})
+
+        assert {:ok, %{id: id}} = Corpus.get_corpus(tenant.id, slug)
+        assert id == corpus.id
+
+        assert {:ok, _} = Corpus.upsert_chunks(tenant.id, slug, [chunk_attrs()])
+
+        assert {:ok, 1} =
+                 Corpus.delete_chunks_for_source(tenant.id, slug, "docs/hcpf-edi/837p.pdf")
+
+        assert {:ok, _} = Corpus.delete_corpus(tenant.id, slug)
+        assert {:error, :not_found} = Corpus.get_corpus(tenant.id, slug)
+      end
+    end
+
+    test "a UUID-shaped slug of ANOTHER tenant stays not_found" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      slug = Ecto.UUID.generate()
+      _theirs = create_corpus!(tenant_b.id, %{slug: slug})
+
+      assert {:error, :not_found} = Corpus.get_corpus(tenant_a.id, slug)
+    end
+
     test "list_corpora/2 returns only the tenant's own rows" do
       tenant_a = fixture(:tenant)
       tenant_b = fixture(:tenant)
@@ -374,6 +519,17 @@ defmodule Loopctl.CorpusTest do
 
       assert Enum.map(Corpus.list_corpora(tenant.id, project_id: project.id), & &1.id) ==
                [scoped.id]
+    end
+
+    test "list_corpora/2 sanitises BOTH pagination opts, not just :limit" do
+      tenant = fixture(:tenant)
+      mine = create_corpus!(tenant.id)
+
+      # Postgres refuses a negative OFFSET, so an unsanitised one raises where the
+      # @spec declares a list. :limit was already clamped; :offset was not.
+      assert Enum.map(Corpus.list_corpora(tenant.id, limit: 5, offset: -1), & &1.id) == [mine.id]
+      assert Corpus.list_corpora(tenant.id, offset: "3") == [mine]
+      assert Corpus.list_corpora(tenant.id, offset: 1) == []
     end
 
     test "delete_chunks_for_source/3 removes one source's chunks and leaves the rest" do

--- a/test/loopctl/corpus_test.exs
+++ b/test/loopctl/corpus_test.exs
@@ -416,7 +416,13 @@ defmodule Loopctl.CorpusTest do
         {%{page: 1}, %{"page" => 1}},
         {%{"page" => 1}, %{"page" => 1.0}},
         {%{"page" => 1, "line" => 2}, %{"line" => 2, "page" => 1}},
-        {%{"path" => ["a", 1]}, %{"path" => ["a", 1.0]}}
+        {%{"path" => ["a", 1]}, %{"path" => ["a", 1.0]}},
+        # VALUES, not just keys: the jsonb encoder renders an atom and a struct as
+        # STRINGS, so each of these pairs is one jsonb value and one row.
+        {%{"kind" => :page}, %{"kind" => "page"}},
+        {%{"on" => ~D[2026-01-01]}, %{"on" => "2026-01-01"}},
+        {%{"path" => [:a, "b"]}, %{"path" => ["a", "b"]}},
+        {:page, "page"}
       ]
 
       for {left, right} <- pairs do
@@ -446,6 +452,76 @@ defmodule Loopctl.CorpusTest do
 
       assert {:ok, written} = Corpus.upsert_chunks(tenant.id, corpus.id, chunks)
       assert length(written) == 4
+    end
+
+    test "a locator may be ANY jsonb value — an array or a scalar, not only an object" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id)
+
+      # AC-43.1.2 gives the shape to the client ("loopctl only stores and returns
+      # it") and the column is plain jsonb. `field :locator, :map` refused a heading
+      # path (the AC's own third example) and a bare page number on the way IN, and
+      # could not LOAD either on the way out.
+      locators = [
+        ["Chapter 1", "Section 2"],
+        7,
+        "page-7",
+        true,
+        %{"path" => ["a", "b"]}
+      ]
+
+      for locator <- locators do
+        assert {:ok, [chunk]} =
+                 Corpus.upsert_chunks(tenant.id, corpus.id, [chunk_attrs(%{locator: locator})])
+
+        assert chunk.locator == locator
+        assert AdminRepo.get!(DocumentChunk, chunk.id).locator == locator
+      end
+
+      assert chunk_count(corpus.id) == length(locators)
+    end
+
+    test "an array locator is the idempotency key it claims to be" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id)
+      attrs = chunk_attrs(%{locator: ["Chapter 1", "Section 2"], content_hash: "sha256:one"})
+
+      {:ok, [first]} = Corpus.upsert_chunks(tenant.id, corpus.id, [attrs])
+      {:ok, [second]} = Corpus.upsert_chunks(tenant.id, corpus.id, [%{attrs | text: "moved"}])
+
+      assert second.id == first.id
+      assert chunk_count(corpus.id) == 1
+    end
+
+    test "a locator the jsonb encoder cannot render is a changeset error, never a raise" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id)
+
+      assert {:error, {:invalid_chunk, 0, changeset}} =
+               Corpus.upsert_chunks(tenant.id, corpus.id, [
+                 chunk_attrs(%{locator: %{"span" => {1, 2}}})
+               ])
+
+      assert Map.has_key?(errors_on(changeset), :locator)
+      assert chunk_count(corpus.id) == 0
+    end
+
+    test "a locator whose keys collide as jsonb strings is refused, not silently truncated" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id)
+
+      # `'{"a":1,"a":2}'::jsonb` is `{"a": 2}` — Postgres keeps the LAST duplicate
+      # key, so this locator has no faithful stored form and the term-comparing
+      # duplicate guard cannot see the collision either.
+      for locator <- [%{:page => 1, "page" => 2}, %{"loc" => %{:page => 1, "page" => 2}}] do
+        assert {:error, {:invalid_chunk, 0, changeset}} =
+                 Corpus.upsert_chunks(tenant.id, corpus.id, [chunk_attrs(%{locator: locator})])
+
+        assert [message] = errors_on(changeset).locator
+        assert message =~ "collide"
+      end
+
+      assert chunk_count(corpus.id) == 0
     end
 
     test "another tenant's corpus is not found" do
@@ -493,6 +569,24 @@ defmodule Loopctl.CorpusTest do
       end
     end
 
+    test "a slug that is already another corpus's id in this tenant is refused at creation" do
+      tenant = fixture(:tenant)
+      other = create_corpus!(tenant.id)
+
+      # `get_corpus/2` resolves an id BEFORE a slug, so this corpus would be
+      # addressable by nobody and `delete_corpus/2` would destroy the OTHER row —
+      # with its chunks and vectors — for a caller that named its own slug.
+      assert {:error, changeset} =
+               Corpus.create_corpus(tenant.id, corpus_attrs(%{slug: other.id}))
+
+      assert [message] = errors_on(changeset).slug
+      assert message =~ "id of another corpus"
+
+      # Scoped to the tenant, and the UUID-shaped-slug support itself is untouched.
+      assert {:ok, _} =
+               Corpus.create_corpus(fixture(:tenant).id, corpus_attrs(%{slug: other.id}))
+    end
+
     test "a UUID-shaped slug of ANOTHER tenant stays not_found" do
       tenant_a = fixture(:tenant)
       tenant_b = fixture(:tenant)
@@ -500,6 +594,16 @@ defmodule Loopctl.CorpusTest do
       _theirs = create_corpus!(tenant_b.id, %{slug: slug})
 
       assert {:error, :not_found} = Corpus.get_corpus(tenant_a.id, slug)
+    end
+
+    test "list_corpora/2 returns no rows for a malformed project_id rather than raising" do
+      tenant = fixture(:tenant)
+      _corpus = create_corpus!(tenant.id)
+
+      # A caller-supplied value lands on a `:binary_id` column, where a non-UUID
+      # raises `Ecto.Query.CastError` — a 500 out of a function whose @spec promises
+      # a list. `Projects.get_project/2` carries the same guard.
+      assert Corpus.list_corpora(tenant.id, project_id: "not-a-uuid") == []
     end
 
     test "list_corpora/2 returns only the tenant's own rows" do
@@ -625,6 +729,42 @@ defmodule Loopctl.CorpusTest do
         HeavyRead.all(tenant.id, from_only)
       end
     end
+  end
+
+  describe "cascade-path indexes" do
+    test "every new FK has an index LEADING with its referencing column" do
+      # Postgres's RI cascade issues `DELETE FROM <child> WHERE <fk> = $1` with no
+      # tenant predicate, so a btree leading with `tenant_id` cannot serve it. This
+      # is the defect `20260721090000` fixed on `article_embeddings`; the corpus
+      # tier copied that table's create migration and not its corrective index.
+      for {table, column} <- [
+            {"document_chunk_embeddings", "document_chunk_id"},
+            {"document_chunks", "tenant_id"},
+            {"corpora", "project_id"}
+          ] do
+        assert leading_index?(table, column),
+               "#{table}.#{column} has no valid index leading with it, so its cascade seq-scans"
+      end
+    end
+  end
+
+  # `indkey[0]` is the index's FIRST key column (int2vector, 0-based). `indisvalid`
+  # matters because a failed CONCURRENTLY build leaves an INVALID index behind that
+  # `pg_indexes` still renders and the planner never uses.
+  defp leading_index?(table, column) do
+    %{rows: [[count]]} =
+      AdminRepo.query!(
+        """
+        SELECT count(*)
+        FROM pg_index i
+        JOIN pg_class c ON c.oid = i.indrelid
+        JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = i.indkey[0]
+        WHERE c.relname = $1 AND a.attname = $2 AND i.indisvalid
+        """,
+        [table, column]
+      )
+
+    count > 0
   end
 
   defp stored_vector_dims(embedding_id) do

--- a/test/loopctl/corpus_test.exs
+++ b/test/loopctl/corpus_test.exs
@@ -1,0 +1,494 @@
+defmodule Loopctl.CorpusTest do
+  @moduledoc """
+  US-43.1 — the corpus tier's storage contract.
+
+  Covers TC-43.1.1 (a corpus pins its OWN dimension, independent of the tenant
+  pin), TC-43.1.2 (the DB CHECK holds against raw SQL), TC-43.1.3 (`dim` / `mode` /
+  `embedding_model` are immutable), TC-43.1.4 (an unsupported dimension is refused
+  with a message that names the supported set), TC-43.1.7 (a chunk-to-embedding
+  join satisfies `Loopctl.HeavyRead`'s conjunctive tenant guard) and TC-43.1.8
+  (corpus delete cascades to chunks and vectors).
+
+  TC-43.1.5's RLS half lives in `Loopctl.CorpusRlsTest` (it needs `async: false`
+  and `Repo`-connection seeding); TC-43.1.6's exclusion guard lives in
+  `Loopctl.CorpusIsolationGuardTest`.
+  """
+
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Corpus
+  alias Loopctl.Corpus.Corpus, as: CorpusSchema
+  alias Loopctl.Corpus.DocumentChunk
+  alias Loopctl.Corpus.DocumentChunkEmbedding
+  alias Loopctl.Embeddings
+  alias Loopctl.HeavyRead
+
+  setup :verify_on_exit!
+
+  defp corpus_attrs(attrs \\ %{}) do
+    seq = System.unique_integer([:positive])
+
+    Map.merge(
+      %{
+        slug: "hcpf-edi-#{seq}",
+        name: "HCPF EDI companion guides",
+        mode: :server_embedded,
+        embedding_model: "nomic-embed-text",
+        dim: 768
+      },
+      attrs
+    )
+  end
+
+  defp create_corpus!(tenant_id, attrs \\ %{}) do
+    {:ok, corpus} = Corpus.create_corpus(tenant_id, corpus_attrs(attrs))
+    corpus
+  end
+
+  defp chunk_attrs(attrs \\ %{}) do
+    seq = System.unique_integer([:positive])
+
+    Map.merge(
+      %{
+        source_ref: "docs/hcpf-edi/837p.pdf",
+        locator: %{"page" => seq},
+        text: "Loop 2310B carries the rendering provider.",
+        content_hash: "sha256:#{seq}",
+        ordinal: seq
+      },
+      attrs
+    )
+  end
+
+  defp embed_chunk!(tenant_id, chunk, dim) do
+    %DocumentChunkEmbedding{tenant_id: tenant_id}
+    |> DocumentChunkEmbedding.changeset(
+      %{document_chunk_id: chunk.id, embedding: test_vec(dim)},
+      dim
+    )
+    |> AdminRepo.insert!()
+  end
+
+  describe "create_corpus/2" do
+    test "creates a corpus with tenant_id set programmatically, never cast" do
+      tenant = fixture(:tenant)
+      other = fixture(:tenant)
+
+      {:ok, corpus} =
+        Corpus.create_corpus(tenant.id, corpus_attrs(%{tenant_id: other.id}))
+
+      assert corpus.tenant_id == tenant.id
+      assert corpus.mode == :server_embedded
+      assert corpus.dim == 768
+      assert corpus.embedding_model == "nomic-embed-text"
+    end
+
+    test "allow_snippets defaults from mode: true server-side, false client-side" do
+      tenant = fixture(:tenant)
+
+      assert create_corpus!(tenant.id, %{mode: :server_embedded}).allow_snippets == true
+      assert create_corpus!(tenant.id, %{mode: :client_embedded}).allow_snippets == false
+    end
+
+    test "an explicit allow_snippets wins over the mode-derived default" do
+      tenant = fixture(:tenant)
+
+      corpus = create_corpus!(tenant.id, %{mode: :server_embedded, allow_snippets: false})
+      assert corpus.allow_snippets == false
+    end
+
+    test "(tenant_id, slug) is unique, and the same slug is free in another tenant" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      attrs = corpus_attrs()
+
+      assert {:ok, _} = Corpus.create_corpus(tenant_a.id, attrs)
+      assert {:error, changeset} = Corpus.create_corpus(tenant_a.id, attrs)
+      assert %{tenant_id: ["has already been taken"]} = errors_on(changeset)
+
+      assert {:ok, _} = Corpus.create_corpus(tenant_b.id, attrs)
+    end
+
+    # TC-43.1.4
+    test "an unsupported dimension is refused, naming the supported set and the reason" do
+      tenant = fixture(:tenant)
+
+      assert {:error, changeset} = Corpus.create_corpus(tenant.id, corpus_attrs(%{dim: 3072}))
+      assert [message] = errors_on(changeset).dim
+
+      assert message =~ inspect(Embeddings.supported_dimensions())
+      assert message =~ "no pre-built"
+      assert message =~ "migration"
+    end
+  end
+
+  # TC-43.1.3 / AC-43.1.13
+  describe "immutability of dim, mode and embedding_model" do
+    setup do
+      tenant = fixture(:tenant)
+      %{corpus: create_corpus!(tenant.id), tenant: tenant}
+    end
+
+    test "changing dim is an ERROR on :dim, not a silent drop", %{corpus: corpus} do
+      changeset = CorpusSchema.update_changeset(corpus, %{name: corpus.name, dim: 1536})
+
+      refute changeset.valid?
+      assert [message] = errors_on(changeset).dim
+      assert message =~ "pinned at creation"
+      refute Map.has_key?(changeset.changes, :dim)
+    end
+
+    test "changing mode is an ERROR on :mode", %{corpus: corpus} do
+      changeset =
+        CorpusSchema.update_changeset(corpus, %{name: corpus.name, mode: :client_embedded})
+
+      refute changeset.valid?
+      assert [_] = errors_on(changeset).mode
+      refute Map.has_key?(changeset.changes, :mode)
+    end
+
+    test "changing embedding_model is an ERROR on :embedding_model", %{corpus: corpus} do
+      changeset =
+        CorpusSchema.update_changeset(corpus, %{
+          name: corpus.name,
+          embedding_model: "text-embedding-3-small"
+        })
+
+      refute changeset.valid?
+      assert [_] = errors_on(changeset).embedding_model
+      refute Map.has_key?(changeset.changes, :embedding_model)
+    end
+
+    test "string keys are rejected too — the shape a params map arrives in", %{corpus: corpus} do
+      changeset = CorpusSchema.update_changeset(corpus, %{"name" => "x", "dim" => 1536})
+
+      refute changeset.valid?
+      assert [_] = errors_on(changeset).dim
+    end
+
+    test "restating the pinned values unchanged is not a change", %{corpus: corpus} do
+      changeset =
+        CorpusSchema.update_changeset(corpus, %{
+          name: "renamed",
+          dim: corpus.dim,
+          mode: corpus.mode,
+          embedding_model: corpus.embedding_model
+        })
+
+      assert changeset.valid?
+    end
+
+    test "no path in the context module can alter a corpus row at all" do
+      source = File.read!(Path.expand("../../lib/loopctl/corpus.ex", __DIR__))
+
+      for forbidden <- ["update_changeset", "AdminRepo.update", "update_all", "Repo.update"] do
+        refute source =~ forbidden,
+               "Loopctl.Corpus reaches #{forbidden}; AC-43.1.13 requires that NO context " <>
+                 "function can alter dim, embedding_model or mode, and the context has no " <>
+                 "update path at all in this story."
+      end
+    end
+  end
+
+  # TC-43.1.1
+  describe "a corpus pins its own dimension independently of the tenant pin" do
+    test "a 768 corpus coexists with a tenant pinned at 1536" do
+      tenant = fixture(:tenant)
+      {:ok, _} = Embeddings.set_tenant_dimension(tenant.id, 1536)
+      assert Embeddings.active_dimension(tenant.id) == 1536
+
+      corpus = create_corpus!(tenant.id, %{dim: 768, embedding_model: "nomic-embed-text"})
+      assert corpus.dim == 768
+
+      {:ok, [chunk]} = Corpus.upsert_chunks(tenant.id, corpus.id, [chunk_attrs()])
+      row = embed_chunk!(tenant.id, chunk, corpus.dim)
+
+      assert row.dim == 768
+      assert stored_vector_dims(row.id) == 768
+
+      # The tenant's ARTICLE corpus is untouched: the corpus write neither read nor
+      # wrote the tenant pin.
+      assert Embeddings.active_dimension(tenant.id) == 1536
+
+      article = fixture(:article, tenant_id: tenant.id)
+
+      assert {:ok, article_embedding} =
+               Embeddings.upsert_article_embedding(
+                 tenant.id,
+                 article,
+                 test_vec(1536),
+                 "hash",
+                 1536
+               )
+
+      assert article_embedding.dim == 1536
+      assert Embeddings.active_dimension(tenant.id) == 1536
+    end
+  end
+
+  # TC-43.1.2
+  describe "the vector_dims CHECK" do
+    test "a 1536-length vector tagged dim 768 is refused even via raw SQL" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id, %{dim: 768})
+      {:ok, [chunk]} = Corpus.upsert_chunks(tenant.id, corpus.id, [chunk_attrs()])
+
+      error =
+        assert_raise Postgrex.Error, fn ->
+          AdminRepo.query!(
+            """
+            INSERT INTO document_chunk_embeddings
+              (id, tenant_id, document_chunk_id, dim, embedding, live_denorm,
+               inserted_at, updated_at)
+            VALUES (gen_random_uuid(), $1, $2, 768, $3::vector, true, NOW(), NOW())
+            """,
+            [
+              Ecto.UUID.dump!(tenant.id),
+              Ecto.UUID.dump!(chunk.id),
+              Pgvector.new(Enum.map(1..1536, &(&1 / 1536)))
+            ]
+          )
+        end
+
+      assert error.postgres.constraint == "document_chunk_embeddings_dim_matches_vector"
+    end
+
+    test "the changeset refuses the same mismatch legibly" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id, %{dim: 768})
+      {:ok, [chunk]} = Corpus.upsert_chunks(tenant.id, corpus.id, [chunk_attrs()])
+
+      changeset =
+        DocumentChunkEmbedding.changeset(
+          %DocumentChunkEmbedding{tenant_id: tenant.id},
+          %{document_chunk_id: chunk.id, embedding: test_vec(1536)},
+          768
+        )
+
+      refute changeset.valid?
+      assert Map.has_key?(errors_on(changeset), :embedding)
+    end
+  end
+
+  describe "upsert_chunks/3" do
+    test "is idempotent on (corpus_id, source_ref, locator) and REPLACES a moved chunk" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id)
+      attrs = chunk_attrs(%{text: "first", content_hash: "sha256:one"})
+
+      {:ok, [first]} = Corpus.upsert_chunks(tenant.id, corpus.id, [attrs])
+
+      {:ok, [second]} =
+        Corpus.upsert_chunks(tenant.id, corpus.id, [
+          %{attrs | text: "second", content_hash: "sha256:two"}
+        ])
+
+      assert second.id == first.id
+      assert second.text == "second"
+      assert second.content_hash == "sha256:two"
+      assert chunk_count(corpus.id) == 1
+    end
+
+    test "stores the locator verbatim, without normalising it" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id)
+      locator = %{"loop" => "2310B", "segment" => "NM1", "occurrence" => 2}
+
+      {:ok, [chunk]} =
+        Corpus.upsert_chunks(tenant.id, corpus.id, [chunk_attrs(%{locator: locator})])
+
+      assert AdminRepo.get!(DocumentChunk, chunk.id).locator == locator
+    end
+
+    test "a mode B chunk stores a NULL text" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id, %{mode: :client_embedded})
+
+      {:ok, [chunk]} =
+        Corpus.upsert_chunks(tenant.id, corpus.id, [chunk_attrs(%{text: nil, snippet: nil})])
+
+      assert chunk.text == nil
+      assert chunk.snippet == nil
+    end
+
+    test "an invalid chunk fails the whole batch, naming its index" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id)
+
+      assert {:error, {:invalid_chunk, 1, changeset}} =
+               Corpus.upsert_chunks(tenant.id, corpus.id, [
+                 chunk_attrs(),
+                 chunk_attrs(%{content_hash: nil})
+               ])
+
+      assert Map.has_key?(errors_on(changeset), :content_hash)
+      assert chunk_count(corpus.id) == 0
+    end
+
+    test "two chunks sharing a key in one batch are refused rather than silently merged" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id)
+      attrs = chunk_attrs()
+
+      assert {:error, {:duplicate_chunk_key, _}} =
+               Corpus.upsert_chunks(tenant.id, corpus.id, [attrs, attrs])
+    end
+
+    test "another tenant's corpus is not found" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      corpus = create_corpus!(tenant_a.id)
+
+      assert {:error, :not_found} = Corpus.upsert_chunks(tenant_b.id, corpus.id, [chunk_attrs()])
+    end
+  end
+
+  describe "get_corpus/2, list_corpora/2 and delete_chunks_for_source/3" do
+    test "get_corpus/2 resolves by id or slug and is tenant scoped" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      corpus = create_corpus!(tenant_a.id)
+
+      assert {:ok, %{id: id}} = Corpus.get_corpus(tenant_a.id, corpus.id)
+      assert id == corpus.id
+      assert {:ok, %{id: ^id}} = Corpus.get_corpus(tenant_a.id, corpus.slug)
+      assert {:error, :not_found} = Corpus.get_corpus(tenant_b.id, corpus.id)
+      assert {:error, :not_found} = Corpus.get_corpus(tenant_b.id, corpus.slug)
+    end
+
+    test "list_corpora/2 returns only the tenant's own rows" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      mine = create_corpus!(tenant_a.id)
+      _theirs = create_corpus!(tenant_b.id)
+
+      assert Enum.map(Corpus.list_corpora(tenant_a.id), & &1.id) == [mine.id]
+    end
+
+    test "list_corpora/2 filters by project scope" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, tenant_id: tenant.id)
+      scoped = create_corpus!(tenant.id, %{project_id: project.id})
+      _unscoped = create_corpus!(tenant.id)
+
+      assert Enum.map(Corpus.list_corpora(tenant.id, project_id: project.id), & &1.id) ==
+               [scoped.id]
+    end
+
+    test "delete_chunks_for_source/3 removes one source's chunks and leaves the rest" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id)
+
+      {:ok, _} =
+        Corpus.upsert_chunks(tenant.id, corpus.id, [
+          chunk_attrs(%{source_ref: "a.pdf"}),
+          chunk_attrs(%{source_ref: "a.pdf"}),
+          chunk_attrs(%{source_ref: "b.pdf"})
+        ])
+
+      assert {:ok, 2} = Corpus.delete_chunks_for_source(tenant.id, corpus.id, "a.pdf")
+      assert chunk_count(corpus.id) == 1
+    end
+
+    test "delete_chunks_for_source/3 cannot reach another tenant's corpus" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      corpus = create_corpus!(tenant_a.id)
+      {:ok, _} = Corpus.upsert_chunks(tenant_a.id, corpus.id, [chunk_attrs()])
+
+      assert {:error, :not_found} =
+               Corpus.delete_chunks_for_source(tenant_b.id, corpus.id, "docs/hcpf-edi/837p.pdf")
+
+      assert chunk_count(corpus.id) == 1
+    end
+  end
+
+  # TC-43.1.8 / AC-43.1.9
+  describe "delete_corpus/2" do
+    test "cascades to chunks and their embeddings, leaving no orphans" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id, %{dim: 768})
+
+      {:ok, chunks} =
+        Corpus.upsert_chunks(
+          tenant.id,
+          corpus.id,
+          Enum.map(1..3, fn i -> chunk_attrs(%{locator: %{"page" => i}}) end)
+        )
+
+      Enum.each(chunks, &embed_chunk!(tenant.id, &1, 768))
+
+      assert chunk_count(corpus.id) == 3
+      assert embedding_count(tenant.id) == 3
+
+      assert {:ok, _} = Corpus.delete_corpus(tenant.id, corpus.id)
+
+      assert chunk_count(corpus.id) == 0
+      assert embedding_count(tenant.id) == 0
+    end
+
+    test "another tenant cannot delete it" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      corpus = create_corpus!(tenant_a.id)
+
+      assert {:error, :not_found} = Corpus.delete_corpus(tenant_b.id, corpus.id)
+      assert {:ok, _} = Corpus.get_corpus(tenant_a.id, corpus.id)
+    end
+  end
+
+  # TC-43.1.7 / AC-43.1.7
+  describe "the heavy-read tenant guard on a chunk-to-embedding join" do
+    test "accepts the join scoped on BOTH sources and refuses the from-only variant" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id, %{dim: 768})
+      {:ok, [chunk]} = Corpus.upsert_chunks(tenant.id, corpus.id, [chunk_attrs()])
+      embed_chunk!(tenant.id, chunk, 768)
+
+      scoped =
+        from(c in DocumentChunk,
+          join: e in DocumentChunkEmbedding,
+          on: e.document_chunk_id == c.id and e.tenant_id == ^tenant.id,
+          where: c.tenant_id == ^tenant.id and c.corpus_id == ^corpus.id and e.dim == 768,
+          select: %{chunk_id: c.id, dim: e.dim}
+        )
+
+      assert [%{chunk_id: chunk_id, dim: 768}] = HeavyRead.all(tenant.id, scoped)
+      assert chunk_id == chunk.id
+
+      from_only =
+        from(c in DocumentChunk,
+          join: e in DocumentChunkEmbedding,
+          on: e.document_chunk_id == c.id,
+          where: c.tenant_id == ^tenant.id,
+          select: %{chunk_id: c.id}
+        )
+
+      assert_raise ArgumentError, ~r/not fully scoped to the given tenant/, fn ->
+        HeavyRead.all(tenant.id, from_only)
+      end
+    end
+  end
+
+  defp stored_vector_dims(embedding_id) do
+    %{rows: [[dims]]} =
+      AdminRepo.query!(
+        "SELECT vector_dims(embedding) FROM document_chunk_embeddings WHERE id = $1",
+        [Ecto.UUID.dump!(embedding_id)]
+      )
+
+    dims
+  end
+
+  defp chunk_count(corpus_id) do
+    AdminRepo.aggregate(from(c in DocumentChunk, where: c.corpus_id == ^corpus_id), :count)
+  end
+
+  defp embedding_count(tenant_id) do
+    AdminRepo.aggregate(
+      from(e in DocumentChunkEmbedding, where: e.tenant_id == ^tenant_id),
+      :count
+    )
+  end
+end

--- a/test/loopctl/corpus_test.exs
+++ b/test/loopctl/corpus_test.exs
@@ -105,7 +105,11 @@ defmodule Loopctl.CorpusTest do
 
       assert {:ok, _} = Corpus.create_corpus(tenant_a.id, attrs)
       assert {:error, changeset} = Corpus.create_corpus(tenant_a.id, attrs)
-      assert %{tenant_id: ["has already been taken"]} = errors_on(changeset)
+
+      # The collision is attributed to `:slug`, NOT to `:tenant_id` — the index's first field,
+      # and one the caller never sends. `error_key:` is what holds that.
+      assert %{slug: ["has already been taken for this tenant"]} = errors_on(changeset)
+      refute Map.has_key?(errors_on(changeset), :tenant_id)
 
       assert {:ok, _} = Corpus.create_corpus(tenant_b.id, attrs)
     end
@@ -338,6 +342,28 @@ defmodule Loopctl.CorpusTest do
       refute changeset.valid?
       assert Map.has_key?(errors_on(changeset), :embedding)
     end
+
+    test "a second embedding for the same chunk and dim is attributed to the chunk, not tenant_id" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id, %{dim: 768})
+      {:ok, [chunk]} = Corpus.upsert_chunks(tenant.id, corpus.id, [chunk_attrs()])
+      embed_chunk!(tenant.id, chunk, 768)
+
+      assert {:error, changeset} =
+               %DocumentChunkEmbedding{tenant_id: tenant.id}
+               |> DocumentChunkEmbedding.changeset(
+                 %{document_chunk_id: chunk.id, embedding: test_vec(768)},
+                 768
+               )
+               |> AdminRepo.insert()
+
+      # `:tenant_id` is never cast and `:dim` is forced from the corpus — neither is a field the
+      # caller could act on, so the index's first field is the wrong place for this error.
+      assert %{document_chunk_id: ["already has an embedding at this dimension"]} =
+               errors_on(changeset)
+
+      refute Map.has_key?(errors_on(changeset), :tenant_id)
+    end
   end
 
   describe "upsert_chunks/3" do
@@ -357,6 +383,27 @@ defmodule Loopctl.CorpusTest do
       assert second.text == "second"
       assert second.content_hash == "sha256:two"
       assert chunk_count(corpus.id) == 1
+    end
+
+    test "a duplicate key reaching the index is attributed to source_ref, not corpus_id" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id)
+      attrs = chunk_attrs(%{locator: %{"page" => 7}})
+
+      {:ok, [_]} = Corpus.upsert_chunks(tenant.id, corpus.id, [attrs])
+
+      # The upsert's ON CONFLICT masks this today; US-43.2 surfaces the changeset directly.
+      # `:corpus_id` is the index's first field but `upsert_chunks/3` overrides it server-side,
+      # so the caller cannot act on it.
+      assert {:error, changeset} =
+               %DocumentChunk{tenant_id: tenant.id}
+               |> DocumentChunk.changeset(Map.put(attrs, :corpus_id, corpus.id))
+               |> AdminRepo.insert()
+
+      assert %{source_ref: ["has already been taken for this locator in this corpus"]} =
+               errors_on(changeset)
+
+      refute Map.has_key?(errors_on(changeset), :corpus_id)
     end
 
     test "stores the locator verbatim, without normalising it" do

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -54,9 +54,10 @@ defmodule Loopctl.DataCase do
   end
 
   # Tables carrying a pgvector HNSW index. Vacuuming these is what removes dead index
-  # entries from the graph; the two side tables are where the flake actually bit, and the
-  # two legacy ones carry indexes over the pre-cutover `embedding` columns.
-  @vector_tables ~w(article_embeddings memory_embeddings articles memories)
+  # entries from the graph; the article/memory side tables are where the flake actually
+  # bit, the two legacy ones carry indexes over the pre-cutover `embedding` columns, and
+  # `document_chunk_embeddings` (US-43.1) carries the corpus tier's per-dimension indexes.
+  @vector_tables ~w(article_embeddings memory_embeddings document_chunk_embeddings articles memories)
 
   @doc """
   Removes dead pgvector HNSW entries left in the shared index graph by rolled-back tests


### PR DESCRIPTION
US-43.1 — the first story of Epic 43 (Corpus Tier). Storage only: three tables, one context module, no HTTP surface, no MCP tool, no search. US-43.2 through US-43.4 follow strictly in order.

## The two decisions this story exists to lock in

**Dimension is a property of the CORPUS, not the tenant.** loopctl resolves an embedding dimension per tenant, and the write-resolving variant PINS tenants.tenant_embedding_dimension and tenant_embedding_model as a side effect — so one corpus write by a tenant that had not yet embedded an article would pin that tenant's ARTICLE corpus to a local document model. Neither resolver appears anywhere on the corpus path. A corpus carries its own dim and embedding_model, pinned at creation and immutable after, so a 768-dimension document corpus and a 1536-dimension article corpus coexist in one tenant as an ordinary case.

**Chunks live in their own tables**, so exclusion from recall, knowledge_heat_index, novelty scoring and the consolidation pass is a consequence of the schema rather than a policy a later change can forget to apply.

## What is here

- corpora — tenant-scoped, unique on (tenant_id, slug), mode as a text column plus a CHECK (this repo creates no Postgres enum types), and allow_snippets NOT NULL with NO DDL default. The changeset supplies it from mode (true for server_embedded, false for client_embedded) because that conditional is expressible in a changeset and not in DDL; a DDL default would silently break US-43.3's privacy default the first time a caller omitted the field.
- document_chunks — unique on (corpus_id, source_ref, locator) WITHOUT content_hash. That is what makes re-indexing idempotent: a chunk whose text moved REPLACES the row at its locator instead of inserting a second one. locator is jsonb, stored and returned verbatim and never normalised, because a normalisation that reordered keys would change the idempotency key and duplicate every chunk on the next run. It is NOT NULL with a '{}' default, since a NULL locator is distinct from every other NULL in a btree unique index and would defeat the key. The migration notes the ~2704-byte btree entry cap and that the fix for a large locator is a generated locator_hash column, not a wider entry. No FTS column: US-43.2 owns the keyword lane and its regconfig decision.
- document_chunk_embeddings — mirrors article_embeddings in shape and constraint set, with the columns named exactly tenant_id, dim, embedding and live_denorm, which is what lets the schema-parameterized kNN builder be reused unchanged in US-43.2. live_denorm carries no trigger and is never written false (a chunk has no supersession state) but the COLUMN is load-bearing: the shared index SQL emits WHERE dim = N AND live_denorm. The migration says so, so nobody removes it as dead.
- Per-dimension partial HNSW indexes from the same generator the article and memory side tables use, in a separate CREATE INDEX CONCURRENTLY migration, and the table is added to HnswIndex's side-table list so the missing_dimension_indexes drift guard covers it.
- Loopctl.Corpus — create_corpus/2, get_corpus/2, list_corpora/2, delete_corpus/2, upsert_chunks/3, delete_chunks_for_source/3. Every one takes tenant_id first; tenant_id is never cast. OLTP runs on AdminRepo with an explicit tenant predicate on every query, mirroring Loopctl.Memory and Loopctl.Knowledge.
- RLS ENABLE (not FORCE) on all three tables, cascade declared in the DDL, and the append-heavy autovacuum tuning on both chunk tables — which matters more here than for articles, because a corpus re-index makes dead tuples arrive in bursts and pgvector's HNSW scan skips dead entries, degrading recall silently rather than visibly.

## Tests

35 new tests across three files, covering TC-43.1.1 through TC-43.1.8: the corpus/tenant dimension independence (with the tenant pinned at 1536 and articles still embedding at 1536 afterwards), the vector_dims CHECK against raw SQL, per-field immutability of dim/mode/embedding_model as ERRORS rather than silent drops, the unsupported-dimension rejection naming the supported set, RLS isolation on all three tables through Loopctl.Repo under the non-owner app role, the chunk-to-embedding join passing HeavyRead's conjunctive tenant guard while the from-only variant raises, and corpus delete cascading to zero rows in both child tables.

Both static guards assert their own matched set is non-empty and were verified by MUTATION rather than by reading: a DocumentChunk reference added to the recall renderer turned the exclusion guard red, and naming the per-tenant resolver in the context turned the dimension guard red. Both mutations were reversed in place.

Full gate green: 8039 tests, 0 failures.

Part of #770 (Epic 43, story 1 of 4) — deliberately NOT a Closes line: the epic's remaining three stories are still open.
