### PR TITLE
Mode B — the server stores and ranks vectors it cannot read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,15 +28,24 @@ All notable changes to loopctl are documented here.
   corresponds to the vector or to the file, and you own that correspondence. Nothing
   checks which model produced a vector either — that is not computable from a vector.
   What IS enforced is the vector's LENGTH against the corpus `dim`, at the API boundary
-  and again by a database CHECK constraint.
+  and again by a database CHECK constraint — and that every element is representable in
+  pgvector's float32 element type, refused as `422 vector_out_of_range` rather than
+  silently truncated by the cast into a phantom dimension mismatch.
 
   **Retrieval is semantic-only,** because there is no text to index. `POST
   /api/v1/corpora/:id/search` takes `query_vector` (validated against the corpus `dim`)
   instead of `query`, and `meta.lanes` is `["semantic"]`. Every mode mismatch is a coded
   422 with a remedy — `query_string_not_accepted`, `query_vector_not_accepted`,
-  `keyword_lane_unavailable`, `query_vector_dimension_mismatch` — never an empty `200`,
-  which an agent reads as an empty corpus. Result and `meta` key sets are identical to a
-  `server_embedded` corpus's, so a client branches on `meta`, not on the mode.
+  `keyword_lane_unavailable`, `query_vector_dimension_mismatch`,
+  `query_vector_out_of_range` — never an empty `200`, which an agent reads as an empty
+  corpus. Send exactly ONE of `query` and `query_vector`: sending both is
+  `422 ambiguous_query`, and an explicit `null` for either counts as absent, so a client
+  that serializes omitted optionals as `null` is not routed to the wrong mode. When the
+  semantic lane is the only lane attempted — a `client_embedded` corpus, or
+  `lanes: ["semantic"]` on a `server_embedded` one — and it fails, the answer is
+  `502 semantic_lane_unavailable` carrying a bounded `details.reason`, never a raw
+  provider term. Result and `meta` key sets are identical to a `server_embedded`
+  corpus's, so a client branches on `meta`, not on the mode.
 
   **Operator impact:** none for existing corpora. `mode` is pinned at creation and
   immutable in BOTH directions — a `server_embedded` corpus can never become

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ All notable changes to loopctl are documented here.
 
 ### Added
 
+- **Corpus mode B (`client_embedded`) — loopctl stores and ranks vectors it cannot read
+  (US-43.3).** A corpus created with `mode: "client_embedded"` is indexed and searched
+  without loopctl ever receiving the document text. **This is the property an operator
+  points a regulated corpus at, so here is exactly what crosses the wire.**
+
+  **What loopctl RECEIVES per chunk:** `source_ref` (your file path or identifier),
+  `locator` (your opaque pointer — a page, a byte range, an EDI loop — stored verbatim),
+  `vector` (the embedding you produced locally, whose length must equal the corpus's
+  pinned `dim`), `content_hash` (yours), `ordinal`, and `snippet` ONLY if the corpus was
+  created with `allow_snippets: true`.
+
+  **What loopctl does NOT receive:** the chunk text — there is no parameter that accepts
+  it, and a chunk carrying `text` is refused with `422 text_not_accepted` rather than
+  silently ignored. And no snippet at all by default: `allow_snippets` defaults to FALSE
+  for a `client_embedded` corpus (a snippet IS text the server would then hold). Ask for
+  it explicitly if you want readable results.
+
+  **What loopctl does NOT verify.** `content_hash` is treated as an opaque idempotency
+  token, never as an integrity proof: holding no text, loopctl cannot check that it
+  corresponds to the vector or to the file, and you own that correspondence. Nothing
+  checks which model produced a vector either — that is not computable from a vector.
+  What IS enforced is the vector's LENGTH against the corpus `dim`, at the API boundary
+  and again by a database CHECK constraint.
+
+  **Retrieval is semantic-only,** because there is no text to index. `POST
+  /api/v1/corpora/:id/search` takes `query_vector` (validated against the corpus `dim`)
+  instead of `query`, and `meta.lanes` is `["semantic"]`. Every mode mismatch is a coded
+  422 with a remedy — `query_string_not_accepted`, `query_vector_not_accepted`,
+  `keyword_lane_unavailable`, `query_vector_dimension_mismatch` — never an empty `200`,
+  which an agent reads as an empty corpus. Result and `meta` key sets are identical to a
+  `server_embedded` corpus's, so a client branches on `meta`, not on the mode.
+
+  **Operator impact:** none for existing corpora. `mode` is pinned at creation and
+  immutable in BOTH directions — a `server_embedded` corpus can never become
+  `client_embedded` or the reverse; changing tier is delete-and-re-index by design. No
+  new environment variable and no migration.
+
 - **`GET /api/v1/channel/claims` — a non-destructive read of coordination claim state
   (#707).** Until now the only way to learn whether a handoff `ref` was claimed was to
   attempt the claim: `201` meant free, `409` meant taken. That probe is destructive on a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,17 +40,41 @@ All notable changes to loopctl are documented here.
   `query_vector_out_of_range` — never an empty `200`, which an agent reads as an empty
   corpus. Send exactly ONE of `query` and `query_vector`: sending both is
   `422 ambiguous_query`, and an explicit `null` for either counts as absent, so a client
-  that serializes omitted optionals as `null` is not routed to the wrong mode. When the
+  that serializes omitted optionals as `null` is not routed to the wrong mode. An EMPTY
+  ARRAY is not absent — it is a malformed vector and is refused as
+  `422 invalid_query_vector` even when a `query` accompanies it. When the
   semantic lane is the only lane attempted — a `client_embedded` corpus, or
   `lanes: ["semantic"]` on a `server_embedded` one — and it fails, the answer is
   `502 semantic_lane_unavailable` carrying a bounded `details.reason`, never a raw
   provider term. Result and `meta` key sets are identical to a `server_embedded`
   corpus's, so a client branches on `meta`, not on the mode.
 
+  **Batch sizing.** A request is bounded BOTH by its item count (`422 batch_too_large`)
+  and by the request body byte cap, and on a `client_embedded` corpus it is the byte one
+  that binds: a JSON-serialized vector costs roughly its dimension times 20 bytes, so a
+  full-size batch of 768-dimension vectors is already over the cap. An over-size body is
+  refused by the parser as `413 request_too_large`, which now carries a code and names
+  the cap. Split the batch — indexing is idempotent, and `source_complete`'s manifest
+  form keeps a document spanning several batches reconcilable.
+
+  **Re-indexing in mode B.** `content_hash` and `vector` are two independent inputs the
+  server cannot relate, so ANY rewrite stores the vector that came with it: a chunk whose
+  only change is its `ordinal` or `snippet` adopts the new vector too (no provider call
+  and no tokens, since none is needed in this mode). An item where the hash, snippet and
+  ordinal are all unchanged still writes nothing — so ROTATE `content_hash` to publish a
+  re-embedded vector for a chunk that did not otherwise move.
+
   **Operator impact:** none for existing corpora. `mode` is pinned at creation and
   immutable in BOTH directions — a `server_embedded` corpus can never become
   `client_embedded` or the reverse; changing tier is delete-and-re-index by design. No
   new environment variable and no migration.
+
+- **API error responses default to JSON when a client sends no `Accept` header.** Error
+  bodies are negotiated from `Accept`, and the fallback for a request that never
+  negotiated one was HTML — so an error raised BEFORE the router (the body-size `413` is
+  the live case, since `plug :accepts, ["json"]` has not run yet) reached a header-less
+  API client as a web page. The fallback is now JSON. Browsers are unaffected: they send
+  `Accept: text/html`, which still selects the HTML error page.
 
 - **`GET /api/v1/channel/claims` — a non-destructive read of coordination claim state
   (#707).** Until now the only way to learn whether a handoff `ref` was claimed was to

--- a/config/config.exs
+++ b/config/config.exs
@@ -332,8 +332,17 @@ config :loopctl, Loopctl.Repo,
 config :loopctl, LoopctlWeb.Endpoint,
   url: [host: "localhost"],
   adapter: Bandit.PhoenixAdapter,
+  # JSON is FIRST because the first entry is the FALLBACK for a request whose format
+  # could not be negotiated, and the requests that reach here without one are API
+  # requests: an error raised BEFORE the router — `Plug.Parsers`' 413 is the live case —
+  # never ran the `plug :accepts, ["json"]` that gives an /api/v1 response its format,
+  # and the conn Phoenix rescues with is the endpoint's ENTRY conn, so nothing an earlier
+  # plug set survives to say so. loopctl is agent-native: a client with no Accept header
+  # is a curl or an SDK, not a browser, and it was being handed an HTML error page for a
+  # JSON request. Browsers are unaffected — they send `Accept: text/html`, which
+  # negotiates `html` explicitly.
   render_errors: [
-    formats: [html: LoopctlWeb.ErrorHTML, json: LoopctlWeb.ErrorJSON],
+    formats: [json: LoopctlWeb.ErrorJSON, html: LoopctlWeb.ErrorHTML],
     layout: false
   ],
   pubsub_server: Loopctl.PubSub,

--- a/lib/loopctl/corpus/document_chunk_embedding.ex
+++ b/lib/loopctl/corpus/document_chunk_embedding.ex
@@ -39,6 +39,14 @@ defmodule Loopctl.Corpus.DocumentChunkEmbedding do
 
   @type t :: %__MODULE__{}
 
+  # pgvector's `vector` element type is float32. An element outside that range is
+  # neither storable nor comparable: Postgres RAISES `infinite value not allowed in
+  # vector` on the write and on a query parameter alike, and `Pgvector.Ecto.Vector`'s
+  # cast silently DISCARDS such elements, which turns a bad element into a phantom
+  # length mismatch. Both are refused at the boundary instead — see the callers in
+  # `Loopctl.Corpus.Indexer` and `Loopctl.Corpus.Search`.
+  @float32_max 3.4_028_235e38
+
   schema "document_chunk_embeddings" do
     tenant_field()
 
@@ -79,5 +87,27 @@ defmodule Loopctl.Corpus.DocumentChunkEmbedding do
       name: :document_chunk_embeddings_dim_matches_vector,
       message: "vector length must equal dim"
     )
+  end
+
+  @doc """
+  The largest magnitude pgvector's float32 element type can represent.
+
+  The ONE number the boundary refusals in `Loopctl.Corpus.Indexer` and
+  `Loopctl.Corpus.Search` enforce and their OpenAPI descriptions state, so the
+  documented bound and the enforced bound cannot drift.
+  """
+  @spec float32_max() :: float()
+  def float32_max, do: @float32_max
+
+  @doc """
+  The index of the first element of `vector` that pgvector's float32 element type
+  cannot represent, or `nil` when every element fits.
+
+  Returns the INDEX rather than a boolean so the refusal can name the offending
+  position, the way the dimension refusals name both numbers.
+  """
+  @spec out_of_float32_range_index([number()]) :: non_neg_integer() | nil
+  def out_of_float32_range_index(vector) when is_list(vector) do
+    Enum.find_index(vector, &(not (is_number(&1) and abs(&1) <= @float32_max)))
   end
 end

--- a/lib/loopctl/corpus/indexer.ex
+++ b/lib/loopctl/corpus/indexer.ex
@@ -1,10 +1,39 @@
 defmodule Loopctl.Corpus.Indexer do
   @moduledoc """
-  US-43.2 — the MODE A ingest path: `POST /api/v1/corpora/:id/index`.
+  The ingest path for BOTH corpus modes: `POST /api/v1/corpora/:id/index`.
 
-  The client sends verbatim chunks; loopctl computes each chunk's `content_hash`
-  server-side, embeds only what actually moved, and writes every chunk and its
-  vector in ONE `Ecto.Multi`, committed once.
+  In mode A (`:server_embedded`) the client sends verbatim chunks; loopctl computes
+  each chunk's `content_hash` server-side, embeds only what actually moved, and
+  writes every chunk and its vector in ONE `Ecto.Multi`, committed once.
+
+  ## Mode B (`:client_embedded`) — US-43.3
+
+  The client embeds locally and sends `{source_ref, locator, vector, content_hash,
+  ordinal, snippet?}`. loopctl NEVER receives the chunk text: there is no parameter
+  that accepts it, and a chunk carrying a `text` key is REFUSED
+  (`{:text_not_accepted, index}`) rather than silently ignored — a dropped `text`
+  would let a client believe the keyword lane works on a corpus that has no text to
+  index.
+
+  Everything downstream of `build_item/3` is shared with mode A: the same
+  classification, the same ONE `Ecto.Multi`, the same `(corpus_id, source_ref,
+  locator)` key, the same `source_complete` reconciliation and the same audit entry.
+  Only two things differ — `content_hash` ARRIVES instead of being computed, and
+  `embed_changed/3` makes no provider call because the vector arrived too.
+
+  `content_hash` in mode B is an OPAQUE IDEMPOTENCY TOKEN and is never treated as an
+  integrity proof. loopctl cannot verify that it corresponds to the vector, to the
+  file, or to anything at all — it holds no text to hash — so the client owns that
+  correspondence. What IS enforced is the vector's LENGTH against the corpus's pinned
+  `dim`, twice: here at the boundary (`{:vector_dimension_mismatch, index, got,
+  expected}`, which names both numbers) and again by the
+  `document_chunk_embeddings_dim_matches_vector` CHECK constraint. Nothing verifies
+  that the vector came from the declared model — that is not computable from a
+  vector, and a check that appeared to prove it while proving nothing would be worse
+  than saying so.
+
+  `snippet` defaults to NULL. A corpus whose `allow_snippets` is false — the mode B
+  DEFAULT — refuses any item carrying one (`{:snippets_not_allowed, index}`).
 
   ## One transaction, per-item step names
 
@@ -116,11 +145,13 @@ defmodule Loopctl.Corpus.Indexer do
 
   @type error ::
           :not_found
-          | :mode_mismatch
           | :audit_write_failed
           | {:batch_too_large, pos_integer()}
           | {:invalid_chunk, non_neg_integer(), String.t() | Ecto.Changeset.t()}
           | {:duplicate_chunk_key, {String.t(), term()}}
+          | {:text_not_accepted, non_neg_integer()}
+          | {:vector_dimension_mismatch, non_neg_integer(), non_neg_integer(), pos_integer()}
+          | {:snippets_not_allowed, non_neg_integer()}
           | {:source_complete_not_carried, [term()]}
           | {:source_complete_invalid, term()}
           | {:source_manifest_too_large, String.t(), pos_integer()}
@@ -132,8 +163,10 @@ defmodule Loopctl.Corpus.Indexer do
   @doc """
   Indexes `chunks` into `corpus_id` (an id or a slug) for `tenant_id`.
 
-  Each chunk is `%{source_ref, locator, text, ordinal}` — `content_hash` is NOT
-  accepted from the client in mode A; it is computed here from the text.
+  In mode A each chunk is `%{source_ref, locator, text, ordinal}` — `content_hash`
+  is NOT accepted from the client; it is computed here from the text. In mode B each
+  chunk is `%{source_ref, locator, vector, content_hash, ordinal, snippet?}` — there
+  is no `text` parameter at all, and sending one is refused.
 
   `opts`:
 
@@ -156,7 +189,6 @@ defmodule Loopctl.Corpus.Indexer do
   def index_chunks(tenant_id, corpus_id, chunks, opts \\ [])
       when is_binary(tenant_id) and is_list(chunks) do
     with {:ok, corpus} <- Corpus.get_corpus(tenant_id, corpus_id),
-         :ok <- validate_mode(corpus),
          :ok <- validate_batch_size(chunks),
          {:ok, items} <- build_items(corpus, chunks),
          :ok <- Corpus.refute_duplicate_keys(Enum.map(items, &{&1.source_ref, &1.locator})),
@@ -168,9 +200,6 @@ defmodule Loopctl.Corpus.Indexer do
   end
 
   # --- validation ---
-
-  defp validate_mode(%CorpusRow{mode: :server_embedded}), do: :ok
-  defp validate_mode(%CorpusRow{}), do: {:error, :mode_mismatch}
 
   defp validate_batch_size(chunks) when length(chunks) > @max_batch_size,
     do: {:error, {:batch_too_large, @max_batch_size}}
@@ -187,7 +216,7 @@ defmodule Loopctl.Corpus.Indexer do
     |> Enum.reduce_while({:ok, []}, fn {attrs, index}, {:ok, acc} ->
       case build_item(corpus, attrs, index) do
         {:ok, item} -> {:cont, {:ok, [item | acc]}}
-        {:error, reason} -> {:halt, {:error, {:invalid_chunk, index, reason}}}
+        {:error, reason} -> {:halt, {:error, wrap_item_error(reason, index)}}
       end
     end)
     |> case do
@@ -196,7 +225,8 @@ defmodule Loopctl.Corpus.Indexer do
     end
   end
 
-  defp build_item(corpus, attrs, index) when is_map(attrs) do
+  defp build_item(%CorpusRow{mode: :server_embedded} = corpus, attrs, index)
+       when is_map(attrs) do
     attrs = stringify_keys(attrs)
 
     cond do
@@ -211,7 +241,65 @@ defmodule Loopctl.Corpus.Indexer do
     end
   end
 
+  # Mode B (US-43.3). The `text` refusal is FIRST and is checked on the KEY's presence,
+  # not on its value: a client that sends `text: ""` or `text: nil` to a corpus with no
+  # text lane has the same misunderstanding as one that sends a page of it, and answering
+  # 200 to either would let it believe the keyword lane works.
+  #
+  # Every other refusal here names what arrived, because the alternative — accepting the
+  # item and letting the CHECK constraint raise — is a raw Postgrex 500 the caller cannot
+  # act on.
+  defp build_item(%CorpusRow{mode: :client_embedded} = corpus, attrs, index)
+       when is_map(attrs) do
+    attrs = stringify_keys(attrs)
+    vector = Map.get(attrs, "vector")
+
+    cond do
+      Map.has_key?(attrs, "text") ->
+        {:error, {:text_not_accepted, index}}
+
+      not present?(Map.get(attrs, "source_ref")) ->
+        {:error, "source_ref is required"}
+
+      not present?(Map.get(attrs, "content_hash")) ->
+        {:error,
+         "content_hash is required — a client_embedded corpus sends no text, so loopctl " <>
+           "has nothing to hash and takes yours as an opaque idempotency token"}
+
+      not vector?(vector) ->
+        {:error,
+         "vector is required and must be a non-empty array of numbers — a " <>
+           "client_embedded corpus stores the vector you embedded locally"}
+
+      length(vector) != corpus.dim ->
+        {:error, {:vector_dimension_mismatch, index, length(vector), corpus.dim}}
+
+      snippet_forbidden?(corpus, attrs) ->
+        {:error, {:snippets_not_allowed, index}}
+
+      true ->
+        client_item(corpus, attrs, vector, index)
+    end
+  end
+
   defp build_item(_corpus, _attrs, _index), do: {:error, "each chunk must be an object"}
+
+  # The dedicated mode B terms already carry their own index and are passed through
+  # whole; a plain message or a changeset is the generic per-item shape and is wrapped.
+  defp wrap_item_error(reason, index) when is_binary(reason), do: {:invalid_chunk, index, reason}
+
+  defp wrap_item_error(%Ecto.Changeset{} = changeset, index),
+    do: {:invalid_chunk, index, changeset}
+
+  defp wrap_item_error(reason, _index), do: reason
+
+  defp snippet_forbidden?(%CorpusRow{allow_snippets: true}, _attrs), do: false
+  defp snippet_forbidden?(_corpus, attrs), do: not is_nil(Map.get(attrs, "snippet"))
+
+  defp vector?(value) when is_list(value),
+    do: value != [] and Enum.all?(value, &is_number/1)
+
+  defp vector?(_value), do: false
 
   defp changeset_item(corpus, attrs, index) do
     text = Map.fetch!(attrs, "text")
@@ -235,6 +323,39 @@ defmodule Loopctl.Corpus.Indexer do
          snippet: chunk.snippet,
          ordinal: chunk.ordinal,
          content_hash: hash
+       }}
+    else
+      {:error, changeset}
+    end
+  end
+
+  # `text` is forced to nil rather than merely absent: the field is castable, and a
+  # `%DocumentChunk{}` reused across a re-index must not carry a value from anywhere.
+  # `vector` is dropped before the cast — it belongs to the EMBEDDING row, not the chunk.
+  defp client_item(corpus, attrs, vector, index) do
+    hash = Map.fetch!(attrs, "content_hash")
+
+    changeset =
+      DocumentChunk.changeset(
+        %DocumentChunk{tenant_id: corpus.tenant_id},
+        attrs
+        |> Map.drop(["vector"])
+        |> Map.merge(%{"corpus_id" => corpus.id, "content_hash" => hash, "text" => nil})
+      )
+
+    if changeset.valid? do
+      chunk = Ecto.Changeset.apply_changes(changeset)
+
+      {:ok,
+       %{
+         index: index,
+         source_ref: chunk.source_ref,
+         locator: chunk.locator,
+         text: nil,
+         snippet: chunk.snippet,
+         ordinal: chunk.ordinal,
+         content_hash: hash,
+         vector: vector
        }}
     else
       {:error, changeset}
@@ -400,6 +521,14 @@ defmodule Loopctl.Corpus.Indexer do
   # slot), and vectors map back by the response's `index` field inside the client —
   # never by array position here. A partial response fails the whole batch. Only
   # changed items are sent, so a re-index of an unchanged corpus spends nothing.
+  # Mode B makes NO provider call: the vector arrived with the chunk, so there is no
+  # admission token, no `ShrinkLadder` run and nothing to truncate. A vector is attached
+  # only where the row is actually being rewritten, so an unchanged mode B re-index
+  # writes no embedding row for the same reason an unchanged mode A one does not.
+  defp embed_changed(_tenant_id, %CorpusRow{mode: :client_embedded}, items) do
+    {:ok, Enum.map(items, &attach_client_vector/1)}
+  end
+
   defp embed_changed(tenant_id, corpus, items) do
     targets = Enum.filter(items, &(&1.rewrite == :full))
 
@@ -409,6 +538,11 @@ defmodule Loopctl.Corpus.Indexer do
       run_embed(tenant_id, corpus, items, targets)
     end
   end
+
+  defp attach_client_vector(%{rewrite: :full} = item),
+    do: Map.merge(item, %{embedding: item.vector, truncated?: false})
+
+  defp attach_client_vector(item), do: Map.merge(item, %{embedding: nil, truncated?: false})
 
   defp run_embed(tenant_id, corpus, items, targets) do
     texts = Enum.map(targets, & &1.text)

--- a/lib/loopctl/corpus/indexer.ex
+++ b/lib/loopctl/corpus/indexer.ex
@@ -51,11 +51,20 @@ defmodule Loopctl.Corpus.Indexer do
   chunk to classify it `unchanged | inserted | replaced`. An unchanged batch writes
   no chunk row, spends no embedding token, and leaves `updated_at` alone.
 
-  `content_hash` covers the TEXT, so it decides the EMBEDDING. It does not decide the
-  WRITE: `snippet` and `ordinal` are cast from the client and are in the upsert's
-  replace list, so a chunk whose text held still while one of them moved is rewritten
-  (`replaced`) without re-embedding. Deciding both on the hash silently discarded a
-  corrected snippet and left no later re-index able to apply it.
+  In MODE A `content_hash` covers the TEXT the server embedded, so it decides the
+  EMBEDDING. It does not decide the WRITE: `snippet` and `ordinal` are cast from the
+  client and are in the upsert's replace list, so a chunk whose text held still while
+  one of them moved is rewritten (`replaced`) without re-embedding. Deciding both on
+  the hash silently discarded a corrected snippet and left no later re-index able to
+  apply it.
+
+  In MODE B the hash decides nothing about the vector: both arrive from the client and
+  loopctl cannot relate them. So every rewrite carries the submitted vector — a
+  metadata-only change is widened to a full rewrite — because reporting `replaced`
+  while discarding the vector that came with the replacement left search ranking the
+  chunk by the old one. `unchanged` still writes nothing, so ROTATING `content_hash` is
+  how a mode B client publishes a new vector for a chunk whose pointer and snippet did
+  not move.
 
   ## Pruning is reconciliation against a DECLARED chunk set, never inference
 
@@ -472,7 +481,7 @@ defmodule Loopctl.Corpus.Indexer do
   defp classify(tenant_id, corpus, items) do
     existing = load_existing(tenant_id, corpus, Enum.map(items, & &1.source_ref))
 
-    {:ok, Enum.map(items, &classify_item(&1, existing))}
+    {:ok, Enum.map(items, &classify_item(&1, existing, corpus.mode))}
   end
 
   # TWO decisions, deliberately separate. `status` is what the caller is told; `rewrite`
@@ -485,14 +494,16 @@ defmodule Loopctl.Corpus.Indexer do
   # answered "unchanged" to a request that corrected a snippet or renumbered a chunk,
   # dropped the values, and left no later re-index able to apply them — the text hash
   # never moves again. A metadata-only change therefore rewrites the ROW (reported
-  # `replaced`, because the row was) and skips the embedding entirely.
-  defp classify_item(item, existing) do
+  # `replaced`, because the row was) and skips the embedding entirely — in MODE A, where
+  # the server computed the hash from the text it embedded, so hash-unchanged provably
+  # means vector-unchanged.
+  defp classify_item(item, existing, mode) do
     case Map.get(existing, {item.source_ref, Corpus.canonical_locator(item.locator)}) do
       nil ->
         Map.merge(item, %{status: :inserted, rewrite: :full, chunk_id: nil})
 
       %{id: id} = stored ->
-        {status, rewrite} = classify_change(stored, item)
+        {status, rewrite} = stored |> classify_change(item) |> widen_rewrite(mode)
         Map.merge(item, %{status: status, rewrite: rewrite, chunk_id: id})
     end
   end
@@ -505,6 +516,22 @@ defmodule Loopctl.Corpus.Indexer do
       true -> {:unchanged, :none}
     end
   end
+
+  # In mode B that implication does not hold: `content_hash` and `vector` are two
+  # INDEPENDENT client inputs (AC-43.3.2 makes the hash an opaque token loopctl cannot
+  # relate to anything), so a metadata rewrite that skipped the embedding step told the
+  # caller its item was `replaced` while discarding the vector that came with the
+  # replacement — search then ranked the chunk by the old one, with no error and no meta
+  # flag to read. An `ordinal` change alone reaches this, which is what a re-chunk or a
+  # re-paginate produces, so it needs no snippet and is reachable on the DEFAULT mode B
+  # corpus. Any rewrite therefore carries the submitted vector. It costs one extra upsert
+  # and no tokens: mode B makes no provider call.
+  #
+  # `:unchanged` is deliberately untouched — with hash, snippet and ordinal all identical,
+  # writing nothing is the documented idempotency contract, and rotating `content_hash`
+  # is how a client publishes a new vector for text it re-embedded.
+  defp widen_rewrite({:replaced, :metadata}, :client_embedded), do: {:replaced, :full}
+  defp widen_rewrite(classification, _mode), do: classification
 
   defp load_existing(tenant_id, corpus, source_refs) do
     refs = Enum.uniq(source_refs)
@@ -680,7 +707,9 @@ defmodule Loopctl.Corpus.Indexer do
 
   # Metadata-only: the row is rewritten so the corrected snippet/ordinal land, and the
   # embedding step is SKIPPED — the text did not move, so the stored vector and its hash
-  # are still the right ones and there is nothing to re-embed.
+  # are still the right ones and there is nothing to re-embed. MODE A only: `widen_rewrite/2`
+  # turns this classification into `:full` on a client_embedded corpus, where the caller's
+  # vector arrived with the change and skipping it would strand a stale embedding.
   defp add_item(multi, tenant_id, corpus, %{rewrite: :metadata} = item) do
     Multi.run(multi, {:chunk, item.index}, fn repo, _changes ->
       upsert_chunk(repo, tenant_id, corpus, item)

--- a/lib/loopctl/corpus/indexer.ex
+++ b/lib/loopctl/corpus/indexer.ex
@@ -151,6 +151,7 @@ defmodule Loopctl.Corpus.Indexer do
           | {:duplicate_chunk_key, {String.t(), term()}}
           | {:text_not_accepted, non_neg_integer()}
           | {:vector_dimension_mismatch, non_neg_integer(), non_neg_integer(), pos_integer()}
+          | {:vector_out_of_range, non_neg_integer(), non_neg_integer()}
           | {:snippets_not_allowed, non_neg_integer()}
           | {:source_complete_not_carried, [term()]}
           | {:source_complete_invalid, term()}
@@ -274,6 +275,9 @@ defmodule Loopctl.Corpus.Indexer do
       length(vector) != corpus.dim ->
         {:error, {:vector_dimension_mismatch, index, length(vector), corpus.dim}}
 
+      out_of_range_index(vector) ->
+        {:error, {:vector_out_of_range, index, out_of_range_index(vector)}}
+
       snippet_forbidden?(corpus, attrs) ->
         {:error, {:snippets_not_allowed, index}}
 
@@ -300,6 +304,14 @@ defmodule Loopctl.Corpus.Indexer do
     do: value != [] and Enum.all?(value, &is_number/1)
 
   defp vector?(_value), do: false
+
+  # `Pgvector.Ecto.Vector`'s cast DISCARDS an element outside pgvector's float32 element
+  # range instead of erroring, so a 1536-element vector carrying one arrives at the
+  # changeset 1535 long and fails the dimension validator with numbers that describe
+  # nothing the caller sent — surfacing as an opaque 500. Refused here, at the same
+  # boundary and in the same shape as the length mismatch above.
+  defp out_of_range_index(vector),
+    do: DocumentChunkEmbedding.out_of_float32_range_index(vector)
 
   defp changeset_item(corpus, attrs, index) do
     text = Map.fetch!(attrs, "text")

--- a/lib/loopctl/corpus/search.ex
+++ b/lib/loopctl/corpus/search.ex
@@ -145,11 +145,16 @@ defmodule Loopctl.Corpus.Search do
   `opts`: `:limit` (default #{@default_limit}, clamped to #{@max_limit}) and `:lanes`
   (a non-empty subset of `lanes/0`, default all of them).
 
-  Returns `{:ok, %{results: [...], meta: %{lanes: [...], ...}}}`. Both lanes failing
-  is the only case that returns `{:error, :heavy_read_overloaded}` — a semantic lane
-  that cannot run (no embedding key, an embed failure, a shed heavy read) degrades to
+  Returns `{:ok, %{results: [...], meta: %{lanes: [...], ...}}}`. A semantic lane that
+  cannot run (no embedding key, an embed failure, a shed heavy read) degrades to
   keyword-only and says so in `meta`, the way semantic article search does. A semantic
   lane that RAN but could not reach the whole corpus sets `meta.semantic_under_filled`.
+
+  Every ATTEMPTED lane failing is the only error case: a shed heavy read is
+  `{:error, :heavy_read_overloaded}`, and a semantic lane asked for ALONE that failed
+  for any other reason is `{:error, {:semantic_lane_unavailable, tag}}` — a NAMED term
+  carrying the same bounded tag `meta.semantic_unavailable_reason` uses, never the raw
+  provider reason.
   """
   @spec search(Ecto.UUID.t(), String.t(), String.t(), keyword()) ::
           {:ok, %{results: [map()], meta: map()}}
@@ -160,6 +165,7 @@ defmodule Loopctl.Corpus.Search do
              | {:invalid_lanes, term()}
              | :empty_query
              | :query_too_long
+             | {:semantic_lane_unavailable, String.t()}
              | :heavy_read_overloaded}
   def search(tenant_id, corpus_id, query_string, opts \\ []) when is_binary(tenant_id) do
     with {:ok, corpus} <- Corpus.get_corpus(tenant_id, corpus_id),
@@ -191,6 +197,8 @@ defmodule Loopctl.Corpus.Search do
              | {:invalid_lanes, term()}
              | :invalid_query_vector
              | {:query_vector_dimension_mismatch, non_neg_integer(), pos_integer()}
+             | {:query_vector_out_of_range, non_neg_integer()}
+             | {:semantic_lane_unavailable, String.t()}
              | :heavy_read_overloaded}
   def search_vector(tenant_id, corpus_id, vector, opts \\ []) when is_binary(tenant_id) do
     with {:ok, corpus} <- Corpus.get_corpus(tenant_id, corpus_id),
@@ -237,11 +245,24 @@ defmodule Loopctl.Corpus.Search do
 
   defp check_lanes(requested, _available), do: {:error, {:invalid_lanes, requested}}
 
+  # The RANGE check is not decoration: pgvector's `vector` is float32, so an element
+  # outside that range (`1.0e40` is legal JSON and a legal Elixir number) is rejected by
+  # Postgres itself with `infinite value not allowed in vector` — RAISED, not returned,
+  # and rendered to the caller as an opaque 500 by the DB backstop. A client-side input
+  # error is refused HERE, naming the bound, exactly as a length mismatch is.
   defp validate_query_vector(vector, dim) when is_list(vector) do
     cond do
-      vector == [] or not Enum.all?(vector, &is_number/1) -> {:error, :invalid_query_vector}
-      length(vector) != dim -> {:error, {:query_vector_dimension_mismatch, length(vector), dim}}
-      true -> :ok
+      vector == [] or not Enum.all?(vector, &is_number/1) ->
+        {:error, :invalid_query_vector}
+
+      length(vector) != dim ->
+        {:error, {:query_vector_dimension_mismatch, length(vector), dim}}
+
+      true ->
+        case DocumentChunkEmbedding.out_of_float32_range_index(vector) do
+          nil -> :ok
+          index -> {:error, {:query_vector_out_of_range, index}}
+        end
     end
   end
 
@@ -283,8 +304,29 @@ defmodule Loopctl.Corpus.Search do
 
     case {attempted, errors} do
       {[], _errors} -> :ok
-      {same, same} -> hd(errors)
+      {same, same} -> all_failed(errors)
       _partial -> :ok
+    end
+  end
+
+  # Every attempted lane failed, so there is nothing to fuse and no degraded answer to
+  # give. A shed heavy read keeps its own tag — that is the documented 429 with a
+  # Retry-After, and it is the ONLY reason the keyword lane produces.
+  #
+  # Anything else is an EMBEDDING failure, reachable since a request may ask for the
+  # semantic lane ALONE, and it is wrapped in a NAMED term rather than returned raw:
+  # `Knowledge.generate_embedding/3` yields `:no_api_key`, `:timeout`, `:circuit_open`,
+  # `:rate_limited_local` and `{:embedding_crash, _}`, none of which the
+  # FallbackController has a clause for — leaking one answers 500 instead of a code the
+  # caller can branch on. The tag is the same BOUNDED one
+  # `meta.semantic_unavailable_reason` carries, so no provider body can ride out on it.
+  defp all_failed(errors) do
+    reasons = Enum.map(errors, fn {:error, reason} -> reason end)
+
+    if :heavy_read_overloaded in reasons do
+      {:error, :heavy_read_overloaded}
+    else
+      {:error, {:semantic_lane_unavailable, to_tag(hd(reasons))}}
     end
   end
 

--- a/lib/loopctl/corpus/search.ex
+++ b/lib/loopctl/corpus/search.ex
@@ -52,6 +52,28 @@ defmodule Loopctl.Corpus.Search do
   tier's form of the article path's under-fill disclosure. Narrowing the query, or a
   corpus of its own for the material, is what a caller does about it.
 
+  ## Mode B is SEMANTIC-ONLY, and says so (US-43.3)
+
+  A `:client_embedded` corpus stores vectors loopctl did not make and cannot read, so
+  the query vector arrives from the client too (`search_vector/4`) and the KEYWORD lane
+  does not exist — there is no text to index. That is STATED rather than discovered:
+  `meta.lanes` is `["semantic"]`, `meta.search_mode` is `"semantic_only"`, and a request
+  that asks for the keyword lane on a mode B corpus is REFUSED
+  (`:keyword_lane_unavailable`) instead of answering an empty set, which an agent reads
+  as an empty corpus.
+
+  The two entry points refuse each other's corpus for the same reason: a query STRING
+  against mode B is `:query_string_not_accepted` (the server cannot embed for this
+  corpus — send `query_vector`), and a query VECTOR against mode A is
+  `:query_vector_not_accepted`.
+
+  Mode B routes through the SAME `ann/3` as mode A — the over-fetched inner pool, the
+  raised `side_table_ef_search` and the bounded under-fill probe are what stop a corpus
+  that is a small minority of the tenant's chunk rows from answering an empty 200, and
+  in mode B there is no keyword lane to mask that. The RESULT and META key sets are
+  identical to mode A's, so a caller branches on `meta` and never on which mode
+  answered.
+
   ## Not a recall surface
 
   `corpus_search` must NEVER be wired into `/api/v1/recall`. That hook injects into
@@ -83,6 +105,9 @@ defmodule Loopctl.Corpus.Search do
   # Per-lane candidate pool before fusion.
   @lane_pool 50
 
+  # The lane names a request may ask for. A mode B corpus admits only `"semantic"`.
+  @lanes ["keyword", "semantic"]
+
   # Extra inner-ANN over-fetch for the corpus residual, ON TOP of the side table's
   # own `side_table_over_fetch/0`. The article path's over-fetch offsets a
   # status/visibility trim; this one additionally offsets `corpus_id`, which can
@@ -110,10 +135,15 @@ defmodule Loopctl.Corpus.Search do
   @spec max_query_chars() :: pos_integer()
   def max_query_chars, do: @max_query_chars
 
-  @doc """
-  Searches `corpus_id` (an id or a slug) for `query_string`.
+  @doc "The lanes a search request may ask for."
+  @spec lanes() :: [String.t()]
+  def lanes, do: @lanes
 
-  `opts`: `:limit` (default #{@default_limit}, clamped to #{@max_limit}).
+  @doc """
+  Searches a `:server_embedded` corpus (an id or a slug) for `query_string`.
+
+  `opts`: `:limit` (default #{@default_limit}, clamped to #{@max_limit}) and `:lanes`
+  (a non-empty subset of `lanes/0`, default all of them).
 
   Returns `{:ok, %{results: [...], meta: %{lanes: [...], ...}}}`. Both lanes failing
   is the only case that returns `{:error, :heavy_read_overloaded}` — a semantic lane
@@ -125,40 +155,136 @@ defmodule Loopctl.Corpus.Search do
           {:ok, %{results: [map()], meta: map()}}
           | {:error,
              :not_found
-             | :mode_mismatch
+             | :query_string_not_accepted
+             | :keyword_lane_unavailable
+             | {:invalid_lanes, term()}
              | :empty_query
              | :query_too_long
              | :heavy_read_overloaded}
   def search(tenant_id, corpus_id, query_string, opts \\ []) when is_binary(tenant_id) do
     with {:ok, corpus} <- Corpus.get_corpus(tenant_id, corpus_id),
-         :ok <- validate_mode(corpus),
+         :ok <- require_mode(corpus, :server_embedded),
+         {:ok, lanes} <- validate_lanes(corpus, opts),
          {:ok, query_string} <- validate_query(query_string) do
-      limit = opts |> Keyword.get(:limit, @default_limit) |> clamp_limit()
-
-      run(tenant_id, corpus, query_string, limit)
+      run(tenant_id, corpus, {:string, query_string}, lanes, limit(opts))
     end
   end
 
-  # The SAME refusal `Loopctl.Corpus.Indexer.validate_mode/1` gives the ingest verb. A
-  # client_embedded corpus holds vectors the server did not make and cannot read: without
-  # this clause a search against one embedded the query on the tenant's own key, billed
-  # the provider call, and answered 200 with an empty set — one half of the surface
-  # refusing mode B with a coded 422 while the other half charged for a query the corpus
-  # can never serve. Both halves refuse it until US-43.3 defines mode B's retrieval
-  # contract.
-  defp validate_mode(%CorpusRow{mode: :server_embedded}), do: :ok
-  defp validate_mode(%CorpusRow{}), do: {:error, :mode_mismatch}
+  @doc """
+  Searches a `:client_embedded` corpus with a CLIENT-SUPPLIED query vector.
 
-  defp run(tenant_id, corpus, query_string, limit) do
-    keyword = keyword_lane(tenant_id, corpus, query_string)
-    semantic = semantic_lane(tenant_id, corpus, query_string)
+  The server cannot embed for a mode B corpus, so the caller sends the vector it
+  produced with the same local pipeline that produced the stored ones. Its length must
+  equal the corpus's pinned `dim`; a mismatch is refused HERE, naming both numbers,
+  rather than reaching pgvector as a raw `different vector dimensions` error.
 
-    case {keyword, semantic} do
-      {{:error, reason}, {:error, _}} ->
-        {:error, reason}
+  Only the SEMANTIC lane exists — there is no text to index — so `meta.lanes` is
+  `["semantic"]` and `meta.search_mode` is `"semantic_only"`. The result and meta key
+  sets are identical to `search/4`'s.
+  """
+  @spec search_vector(Ecto.UUID.t(), String.t(), [number()], keyword()) ::
+          {:ok, %{results: [map()], meta: map()}}
+          | {:error,
+             :not_found
+             | :query_vector_not_accepted
+             | :keyword_lane_unavailable
+             | {:invalid_lanes, term()}
+             | :invalid_query_vector
+             | {:query_vector_dimension_mismatch, non_neg_integer(), pos_integer()}
+             | :heavy_read_overloaded}
+  def search_vector(tenant_id, corpus_id, vector, opts \\ []) when is_binary(tenant_id) do
+    with {:ok, corpus} <- Corpus.get_corpus(tenant_id, corpus_id),
+         :ok <- require_mode(corpus, :client_embedded),
+         {:ok, lanes} <- validate_lanes(corpus, opts),
+         :ok <- validate_query_vector(vector, corpus.dim) do
+      run(tenant_id, corpus, {:vector, vector}, lanes, limit(opts))
+    end
+  end
 
-      _ ->
-        {:ok, fuse(corpus, keyword, semantic, limit)}
+  # Each entry point serves ONE mode and refuses the other by name. A mode mismatch is
+  # never an empty result set: an agent reads that as an empty corpus, so every refusal
+  # here carries the remedy — send `query_vector` for a client_embedded corpus, send
+  # `query` for a server_embedded one.
+  defp require_mode(%CorpusRow{mode: mode}, mode), do: :ok
+
+  defp require_mode(%CorpusRow{mode: :client_embedded}, _mode),
+    do: {:error, :query_string_not_accepted}
+
+  defp require_mode(%CorpusRow{}, _mode), do: {:error, :query_vector_not_accepted}
+
+  # The keyword lane is UNAVAILABLE on a mode B corpus, and asking for it is an ERROR
+  # rather than an empty lane: a request that believes it ran a keyword search over
+  # text loopctl never received must learn that, not read zero hits as zero matches.
+  defp validate_lanes(corpus, opts) do
+    available = available_lanes(corpus)
+
+    case Keyword.get(opts, :lanes) do
+      nil -> {:ok, available}
+      requested -> check_lanes(requested, available)
+    end
+  end
+
+  defp available_lanes(%CorpusRow{mode: :client_embedded}), do: ["semantic"]
+  defp available_lanes(%CorpusRow{}), do: @lanes
+
+  defp check_lanes(requested, available) when is_list(requested) and requested != [] do
+    cond do
+      not Enum.all?(requested, &(&1 in @lanes)) -> {:error, {:invalid_lanes, requested}}
+      "keyword" in requested and "keyword" not in available -> {:error, :keyword_lane_unavailable}
+      true -> {:ok, Enum.uniq(requested)}
+    end
+  end
+
+  defp check_lanes(requested, _available), do: {:error, {:invalid_lanes, requested}}
+
+  defp validate_query_vector(vector, dim) when is_list(vector) do
+    cond do
+      vector == [] or not Enum.all?(vector, &is_number/1) -> {:error, :invalid_query_vector}
+      length(vector) != dim -> {:error, {:query_vector_dimension_mismatch, length(vector), dim}}
+      true -> :ok
+    end
+  end
+
+  defp validate_query_vector(_vector, _dim), do: {:error, :invalid_query_vector}
+
+  defp limit(opts), do: opts |> Keyword.get(:limit, @default_limit) |> clamp_limit()
+
+  defp run(tenant_id, corpus, query, lanes, limit) do
+    keyword = run_lane(:keyword, tenant_id, corpus, query, lanes)
+    semantic = run_lane(:semantic, tenant_id, corpus, query, lanes)
+
+    case attempted_outcome([keyword, semantic]) do
+      {:error, reason} -> {:error, reason}
+      :ok -> {:ok, fuse(corpus, keyword, semantic, limit)}
+    end
+  end
+
+  # A lane that was never asked for is `:skipped`, which is NOT a degradation: it is
+  # absent from `meta.lanes` and contributes no `*_unavailable_reason` key, so a mode B
+  # response carries exactly the meta keys a mode A one does.
+  defp run_lane(:keyword, tenant_id, corpus, {:string, query_string}, lanes) do
+    if "keyword" in lanes, do: keyword_lane(tenant_id, corpus, query_string), else: :skipped
+  end
+
+  defp run_lane(:keyword, _tenant_id, _corpus, {:vector, _vector}, _lanes), do: :skipped
+
+  defp run_lane(:semantic, tenant_id, corpus, {:string, query_string}, lanes) do
+    if "semantic" in lanes, do: semantic_lane(tenant_id, corpus, query_string), else: :skipped
+  end
+
+  defp run_lane(:semantic, tenant_id, corpus, {:vector, vector}, _lanes),
+    do: ann(tenant_id, corpus, vector)
+
+  # Only the lanes that were ATTEMPTED decide this: every attempted lane failing is the
+  # one case with nothing to fuse and no degraded answer to give.
+  defp attempted_outcome(lanes) do
+    attempted = Enum.reject(lanes, &(&1 == :skipped))
+    errors = Enum.filter(attempted, &match?({:error, _reason}, &1))
+
+    case {attempted, errors} do
+      {[], _errors} -> :ok
+      {same, same} -> hd(errors)
+      _partial -> :ok
     end
   end
 
@@ -184,11 +310,12 @@ defmodule Loopctl.Corpus.Search do
   defp lane_results({:ok, results}), do: results
   defp lane_results({:partial, results}), do: results
   defp lane_results({:error, _reason}), do: []
+  defp lane_results(:skipped), do: []
 
   defp meta(corpus, keyword, semantic, limit) do
     lanes =
       [{"keyword", keyword}, {"semantic", semantic}]
-      |> Enum.reject(&match?({_name, {:error, _}}, &1))
+      |> Enum.reject(&(match?({_name, {:error, _reason}}, &1) or match?({_name, :skipped}, &1)))
       |> Enum.map(&elem(&1, 0))
 
     %{

--- a/lib/loopctl_web/controllers/corpus_controller.ex
+++ b/lib/loopctl_web/controllers/corpus_controller.ex
@@ -38,6 +38,18 @@ defmodule LoopctlWeb.CorpusController do
   session, and verbatim spec chunks there are precisely the pollution the corpus tier's
   separate tables exist to prevent BY CONSTRUCTION.
 
+  ## Mode B: loopctl stores and ranks vectors it cannot read (US-43.3)
+
+  A `client_embedded` corpus is indexed with `{source_ref, locator, vector,
+  content_hash, ordinal, snippet?}`. There is NO parameter on this surface that accepts
+  chunk text for such a corpus, and a chunk carrying `text` is refused
+  (`422 text_not_accepted`) rather than silently ignored. `content_hash` is
+  CLIENT-SUPPLIED and opaque — loopctl holds no text to hash and cannot verify the hash
+  corresponds to the vector or to the file; the client owns that correspondence.
+  Retrieval is semantic-only (there is no text to index) and takes a client-supplied
+  `query_vector`. Every mode mismatch on this surface is a coded 422 with a remedy,
+  never an empty 200 — an agent reads an empty result set as an empty corpus.
+
   ## Mode A is mandatory-BYO, and the failure is moved forward
 
   A `server_embedded` corpus embeds SERVER-SIDE on the TENANT's own embedding key, so a
@@ -79,6 +91,7 @@ defmodule LoopctlWeb.CorpusController do
   @max_snippet_chars Search.max_snippet_chars()
   @max_search_limit Search.max_limit()
   @max_query_chars Search.max_query_chars()
+  @search_lanes Search.lanes()
 
   @rate_limit_window_ms 60_000
 
@@ -113,7 +126,11 @@ defmodule LoopctlWeb.CorpusController do
         "In mode server_embedded loopctl embeds the chunk text you send, on YOUR embedding " <>
         "key — a tenant with no embedding credential is refused here (422 no_embedding_key) " <>
         "rather than at first index. A declared dim that disagrees with the model's native " <>
-        "dimension is refused too; an UNKNOWN model is accepted (the server cannot check it).",
+        "dimension is refused too; an UNKNOWN model is accepted (the server cannot check it). " <>
+        "In mode client_embedded loopctl never embeds anything: you send vectors and it " <>
+        "stores content it cannot read, so no embedding key is required and " <>
+        "allow_snippets defaults to FALSE — the privacy-preserving default, since a " <>
+        "snippet IS text the server would then hold. Ask for it explicitly if you want it.",
     request_body:
       {"Corpus attributes", "application/json",
        %OpenApiSpex.Schema{
@@ -291,9 +308,20 @@ defmodule LoopctlWeb.CorpusController do
   operation(:ingest,
     summary: "Index a batch of chunks",
     description:
-      "Accepts up to #{@max_batch_size} chunks, each {source_ref, locator, text, ordinal}. " <>
-        "content_hash is computed SERVER-SIDE from the text and is not accepted from the " <>
-        "client in mode A. Indexing is idempotent on (corpus_id, source_ref, locator): an " <>
+      "Accepts up to #{@max_batch_size} chunks. In a server_embedded corpus each chunk is " <>
+        "{source_ref, locator, text, ordinal} and content_hash is computed SERVER-SIDE from " <>
+        "the text, not accepted from the client. In a client_embedded corpus each chunk is " <>
+        "{source_ref, locator, vector, content_hash, ordinal, snippet?}: there is NO text " <>
+        "parameter, and a chunk carrying text is refused (422 text_not_accepted) rather " <>
+        "than silently ignored, because dropping it would let you believe the keyword lane " <>
+        "works on a corpus with no text to index. In that mode content_hash is yours and is " <>
+        "treated as an OPAQUE IDEMPOTENCY TOKEN, never as an integrity proof — loopctl " <>
+        "cannot verify that it corresponds to the vector or to the file, and you own that " <>
+        "correspondence. The vector's length must equal the corpus dim (422 " <>
+        "vector_dimension_mismatch, naming both numbers), and nothing verifies which model " <>
+        "produced it: that is not computable from a vector. A snippet is refused (422 " <>
+        "snippets_not_allowed) unless the corpus was created with allow_snippets true, " <>
+        "which for a client_embedded corpus defaults to FALSE. Indexing is idempotent on (corpus_id, source_ref, locator): an " <>
         "unchanged batch writes nothing, spends no embedding tokens, and reports every item " <>
         "as unchanged; a chunk whose text is unchanged but whose snippet or ordinal moved is " <>
         "reported replaced — the row is rewritten and no embedding is spent. source_complete " <>
@@ -320,18 +348,55 @@ defmodule LoopctlWeb.CorpusController do
              type: :array,
              maxItems: @max_batch_size,
              items: %OpenApiSpex.Schema{
-               type: :object,
-               required: [:source_ref, :text],
-               properties: %{
-                 source_ref: %OpenApiSpex.Schema{type: :string},
-                 locator: %OpenApiSpex.Schema{
+               oneOf: [
+                 %OpenApiSpex.Schema{
+                   type: :object,
+                   title: "ServerEmbeddedChunk",
                    description:
-                     "Opaque client-owned pointer (object, array or scalar), stored verbatim."
+                     "A chunk for a server_embedded corpus. content_hash is computed " <>
+                       "server-side from the text and is not accepted here.",
+                   required: [:source_ref, :text],
+                   properties: %{
+                     source_ref: %OpenApiSpex.Schema{type: :string},
+                     locator: %OpenApiSpex.Schema{
+                       description:
+                         "Opaque client-owned pointer (object, array or scalar), stored verbatim."
+                     },
+                     text: %OpenApiSpex.Schema{type: :string},
+                     ordinal: %OpenApiSpex.Schema{type: :integer},
+                     snippet: %OpenApiSpex.Schema{type: :string, maxLength: @max_snippet_chars}
+                   }
                  },
-                 text: %OpenApiSpex.Schema{type: :string},
-                 ordinal: %OpenApiSpex.Schema{type: :integer},
-                 snippet: %OpenApiSpex.Schema{type: :string, maxLength: @max_snippet_chars}
-               }
+                 %OpenApiSpex.Schema{
+                   type: :object,
+                   title: "ClientEmbeddedChunk",
+                   description:
+                     "A chunk for a client_embedded corpus. There is no text property: " <>
+                       "sending one is refused, not ignored. content_hash is YOURS and is " <>
+                       "an opaque idempotency token — loopctl cannot verify that it " <>
+                       "corresponds to the vector or to the file, and you own that " <>
+                       "correspondence. snippet is accepted only when the corpus allows " <>
+                       "snippets, which defaults to false in this mode.",
+                   required: [:source_ref, :vector, :content_hash],
+                   properties: %{
+                     source_ref: %OpenApiSpex.Schema{type: :string},
+                     locator: %OpenApiSpex.Schema{
+                       description:
+                         "Opaque client-owned pointer (object, array or scalar), stored verbatim."
+                     },
+                     vector: %OpenApiSpex.Schema{
+                       type: :array,
+                       items: %OpenApiSpex.Schema{type: :number},
+                       description:
+                         "The locally-produced embedding. Its length must equal the " <>
+                           "corpus dim."
+                     },
+                     content_hash: %OpenApiSpex.Schema{type: :string},
+                     ordinal: %OpenApiSpex.Schema{type: :integer},
+                     snippet: %OpenApiSpex.Schema{type: :string, maxLength: @max_snippet_chars}
+                   }
+                 }
+               ]
              }
            },
            source_complete: %OpenApiSpex.Schema{
@@ -407,9 +472,18 @@ defmodule LoopctlWeb.CorpusController do
   operation(:search,
     summary: "Search a corpus for pointers",
     description:
-      "Embeds the query with the CORPUS's pinned model and runs both lanes — semantic over " <>
-        "the per-dimension HNSW index and keyword over the chunk text — fused by the same " <>
-        "Reciprocal Rank Fusion the article path uses. Returns {source_ref, locator, snippet, " <>
+      "In a server_embedded corpus, embeds the query with the CORPUS's pinned model and " <>
+        "runs both lanes — semantic over the per-dimension HNSW index and keyword over the " <>
+        "chunk text — fused by the same " <>
+        "Reciprocal Rank Fusion the article path uses. A client_embedded corpus is " <>
+        "SEMANTIC-ONLY, because there is no text to index: send query_vector (validated " <>
+        "against the corpus dim) instead of query, and meta.lanes is [semantic]. Sending a " <>
+        "query STRING to a client_embedded corpus is refused (422 " <>
+        "query_string_not_accepted) rather than answered with an empty set, as is sending " <>
+        "a query_vector to a server_embedded one (422 query_vector_not_accepted) and asking " <>
+        "for the keyword lane on a client_embedded one (422 keyword_lane_unavailable). The " <>
+        "result and meta key sets are the same in both modes, so branch on meta rather than " <>
+        "on the mode. Returns {source_ref, locator, snippet, " <>
         "score, corpus_id, chunk_id} by descending score and NEVER the full chunk text. " <>
         "meta.lanes names the lanes that actually ran, and meta.semantic_under_filled says " <>
         "when the semantic lane ran but could not reach the whole corpus. Scores are " <>
@@ -423,9 +497,27 @@ defmodule LoopctlWeb.CorpusController do
       {"Search request", "application/json",
        %OpenApiSpex.Schema{
          type: :object,
-         required: [:query],
+         description: "Exactly one of query (server_embedded) or query_vector (client_embedded).",
          properties: %{
-           query: %OpenApiSpex.Schema{type: :string, maxLength: @max_query_chars},
+           query: %OpenApiSpex.Schema{
+             type: :string,
+             maxLength: @max_query_chars,
+             description: "A query string. server_embedded corpora only."
+           },
+           query_vector: %OpenApiSpex.Schema{
+             type: :array,
+             items: %OpenApiSpex.Schema{type: :number},
+             description:
+               "A locally-produced query vector whose length equals the corpus dim. " <>
+                 "client_embedded corpora only — the server cannot embed for them."
+           },
+           lanes: %OpenApiSpex.Schema{
+             type: :array,
+             items: %OpenApiSpex.Schema{type: :string, enum: @search_lanes},
+             description:
+               "The lanes to run (default: all available). A client_embedded corpus " <>
+                 "offers only the semantic lane; asking for keyword there is refused."
+           },
            limit: %OpenApiSpex.Schema{type: :integer, maximum: @max_search_limit}
          }
        }},
@@ -463,7 +555,11 @@ defmodule LoopctlWeb.CorpusController do
       401 => {"Unauthorized", "application/json", Schemas.ErrorResponse},
       404 => {"Not found", "application/json", Schemas.ErrorResponse},
       422 =>
-        {"Empty or over-long query, or a client_embedded corpus", "application/json",
+        {"Empty or over-long query (empty_query, query_too_long), a query/corpus mode " <>
+           "mismatch (query_string_not_accepted, query_vector_not_accepted), a keyword " <>
+           "lane asked of a client_embedded corpus (keyword_lane_unavailable), an " <>
+           "unknown lane (invalid_lanes), or a malformed or wrong-length query_vector " <>
+           "(invalid_query_vector, query_vector_dimension_mismatch)", "application/json",
          Schemas.ErrorResponse},
       429 =>
         {"Rate limited (code rate_limited), or BOTH lanes shed by the per-tenant " <>
@@ -475,35 +571,139 @@ defmodule LoopctlWeb.CorpusController do
   @doc "POST /api/v1/corpora/:id/search"
   def search(conn, %{"id" => id} = params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
-    opts = [limit: to_int(Map.get(params, "limit"))] |> Enum.reject(&is_nil(elem(&1, 1)))
 
-    case Search.search(tenant_id, id, Map.get(params, "query"), opts) do
-      {:ok, result} ->
-        json(conn, %{data: result.results, meta: result.meta})
+    opts =
+      [limit: to_int(Map.get(params, "limit")), lanes: Map.get(params, "lanes")]
+      |> Enum.reject(&is_nil(elem(&1, 1)))
 
-      {:error, :empty_query} ->
-        error(conn, 422, "empty_query", "A query string is required.")
-
-      {:error, :query_too_long} ->
-        error(conn, 422, "query_too_long", query_too_long_message())
-
-      {:error, :mode_mismatch} ->
-        error(conn, 422, "mode_mismatch", search_mode_mismatch_message())
-
-      {:error, reason} ->
-        {:error, reason}
+    case run_search(tenant_id, id, params, opts) do
+      {:ok, result} -> json(conn, %{data: result.results, meta: result.meta})
+      {:error, reason} -> handle_search_error(conn, reason)
     end
   end
 
-  # --- error rendering ---
+  # A `query_vector` names the mode B path; the MODE decides whether it is accepted, so a
+  # vector sent to a server_embedded corpus is refused by name rather than embedded or
+  # ignored.
+  defp run_search(tenant_id, id, %{"query_vector" => vector}, opts),
+    do: Search.search_vector(tenant_id, id, vector, opts)
 
-  defp handle_index_error(conn, :mode_mismatch) do
+  defp run_search(tenant_id, id, params, opts),
+    do: Search.search(tenant_id, id, Map.get(params, "query"), opts)
+
+  defp handle_search_error(conn, :empty_query),
+    do: error(conn, 422, "empty_query", "A query string is required.")
+
+  defp handle_search_error(conn, :query_too_long),
+    do: error(conn, 422, "query_too_long", query_too_long_message())
+
+  # NOT an empty 200. An agent reads an empty result set as an empty corpus, so every
+  # mode mismatch names the remedy instead.
+  defp handle_search_error(conn, :query_string_not_accepted) do
     error(
       conn,
       422,
-      "mode_mismatch",
-      "This corpus is client_embedded: it stores vectors the server cannot read, so it " <>
-        "does not accept chunk text on this endpoint."
+      "query_string_not_accepted",
+      "This corpus is client_embedded: it stores vectors loopctl did not make and cannot " <>
+        "read, so the server cannot embed a query for it. Send query_vector — a vector " <>
+        "from the same local pipeline that produced the stored ones, at this corpus's dim."
+    )
+  end
+
+  defp handle_search_error(conn, :query_vector_not_accepted) do
+    error(
+      conn,
+      422,
+      "query_vector_not_accepted",
+      "This corpus is server_embedded: loopctl embeds the query with the corpus's own " <>
+        "pinned model. Send query instead of query_vector."
+    )
+  end
+
+  defp handle_search_error(conn, :keyword_lane_unavailable) do
+    error(
+      conn,
+      422,
+      "keyword_lane_unavailable",
+      "This corpus is client_embedded, so it is SEMANTIC-ONLY: loopctl never received " <>
+        "the chunk text and has nothing to index for a keyword lane. Ask for the semantic " <>
+        "lane, or omit lanes entirely."
+    )
+  end
+
+  defp handle_search_error(conn, {:invalid_lanes, received}) do
+    error(
+      conn,
+      422,
+      "invalid_lanes",
+      "lanes must be a non-empty array drawn from #{inspect(@search_lanes)}.",
+      %{received: inspect(received)}
+    )
+  end
+
+  defp handle_search_error(conn, :invalid_query_vector) do
+    error(
+      conn,
+      422,
+      "invalid_query_vector",
+      "query_vector must be a non-empty array of numbers at this corpus's dim."
+    )
+  end
+
+  defp handle_search_error(conn, {:query_vector_dimension_mismatch, got, expected}) do
+    error(
+      conn,
+      422,
+      "query_vector_dimension_mismatch",
+      "query_vector has #{got} dimensions but this corpus is pinned at #{expected}. " <>
+        "Embed the query with the same local model that produced the stored vectors.",
+      %{received_dim: got, corpus_dim: expected}
+    )
+  end
+
+  defp handle_search_error(_conn, reason), do: {:error, reason}
+
+  # --- error rendering ---
+
+  # REFUSED, never dropped. Accepting the item and ignoring the text would leave the
+  # client believing loopctl holds text it never received — and therefore believing the
+  # keyword lane works on a corpus that has none.
+  defp handle_index_error(conn, {:text_not_accepted, index}) do
+    error(
+      conn,
+      422,
+      "text_not_accepted",
+      "chunks[#{index}] carries text, but this corpus is client_embedded: it has no text " <>
+        "lane and loopctl must never receive the content. Send only {source_ref, locator, " <>
+        "vector, content_hash, ordinal, snippet?}.",
+      %{index: index}
+    )
+  end
+
+  # Names BOTH numbers, at the boundary, so the caller does not meet the
+  # document_chunk_embeddings_dim_matches_vector CHECK as a raw Postgrex 500.
+  defp handle_index_error(conn, {:vector_dimension_mismatch, index, got, expected}) do
+    error(
+      conn,
+      422,
+      "vector_dimension_mismatch",
+      "chunks[#{index}] carries a #{got}-dimension vector but this corpus is pinned at " <>
+        "#{expected}. The dimension is pinned at creation; re-dimensioning a corpus is " <>
+        "delete-and-re-index by design.",
+      %{index: index, received_dim: got, corpus_dim: expected}
+    )
+  end
+
+  defp handle_index_error(conn, {:snippets_not_allowed, index}) do
+    error(
+      conn,
+      422,
+      "snippets_not_allowed",
+      "chunks[#{index}] carries a snippet, but this corpus forbids them " <>
+        "(allow_snippets is false — the default for a client_embedded corpus, since a " <>
+        "snippet IS text the server would then hold). Create a corpus with " <>
+        "allow_snippets true if you want readable results.",
+      %{index: index}
     )
   end
 
@@ -646,15 +846,6 @@ defmodule LoopctlWeb.CorpusController do
     |> put_status(status)
     |> json(%{error: if(details, do: Map.put(body, :details, details), else: body)})
   end
-
-  # The mode refusal the INGEST verb already gives, in the read verb's own words: both
-  # halves of the surface refuse a client_embedded corpus identically, rather than one
-  # answering a coded 422 and the other spending a provider embedding call to return an
-  # empty set with a 200.
-  defp search_mode_mismatch_message,
-    do:
-      "This corpus is client_embedded: it stores vectors loopctl did not make and cannot " <>
-        "read, so the server cannot embed a query against it."
 
   defp query_too_long_message,
     do: "The query is longer than #{@max_query_chars} characters."

--- a/lib/loopctl_web/controllers/corpus_controller.ex
+++ b/lib/loopctl_web/controllers/corpus_controller.ex
@@ -64,6 +64,7 @@ defmodule LoopctlWeb.CorpusController do
 
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Corpus
+  alias Loopctl.Corpus.DocumentChunkEmbedding
   alias Loopctl.Corpus.Indexer
   alias Loopctl.Corpus.Search
   alias Loopctl.Llm
@@ -92,6 +93,7 @@ defmodule LoopctlWeb.CorpusController do
   @max_search_limit Search.max_limit()
   @max_query_chars Search.max_query_chars()
   @search_lanes Search.lanes()
+  @float32_max DocumentChunkEmbedding.float32_max()
 
   @rate_limit_window_ms 60_000
 
@@ -389,7 +391,10 @@ defmodule LoopctlWeb.CorpusController do
                        items: %OpenApiSpex.Schema{type: :number},
                        description:
                          "The locally-produced embedding. Its length must equal the " <>
-                           "corpus dim."
+                           "corpus dim, and every element must be float32-representable " <>
+                           "(magnitude at most #{@float32_max}) — pgvector stores float32, " <>
+                           "so a larger value is refused (422 vector_out_of_range) rather " <>
+                           "than silently dropped."
                      },
                      content_hash: %OpenApiSpex.Schema{type: :string},
                      ordinal: %OpenApiSpex.Schema{type: :integer},
@@ -435,7 +440,10 @@ defmodule LoopctlWeb.CorpusController do
       401 => {"Unauthorized", "application/json", Schemas.ErrorResponse},
       403 => {"Insufficient role", "application/json", Schemas.ErrorResponse},
       404 => {"Not found", "application/json", Schemas.ErrorResponse},
-      422 => {"Invalid batch", "application/json", Schemas.ErrorResponse},
+      422 =>
+        {"Invalid batch — includes text_not_accepted, vector_dimension_mismatch, " <>
+           "vector_out_of_range and snippets_not_allowed", "application/json",
+         Schemas.ErrorResponse},
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError},
       500 =>
         {"Audit write failed — nothing was written", "application/json", Schemas.ErrorResponse},
@@ -502,14 +510,18 @@ defmodule LoopctlWeb.CorpusController do
            query: %OpenApiSpex.Schema{
              type: :string,
              maxLength: @max_query_chars,
-             description: "A query string. server_embedded corpora only."
+             description:
+               "A query string. server_embedded corpora only. Send this OR query_vector, " <>
+                 "never both."
            },
            query_vector: %OpenApiSpex.Schema{
              type: :array,
              items: %OpenApiSpex.Schema{type: :number},
              description:
-               "A locally-produced query vector whose length equals the corpus dim. " <>
-                 "client_embedded corpora only — the server cannot embed for them."
+               "A locally-produced query vector whose length equals the corpus dim and " <>
+                 "whose elements are float32-representable (magnitude at most " <>
+                 "#{@float32_max}). client_embedded corpora only — the server cannot " <>
+                 "embed for them. Send this OR query, never both."
            },
            lanes: %OpenApiSpex.Schema{
              type: :array,
@@ -555,16 +567,24 @@ defmodule LoopctlWeb.CorpusController do
       401 => {"Unauthorized", "application/json", Schemas.ErrorResponse},
       404 => {"Not found", "application/json", Schemas.ErrorResponse},
       422 =>
-        {"Empty or over-long query (empty_query, query_too_long), a query/corpus mode " <>
+        {"Empty or over-long query (empty_query, query_too_long), both query and " <>
+           "query_vector given (ambiguous_query), a query/corpus mode " <>
            "mismatch (query_string_not_accepted, query_vector_not_accepted), a keyword " <>
            "lane asked of a client_embedded corpus (keyword_lane_unavailable), an " <>
-           "unknown lane (invalid_lanes), or a malformed or wrong-length query_vector " <>
-           "(invalid_query_vector, query_vector_dimension_mismatch)", "application/json",
+           "unknown lane (invalid_lanes), or a malformed, wrong-length or " <>
+           "out-of-float32-range query_vector (invalid_query_vector, " <>
+           "query_vector_dimension_mismatch, query_vector_out_of_range)", "application/json",
          Schemas.ErrorResponse},
       429 =>
         {"Rate limited (code rate_limited), or BOTH lanes shed by the per-tenant " <>
            "heavy-read gate (code heavy_read_overloaded, with Retry-After)", "application/json",
-         Schemas.RateLimitError}
+         Schemas.RateLimitError},
+      502 =>
+        {"Every lane attempted failed and none of them was a shed heavy read (code " <>
+           "semantic_lane_unavailable, details.reason naming the bounded embedding " <>
+           "failure tag). Reachable when the semantic lane is the only lane attempted — " <>
+           "asked for by lanes:[semantic], or by a client_embedded corpus, which has no " <>
+           "other lane.", "application/json", Schemas.ErrorResponse}
     }
   )
 
@@ -585,11 +605,32 @@ defmodule LoopctlWeb.CorpusController do
   # A `query_vector` names the mode B path; the MODE decides whether it is accepted, so a
   # vector sent to a server_embedded corpus is refused by name rather than embedded or
   # ignored.
-  defp run_search(tenant_id, id, %{"query_vector" => vector}, opts),
-    do: Search.search_vector(tenant_id, id, vector, opts)
+  #
+  # Dispatch is on the VALUE, never on the key's presence. Emitting `null` for an absent
+  # optional is ordinary client serialization (Go's encoding/json without omitempty,
+  # `json.dumps({"query_vector": None})`, most generated clients), and matching the key
+  # sent such a request down the mode B path to be refused with
+  # `query_vector_not_accepted` — a message telling the caller to send the `query` it had
+  # already sent. The mirror case, BOTH given, used to silently drop `query`; the request
+  # schema says exactly one, so it is refused by name instead of one being preferred.
+  defp run_search(tenant_id, id, params, opts) do
+    query = Map.get(params, "query")
+    vector = Map.get(params, "query_vector")
 
-  defp run_search(tenant_id, id, params, opts),
-    do: Search.search(tenant_id, id, Map.get(params, "query"), opts)
+    cond do
+      given?(query) and given?(vector) -> {:error, :ambiguous_query}
+      given?(vector) -> Search.search_vector(tenant_id, id, vector, opts)
+      true -> Search.search(tenant_id, id, query, opts)
+    end
+  end
+
+  # A blank string is ABSENT for dispatch purposes, for the same serialization reason a
+  # null is: a client without omitempty sends `query: ""` alongside a real vector. An
+  # empty ARRAY is present — it is a malformed vector, and `invalid_query_vector` says
+  # more than routing it to the query lane would.
+  defp given?(nil), do: false
+  defp given?(value) when is_binary(value), do: String.trim(value) != ""
+  defp given?(_value), do: true
 
   defp handle_search_error(conn, :empty_query),
     do: error(conn, 422, "empty_query", "A query string is required.")
@@ -661,6 +702,45 @@ defmodule LoopctlWeb.CorpusController do
     )
   end
 
+  defp handle_search_error(conn, {:query_vector_out_of_range, index}) do
+    error(
+      conn,
+      422,
+      "query_vector_out_of_range",
+      "query_vector[#{index}] is outside the range pgvector's float32 element type can " <>
+        "represent (magnitude at most #{@float32_max}). Postgres refuses such a value, so " <>
+        "it is refused here rather than reaching the database as an unactionable error.",
+      %{index: index}
+    )
+  end
+
+  # The lanes that ran all failed AND none of them was the shed heavy read, which is only
+  # reachable when the semantic lane was asked for alone. There is no degraded answer to
+  # give, and the raw provider reason must never reach the FallbackController — it has no
+  # clause for one and would answer 500 instead of a code the caller can branch on.
+  defp handle_search_error(conn, {:semantic_lane_unavailable, reason}) do
+    error(
+      conn,
+      502,
+      "semantic_lane_unavailable",
+      "The semantic lane could not run and it was the only lane attempted, so there is no " <>
+        "degraded answer to return. Retry; on a server_embedded corpus, omitting lanes " <>
+        "lets the keyword lane answer while the embedding path is unavailable.",
+      %{reason: reason}
+    )
+  end
+
+  defp handle_search_error(conn, :ambiguous_query) do
+    error(
+      conn,
+      422,
+      "ambiguous_query",
+      "Send exactly one of query (server_embedded) or query_vector (client_embedded). " <>
+        "Both arrived non-empty, and silently preferring one would answer a search the " <>
+        "caller did not ask for."
+    )
+  end
+
   defp handle_search_error(_conn, reason), do: {:error, reason}
 
   # --- error rendering ---
@@ -691,6 +771,21 @@ defmodule LoopctlWeb.CorpusController do
         "#{expected}. The dimension is pinned at creation; re-dimensioning a corpus is " <>
         "delete-and-re-index by design.",
       %{index: index, received_dim: got, corpus_dim: expected}
+    )
+  end
+
+  # `Pgvector.Ecto.Vector` DISCARDS an out-of-float32-range element on cast rather than
+  # erroring, so without this the item reaches the changeset one element short and the
+  # request fails as a 500 corpus_write_failed naming numbers the caller never sent.
+  defp handle_index_error(conn, {:vector_out_of_range, index, at}) do
+    error(
+      conn,
+      422,
+      "vector_out_of_range",
+      "chunks[#{index}].vector[#{at}] is outside the range pgvector's float32 element " <>
+        "type can represent (magnitude at most #{@float32_max}). Re-embed with a pipeline " <>
+        "that emits float32-representable values.",
+      %{index: index, element_index: at}
     )
   end
 

--- a/lib/loopctl_web/controllers/corpus_controller.ex
+++ b/lib/loopctl_web/controllers/corpus_controller.ex
@@ -95,6 +95,13 @@ defmodule LoopctlWeb.CorpusController do
   @search_lanes Search.lanes()
   @float32_max DocumentChunkEmbedding.float32_max()
 
+  # The endpoint's `Plug.Parsers` cap, read from the module the parser itself reads. The
+  # item ceiling above is NOT the binding bound on a client_embedded batch — vectors are
+  # bytes, and the parser refuses the body before any guard here can name a ceiling — so
+  # the description publishes both bounds and the 413 (LoopctlWeb.ErrorJSON) names this
+  # one.
+  @max_body_bytes LoopctlWeb.RequestLimits.max_body_bytes()
+
   @rate_limit_window_ms 60_000
 
   # A generic 2xx envelope for the responses whose payload is documented in prose
@@ -310,7 +317,15 @@ defmodule LoopctlWeb.CorpusController do
   operation(:ingest,
     summary: "Index a batch of chunks",
     description:
-      "Accepts up to #{@max_batch_size} chunks. In a server_embedded corpus each chunk is " <>
+      "Accepts up to #{@max_batch_size} chunks, and a request body of at most " <>
+        "#{@max_body_bytes} bytes. BOTH bounds apply, and on a client_embedded corpus it " <>
+        "is the byte one that binds: a JSON-serialized vector costs roughly its dimension " <>
+        "times 20 bytes, so a full-size batch of 768-dimension vectors is already over the " <>
+        "cap. An over-size body is refused by the parser, before this action runs, as 413 " <>
+        "request_too_large naming the cap — split the batch; indexing is idempotent and " <>
+        "source_complete's manifest form exists so a document spanning several batches is " <>
+        "still reconcilable. An over-size ITEM COUNT is 422 batch_too_large. " <>
+        "In a server_embedded corpus each chunk is " <>
         "{source_ref, locator, text, ordinal} and content_hash is computed SERVER-SIDE from " <>
         "the text, not accepted from the client. In a client_embedded corpus each chunk is " <>
         "{source_ref, locator, vector, content_hash, ordinal, snippet?}: there is NO text " <>
@@ -326,7 +341,12 @@ defmodule LoopctlWeb.CorpusController do
         "which for a client_embedded corpus defaults to FALSE. Indexing is idempotent on (corpus_id, source_ref, locator): an " <>
         "unchanged batch writes nothing, spends no embedding tokens, and reports every item " <>
         "as unchanged; a chunk whose text is unchanged but whose snippet or ordinal moved is " <>
-        "reported replaced — the row is rewritten and no embedding is spent. source_complete " <>
+        "reported replaced — the row is rewritten and no embedding is spent. In a " <>
+        "client_embedded corpus the hash decides nothing about the vector (both are yours " <>
+        "and loopctl cannot relate them), so EVERY rewrite stores the vector that request " <>
+        "carried, and rotating content_hash is how you publish a new vector for a chunk " <>
+        "whose pointer, snippet and ordinal did not move — an unchanged item still writes " <>
+        "nothing. source_complete " <>
         "names the sources to RECONCILE, and each name declares that source's COMPLETE chunk " <>
         "set: a bare string means the set is what THIS request carries for it, while " <>
         "{source_ref, locators} declares the set explicitly so a document spanning several " <>
@@ -444,6 +464,9 @@ defmodule LoopctlWeb.CorpusController do
         {"Invalid batch — includes text_not_accepted, vector_dimension_mismatch, " <>
            "vector_out_of_range and snippets_not_allowed", "application/json",
          Schemas.ErrorResponse},
+      413 =>
+        {"Request body over the byte cap — refused by the parser before this action ran",
+         "application/json", Schemas.ErrorResponse},
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError},
       500 =>
         {"Audit write failed — nothing was written", "application/json", Schemas.ErrorResponse},
@@ -521,7 +544,9 @@ defmodule LoopctlWeb.CorpusController do
                "A locally-produced query vector whose length equals the corpus dim and " <>
                  "whose elements are float32-representable (magnitude at most " <>
                  "#{@float32_max}). client_embedded corpora only — the server cannot " <>
-                 "embed for them. Send this OR query, never both."
+                 "embed for them. Send this OR query, never both. null and an ABSENT " <>
+                 "key mean absent; an EMPTY ARRAY is a malformed vector and is refused " <>
+                 "(422 invalid_query_vector) even when a query accompanies it."
            },
            lanes: %OpenApiSpex.Schema{
              type: :array,
@@ -618,6 +643,7 @@ defmodule LoopctlWeb.CorpusController do
     vector = Map.get(params, "query_vector")
 
     cond do
+      empty_vector?(vector) -> {:error, :invalid_query_vector}
       given?(query) and given?(vector) -> {:error, :ambiguous_query}
       given?(vector) -> Search.search_vector(tenant_id, id, vector, opts)
       true -> Search.search(tenant_id, id, query, opts)
@@ -628,6 +654,15 @@ defmodule LoopctlWeb.CorpusController do
   # null is: a client without omitempty sends `query: ""` alongside a real vector. An
   # empty ARRAY is present — it is a malformed vector, and `invalid_query_vector` says
   # more than routing it to the query lane would.
+  #
+  # That refusal is tested FIRST, before the ambiguity branch, because the branch order
+  # decided the outcome: with the ambiguity test first, `{query: "x", query_vector: []}`
+  # was refused as `ambiguous_query` with a message asserting "both arrived non-empty"
+  # about a field that is demonstrably empty, and the malformed-vector outcome this
+  # comment declares was unreachable whenever a query was present.
+  defp empty_vector?([]), do: true
+  defp empty_vector?(_value), do: false
+
   defp given?(nil), do: false
   defp given?(value) when is_binary(value), do: String.trim(value) != ""
   defp given?(_value), do: true
@@ -687,7 +722,9 @@ defmodule LoopctlWeb.CorpusController do
       conn,
       422,
       "invalid_query_vector",
-      "query_vector must be a non-empty array of numbers at this corpus's dim."
+      "query_vector must be a non-empty array of numbers at this corpus's dim. An empty " <>
+        "array is a MALFORMED vector, not an absent one: omit the field or send null if " <>
+        "you meant to search a server_embedded corpus with query."
     )
   end
 

--- a/lib/loopctl_web/controllers/error_json.ex
+++ b/lib/loopctl_web/controllers/error_json.ex
@@ -89,6 +89,30 @@ defmodule LoopctlWeb.ErrorJSON do
     }
   end
 
+  # US-43.3 (review): `Plug.Parsers` raises RequestTooLargeError in the ENDPOINT, before
+  # any controller plug runs — so a corpus ingest batch that exceeds the byte cap never
+  # reaches the 422 that names the item ceiling and used to fall to the catch-all below
+  # as {"status": 413, "message": "Request Entity Too Large"}: no code, no remedy, and no
+  # hint that the body rather than the item count was the binding bound. That is exactly
+  # the opaque answer the mode B refusals exist to avoid. The cap is read from
+  # LoopctlWeb.RequestLimits — the same value the parser enforces and the ingest OpenAPI
+  # description publishes.
+  def render("413.json", _assigns) do
+    %{
+      error: %{
+        status: 413,
+        code: "request_too_large",
+        message:
+          "The request body exceeds #{LoopctlWeb.RequestLimits.max_body_bytes()} bytes and " <>
+            "was refused before it was parsed. Send the same work in smaller requests. " <>
+            "On a client_embedded corpus this bound, not the per-request item ceiling, is " <>
+            "usually what binds: a JSON-serialized vector costs roughly its dimension " <>
+            "times 20 bytes, so a batch of them runs out of bytes long before it runs out " <>
+            "of items."
+      }
+    }
+  end
+
   # Catch-all for any other status code templates
   def render(template, _assigns) do
     status =

--- a/lib/loopctl_web/endpoint.ex
+++ b/lib/loopctl_web/endpoint.ex
@@ -97,10 +97,14 @@ defmodule LoopctlWeb.Endpoint do
   plug :clear_tenant_metadata
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 
+  # The byte cap lives in LoopctlWeb.RequestLimits because it is PUBLISHED as well as
+  # enforced: the corpus ingest description states it next to its item ceiling (a batch
+  # of client-supplied vectors runs out of bytes long before it runs out of items) and
+  # LoopctlWeb.ErrorJSON names it in the 413 body. One source, so they cannot drift.
   plug Plug.Parsers,
     parsers: [:urlencoded, :json],
     pass: ["*/*"],
-    length: 2_000_000,
+    length: LoopctlWeb.RequestLimits.max_body_bytes(),
     json_decoder: Phoenix.json_library()
 
   plug Plug.MethodOverride

--- a/lib/loopctl_web/request_limits.ex
+++ b/lib/loopctl_web/request_limits.ex
@@ -1,0 +1,23 @@
+defmodule LoopctlWeb.RequestLimits do
+  @moduledoc """
+  The transport-level request bounds, in ONE place.
+
+  `max_body_bytes/0` is the length `Plug.Parsers` is mounted with in
+  `LoopctlWeb.Endpoint`, the message `LoopctlWeb.ErrorJSON` renders when the parser
+  refuses a body, and the bound the corpus ingest OpenAPI description publishes
+  alongside its item ceiling. Those three read the same number because they used to
+  drift: the ingest schema advertised an item ceiling that a `client_embedded` batch
+  could not reach, since a batch of vectors is bounded by BYTES long before it is
+  bounded by items, and the refusal arrived as an uncoded 413 from the parser — for a
+  request the published schema declared valid.
+
+  A cap raise is therefore a one-line change here, and every site that speaks about it
+  moves with it.
+  """
+
+  @max_body_bytes 2_000_000
+
+  @doc "The maximum request body `Plug.Parsers` will read, in bytes."
+  @spec max_body_bytes() :: pos_integer()
+  def max_body_bytes, do: @max_body_bytes
+end

--- a/test/loopctl/corpus/indexer_test.exs
+++ b/test/loopctl/corpus/indexer_test.exs
@@ -105,6 +105,21 @@ defmodule Loopctl.Corpus.IndexerTest do
     )
   end
 
+  # The stored VECTORS, not just their count — the only way to see whether a rewrite
+  # actually adopted the vector the request carried.
+  defp stored_vectors(corpus) do
+    AdminRepo.all(
+      from(e in DocumentChunkEmbedding,
+        join: c in DocumentChunk,
+        on: c.id == e.document_chunk_id,
+        where: c.corpus_id == ^corpus.id,
+        order_by: [asc: c.ordinal],
+        select: e.embedding
+      )
+    )
+    |> Enum.map(&Pgvector.to_list/1)
+  end
+
   defp index!(tenant_id, corpus, chunks, opts \\ []) do
     {:ok, result} =
       Indexer.index_chunks(
@@ -977,6 +992,50 @@ defmodule Loopctl.Corpus.IndexerTest do
       assert statuses(result) == [:replaced]
       assert [%{content_hash: "hash-two"}] = chunks_of(corpus)
       assert embedding_count(corpus) == 1
+      assert stored_vectors(corpus) == [client_vector(tenant.id, 8..15)]
+    end
+
+    # In mode A a metadata-only change skips the embedding step because the server
+    # computed the hash from the text it embedded, so hash-unchanged PROVES
+    # vector-unchanged. In mode B the hash and the vector are two independent client
+    # inputs and that implication is gone: the request was answered `replaced` while the
+    # vector it carried was dropped, and search went on ranking the chunk by the old one
+    # with no error and no meta flag to read. An `ordinal` move alone reaches this, so it
+    # needs no snippet and is reachable on the DEFAULT (allow_snippets false) corpus.
+    test "a metadata-only rewrite stores the vector that came with it" do
+      tenant = fixture(:tenant)
+      corpus = mode_b_corpus!(tenant.id)
+
+      index!(tenant.id, corpus, [vector_chunk(tenant.id, "spec.pdf", 1, 0..7, "hash-one")])
+      assert stored_vectors(corpus) == [client_vector(tenant.id, 0..7)]
+
+      moved =
+        tenant.id
+        |> vector_chunk("spec.pdf", 1, 8..15, "hash-one")
+        |> Map.put("ordinal", 7)
+
+      result = index!(tenant.id, corpus, [moved])
+
+      assert statuses(result) == [:replaced]
+      assert [%{ordinal: 7, content_hash: "hash-one"}] = chunks_of(corpus)
+      assert embedding_count(corpus) == 1
+      assert stored_vectors(corpus) == [client_vector(tenant.id, 8..15)]
+    end
+
+    # The other half of the same rule: with hash, snippet and ordinal all identical,
+    # writing nothing is the documented idempotency contract, so rotating `content_hash`
+    # is how a client publishes a new vector for a chunk that did not otherwise move.
+    test "an unchanged item does NOT adopt a newly submitted vector" do
+      tenant = fixture(:tenant)
+      corpus = mode_b_corpus!(tenant.id)
+
+      index!(tenant.id, corpus, [vector_chunk(tenant.id, "spec.pdf", 1, 0..7, "hash-one")])
+
+      result =
+        index!(tenant.id, corpus, [vector_chunk(tenant.id, "spec.pdf", 1, 8..15, "hash-one")])
+
+      assert statuses(result) == [:unchanged]
+      assert stored_vectors(corpus) == [client_vector(tenant.id, 0..7)]
     end
 
     test "source_complete prunes a mode B source exactly as it does a mode A one" do

--- a/test/loopctl/corpus/indexer_test.exs
+++ b/test/loopctl/corpus/indexer_test.exs
@@ -58,6 +58,31 @@ defmodule Loopctl.Corpus.IndexerTest do
     }
   end
 
+  # US-43.3. Mode B carries no text at all — only a locally-produced vector and the
+  # client's own opaque hash.
+  defp mode_b_corpus!(tenant_id, attrs \\ %{}),
+    do: create_corpus!(tenant_id, Map.merge(%{mode: :client_embedded}, attrs))
+
+  defp vector_chunk(tenant_id, source_ref, page, dims, hash) do
+    %{
+      "source_ref" => source_ref,
+      "locator" => %{"page" => page},
+      "vector" => client_vector(tenant_id, dims),
+      "content_hash" => hash,
+      "ordinal" => page
+    }
+  end
+
+  # Each tenant's vectors occupy its OWN contiguous block of the space, so tenants stay
+  # well-separated points in the shared HNSW index — the same reason the suite's default
+  # embedding stub keys on `tenant_id`.
+  defp client_vector(tenant_id, dims) do
+    base = rem(:erlang.phash2(tenant_id), 1500)
+    hot = MapSet.new(dims, &(base + &1))
+
+    Enum.map(0..1535, fn i -> if MapSet.member?(hot, i), do: 1.0, else: 0.0 end)
+  end
+
   defp pages(source_ref, count, prefix \\ "Loop 2310B carries the rendering provider, page ") do
     for page <- 1..count, do: chunk(source_ref, page, prefix <> Integer.to_string(page))
   end
@@ -138,12 +163,16 @@ defmodule Loopctl.Corpus.IndexerTest do
       assert max == Indexer.max_batch_size()
     end
 
-    test "a client_embedded corpus refuses this endpoint" do
+    test "a mode A corpus still requires the text it embeds" do
       tenant = fixture(:tenant)
-      corpus = create_corpus!(tenant.id, %{mode: :client_embedded})
+      corpus = create_corpus!(tenant.id)
 
-      assert {:error, :mode_mismatch} =
-               Indexer.index_chunks(tenant.id, corpus.id, pages("a.pdf", 1))
+      assert {:error, {:invalid_chunk, 0, message}} =
+               Indexer.index_chunks(tenant.id, corpus.id, [
+                 %{"source_ref" => "a.pdf", "locator" => %{"page" => 1}}
+               ])
+
+      assert message =~ "text is required"
     end
 
     test "two chunks sharing one (source_ref, locator) in ONE batch are refused" do
@@ -728,6 +757,255 @@ defmodule Loopctl.Corpus.IndexerTest do
                )
 
       assert length(chunks_of(corpus_b)) == 2
+    end
+  end
+
+  # --- US-43.3: mode B, the ingest path for vectors loopctl cannot read ---
+
+  describe "index_chunks/4 in mode B (US-43.3)" do
+    test "accepts {source_ref, locator, vector, content_hash, ordinal} and stores no text" do
+      tenant = fixture(:tenant)
+      corpus = mode_b_corpus!(tenant.id)
+
+      calls = :counters.new(1, [])
+
+      stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _scope, texts, _opts ->
+        :counters.add(calls, 1, 1)
+        {:ok, Enum.map(texts, fn _text -> client_vector(tenant.id, 0..7) end)}
+      end)
+
+      result =
+        index!(tenant.id, corpus, [
+          vector_chunk(tenant.id, "spec.pdf", 1, 0..7, "hash-one"),
+          vector_chunk(tenant.id, "spec.pdf", 2, 8..15, "hash-two")
+        ])
+
+      assert statuses(result) == [:inserted, :inserted]
+      assert embedding_count(corpus) == 2
+      # NOT ONE provider call: the vector arrived with the chunk.
+      assert :counters.get(calls, 1) == 0
+
+      chunks = chunks_of(corpus) |> Enum.sort_by(& &1.ordinal)
+      assert Enum.map(chunks, & &1.text) == [nil, nil]
+      assert Enum.map(chunks, & &1.snippet) == [nil, nil]
+      # The CLIENT's hash, verbatim — the server has no text to hash.
+      assert Enum.map(chunks, & &1.content_hash) == ["hash-one", "hash-two"]
+      assert Enum.map(chunks, & &1.locator) == [%{"page" => 1}, %{"page" => 2}]
+    end
+
+    # TC-43.3.2 — refused, not ignored. Dropping the text would let a client believe the
+    # keyword lane works on a corpus that has no text to index.
+    test "a chunk carrying text is REFUSED by name and nothing is written" do
+      tenant = fixture(:tenant)
+      corpus = mode_b_corpus!(tenant.id)
+
+      batch = [
+        vector_chunk(tenant.id, "spec.pdf", 1, 0..7, "hash-one"),
+        tenant.id
+        |> vector_chunk("spec.pdf", 2, 8..15, "hash-two")
+        |> Map.put("text", "Loop 2310B carries the rendering provider")
+      ]
+
+      assert {:error, {:text_not_accepted, 1}} =
+               Indexer.index_chunks(tenant.id, corpus.id, batch, audit: audit_opts())
+
+      assert chunks_of(corpus) == []
+    end
+
+    # A nil or empty `text` is the SAME misunderstanding as a page of it, so the refusal
+    # is on the KEY's presence. Answering 200 to this would be the silent drop.
+    test "an empty or nil text key is refused too" do
+      tenant = fixture(:tenant)
+      corpus = mode_b_corpus!(tenant.id)
+
+      for value <- ["", nil] do
+        batch = [
+          tenant.id
+          |> vector_chunk("spec.pdf", 1, 0..7, "hash-one")
+          |> Map.put("text", value)
+        ]
+
+        assert {:error, {:text_not_accepted, 0}} =
+                 Indexer.index_chunks(tenant.id, corpus.id, batch, audit: audit_opts())
+      end
+
+      assert chunks_of(corpus) == []
+    end
+
+    test "content_hash is required and is client-supplied" do
+      tenant = fixture(:tenant)
+      corpus = mode_b_corpus!(tenant.id)
+
+      batch = [
+        tenant.id |> vector_chunk("spec.pdf", 1, 0..7, "hash-one") |> Map.delete("content_hash")
+      ]
+
+      assert {:error, {:invalid_chunk, 0, message}} =
+               Indexer.index_chunks(tenant.id, corpus.id, batch, audit: audit_opts())
+
+      assert message =~ "content_hash is required"
+      assert message =~ "idempotency token"
+      assert chunks_of(corpus) == []
+    end
+
+    test "a missing or non-numeric vector is refused" do
+      tenant = fixture(:tenant)
+      corpus = mode_b_corpus!(tenant.id)
+
+      for value <- [nil, "not-a-vector", [], ["a", "b"]] do
+        batch = [
+          tenant.id |> vector_chunk("spec.pdf", 1, 0..7, "hash-one") |> Map.put("vector", value)
+        ]
+
+        assert {:error, {:invalid_chunk, 0, message}} =
+                 Indexer.index_chunks(tenant.id, corpus.id, batch, audit: audit_opts())
+
+        assert message =~ "vector is required"
+      end
+
+      assert chunks_of(corpus) == []
+    end
+
+    # TC-43.3.4, write side. The CHECK constraint is the second enforcement point; this
+    # one exists so the caller meets a named 422 rather than a raw Postgrex error.
+    test "a wrong-length vector is refused at the boundary, naming BOTH numbers" do
+      tenant = fixture(:tenant)
+      corpus = mode_b_corpus!(tenant.id)
+
+      short = List.duplicate(0.0, 768)
+
+      batch = [
+        tenant.id |> vector_chunk("spec.pdf", 1, 0..7, "hash-one") |> Map.put("vector", short)
+      ]
+
+      assert {:error, {:vector_dimension_mismatch, 0, 768, 1536}} =
+               Indexer.index_chunks(tenant.id, corpus.id, batch, audit: audit_opts())
+
+      assert chunks_of(corpus) == []
+      assert embedding_count(corpus) == 0
+    end
+
+    # TC-43.3.5, the write half. `allow_snippets` defaults to FALSE in mode B, and the
+    # refusal is what makes that default enforceable rather than advisory.
+    test "a snippet is refused when the corpus forbids them, and bounded when it allows them" do
+      tenant = fixture(:tenant)
+      closed = mode_b_corpus!(tenant.id)
+      open = mode_b_corpus!(tenant.id, %{allow_snippets: true})
+
+      refute closed.allow_snippets
+      assert open.allow_snippets
+
+      carrying = fn ref, snippet ->
+        [
+          tenant.id
+          |> vector_chunk(ref, 1, 0..7, "hash-one")
+          |> Map.put("snippet", snippet)
+        ]
+      end
+
+      assert {:error, {:snippets_not_allowed, 0}} =
+               Indexer.index_chunks(tenant.id, closed.id, carrying.("spec.pdf", "page 1 excerpt"),
+                 audit: audit_opts()
+               )
+
+      assert chunks_of(closed) == []
+
+      index!(tenant.id, open, carrying.("spec.pdf", "page 1 excerpt"))
+      assert [%{snippet: "page 1 excerpt", text: nil}] = chunks_of(open)
+
+      # The SAME bound the search truncation and the OpenAPI maxLength read.
+      too_long = String.duplicate("x", DocumentChunk.max_snippet_chars() + 1)
+
+      assert {:error, {:invalid_chunk, 0, changeset}} =
+               Indexer.index_chunks(tenant.id, open.id, carrying.("other.pdf", too_long),
+                 audit: audit_opts()
+               )
+
+      assert errors_on(changeset).snippet != []
+    end
+
+    test "re-indexing an unchanged mode B batch writes nothing" do
+      tenant = fixture(:tenant)
+      corpus = mode_b_corpus!(tenant.id)
+      batch = [vector_chunk(tenant.id, "spec.pdf", 1, 0..7, "hash-one")]
+
+      index!(tenant.id, corpus, batch)
+      [before] = chunks_of(corpus)
+
+      result = index!(tenant.id, corpus, batch)
+
+      assert statuses(result) == [:unchanged]
+      assert [^before] = chunks_of(corpus)
+      assert embedding_count(corpus) == 1
+    end
+
+    test "a moved content_hash replaces the row and its vector" do
+      tenant = fixture(:tenant)
+      corpus = mode_b_corpus!(tenant.id)
+
+      index!(tenant.id, corpus, [vector_chunk(tenant.id, "spec.pdf", 1, 0..7, "hash-one")])
+
+      result =
+        index!(tenant.id, corpus, [vector_chunk(tenant.id, "spec.pdf", 1, 8..15, "hash-two")])
+
+      assert statuses(result) == [:replaced]
+      assert [%{content_hash: "hash-two"}] = chunks_of(corpus)
+      assert embedding_count(corpus) == 1
+    end
+
+    test "source_complete prunes a mode B source exactly as it does a mode A one" do
+      tenant = fixture(:tenant)
+      corpus = mode_b_corpus!(tenant.id)
+
+      index!(tenant.id, corpus, [
+        vector_chunk(tenant.id, "spec.pdf", 1, 0..7, "hash-one"),
+        vector_chunk(tenant.id, "spec.pdf", 2, 8..15, "hash-two")
+      ])
+
+      result =
+        index!(
+          tenant.id,
+          corpus,
+          [vector_chunk(tenant.id, "spec.pdf", 1, 0..7, "hash-one")],
+          source_complete: ["spec.pdf"]
+        )
+
+      assert result.pruned == 1
+      assert result.pruned_by_source == %{"spec.pdf" => 1}
+      assert [%{ordinal: 1}] = chunks_of(corpus)
+    end
+
+    test "a mode A corpus refuses a vector item's missing text" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id)
+
+      assert {:error, {:invalid_chunk, 0, message}} =
+               Indexer.index_chunks(
+                 tenant.id,
+                 corpus.id,
+                 [vector_chunk(tenant.id, "spec.pdf", 1, 0..7, "hash-one")],
+                 audit: audit_opts()
+               )
+
+      assert message =~ "text is required"
+    end
+
+    test "another tenant cannot index a mode B corpus it does not own" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      corpus_b = mode_b_corpus!(tenant_b.id)
+
+      index!(tenant_b.id, corpus_b, [vector_chunk(tenant_b.id, "spec.pdf", 1, 0..7, "hash-one")])
+
+      assert {:error, :not_found} =
+               Indexer.index_chunks(
+                 tenant_a.id,
+                 corpus_b.id,
+                 [vector_chunk(tenant_a.id, "spec.pdf", 1, 0..7, "hash-evil")],
+                 audit: audit_opts()
+               )
+
+      assert [%{content_hash: "hash-one"}] = chunks_of(corpus_b)
     end
   end
 end

--- a/test/loopctl/corpus/indexer_test.exs
+++ b/test/loopctl/corpus/indexer_test.exs
@@ -885,6 +885,32 @@ defmodule Loopctl.Corpus.IndexerTest do
       assert embedding_count(corpus) == 0
     end
 
+    # `Pgvector.Ecto.Vector`'s cast DISCARDS an element outside pgvector's float32 element
+    # range instead of erroring, so an over-long value arrives at the changeset as a
+    # SHORT vector and fails the dimension validator with numbers the caller never sent —
+    # a 500 for a purely client-side input error. Refused at the same boundary instead.
+    test "an out-of-float32-range element is refused at the boundary, naming the element" do
+      tenant = fixture(:tenant)
+      corpus = mode_b_corpus!(tenant.id)
+
+      out_of_range =
+        tenant.id
+        |> client_vector(0..7)
+        |> List.replace_at(5, 1.0e40)
+
+      batch = [
+        tenant.id
+        |> vector_chunk("spec.pdf", 1, 0..7, "hash-one")
+        |> Map.put("vector", out_of_range)
+      ]
+
+      assert {:error, {:vector_out_of_range, 0, 5}} =
+               Indexer.index_chunks(tenant.id, corpus.id, batch, audit: audit_opts())
+
+      assert chunks_of(corpus) == []
+      assert embedding_count(corpus) == 0
+    end
+
     # TC-43.3.5, the write half. `allow_snippets` defaults to FALSE in mode B, and the
     # refusal is what makes that default enforceable rather than advisory.
     test "a snippet is refused when the corpus forbids them, and bounded when it allows them" do

--- a/test/loopctl/corpus/mode_b_privacy_test.exs
+++ b/test/loopctl/corpus/mode_b_privacy_test.exs
@@ -1,0 +1,284 @@
+defmodule Loopctl.Corpus.ModeBPrivacyTest do
+  @moduledoc """
+  US-43.3 AC-43.3.8 / TC-43.3.1 — the property mode B exists for, asserted DIRECTLY
+  rather than inferred from the shape of the API.
+
+  A regulated corpus is indexed end to end over HTTP with a marker string that is
+  NEVER sent: the client hashes and embeds it locally and loopctl receives only a
+  vector, a pointer and an opaque hash. The marker is then hunted for in every place
+  it could possibly have landed — every COLUMN of `document_chunks` and
+  `document_chunk_embeddings` (the whole row cast to text, not just `text`), the
+  audit rows the ingest wrote, the captured log, and every field of the ingest and
+  search responses.
+
+  ## Why each scan carries a positive control
+
+  A `refute haystack =~ marker` passes VACUOUSLY when the haystack was never
+  populated in the first place — the failure class the repo's own guard tests are
+  written against. So every scan here is run TWICE: once for the marker, which must
+  be absent, and once for a string that IS legitimately submitted (`source_ref`,
+  a permitted `snippet`), which must be PRESENT. If the scan stops working, the
+  control fails first.
+
+  The second test covers the other direction: a snippet sent to a corpus that
+  FORBIDS them is refused, and the refusal must not echo, store or log it — the
+  "convenience field" regression this file is written to catch.
+  """
+
+  use LoopctlWeb.ConnCase, async: true
+
+  import Ecto.Query
+  import ExUnit.CaptureLog
+
+  require Logger
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
+  alias Loopctl.Corpus
+  alias Loopctl.Corpus.DocumentChunk
+
+  setup :verify_on_exit!
+
+  # Never sent. The client holds it, hashes it and embeds it; loopctl sees neither the
+  # string nor anything derived from it that could reconstruct it.
+  @marker "zorbitrandex-phi-body-marker-7Q"
+
+  # Sent, and REFUSED, because the corpus forbids snippets.
+  @refused_snippet "quixotrimble-phi-snippet-3W"
+
+  @source_ref "regulated/837p-companion.pdf"
+
+  # The control token for the log capture (see the assertion that uses it).
+  @log_probe "log-capture-control-5R"
+
+  # The modules a mode B request passes through. A log line on this path is the one way
+  # content could leave the request without touching a column, so the guard below reads
+  # their SOURCE rather than trusting an environment that cannot emit `:debug`.
+  @mode_b_path [
+    "lib/loopctl/corpus/indexer.ex",
+    "lib/loopctl/corpus/search.ex",
+    "lib/loopctl_web/controllers/corpus_controller.ex"
+  ]
+
+  # Bindings that hold caller-supplied content at some point on that path.
+  @payload_bindings ~w(chunks attrs item items text snippet vector params body_params)
+
+  defp keyed_tenant do
+    tenant = fixture(:tenant)
+    {raw_key, _key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+    {tenant, raw_key}
+  end
+
+  defp auth(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+  defp mode_b_corpus!(tenant_id, attrs \\ %{}) do
+    {:ok, corpus} =
+      Corpus.create_corpus(
+        tenant_id,
+        Map.merge(
+          %{
+            slug: "regulated-#{System.unique_integer([:positive])}",
+            name: "Regulated companion",
+            mode: :client_embedded,
+            embedding_model: "local-nomic-embed",
+            dim: 1536
+          },
+          attrs
+        )
+      )
+
+    corpus
+  end
+
+  # The CLIENT's pipeline, run entirely in the test: the text is hashed and embedded
+  # here and neither the text nor the request ever carries it.
+  defp client_hash(text), do: :crypto.hash(:sha256, text) |> Base.encode16(case: :lower)
+
+  defp client_vector(tenant_id, dims) do
+    base = rem(:erlang.phash2(tenant_id), 1500)
+    hot = MapSet.new(dims, &(base + &1))
+
+    Enum.map(0..1535, fn i -> if MapSet.member?(hot, i), do: 1.0, else: 0.0 end)
+  end
+
+  # Casting the WHOLE ROW to text catches every column — including one a later change
+  # adds — rather than only the ones this test knew to name.
+  defp row_matches(table, tenant_id, needle) do
+    %{rows: [[count]]} =
+      AdminRepo.query!(
+        "SELECT count(*) FROM #{table} t WHERE t.tenant_id = $1::uuid AND t::text LIKE $2",
+        [Ecto.UUID.dump!(tenant_id), "%#{needle}%"]
+      )
+
+    count
+  end
+
+  describe "the server never receives the text (TC-43.3.1)" do
+    test "a marker the client never sends appears in no row, no audit entry, no log and no response",
+         %{conn: conn} do
+      {tenant, raw_key} = keyed_tenant()
+      corpus = mode_b_corpus!(tenant.id)
+
+      # The client's own chunking. `text` exists only here.
+      text = "#{@marker} — member 12345678 rendering provider taxonomy 207Q00000X"
+
+      chunk = %{
+        "source_ref" => @source_ref,
+        "locator" => %{"page" => 47},
+        "vector" => client_vector(tenant.id, 0..7),
+        "content_hash" => client_hash(text),
+        "ordinal" => 47
+      }
+
+      refute inspect(chunk) =~ @marker
+
+      {{ingest_body, search_body}, log} =
+        with_log([level: :debug], fn ->
+          # The control for the capture itself. The test env's primary logger level is
+          # `:warning`, so a capture with nothing at that level in it is EMPTY and
+          # `refute log =~ marker` passes vacuously. This line proves the capture is live
+          # at the level the refusal and write-failure paths actually log at; the
+          # source-level guard below is what covers the `:debug`/`:info` lines this
+          # environment cannot emit.
+          Logger.warning("corpus mode B privacy probe #{@log_probe}")
+
+          ingest =
+            conn
+            |> auth(raw_key)
+            |> post(~p"/api/v1/corpora/#{corpus.id}/index", %{"chunks" => [chunk]})
+            |> json_response(200)
+
+          search =
+            conn
+            |> auth(raw_key)
+            |> post(~p"/api/v1/corpora/#{corpus.id}/search", %{
+              "query_vector" => client_vector(tenant.id, 0..7)
+            })
+            |> json_response(200)
+
+          {ingest, search}
+        end)
+
+      # --- the controls: the scans below are live and the haystacks are populated ---
+      assert [%{"status" => "inserted"}] = ingest_body["data"]
+      assert [%{"source_ref" => @source_ref}] = search_body["data"]
+      assert row_matches("document_chunks", tenant.id, @source_ref) == 1
+
+      audit_rows =
+        AdminRepo.all(
+          from(a in AuditLog,
+            where: a.tenant_id == ^tenant.id and a.action == "corpus_indexed"
+          )
+        )
+
+      assert length(audit_rows) == 1
+      assert row_matches("audit_log", tenant.id, "corpus_indexed") == 1
+
+      embedding_rows =
+        AdminRepo.aggregate(
+          from(e in Loopctl.Corpus.DocumentChunkEmbedding, where: e.tenant_id == ^tenant.id),
+          :count,
+          :id
+        )
+
+      assert embedding_rows == 1
+
+      # --- the property ---
+      assert row_matches("document_chunks", tenant.id, @marker) == 0
+      assert row_matches("document_chunk_embeddings", tenant.id, @marker) == 0
+      assert row_matches("audit_log", tenant.id, @marker) == 0
+      assert log =~ @log_probe, "the log capture is empty — the refutation below is vacuous"
+      refute log =~ @marker
+      refute inspect(ingest_body) =~ @marker
+      refute inspect(search_body) =~ @marker
+
+      # And the column that would hold it is NULL, not merely free of this one string.
+      assert [%DocumentChunk{text: nil, snippet: nil}] =
+               AdminRepo.all(from(c in DocumentChunk, where: c.corpus_id == ^corpus.id))
+    end
+  end
+
+  describe "a snippet the corpus forbids is refused, never stored and never echoed" do
+    test "the 422 names the rule without repeating the value", %{conn: conn} do
+      {tenant, raw_key} = keyed_tenant()
+      corpus = mode_b_corpus!(tenant.id)
+
+      refute corpus.allow_snippets
+
+      chunk = %{
+        "source_ref" => @source_ref,
+        "locator" => %{"page" => 47},
+        "vector" => client_vector(tenant.id, 0..7),
+        "content_hash" => client_hash("whatever the client held"),
+        "snippet" => @refused_snippet
+      }
+
+      body =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/index", %{"chunks" => [chunk]})
+        |> json_response(422)
+
+      assert body["error"]["code"] == "snippets_not_allowed"
+      assert body["error"]["message"] =~ "allow_snippets"
+      refute inspect(body) =~ @refused_snippet
+
+      assert row_matches("document_chunks", tenant.id, @refused_snippet) == 0
+      assert AdminRepo.all(from(c in DocumentChunk, where: c.corpus_id == ^corpus.id)) == []
+    end
+
+    # The CONTROL for the scan above: the very same needle IS found once a corpus that
+    # permits snippets stores one, so a zero above means absence and not a broken scan.
+    test "the identical scan finds the value once a corpus that permits snippets stores it",
+         %{conn: conn} do
+      {tenant, raw_key} = keyed_tenant()
+      corpus = mode_b_corpus!(tenant.id, %{allow_snippets: true})
+
+      chunk = %{
+        "source_ref" => @source_ref,
+        "locator" => %{"page" => 47},
+        "vector" => client_vector(tenant.id, 0..7),
+        "content_hash" => client_hash("whatever the client held"),
+        "snippet" => @refused_snippet
+      }
+
+      conn
+      |> auth(raw_key)
+      |> post(~p"/api/v1/corpora/#{corpus.id}/index", %{"chunks" => [chunk]})
+      |> json_response(200)
+
+      assert row_matches("document_chunks", tenant.id, @refused_snippet) == 1
+    end
+  end
+
+  # The half the environment cannot test: this suite runs at `:warning`, production at
+  # `:info`, so a `Logger.debug`/`Logger.info` echoing a request body would emit in
+  # production and be invisible here. Read the source instead.
+  #
+  # MUTATION-VERIFIED: adding `Logger.info("payload " <> inspect(chunks))` to
+  # `Loopctl.Corpus.Indexer.index_chunks/4` turns this red.
+  describe "no module on the mode B path logs the payload" do
+    test "every Logger call on the ingest and search path is free of payload bindings" do
+      call_sites =
+        Enum.flat_map(@mode_b_path, fn path ->
+          lines = path |> File.read!() |> String.split("\n")
+
+          for {line, index} <- Enum.with_index(lines),
+              String.contains?(line, "Logger.") and not String.contains?(line, "#"),
+              do: {path, index + 1, lines |> Enum.slice(index, 4) |> Enum.join(" ")}
+        end)
+
+      # Non-vacuity: the scan found the log lines that ARE there (the write-failure
+      # error), so an empty offender list means absence and not a broken scan.
+      assert call_sites != []
+
+      offenders =
+        for {path, line, window} <- call_sites,
+            binding <- @payload_bindings,
+            Regex.match?(~r/\binspect\(#{binding}\)|\#\{#{binding}\}/, window),
+            do: "#{path}:#{line} logs #{binding}"
+
+      assert offenders == []
+    end
+  end
+end

--- a/test/loopctl/corpus/mode_b_privacy_test.exs
+++ b/test/loopctl/corpus/mode_b_privacy_test.exs
@@ -60,8 +60,12 @@ defmodule Loopctl.Corpus.ModeBPrivacyTest do
     "lib/loopctl_web/controllers/corpus_controller.ex"
   ]
 
-  # Bindings that hold caller-supplied content at some point on that path.
-  @payload_bindings ~w(chunks attrs item items text snippet vector params body_params)
+  # Bindings that hold caller-supplied content at some point on that path. `chunk` is
+  # listed separately from `chunks` on purpose: the regex matches a WORD, so `\bchunks\b`
+  # never covers it, and `chunk` is the SINGULAR applied struct the mode B item builder
+  # binds — the one carrying the caller's snippet. `conn` covers the reach to
+  # `conn.body_params` by name rather than only through the `body_params` entry.
+  @payload_bindings ~w(chunk chunks attrs item items text snippet vector params body_params conn)
 
   defp keyed_tenant do
     tenant = fixture(:tenant)

--- a/test/loopctl/corpus/mode_b_privacy_test.exs
+++ b/test/loopctl/corpus/mode_b_privacy_test.exs
@@ -255,16 +255,21 @@ defmodule Loopctl.Corpus.ModeBPrivacyTest do
   # `:info`, so a `Logger.debug`/`Logger.info` echoing a request body would emit in
   # production and be invisible here. Read the source instead.
   #
-  # MUTATION-VERIFIED: adding `Logger.info("payload " <> inspect(chunks))` to
-  # `Loopctl.Corpus.Indexer.index_chunks/4` turns this red.
+  # MUTATION-VERIFIED, in the INTERPOLATED form — the one an author actually writes, and
+  # the one an earlier version of this guard could not see because it rejected every line
+  # containing a `#` (the first character of `\#{}`) as a comment: adding
+  # `Logger.info("payload \#{inspect(chunks)}")` to `Loopctl.Corpus.Indexer.index_chunks/4`
+  # turns this red, as does the `<>` concatenation form.
   describe "no module on the mode B path logs the payload" do
     test "every Logger call on the ingest and search path is free of payload bindings" do
       call_sites =
         Enum.flat_map(@mode_b_path, fn path ->
-          lines = path |> File.read!() |> String.split("\n")
+          # Comments are stripped, not used to reject the whole line: a trailing `# ...`
+          # must not hide the code before it, and an interpolation is not a comment.
+          lines = path |> File.read!() |> String.split("\n") |> Enum.map(&strip_comment/1)
 
           for {line, index} <- Enum.with_index(lines),
-              String.contains?(line, "Logger.") and not String.contains?(line, "#"),
+              String.contains?(line, "Logger."),
               do: {path, index + 1, lines |> Enum.slice(index, 4) |> Enum.join(" ")}
         end)
 
@@ -275,10 +280,21 @@ defmodule Loopctl.Corpus.ModeBPrivacyTest do
       offenders =
         for {path, line, window} <- call_sites,
             binding <- @payload_bindings,
-            Regex.match?(~r/\binspect\(#{binding}\)|\#\{#{binding}\}/, window),
+            Regex.match?(payload_regex(binding), window),
             do: "#{path}:#{line} logs #{binding}"
 
       assert offenders == []
     end
   end
+
+  # Everything from the first `#` that does not open an interpolation. Crude for Elixir
+  # in general (a literal `#` inside a string is not a comment), but exact for the one
+  # question asked here: whether a Logger call names a payload binding.
+  defp strip_comment(line), do: line |> String.split(~r/#(?!\{)/, parts: 2) |> hd()
+
+  # The binding may be reached through a field or an index (`inspect(item.snippet)`,
+  # `\#{hd(chunks)}`), so it is matched as a WORD anywhere inside the `inspect(...)` call
+  # or the interpolation rather than as the whole argument.
+  defp payload_regex(binding),
+    do: ~r/inspect\([^)]*\b#{binding}\b|\#\{[^}]*\b#{binding}\b/
 end

--- a/test/loopctl/corpus/search_test.exs
+++ b/test/loopctl/corpus/search_test.exs
@@ -49,6 +49,34 @@ defmodule Loopctl.Corpus.SearchTest do
     result
   end
 
+  # US-43.3. A mode B corpus never receives text: the caller sends the vector it produced
+  # locally, and the query arrives as a vector too.
+  defp mode_b_corpus!(tenant_id, attrs \\ %{}),
+    do: create_corpus!(tenant_id, Map.merge(%{mode: :client_embedded}, attrs))
+
+  defp vector_chunk(tenant_id, source_ref, page, dims, hash, attrs \\ %{}) do
+    Map.merge(
+      %{
+        "source_ref" => source_ref,
+        "locator" => %{"page" => page},
+        "vector" => client_vector(tenant_id, dims),
+        "content_hash" => hash,
+        "ordinal" => page
+      },
+      attrs
+    )
+  end
+
+  # Each tenant's vectors occupy its OWN contiguous block, so tenants stay well-separated
+  # points in the shared HNSW index and recall here is deterministic under `async: true`
+  # — the same discipline as the per-tenant mock embeddings above.
+  defp client_vector(tenant_id, dims) do
+    base = rem(:erlang.phash2(tenant_id), 1500)
+    hot = MapSet.new(dims, &(base + &1))
+
+    Enum.map(0..1535, fn i -> if MapSet.member?(hot, i), do: 1.0, else: 0.0 end)
+  end
+
   defp chunk(source_ref, page, text) do
     %{
       "source_ref" => source_ref,
@@ -99,10 +127,10 @@ defmodule Loopctl.Corpus.SearchTest do
       assert {:error, :not_found} = Search.search(other.id, corpus.id, "rendering provider")
     end
 
-    # The ingest verb guards mode explicitly; without the same clause here, searching a
-    # client_embedded corpus spent a provider embedding call on the tenant's own key and
-    # answered 200 with an empty set for an operation the corpus can never serve.
-    test "a client_embedded corpus is refused before any provider call" do
+    # Without this clause, searching a client_embedded corpus spent a provider embedding
+    # call on the tenant's own key and answered 200 with an empty set for an operation the
+    # corpus can never serve. TC-43.3.3: it is a NAMED refusal, not an empty result.
+    test "a query string against a client_embedded corpus is refused before any provider call" do
       tenant = fixture(:tenant)
       corpus = create_corpus!(tenant.id, %{mode: :client_embedded})
 
@@ -113,7 +141,9 @@ defmodule Loopctl.Corpus.SearchTest do
         {:ok, List.duplicate(0.01, 1536)}
       end)
 
-      assert {:error, :mode_mismatch} = Search.search(tenant.id, corpus.id, "taxonomy code")
+      assert {:error, :query_string_not_accepted} =
+               Search.search(tenant.id, corpus.id, "taxonomy code")
+
       assert :counters.get(calls, 1) == 0
     end
 
@@ -333,6 +363,198 @@ defmodule Loopctl.Corpus.SearchTest do
 
       assert length(results) == 1
       refute Map.has_key?(meta, :semantic_under_filled)
+    end
+  end
+
+  # --- US-43.3: mode B retrieval ---
+
+  describe "search_vector/4 on a client_embedded corpus (US-43.3)" do
+    # TC-43.3.6 — a known neighbour, ranked. `near` shares the query's whole direction,
+    # `mid` half of it, `far` none.
+    test "ranks by descending similarity and names the semantic lane ALONE" do
+      tenant = fixture(:tenant)
+      corpus = mode_b_corpus!(tenant.id)
+
+      index!(tenant.id, corpus, [
+        vector_chunk(tenant.id, "spec.pdf", 1, 0..7, "hash-near"),
+        vector_chunk(tenant.id, "spec.pdf", 2, 0..15, "hash-mid"),
+        vector_chunk(tenant.id, "spec.pdf", 3, 8..15, "hash-far")
+      ])
+
+      {:ok, %{results: results, meta: meta}} =
+        Search.search_vector(tenant.id, corpus.id, client_vector(tenant.id, 0..7))
+
+      assert Enum.map(results, & &1.locator) == [
+               %{"page" => 1},
+               %{"page" => 2},
+               %{"page" => 3}
+             ]
+
+      scores = Enum.map(results, & &1.score)
+      assert scores == Enum.sort(scores, :desc)
+
+      # STATED, not discovered: mode B is semantic-only because there is no text lane.
+      assert meta.lanes == ["semantic"]
+      assert meta.search_mode == "semantic_only"
+      refute Map.has_key?(meta, :keyword_unavailable_reason)
+    end
+
+    # AC-43.3.7 — a mode B result carries the same pointer fields a mode A one does.
+    test "a result carries {source_ref, locator, score, corpus_id, chunk_id} and a null snippet" do
+      tenant = fixture(:tenant)
+      corpus = mode_b_corpus!(tenant.id)
+
+      index!(tenant.id, corpus, [vector_chunk(tenant.id, "spec.pdf", 47, 0..7, "hash-one")])
+
+      {:ok, %{results: [result], meta: meta}} =
+        Search.search_vector(tenant.id, corpus.id, client_vector(tenant.id, 0..7))
+
+      assert result.source_ref == "spec.pdf"
+      assert result.locator == %{"page" => 47}
+      assert result.corpus_id == corpus.id
+      assert is_binary(result.chunk_id)
+      assert is_number(result.score)
+      # NULL by default: allow_snippets is false for a mode B corpus that did not ask.
+      assert Map.has_key?(result, :snippet)
+      assert result.snippet == nil
+      assert meta.allow_snippets == false
+    end
+
+    test "a stored snippet IS returned when the corpus allows them" do
+      tenant = fixture(:tenant)
+      corpus = mode_b_corpus!(tenant.id, %{allow_snippets: true})
+
+      index!(tenant.id, corpus, [
+        vector_chunk(tenant.id, "spec.pdf", 1, 0..7, "hash-one", %{
+          "snippet" => "loop 2310B excerpt"
+        })
+      ])
+
+      {:ok, %{results: [result]}} =
+        Search.search_vector(tenant.id, corpus.id, client_vector(tenant.id, 0..7))
+
+      assert result.snippet == "loop 2310B excerpt"
+    end
+
+    # TC-43.3.4, read side.
+    test "a wrong-length query vector is refused at the boundary, naming both dimensions" do
+      tenant = fixture(:tenant)
+      corpus = mode_b_corpus!(tenant.id)
+
+      index!(tenant.id, corpus, [vector_chunk(tenant.id, "spec.pdf", 1, 0..7, "hash-one")])
+
+      assert {:error, {:query_vector_dimension_mismatch, 768, 1536}} =
+               Search.search_vector(tenant.id, corpus.id, List.duplicate(0.0, 768))
+
+      assert {:error, :invalid_query_vector} =
+               Search.search_vector(tenant.id, corpus.id, "not a vector")
+
+      assert {:error, :invalid_query_vector} = Search.search_vector(tenant.id, corpus.id, [])
+    end
+
+    # AC-43.3.5 — refused, never an empty set, because an agent reads an empty set as an
+    # empty corpus.
+    test "asking for the keyword lane on a mode B corpus is refused" do
+      tenant = fixture(:tenant)
+      corpus = mode_b_corpus!(tenant.id)
+
+      index!(tenant.id, corpus, [vector_chunk(tenant.id, "spec.pdf", 1, 0..7, "hash-one")])
+
+      assert {:error, :keyword_lane_unavailable} =
+               Search.search_vector(tenant.id, corpus.id, client_vector(tenant.id, 0..7),
+                 lanes: ["keyword"]
+               )
+
+      assert {:error, :keyword_lane_unavailable} =
+               Search.search_vector(tenant.id, corpus.id, client_vector(tenant.id, 0..7),
+                 lanes: ["keyword", "semantic"]
+               )
+
+      assert {:ok, %{results: [_result]}} =
+               Search.search_vector(tenant.id, corpus.id, client_vector(tenant.id, 0..7),
+                 lanes: ["semantic"]
+               )
+
+      assert {:error, {:invalid_lanes, ["graph"]}} =
+               Search.search_vector(tenant.id, corpus.id, client_vector(tenant.id, 0..7),
+                 lanes: ["graph"]
+               )
+    end
+
+    test "a query vector against a mode A corpus is refused by name" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id)
+
+      assert {:error, :query_vector_not_accepted} =
+               Search.search_vector(tenant.id, corpus.id, client_vector(tenant.id, 0..7))
+    end
+
+    test "a mode B corpus of another tenant is a 404, and its chunks never surface" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      corpus_a = mode_b_corpus!(tenant_a.id)
+      corpus_b = mode_b_corpus!(tenant_b.id)
+
+      index!(tenant_a.id, corpus_a, [vector_chunk(tenant_a.id, "a.pdf", 1, 0..7, "hash-a")])
+      index!(tenant_b.id, corpus_b, [vector_chunk(tenant_b.id, "b.pdf", 1, 0..7, "hash-b")])
+
+      assert {:error, :not_found} =
+               Search.search_vector(tenant_a.id, corpus_b.id, client_vector(tenant_b.id, 0..7))
+
+      # Searching its OWN corpus with tenant B's vector still reaches only tenant A's rows.
+      {:ok, %{results: results}} =
+        Search.search_vector(tenant_a.id, corpus_a.id, client_vector(tenant_b.id, 0..7))
+
+      for result <- results do
+        assert result.corpus_id == corpus_a.id
+        assert result.source_ref == "a.pdf"
+      end
+    end
+  end
+
+  # TC-43.3.8 — a caller branches on `meta`, never on which mode answered.
+  describe "mode A and mode B answer on ONE shape" do
+    test "the result and meta key sets are identical; only meta.lanes differs" do
+      tenant = fixture(:tenant)
+      mode_a = create_corpus!(tenant.id)
+      mode_b = mode_b_corpus!(tenant.id)
+
+      index!(tenant.id, mode_a, [chunk("a.pdf", 1, "rendering provider taxonomy code")])
+      index!(tenant.id, mode_b, [vector_chunk(tenant.id, "b.pdf", 1, 0..7, "hash-one")])
+
+      {:ok, %{results: [a_result], meta: a_meta}} =
+        Search.search(tenant.id, mode_a.id, "rendering provider")
+
+      {:ok, %{results: [b_result], meta: b_meta}} =
+        Search.search_vector(tenant.id, mode_b.id, client_vector(tenant.id, 0..7))
+
+      assert Map.keys(a_result) == Map.keys(b_result)
+      assert Map.keys(a_meta) == Map.keys(b_meta)
+
+      assert a_meta.lanes == ["keyword", "semantic"]
+      assert b_meta.lanes == ["semantic"]
+      assert a_meta.search_mode == "combined"
+      assert b_meta.search_mode == "semantic_only"
+
+      # Everything else about the envelope is the same number or the same basis.
+      assert a_meta.score_basis == b_meta.score_basis
+      assert a_meta.snippet_max_chars == b_meta.snippet_max_chars
+      assert a_meta.limit == b_meta.limit
+    end
+
+    # The mode A half of the lane contract: `lanes` is honoured there too, so a caller
+    # that names one is not silently given both.
+    test "a mode A corpus honours a lane restriction" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id)
+
+      index!(tenant.id, corpus, [chunk("a.pdf", 1, "rendering provider taxonomy code")])
+
+      {:ok, %{meta: meta}} =
+        Search.search(tenant.id, corpus.id, "rendering provider", lanes: ["keyword"])
+
+      assert meta.lanes == ["keyword"]
+      assert meta.search_mode == "keyword_only"
     end
   end
 end

--- a/test/loopctl/corpus/search_test.exs
+++ b/test/loopctl/corpus/search_test.exs
@@ -222,6 +222,27 @@ defmodule Loopctl.Corpus.SearchTest do
       assert meta.semantic_unavailable_reason == "dimension_mismatch"
     end
 
+    # The semantic lane asked for ALONE and failing leaves nothing to fuse and no degraded
+    # answer. The raw provider reason must never escape: the FallbackController has no
+    # clause for one, so returning it verbatim answers 500 instead of a coded refusal.
+    test "a semantic-only request whose embedding fails returns a NAMED error" do
+      tenant = fixture(:tenant)
+      corpus = create_corpus!(tenant.id)
+      index!(tenant.id, corpus, [chunk("a.pdf", 1, "rendering provider taxonomy code")])
+
+      stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _scope, _text, _opts ->
+        {:error, :no_api_key}
+      end)
+
+      assert {:error, {:semantic_lane_unavailable, "no_api_key"}} =
+               Search.search(tenant.id, corpus.id, "taxonomy", lanes: ["semantic"])
+
+      # The SAME failure with the keyword lane available is still a degradation, not an
+      # error — the behaviour the named term must not have changed.
+      assert {:ok, %{meta: %{lanes: ["keyword"]}}} =
+               Search.search(tenant.id, corpus.id, "taxonomy")
+    end
+
     test "the semantic lane alone still answers when the query matches no keyword" do
       tenant = fixture(:tenant)
       corpus = create_corpus!(tenant.id)
@@ -479,6 +500,19 @@ defmodule Loopctl.Corpus.SearchTest do
                Search.search_vector(tenant.id, corpus.id, client_vector(tenant.id, 0..7),
                  lanes: ["graph"]
                )
+    end
+
+    # pgvector's element type is float32, and Postgres RAISES on a larger value rather
+    # than returning an error — refused at the boundary, naming the element, the same way
+    # a length mismatch is.
+    test "an out-of-float32-range element in the query vector is refused at the boundary" do
+      tenant = fixture(:tenant)
+      corpus = mode_b_corpus!(tenant.id)
+
+      vector = List.replace_at(client_vector(tenant.id, 0..7), 3, 1.0e40)
+
+      assert {:error, {:query_vector_out_of_range, 3}} =
+               Search.search_vector(tenant.id, corpus.id, vector)
     end
 
     test "a query vector against a mode A corpus is refused by name" do

--- a/test/loopctl/corpus_test.exs
+++ b/test/loopctl/corpus_test.exs
@@ -197,13 +197,32 @@ defmodule Loopctl.CorpusTest do
       refute Map.has_key?(changeset.changes, :dim)
     end
 
-    test "changing mode is an ERROR on :mode", %{corpus: corpus} do
+    # TC-43.3.7 — BOTH directions. A mode A corpus can never become mode B and a mode B
+    # corpus can never become mode A: mode decides whether the server holds text at all,
+    # so a flip would leave every stored chunk in the wrong shape with no repair. The
+    # error names the supported path.
+    test "changing mode is an ERROR on :mode in BOTH directions", %{
+      corpus: corpus,
+      tenant: tenant
+    } do
       changeset =
         CorpusSchema.update_changeset(corpus, %{name: corpus.name, mode: :client_embedded})
 
       refute changeset.valid?
-      assert [_] = errors_on(changeset).mode
+      assert [message] = errors_on(changeset).mode
+      assert message =~ "pinned at creation"
+      assert message =~ "delete-and-re-index"
       refute Map.has_key?(changeset.changes, :mode)
+
+      mode_b = create_corpus!(tenant.id, %{mode: :client_embedded})
+
+      reverse =
+        CorpusSchema.update_changeset(mode_b, %{name: mode_b.name, mode: :server_embedded})
+
+      refute reverse.valid?
+      assert [reverse_message] = errors_on(reverse).mode
+      assert reverse_message =~ "delete-and-re-index"
+      refute Map.has_key?(reverse.changes, :mode)
     end
 
     test "changing embedding_model is an ERROR on :embedding_model", %{corpus: corpus} do

--- a/test/loopctl_web/controllers/corpus_controller_test.exs
+++ b/test/loopctl_web/controllers/corpus_controller_test.exs
@@ -32,6 +32,48 @@ defmodule LoopctlWeb.CorpusControllerTest do
     {tenant, raw_key}
   end
 
+  # US-43.3. Mode B carries a locally-produced vector and the client's own opaque hash.
+  defp mode_b_corpus!(tenant_id, attrs \\ %{}) do
+    {:ok, corpus} =
+      Corpus.create_corpus(
+        tenant_id,
+        Map.merge(
+          %{
+            slug: "byo-#{System.unique_integer([:positive])}",
+            name: "Client embedded",
+            mode: :client_embedded,
+            embedding_model: "local-nomic-embed",
+            dim: 1536
+          },
+          attrs
+        )
+      )
+
+    corpus
+  end
+
+  defp mode_b_chunk(tenant_id, attrs \\ %{}) do
+    Map.merge(
+      %{
+        "source_ref" => "spec.pdf",
+        "locator" => %{"page" => 1},
+        "vector" => mode_b_vector(tenant_id),
+        "content_hash" => "client-hash-one",
+        "ordinal" => 1
+      },
+      attrs
+    )
+  end
+
+  # Per-tenant separation in the shared HNSW index, the convention the corpus search
+  # tests already follow.
+  defp mode_b_vector(tenant_id) do
+    base = rem(:erlang.phash2(tenant_id), 1500)
+    hot = MapSet.new(0..7, &(base + &1))
+
+    Enum.map(0..1535, fn i -> if MapSet.member?(hot, i), do: 1.0, else: 0.0 end)
+  end
+
   defp corpus_body(attrs \\ %{}) do
     seq = System.unique_integer([:positive])
 
@@ -624,10 +666,10 @@ defmodule LoopctlWeb.CorpusControllerTest do
       assert body["meta"]["lanes"] == ["keyword", "semantic"]
     end
 
-    # Both halves of the surface refuse a client_embedded corpus identically: the ingest
-    # verb already answered a coded 422 while search spent a provider call and answered
-    # 200 with an empty set.
-    test "a client_embedded corpus is a coded 422, not an empty 200", %{conn: conn} do
+    # TC-43.3.3 at the HTTP boundary: an agent reads an empty 200 as an empty corpus, so
+    # a query STRING against a mode B corpus is a coded 422 naming what to send instead.
+    test "a query string against a client_embedded corpus is a coded 422, not an empty 200",
+         %{conn: conn} do
       {tenant, raw_key} = keyed_tenant()
 
       {:ok, corpus} =
@@ -645,7 +687,8 @@ defmodule LoopctlWeb.CorpusControllerTest do
         |> post(~p"/api/v1/corpora/#{corpus.id}/search", %{"query" => "taxonomy"})
         |> json_response(422)
 
-      assert body["error"]["code"] == "mode_mismatch"
+      assert body["error"]["code"] == "query_string_not_accepted"
+      assert body["error"]["message"] =~ "query_vector"
     end
 
     test "an empty query is a coded 422", %{conn: conn} do
@@ -708,8 +751,13 @@ defmodule LoopctlWeb.CorpusControllerTest do
          %{conn: conn} do
       spec = Loopctl.ApiSpec.spec()
 
-      documented =
-        spec.paths["/api/v1/corpora/{id}/index"].post.requestBody.content["application/json"].schema.properties.chunks.items.properties.snippet.maxLength
+      # US-43.3 gave `chunks.items` a `oneOf` (one item shape per corpus mode); this is
+      # the server_embedded arm, which is what the mode A request below sends.
+      server_schema =
+        spec.paths["/api/v1/corpora/{id}/index"].post.requestBody.content["application/json"].schema.properties.chunks.items.oneOf
+        |> Enum.find(&(&1.title == "ServerEmbeddedChunk"))
+
+      documented = server_schema.properties.snippet.maxLength
 
       assert is_integer(documented) and documented > 0
 
@@ -753,6 +801,186 @@ defmodule LoopctlWeb.CorpusControllerTest do
 
       assert Enum.any?(spec.tags, &(&1.name == "Corpus"))
       assert "Corpus" in spec.paths["/api/v1/corpora"].get.tags
+    end
+  end
+
+  # --- US-43.3: mode B over HTTP ---
+
+  describe "mode B ingest (US-43.3)" do
+    test "accepts vector chunks and refuses text, a wrong-length vector and a snippet",
+         %{conn: conn} do
+      {tenant, raw_key} = keyed_tenant()
+      corpus = mode_b_corpus!(tenant.id)
+
+      ok =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/index", %{
+          "chunks" => [mode_b_chunk(tenant.id)]
+        })
+        |> json_response(200)
+
+      assert [%{"status" => "inserted"}] = ok["data"]
+
+      with_text = Map.put(mode_b_chunk(tenant.id), "text", "loop 2310B rendering provider")
+
+      refused =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/index", %{"chunks" => [with_text]})
+        |> json_response(422)
+
+      assert refused["error"]["code"] == "text_not_accepted"
+      assert refused["error"]["message"] =~ "client_embedded"
+
+      short = Map.put(mode_b_chunk(tenant.id), "vector", List.duplicate(0.0, 768))
+
+      mismatch =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/index", %{"chunks" => [short]})
+        |> json_response(422)
+
+      assert mismatch["error"]["code"] == "vector_dimension_mismatch"
+      assert mismatch["error"]["details"]["received_dim"] == 768
+      assert mismatch["error"]["details"]["corpus_dim"] == 1536
+
+      snippetted = Map.put(mode_b_chunk(tenant.id), "snippet", "an excerpt")
+
+      forbidden =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/index", %{"chunks" => [snippetted]})
+        |> json_response(422)
+
+      assert forbidden["error"]["code"] == "snippets_not_allowed"
+    end
+
+    test "a missing content_hash is a coded 422", %{conn: conn} do
+      {tenant, raw_key} = keyed_tenant()
+      corpus = mode_b_corpus!(tenant.id)
+      chunk = Map.delete(mode_b_chunk(tenant.id), "content_hash")
+
+      body =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/index", %{"chunks" => [chunk]})
+        |> json_response(422)
+
+      assert body["error"]["code"] == "invalid_chunk"
+      assert body["error"]["message"] =~ "content_hash is required"
+    end
+  end
+
+  describe "mode B search (US-43.3)" do
+    test "a query vector answers pointers and names the semantic lane alone", %{conn: conn} do
+      {tenant, raw_key} = keyed_tenant()
+      corpus = mode_b_corpus!(tenant.id)
+
+      conn
+      |> auth(raw_key)
+      |> post(~p"/api/v1/corpora/#{corpus.id}/index", %{"chunks" => [mode_b_chunk(tenant.id)]})
+      |> json_response(200)
+
+      body =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/search", %{
+          "query_vector" => mode_b_vector(tenant.id)
+        })
+        |> json_response(200)
+
+      assert [%{"source_ref" => "spec.pdf", "snippet" => nil}] = body["data"]
+      assert body["meta"]["lanes"] == ["semantic"]
+      assert body["meta"]["search_mode"] == "semantic_only"
+    end
+
+    test "a wrong-length query vector is a coded 422 naming both dimensions", %{conn: conn} do
+      {tenant, raw_key} = keyed_tenant()
+      corpus = mode_b_corpus!(tenant.id)
+
+      body =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/search", %{
+          "query_vector" => List.duplicate(0.0, 768)
+        })
+        |> json_response(422)
+
+      assert body["error"]["code"] == "query_vector_dimension_mismatch"
+      assert body["error"]["details"] == %{"received_dim" => 768, "corpus_dim" => 1536}
+    end
+
+    test "asking for the keyword lane on a mode B corpus is a coded 422", %{conn: conn} do
+      {tenant, raw_key} = keyed_tenant()
+      corpus = mode_b_corpus!(tenant.id)
+
+      body =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/search", %{
+          "query_vector" => mode_b_vector(tenant.id),
+          "lanes" => ["keyword"]
+        })
+        |> json_response(422)
+
+      assert body["error"]["code"] == "keyword_lane_unavailable"
+      assert body["error"]["message"] =~ "semantic"
+    end
+
+    test "a query vector against a mode A corpus is a coded 422", %{conn: conn} do
+      {tenant, raw_key} = keyed_tenant()
+      corpus = create_corpus!(tenant.id)
+
+      body =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/search", %{
+          "query_vector" => mode_b_vector(tenant.id)
+        })
+        |> json_response(422)
+
+      assert body["error"]["code"] == "query_vector_not_accepted"
+      assert body["error"]["message"] =~ "query"
+    end
+  end
+
+  # The mode B half of TC-43.2.5's discipline: the DOCUMENTED shape is read out of the
+  # GENERATED spec, and its bounds are the attributes the runtime enforces.
+  describe "the OpenAPI document describes mode B as it is enforced" do
+    test "the client_embedded chunk schema has no text property and states the hash contract" do
+      spec = Loopctl.ApiSpec.spec()
+
+      chunks =
+        spec.paths["/api/v1/corpora/{id}/index"].post.requestBody.content["application/json"].schema.properties.chunks
+
+      assert chunks.maxItems == Indexer.max_batch_size()
+
+      client_schema =
+        Enum.find(chunks.items.oneOf, &(&1.title == "ClientEmbeddedChunk"))
+
+      assert client_schema
+      # There is NO parameter that accepts chunk text in mode B (AC-43.3.1).
+      refute Map.has_key?(client_schema.properties, :text)
+      assert :vector in Map.keys(client_schema.properties)
+      assert :content_hash in client_schema.required
+      assert client_schema.properties.snippet.maxLength == Search.max_snippet_chars()
+
+      # AC-43.3.2 — the honesty the story requires, stated where a caller reads it.
+      assert client_schema.description =~ "opaque idempotency token"
+      assert client_schema.description =~ "cannot verify"
+    end
+
+    test "the search schema documents query_vector and says why mode B is semantic-only" do
+      spec = Loopctl.ApiSpec.spec()
+      search = spec.paths["/api/v1/corpora/{id}/search"].post
+      request = search.requestBody.content["application/json"].schema
+
+      assert :query_vector in Map.keys(request.properties)
+      assert request.properties.lanes.items.enum == Search.lanes()
+      assert search.description =~ "SEMANTIC-ONLY"
+      assert search.description =~ "no text to index"
+      assert search.description =~ "query_string_not_accepted"
     end
   end
 end

--- a/test/loopctl_web/controllers/corpus_controller_test.exs
+++ b/test/loopctl_web/controllers/corpus_controller_test.exs
@@ -872,6 +872,35 @@ defmodule LoopctlWeb.CorpusControllerTest do
     end
   end
 
+  describe "mode B ingest rejects a vector pgvector cannot store" do
+    # `Pgvector.Ecto.Vector` DISCARDS an out-of-float32-range element on cast instead of
+    # erroring, so the item reached the changeset one element short and the request
+    # failed as a 500 corpus_write_failed naming numbers the caller never sent.
+    test "an out-of-float32-range element is a coded 422 naming the element", %{conn: conn} do
+      {tenant, raw_key} = keyed_tenant()
+      corpus = mode_b_corpus!(tenant.id)
+
+      vector = List.replace_at(mode_b_vector(tenant.id), 5, -1.0e40)
+
+      body =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/index", %{
+          "chunks" => [mode_b_chunk(tenant.id, %{"vector" => vector})]
+        })
+        |> json_response(422)
+
+      assert body["error"]["code"] == "vector_out_of_range"
+      assert body["error"]["details"] == %{"index" => 0, "element_index" => 5}
+
+      assert AdminRepo.aggregate(
+               from(c in DocumentChunk, where: c.corpus_id == ^corpus.id),
+               :count,
+               :id
+             ) == 0
+    end
+  end
+
   describe "mode B search (US-43.3)" do
     test "a query vector answers pointers and names the semantic lane alone", %{conn: conn} do
       {tenant, raw_key} = keyed_tenant()
@@ -943,6 +972,152 @@ defmodule LoopctlWeb.CorpusControllerTest do
       assert body["error"]["code"] == "query_vector_not_accepted"
       assert body["error"]["message"] =~ "query"
     end
+
+    # pgvector's element type is float32. Postgres RAISES on a larger value
+    # (`infinite value not allowed in vector`), which the DB backstop renders as an
+    # opaque 500 — a caller-side input error answered with a server error.
+    test "an out-of-float32-range query vector is a coded 422, not a 500", %{conn: conn} do
+      {tenant, raw_key} = keyed_tenant()
+      corpus = mode_b_corpus!(tenant.id)
+
+      vector = List.replace_at(mode_b_vector(tenant.id), 3, 1.0e40)
+
+      body =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/search", %{"query_vector" => vector})
+        |> json_response(422)
+
+      assert body["error"]["code"] == "query_vector_out_of_range"
+      assert body["error"]["details"] == %{"index" => 3}
+    end
+  end
+
+  # The dispatch defects the enhanced review found: a search must be routed by the VALUE
+  # of query_vector, and a lane set that leaves the semantic lane alone must not leak a
+  # raw provider term into the FallbackController.
+  describe "search dispatch and lane-failure coding" do
+    # Emitting `null` for an absent optional is ordinary client serialization. Matching
+    # the KEY sent this valid mode A request down the mode B path, where it was refused
+    # with a message telling the caller to send the `query` it had already sent.
+    test "an explicit query_vector null on a mode A corpus is a normal search", %{conn: conn} do
+      {tenant, raw_key} = keyed_tenant()
+      corpus = create_corpus!(tenant.id)
+
+      {:ok, _result} =
+        Indexer.index_chunks(tenant.id, corpus.id, [page_chunk(1, "taxonomy code")],
+          audit: [actor_type: "api_key"]
+        )
+
+      body =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/search", %{
+          "query" => "taxonomy code",
+          "query_vector" => nil
+        })
+        |> json_response(200)
+
+      assert [%{"source_ref" => "a.pdf"}] = body["data"]
+    end
+
+    # The mirror serialization case: a client without omitempty sends `query: ""`
+    # alongside the vector it means.
+    test "an empty query string alongside a query vector still runs the vector search",
+         %{conn: conn} do
+      {tenant, raw_key} = keyed_tenant()
+      corpus = mode_b_corpus!(tenant.id)
+
+      conn
+      |> auth(raw_key)
+      |> post(~p"/api/v1/corpora/#{corpus.id}/index", %{"chunks" => [mode_b_chunk(tenant.id)]})
+      |> json_response(200)
+
+      body =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/search", %{
+          "query" => "",
+          "query_vector" => mode_b_vector(tenant.id)
+        })
+        |> json_response(200)
+
+      assert [%{"source_ref" => "spec.pdf"}] = body["data"]
+      assert body["meta"]["lanes"] == ["semantic"]
+    end
+
+    # Both given is genuinely ambiguous, and silently preferring the vector answered a
+    # search the caller did not ask for.
+    test "both query and query_vector given is a coded 422", %{conn: conn} do
+      {tenant, raw_key} = keyed_tenant()
+      corpus = mode_b_corpus!(tenant.id)
+
+      body =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/search", %{
+          "query" => "taxonomy",
+          "query_vector" => mode_b_vector(tenant.id)
+        })
+        |> json_response(422)
+
+      assert body["error"]["code"] == "ambiguous_query"
+    end
+
+    # The semantic lane asked for ALONE and failing leaves no degraded answer. The raw
+    # provider reason has no FallbackController clause, so returning it verbatim raised
+    # a FunctionClauseError and answered 500.
+    test "a semantic-only request whose embedding fails is a coded 502", %{conn: conn} do
+      {tenant, raw_key} = keyed_tenant()
+      corpus = create_corpus!(tenant.id)
+
+      {:ok, _result} =
+        Indexer.index_chunks(tenant.id, corpus.id, [page_chunk(1, "taxonomy code")],
+          audit: [actor_type: "api_key"]
+        )
+
+      stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _scope, _text, _opts ->
+        {:error, :circuit_open}
+      end)
+
+      body =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/search", %{
+          "query" => "taxonomy",
+          "lanes" => ["semantic"]
+        })
+        |> json_response(502)
+
+      assert body["error"]["code"] == "semantic_lane_unavailable"
+      assert body["error"]["details"] == %{"reason" => "circuit_open"}
+    end
+
+    # The same failure with the keyword lane still available is a DEGRADATION, not an
+    # error — the behaviour this fix must not have changed.
+    test "the same embedding failure with both lanes still degrades to keyword-only",
+         %{conn: conn} do
+      {tenant, raw_key} = keyed_tenant()
+      corpus = create_corpus!(tenant.id)
+
+      {:ok, _result} =
+        Indexer.index_chunks(tenant.id, corpus.id, [page_chunk(1, "taxonomy code")],
+          audit: [actor_type: "api_key"]
+        )
+
+      stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _scope, _text, _opts ->
+        {:error, :circuit_open}
+      end)
+
+      body =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/search", %{"query" => "taxonomy code"})
+        |> json_response(200)
+
+      assert body["meta"]["lanes"] == ["keyword"]
+      assert body["meta"]["semantic_unavailable_reason"] == "circuit_open"
+    end
   end
 
   # The mode B half of TC-43.2.5's discipline: the DOCUMENTED shape is read out of the
@@ -981,6 +1156,61 @@ defmodule LoopctlWeb.CorpusControllerTest do
       assert search.description =~ "SEMANTIC-ONLY"
       assert search.description =~ "no text to index"
       assert search.description =~ "query_string_not_accepted"
+    end
+
+    # A status a caller can meet must be a status the document names. The 502 is
+    # reachable whenever the semantic lane is the only lane attempted, which the new
+    # `lanes` parameter made askable on a mode A corpus too.
+    test "the statuses and codes a search can answer with are the documented ones" do
+      spec = Loopctl.ApiSpec.spec()
+      search = spec.paths["/api/v1/corpora/{id}/search"].post
+
+      assert 502 in Map.keys(search.responses)
+      assert search.responses[502].description =~ "semantic_lane_unavailable"
+      assert search.responses[422].description =~ "ambiguous_query"
+      assert search.responses[422].description =~ "query_vector_out_of_range"
+    end
+
+    # The float32 element bound is BOTH documented and enforced, so both sides read the
+    # one attribute — and the documented number is then held against a real refusal so
+    # the assertion is not a both-sides-read-one-attribute tautology.
+    test "the documented float32 element bound is the one the ingest enforces", %{conn: conn} do
+      spec = Loopctl.ApiSpec.spec()
+
+      client_schema =
+        spec.paths["/api/v1/corpora/{id}/index"].post.requestBody.content["application/json"].schema.properties.chunks.items.oneOf
+        |> Enum.find(&(&1.title == "ClientEmbeddedChunk"))
+
+      documented = client_schema.properties.vector.description
+
+      assert documented =~ to_string(DocumentChunkEmbedding.float32_max())
+
+      {tenant, raw_key} = keyed_tenant()
+      corpus = mode_b_corpus!(tenant.id)
+
+      over = DocumentChunkEmbedding.float32_max() * 10
+      vector = List.replace_at(mode_b_vector(tenant.id), 0, over)
+
+      body =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/index", %{
+          "chunks" => [mode_b_chunk(tenant.id, %{"vector" => vector})]
+        })
+        |> json_response(422)
+
+      assert body["error"]["code"] == "vector_out_of_range"
+
+      # And a value just INSIDE the documented bound is accepted, so the assertion above
+      # is a boundary and not a blanket refusal.
+      inside = List.replace_at(mode_b_vector(tenant.id), 0, 1.0e38)
+
+      conn
+      |> auth(raw_key)
+      |> post(~p"/api/v1/corpora/#{corpus.id}/index", %{
+        "chunks" => [mode_b_chunk(tenant.id, %{"vector" => inside})]
+      })
+      |> json_response(200)
     end
   end
 end

--- a/test/loopctl_web/controllers/corpus_controller_test.exs
+++ b/test/loopctl_web/controllers/corpus_controller_test.exs
@@ -367,6 +367,53 @@ defmodule LoopctlWeb.CorpusControllerTest do
       assert body["error"]["message"] =~ Integer.to_string(Indexer.max_batch_size())
     end
 
+    # The ITEM ceiling is not the only bound, and on a client_embedded corpus it is not
+    # the binding one: a vector is bytes, and `Plug.Parsers` refuses an over-size body in
+    # the ENDPOINT — before this controller's plugs, so before the 422 that names the item
+    # ceiling can run. That refusal used to fall to the catch-all error view as an
+    # uncoded {"status": 413, "message": "Request Entity Too Large"} for a batch the
+    # published schema declared valid. It now carries a code and a remedy, and the byte
+    # cap it names is the one the parser enforces.
+    test "an over-size BODY under the item ceiling is a coded 413 naming the byte cap",
+         %{conn: conn} do
+      {tenant, raw_key} = keyed_tenant()
+      corpus = mode_b_corpus!(tenant.id)
+
+      # Schema-conforming: fewer items than the published ceiling, each a well-formed
+      # mode B chunk. Only the byte total is out of bounds.
+      chunks =
+        for page <- 1..180 do
+          %{
+            "source_ref" => "spec.pdf",
+            "locator" => %{"page" => page},
+            "vector" => Enum.map(0..1535, fn i -> i / 1_000_000_000 end),
+            "content_hash" => "client-hash-#{page}",
+            "ordinal" => page
+          }
+        end
+
+      raw = Jason.encode!(%{"chunks" => chunks})
+
+      assert length(chunks) <= Indexer.max_batch_size()
+      assert byte_size(raw) > LoopctlWeb.RequestLimits.max_body_bytes()
+
+      assert {413, _headers, body} =
+               assert_error_sent(413, fn ->
+                 conn
+                 |> auth(raw_key)
+                 |> put_req_header("content-type", "application/json")
+                 |> post(~p"/api/v1/corpora/#{corpus.id}/index", raw)
+               end)
+
+      decoded = Jason.decode!(body)
+      assert decoded["error"]["code"] == "request_too_large"
+
+      assert decoded["error"]["message"] =~
+               Integer.to_string(LoopctlWeb.RequestLimits.max_body_bytes())
+
+      assert decoded["error"]["message"] =~ "smaller requests"
+    end
+
     # The rate-limit plug runs BEFORE the action, and the bucket is charged once per
     # ITEM. Without the ceiling in the plug an over-size batch spent the tenant's whole
     # per-minute index budget one item at a time and came back as an opaque 429 — for a
@@ -796,6 +843,18 @@ defmodule LoopctlWeb.CorpusControllerTest do
       assert documented == Indexer.max_batch_size()
     end
 
+    # The item ceiling is only HALF the published bound: a mode B batch is refused on
+    # bytes long before it reaches 200 items, so the description states the byte cap too
+    # — and states the same number the parser enforces and the 413 body names.
+    test "the ingest description publishes the byte cap the parser actually enforces" do
+      spec = Loopctl.ApiSpec.spec()
+      description = spec.paths["/api/v1/corpora/{id}/index"].post.description
+
+      assert description =~ Integer.to_string(LoopctlWeb.RequestLimits.max_body_bytes())
+      assert description =~ "request_too_large"
+      assert spec.paths["/api/v1/corpora/{id}/index"].post.responses[413]
+    end
+
     test "the corpus endpoints are tagged, not untagged" do
       spec = Loopctl.ApiSpec.spec()
 
@@ -1062,6 +1121,43 @@ defmodule LoopctlWeb.CorpusControllerTest do
         |> json_response(422)
 
       assert body["error"]["code"] == "ambiguous_query"
+    end
+
+    # An EMPTY ARRAY is neither of the two serialization artifacts above: a client that
+    # emitted one built a vector and put nothing in it. It is refused as the malformed
+    # vector it is — and refused FIRST, before the ambiguity branch, which used to claim
+    # "both arrived non-empty" about a field that is demonstrably empty and told the
+    # caller to drop a field it effectively had not sent.
+    test "an EMPTY query_vector alongside a query is a malformed vector, not an ambiguity",
+         %{conn: conn} do
+      {tenant, raw_key} = keyed_tenant()
+      corpus = create_corpus!(tenant.id)
+
+      body =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/search", %{
+          "query" => "taxonomy",
+          "query_vector" => []
+        })
+        |> json_response(422)
+
+      assert body["error"]["code"] == "invalid_query_vector"
+      assert body["error"]["message"] =~ "MALFORMED"
+      assert body["error"]["message"] =~ "omit the field or send null"
+    end
+
+    test "an EMPTY query_vector on its own is the same refusal", %{conn: conn} do
+      {tenant, raw_key} = keyed_tenant()
+      corpus = mode_b_corpus!(tenant.id)
+
+      body =
+        conn
+        |> auth(raw_key)
+        |> post(~p"/api/v1/corpora/#{corpus.id}/search", %{"query_vector" => []})
+        |> json_response(422)
+
+      assert body["error"]["code"] == "invalid_query_vector"
     end
 
     # The semantic lane asked for ALONE and failing leaves no degraded answer. The raw

--- a/test/loopctl_web/controllers/error_json_test.exs
+++ b/test/loopctl_web/controllers/error_json_test.exs
@@ -35,6 +35,19 @@ defmodule LoopctlWeb.ErrorJSONTest do
              %{error: %{status: 500, code: "db_error", message: "Internal server error"}}
   end
 
+  # US-43.3 (review): the parser's 413 used to fall to the catch-all below, which gives
+  # a reason phrase and nothing else — for a corpus batch the published schema declared
+  # valid. It now carries a code and a remedy, and names the SAME cap the parser
+  # enforces.
+  test "renders 413 with a code, a remedy and the enforced byte cap" do
+    body = LoopctlWeb.ErrorJSON.render("413.json", %{})
+
+    assert body.error.status == 413
+    assert body.error.code == "request_too_large"
+    assert body.error.message =~ Integer.to_string(LoopctlWeb.RequestLimits.max_body_bytes())
+    assert body.error.message =~ "smaller requests"
+  end
+
   test "renders arbitrary status code via the catch-all reason phrase" do
     # 502 has no explicit clause, so it exercises the catch-all reason_phrase/1.
     # (503/504 now have explicit US-27.3 clauses asserted in fallback tests.)


### PR DESCRIPTION
## US-43.3 — Mode B: the server stores and ranks vectors it cannot read

A corpus created with `mode: client_embedded` is now indexed and searched without loopctl ever receiving the document text. This is a **mode dispatch through machinery US-43.1 and US-43.2 already built** — no migration, and everything downstream of item validation (classification, the one `Ecto.Multi`, the `(corpus_id, source_ref, locator)` key, `source_complete` reconciliation, the audit entry, the ANN pool sizing and the under-fill probe) is reused unchanged. Production diff is ~540 insertions across three files.

### Ingest (AC-43.3.1 / .2 / .3 / .6)

The mode B item is `{source_ref, locator, vector, content_hash, ordinal, snippet?}` and **there is no parameter that accepts chunk text**. A chunk carrying a `text` key is refused with `422 text_not_accepted` rather than silently ignored — checked on the KEY's presence, not its value, because `text: ""` is the same misunderstanding as a page of it, and dropping either would let a client believe the keyword lane works.

`content_hash` arrives from the client and is treated as an **opaque idempotency token, never an integrity proof**. loopctl holds no text to hash and states in the OpenAPI description that it cannot verify the hash corresponds to the vector or to the file. Nothing checks which model produced a vector — that is not computable from a vector, per the story's technical note. What IS enforced is the vector's LENGTH against the corpus `dim`, twice: at the boundary naming both numbers, and again by the `document_chunk_embeddings_dim_matches_vector` CHECK.

`allow_snippets` already defaulted to FALSE for mode B; this PR adds the ENFORCEMENT (`422 snippets_not_allowed`) plus the test. No provider call, admission token or ShrinkLadder run happens on this path at all.

### Search (AC-43.3.4 / .5 / .7)

`Search.search_vector/4` takes a client-supplied query vector, validated the same way, and routes through the **same `ann/3`** as mode A — the x4 over-fetched inner pool, `side_table_ef_search` and the bounded under-fill probe are what stop a minority corpus from answering an empty 200, and in mode B there is no keyword lane to mask that (KB `c2045077`).

The keyword lane is unavailable and **stated, not discovered**: `meta.lanes` is `["semantic"]`, `meta.search_mode` is `"semantic_only"`, and a request asking for it is refused. A `lanes` request parameter was added so AC-43.3.5's "a keyword-only search request is refused" is a real, testable refusal rather than an untestable one; it is honoured in both modes so it is never silently ignored.

Every mode mismatch is a coded 422 carrying a remedy — `query_string_not_accepted`, `query_vector_not_accepted`, `keyword_lane_unavailable`, `query_vector_dimension_mismatch`, `invalid_query_vector`, `invalid_lanes` — **never an empty result set**, which an agent reads as an empty corpus (the home_care_billing#1385 failure the story names). Result and `meta` key sets are byte-identical to mode A's, asserted directly (TC-43.3.8).

### The privacy test is the deliverable (AC-43.3.8 / TC-43.3.1)

`test/loopctl/corpus/mode_b_privacy_test.exs` indexes a mode B corpus **over HTTP** with a marker string the client never sends — it hashes and embeds locally — then hunts the marker in every column of `document_chunks` and `document_chunk_embeddings` (the whole row cast to text, not just `text`), in the audit rows the ingest wrote, in the captured log, and in every field of the ingest and search responses.

Every scan carries a **positive control**, so a zero means absence and not a broken scan: the same scans must FIND `source_ref`, must find a permitted snippet, and the log capture must contain its own probe line.

Two things worth flagging honestly:

- **This suite runs at logger level `warning` while production runs at `info`,** so a `Logger.debug`/`Logger.info` echoing a request body would emit in production and be invisible to any capture-based assertion here. That gap is closed by a source-level guard: no `Logger` call on the mode B path may interpolate a payload binding.
- **Both halves were mutation-verified.** Adding `Logger.info("corpus index payload " <> inspect(chunks))` to `index_chunks/4` turns the guard red (and, tellingly, does NOT turn the log-capture assertion red — which is exactly why the guard exists). Echoing a refused snippet into the 422 details turns the response refutation red. Both mutations were reversed by writing the original text back in place, and `diff` against a pre-mutation copy confirms the tree is clean.

### Also

- **AC-43.3.9** (mode immutable both directions) already held in `update_changeset/2`; the test now asserts both directions and that the message names delete-and-re-index.
- **AC-43.3.10** — operator-facing CHANGELOG entry stating exactly what loopctl receives and what it does not.
- The `:mode_mismatch` refusals both halves gave are gone; their tests were rewritten to the new named codes.

### Gates

`mix precommit` via the commit hook: **8172 tests, 0 failures** (86 excluded). Compile clean with warnings-as-errors, `credo --strict` clean, dialyzer clean.

### Note for the run

`mcp-server/` has **no corpus tools at all** yet, so AC-43.3.2's "the tool and OpenAPI descriptions" is satisfied by the OpenAPI half only. When corpus tools are added, their descriptions need the same client-owns-the-correspondence statement.

Part of #770 (Corpus tier). US-43.1 landed in #772 and US-43.2 in #773; there is no separate issue for US-43.3 to close.
