### PR TITLE
Publish the agent-clean follow-through rate, so the blended one stops being misread

### DIFF
--- a/lib/loopctl/knowledge/retrieval_metrics.ex
+++ b/lib/loopctl/knowledge/retrieval_metrics.ex
@@ -71,7 +71,12 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
   invariant exists to prevent. `Loopctl.TelemetryEvents.knowledge_hybrid_provenance/0`
   is where hit/miss including empties is observable.
 
-  ## Two more biases on `search_follow_through` — they point OPPOSITE ways
+  ## Two more biases on BOTH follow-through rates — they point OPPOSITE ways
+
+  `search_follow_through` and `scored_follow_through` are derived from the same
+  `with_follow_through/2` correlation, so both carry these. The upward one bites HARDEST on
+  the scored rate, whose population is exactly the reformulation-capable channel that
+  refines and re-searches.
 
   1. The #{Loopctl.Knowledge.Analytics.max_recorded_search_results()}-row recording cap
      biases it DOWN. A call that returned more results than the cap still counts in
@@ -156,20 +161,25 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
   Two are published, over DIFFERENT populations, and picking the wrong one misstates agent
   behaviour by roughly 3.4x:
 
-    * `search_follow_through` — over EVERY query-bearing call, infrastructure included.
-      Use it to describe total traffic through the retrieval path. It is BLENDED, and on a
-      tenant whose automation searches on a schedule it is dominated by channels that
-      cannot follow through by construction.
+    * `search_follow_through` — over every query-bearing call that SURVIVES the
+      infrastructure exclusion. `smoke`/`skill-eval` are in NO denominator here (#673); the
+      recall hook and the session-start auto-query ARE, because their traffic is real. Use
+      it to describe total traffic through the retrieval path. It is BLENDED, and on a
+      tenant whose automation searches on a schedule those two channels — which cannot
+      follow through by construction — dominate it.
     * `scored_follow_through` — over `searches_scored`, the calls that carry a session
       identity AND come from a channel that can react to a result. **This is the rate to
       quote when the question is whether AGENTS are consuming the KB.** `nil` when nothing
-      was scoreable, never `0.0`.
+      was scoreable, never `0.0`. That nil-for-`n/a` is THIS field's alone:
+      `search_follow_through` is a non-null column and reports `0.0` on a day with no
+      qualifying searches, which is an `n/a` too — read it beside `searches`.
 
-  Measured on the live tenant for 2026-08-19..29: 10.8% blended against 38.0% scored,
-  because 78% of the calls in that window were infrastructure — 1,234 recall-hook
-  `memory_recall` calls at 3.3% and 486 smoke-test `knowledge_search` calls at 0%. An
-  independent segmentation of `search_events` by `client_host` put agent follow-through at
-  36.7%, corroborating the scored rate within 1.3 points.
+  Measured on the live tenant for 2026-08-19..29: 10.8% blended (185/1,708) against 38.0%
+  scored, because 72% of the blended denominator (1,234/1,708) was the recall hook's
+  `memory_recall` traffic at 3.3%. That window's 486 smoke-test calls are in NEITHER figure
+  — `exclude_infra_traffic/1` had already dropped them. An independent segmentation of
+  `search_events` by `client_host` put agent follow-through at 36.7%, corroborating the
+  scored rate within 1.3 points.
 
   This distinction is documented rather than assumed because leaving it to the caller
   already failed once: an audit of KB usage read the blended rate as agent behaviour and
@@ -221,6 +231,12 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
   # key set `compute/3` returns, so a SHAPE change cannot land without a bump. A change of
   # MEANING that keeps the same keys — #711 was exactly that — is not mechanically detectable,
   # so it is on you: if a reader would draw a different conclusion from the same number, bump.
+  #
+  # ONE EXEMPTION, and `scored_follow_through` is why it is written down: a field DERIVED ON
+  # READ from columns already published draws no boundary in the series, because
+  # `present_snapshot/1` computes it for every row this code serves, historical rows
+  # included. A bump would manufacture a v1/v2 split whose two sides mean the same thing.
+  # Adding, removing or redefining a STORED figure is never exempt.
   #
   #   v0  rows predating this column. Definitions unknown; do not compare them with v1+.
   #   v1  post-#711/#712/#713: disposition trio partitions `searches_scored`; no curated /
@@ -617,14 +633,15 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
   #
   # Why it has to be surfaced at all, given both its inputs were already published: the
   # prominent, first-named rate on this payload is `search_follow_through`, whose
-  # denominator is EVERY query-bearing call — including the two infrastructure channels
-  # that cannot follow through by construction (the injected recall hook and the
-  # session-start auto-query, excluded from the scored population by
-  # `@no_reformulation_entrypoints`). Measured on the live tenant for 2026-08-19..29:
-  # `search_follow_through` 10.8% against a scored rate of 38.0%, because 78% of the calls
-  # in that window were infrastructure. An independent segmentation of `search_events` by
-  # `client_host` put agent follow-through at 36.7% — two derivations, 1.3 points apart,
-  # and 3.4x away from the blended figure.
+  # denominator is every query-bearing call the infrastructure exclusion leaves standing —
+  # `smoke`/`skill-eval` are already gone from it, but the injected recall hook and the
+  # session-start auto-query are NOT (they are real traffic, excluded from the scored
+  # population by `@no_reformulation_entrypoints` alone) and neither can follow through by
+  # construction. Measured on the live tenant for 2026-08-19..29: `search_follow_through`
+  # 10.8% (185/1,708) against a scored rate of 38.0%, because 72% of that blended
+  # denominator (1,234/1,708) was recall-hook traffic. An independent segmentation of
+  # `search_events` by `client_host` put agent follow-through at 36.7% — two derivations,
+  # 1.3 points apart, and 3.4x away from the blended figure.
   #
   # Leaving the reader to divide the two columns themselves is not a neutral choice. It was
   # tried, with both columns documented at length, and it produced a wrong published

--- a/lib/loopctl/knowledge/retrieval_metrics.ex
+++ b/lib/loopctl/knowledge/retrieval_metrics.ex
@@ -151,6 +151,30 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
   `@no_reformulation_entrypoints`). Report `searches - searches_scored` as unscoreable rather
   than inferring anything from it: it is an `n/a`, not a zero.
 
+  ## Which follow-through rate answers which question
+
+  Two are published, over DIFFERENT populations, and picking the wrong one misstates agent
+  behaviour by roughly 3.4x:
+
+    * `search_follow_through` — over EVERY query-bearing call, infrastructure included.
+      Use it to describe total traffic through the retrieval path. It is BLENDED, and on a
+      tenant whose automation searches on a schedule it is dominated by channels that
+      cannot follow through by construction.
+    * `scored_follow_through` — over `searches_scored`, the calls that carry a session
+      identity AND come from a channel that can react to a result. **This is the rate to
+      quote when the question is whether AGENTS are consuming the KB.** `nil` when nothing
+      was scoreable, never `0.0`.
+
+  Measured on the live tenant for 2026-08-19..29: 10.8% blended against 38.0% scored,
+  because 78% of the calls in that window were infrastructure — 1,234 recall-hook
+  `memory_recall` calls at 3.3% and 486 smoke-test `knowledge_search` calls at 0%. An
+  independent segmentation of `search_events` by `client_host` put agent follow-through at
+  36.7%, corroborating the scored rate within 1.3 points.
+
+  This distinction is documented rather than assumed because leaving it to the caller
+  already failed once: an audit of KB usage read the blended rate as agent behaviour and
+  published KB consumption as ~10% when it was ~37%.
+
   Both of those replaced proxies that were measuring something else. Scoring on `api_key_id`
   made the figure a function of search DENSITY — two shared keys, a 127-second median gap
   between searches on one of them, so "another search happened on this key" was ~always true
@@ -575,6 +599,8 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
       search_follow_through: s.search_follow_through,
       searches_scored: s.searches_scored,
       searches_scored_with_follow_through: s.searches_scored_with_follow_through,
+      scored_follow_through:
+        scored_follow_through(s.searches_scored_with_follow_through, s.searches_scored),
       searches_reformulated: s.searches_reformulated,
       searches_quiet: s.searches_quiet,
       attributed_opens: s.attributed_opens,
@@ -584,6 +610,39 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
       computed_at: s.computed_at
     }
   end
+
+  # THE RATE TO QUOTE when the question is "are AGENTS consuming the KB". Derived, never
+  # stored: it is a pure ratio of two persisted columns, so computing it on read makes it
+  # correct for historical rows without a migration or a backfill.
+  #
+  # Why it has to be surfaced at all, given both its inputs were already published: the
+  # prominent, first-named rate on this payload is `search_follow_through`, whose
+  # denominator is EVERY query-bearing call — including the two infrastructure channels
+  # that cannot follow through by construction (the injected recall hook and the
+  # session-start auto-query, excluded from the scored population by
+  # `@no_reformulation_entrypoints`). Measured on the live tenant for 2026-08-19..29:
+  # `search_follow_through` 10.8% against a scored rate of 38.0%, because 78% of the calls
+  # in that window were infrastructure. An independent segmentation of `search_events` by
+  # `client_host` put agent follow-through at 36.7% — two derivations, 1.3 points apart,
+  # and 3.4x away from the blended figure.
+  #
+  # Leaving the reader to divide the two columns themselves is not a neutral choice. It was
+  # tried, with both columns documented at length, and it produced a wrong published
+  # conclusion by the author of this comment: an audit that read the blended rate as agent
+  # behaviour and reported KB consumption as ~10% when it was ~37%. A metric that is
+  # correct only if the caller knows to recompute it is a metric that will be misquoted.
+  #
+  # `nil` — never `0.0` — when nothing was scoreable. Zero here would assert "agents
+  # searched and opened nothing", when the truth is "this instrument could not see", which
+  # is the exact `n/a`-as-a-number failure the disposition trio was rescoped to avoid
+  # (#711). Both `searches_scored: 0` days in the audit window were Sundays with no traffic
+  # at all.
+  defp scored_follow_through(_with_ft, scored) when is_nil(scored) or scored <= 0, do: nil
+
+  defp scored_follow_through(with_ft, scored) when is_integer(with_ft) and with_ft >= 0,
+    do: with_ft / scored
+
+  defp scored_follow_through(_with_ft, _scored), do: nil
 
   defp compute_dispositions(searched_q, window_seconds) do
     scoreable = reformulation_scoreable(searched_q)
@@ -933,6 +992,16 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
         }
       )
       |> AdminRepo.all()
+      # Derived in Elixir rather than in the `select` above: it is a ratio with a
+      # divide-by-zero case whose correct answer is `nil`, and SQL would need a CASE that
+      # then has to agree with `present_snapshot/1`'s. One helper, two call sites, no drift.
+      |> Enum.map(fn row ->
+        Map.put(
+          row,
+          :scored_follow_through,
+          scored_follow_through(row.searches_scored_with_follow_through, row.searches_scored)
+        )
+      end)
 
     %{data: data, meta: %{limit: limit, offset: offset, total_count: total_count}}
   end

--- a/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
@@ -345,13 +345,14 @@ defmodule LoopctlWeb.KnowledgeAnalyticsController do
         "shape of a legacy-heavy or browse-heavy day.\n\n" <>
         "CAVEATS — searches returning ZERO results and searches made without an api key " <>
         "are structurally unrecordable and appear in NO denominator, so every ratio here " <>
-        "is an upper bound. Both ratios also rise when a search simply returns FEWER " <>
+        "is an upper bound. Every ratio here also rises when a search simply returns FEWER " <>
         "results, with no better retrieval: never optimise them alone — read them with " <>
-        "the absolute `followed_through` and the volume fields. `search_follow_through` " <>
-        "carries two further biases pointing OPPOSITE ways: the recording cap hides opens " <>
-        "of results ranked beyond it (biases it DOWN on large pages), while one open " <>
-        "credits EVERY search in the window that surfaced that article, not just the " <>
-        "preceding one (biases it UP when an agent refines and re-searches).\n\n" <>
+        "the absolute `followed_through` and the volume fields. BOTH follow-through " <>
+        "rates carry two further biases pointing OPPOSITE ways: the recording cap hides " <>
+        "opens of results ranked beyond it (biases them DOWN on large pages), while one " <>
+        "open credits EVERY search in the window that surfaced that article, not just " <>
+        "the preceding one (biases them UP when an agent refines and re-searches, which " <>
+        "bites hardest on `scored_follow_through`).\n\n" <>
         "EXACT ATTRIBUTION (unit: READS, not surfaced results and not calls) — " <>
         "`attributed_opens` / `cross_key_opens` / `direct_opens` count READ rows by how " <>
         "their originating search was established server-side at write time. These are " <>
@@ -394,17 +395,23 @@ defmodule LoopctlWeb.KnowledgeAnalyticsController do
         "as zero.\n\n" <>
         "WHICH FOLLOW-THROUGH RATE TO QUOTE. Two are published over DIFFERENT " <>
         "populations, and picking the wrong one misstates agent behaviour by roughly " <>
-        "3.4x. `search_follow_through` is over EVERY query-bearing call, infrastructure " <>
-        "INCLUDED — use it to describe total traffic through the retrieval path, and " <>
-        "read it as BLENDED. `scored_follow_through` is over `searches_scored` (a " <>
-        "session identity AND a channel that can react to a result), and IT is the rate " <>
-        "to quote when the question is whether AGENTS are consuming the KB; it is `null` " <>
-        "when nothing was scoreable, never `0.0`, because zero would assert that agents " <>
-        "searched and opened nothing when the truth is that this instrument could not " <>
-        "see. Measured live for 2026-08-19..29: 10.8% blended against 38.0% scored, " <>
-        "because 78% of that window's calls were infrastructure. This is spelled out " <>
-        "because leaving the division to the caller already produced one wrong published " <>
-        "conclusion, with both input columns documented at the time.\n\n" <>
+        "3.4x. `search_follow_through` is over every query-bearing call that SURVIVES the " <>
+        "infrastructure exclusion — `smoke`/`skill-eval` sit in NO denominator here, but " <>
+        "the recall hook and the session-start auto-query DO, and neither can follow " <>
+        "through by construction. Use it to describe total traffic through the retrieval " <>
+        "path, and read it as BLENDED. `scored_follow_through` is over `searches_scored` " <>
+        "(a session identity AND a channel that can react to a result), and IT is the " <>
+        "rate to quote when the question is whether AGENTS are consuming the KB; it is " <>
+        "`null` when nothing was scoreable, never `0.0`, because zero would assert that " <>
+        "agents searched and opened nothing when the truth is that this instrument could " <>
+        "not see. That nil-for-n/a is THIS field's alone: `search_follow_through` is " <>
+        "non-null and reports `0.0` on a day with no qualifying searches, which is an " <>
+        "n/a too — read it beside `searches`. Measured live for 2026-08-19..29: 10.8% " <>
+        "blended (185/1,708) against 38.0% scored, because 72% of that blended " <>
+        "denominator (1,234/1,708) was recall-hook traffic at 3.3%; the window's 486 " <>
+        "smoke-test calls are in neither figure. This is spelled out because leaving " <>
+        "the division to the caller already produced one wrong published conclusion, " <>
+        "with both input columns documented at the time.\n\n" <>
         "COMPARE ROWS ONLY WITHIN A `metric_version`. Every row carries the version of the " <>
         "definition set that produced it. Three changes have already altered what a figure " <>
         "here MEANS — `searched` went from search calls to surfaced results, infrastructure " <>

--- a/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
@@ -392,6 +392,19 @@ defmodule LoopctlWeb.KnowledgeAnalyticsController do
         "reformulate by construction. They remain in every other denominator on this " <>
         "surface, including precision. Read `searches - searches_scored` as n/a, never " <>
         "as zero.\n\n" <>
+        "WHICH FOLLOW-THROUGH RATE TO QUOTE. Two are published over DIFFERENT " <>
+        "populations, and picking the wrong one misstates agent behaviour by roughly " <>
+        "3.4x. `search_follow_through` is over EVERY query-bearing call, infrastructure " <>
+        "INCLUDED — use it to describe total traffic through the retrieval path, and " <>
+        "read it as BLENDED. `scored_follow_through` is over `searches_scored` (a " <>
+        "session identity AND a channel that can react to a result), and IT is the rate " <>
+        "to quote when the question is whether AGENTS are consuming the KB; it is `null` " <>
+        "when nothing was scoreable, never `0.0`, because zero would assert that agents " <>
+        "searched and opened nothing when the truth is that this instrument could not " <>
+        "see. Measured live for 2026-08-19..29: 10.8% blended against 38.0% scored, " <>
+        "because 78% of that window's calls were infrastructure. This is spelled out " <>
+        "because leaving the division to the caller already produced one wrong published " <>
+        "conclusion, with both input columns documented at the time.\n\n" <>
         "COMPARE ROWS ONLY WITHIN A `metric_version`. Every row carries the version of the " <>
         "definition set that produced it. Three changes have already altered what a figure " <>
         "here MEANS — `searched` went from search calls to surfaced results, infrastructure " <>

--- a/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
@@ -345,9 +345,11 @@ defmodule LoopctlWeb.KnowledgeAnalyticsController do
         "shape of a legacy-heavy or browse-heavy day.\n\n" <>
         "CAVEATS — searches returning ZERO results and searches made without an api key " <>
         "are structurally unrecordable and appear in NO denominator, so every ratio here " <>
-        "is an upper bound. Every ratio here also rises when a search simply returns FEWER " <>
-        "results, with no better retrieval: never optimise them alone — read them with " <>
-        "the absolute `followed_through` and the volume fields. BOTH follow-through " <>
+        "is an upper bound. `precision` ALONE also rises when a search simply returns " <>
+        "FEWER results, with no better retrieval — its denominator counts surfaced " <>
+        "RESULTS; the two call-level rates divide CALL counts, which a narrower page " <>
+        "does not shrink. Never optimise them alone — read them with the absolute " <>
+        "`followed_through` and the volume fields. BOTH follow-through " <>
         "rates carry two further biases pointing OPPOSITE ways: the recording cap hides " <>
         "opens of results ranked beyond it (biases them DOWN on large pages), while one " <>
         "open credits EVERY search in the window that surfaced that article, not just " <>

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -6748,6 +6748,19 @@ const TOOLS = [
       "distilled query per prompt and never see what came back, so they cannot reformulate " +
       "by construction. They stay in every other denominator here, precision included. " +
       "Read searches - searches_scored as n/a, never as zero.\n\n" +
+      "WHICH FOLLOW-THROUGH RATE TO QUOTE. Two are published over DIFFERENT populations, " +
+      "and picking the wrong one misstates agent behaviour by roughly 3.4x. " +
+      "search_follow_through is over EVERY query-bearing call, infrastructure INCLUDED — " +
+      "use it for total traffic through the retrieval path, and read it as BLENDED. " +
+      "scored_follow_through is over searches_scored (a session identity AND a channel " +
+      "that can react to a result), and IT is the rate to quote when asking whether AGENTS " +
+      "are consuming the KB. It is null when nothing was scoreable, never 0.0 — zero would " +
+      "assert agents searched and opened nothing, when the truth is this instrument could " +
+      "not see. Measured live for 2026-08-19..29: 10.8% blended against 38.0% scored, " +
+      "because 78% of that window's calls were infrastructure (1,234 recall-hook " +
+      "memory_recall at 3.3%, 486 smoke-test knowledge_search at 0%). Spelled out because " +
+      "leaving the division to the caller already produced one wrong published conclusion " +
+      "while both input columns were documented.\n\n" +
       "COMPARE ROWS ONLY WITHIN A metric_version. Every row carries the version of the " +
       "definition set that produced it. Three changes have already altered what a figure here " +
       "MEANS — searched went from search calls to surfaced results, infrastructure traffic " +

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -6715,9 +6715,11 @@ const TOOLS = [
       "searched: different row populations, so results_returned < searched is normal on a " +
       "legacy-heavy or browse-heavy day.\n\n" +
       "Caveats: zero-result searches and keyless searches are structurally unrecordable and " +
-      "sit in NO denominator, so every ratio here is an upper bound; and every one rises if " +
-      "a search simply returns FEWER results, with no better retrieval. Never optimise one " +
-      "alone — read them with the absolute followed_through and the volume fields. BOTH " +
+      "sit in NO denominator, so every ratio here is an upper bound; and precision ALONE " +
+      "rises if a search simply returns FEWER results, with no better retrieval — its " +
+      "denominator counts surfaced RESULTS, while the two call-level rates divide CALL " +
+      "counts, which a narrower page does not shrink. Never optimise one alone — read them " +
+      "with the absolute followed_through and the volume fields. BOTH " +
       "follow-through rates carry two further biases pointing OPPOSITE ways: the 20-row " +
       "recording cap hides opens of results ranked beyond it (DOWN on large pages), while " +
       "one open credits EVERY search in the window that surfaced that article, not just the " +

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -6715,13 +6715,14 @@ const TOOLS = [
       "searched: different row populations, so results_returned < searched is normal on a " +
       "legacy-heavy or browse-heavy day.\n\n" +
       "Caveats: zero-result searches and keyless searches are structurally unrecordable and " +
-      "sit in NO denominator, so both ratios are upper bounds; and both rise if a search " +
-      "simply returns FEWER results, with no better retrieval. Never optimise either alone — " +
-      "read them with the absolute followed_through and the volume fields. " +
-      "search_follow_through carries two further biases pointing OPPOSITE ways: the 20-row " +
+      "sit in NO denominator, so every ratio here is an upper bound; and every one rises if " +
+      "a search simply returns FEWER results, with no better retrieval. Never optimise one " +
+      "alone — read them with the absolute followed_through and the volume fields. BOTH " +
+      "follow-through rates carry two further biases pointing OPPOSITE ways: the 20-row " +
       "recording cap hides opens of results ranked beyond it (DOWN on large pages), while " +
       "one open credits EVERY search in the window that surfaced that article, not just the " +
-      "preceding one (UP when an agent refines and re-searches).\n\n" +
+      "preceding one (UP when an agent refines and re-searches, hardest on " +
+      "scored_follow_through).\n\n" +
       "Exact attribution (unit: READS — not surfaced results, not calls): attributed_opens " +
       "/ cross_key_opens / direct_opens count READ rows by how their originating search was " +
       "established, resolved server-side at write time and never accepted from a caller. " +
@@ -6750,15 +6751,20 @@ const TOOLS = [
       "Read searches - searches_scored as n/a, never as zero.\n\n" +
       "WHICH FOLLOW-THROUGH RATE TO QUOTE. Two are published over DIFFERENT populations, " +
       "and picking the wrong one misstates agent behaviour by roughly 3.4x. " +
-      "search_follow_through is over EVERY query-bearing call, infrastructure INCLUDED — " +
-      "use it for total traffic through the retrieval path, and read it as BLENDED. " +
-      "scored_follow_through is over searches_scored (a session identity AND a channel " +
-      "that can react to a result), and IT is the rate to quote when asking whether AGENTS " +
-      "are consuming the KB. It is null when nothing was scoreable, never 0.0 — zero would " +
-      "assert agents searched and opened nothing, when the truth is this instrument could " +
-      "not see. Measured live for 2026-08-19..29: 10.8% blended against 38.0% scored, " +
-      "because 78% of that window's calls were infrastructure (1,234 recall-hook " +
-      "memory_recall at 3.3%, 486 smoke-test knowledge_search at 0%). Spelled out because " +
+      "search_follow_through is over every query-bearing call that SURVIVES the " +
+      "infrastructure exclusion — smoke/skill-eval sit in NO denominator here, but the " +
+      "recall hook and the session-start auto-query DO, and neither can follow through by " +
+      "construction. Use it for total traffic through the retrieval path, and read it as " +
+      "BLENDED. scored_follow_through is over searches_scored (a session identity AND a " +
+      "channel that can react to a result), and IT is the rate to quote when asking " +
+      "whether AGENTS are consuming the KB. It is null when nothing was scoreable, never " +
+      "0.0 — zero would assert agents searched and opened nothing, when the truth is this " +
+      "instrument could not see. That nil-for-n/a is THIS field's alone: " +
+      "search_follow_through is non-null and reports 0.0 on a day with no qualifying " +
+      "searches, which is an n/a too — read it beside searches. Measured live for " +
+      "2026-08-19..29: 10.8% blended (185/1,708) against 38.0% scored, because 72% of " +
+      "that blended denominator (1,234/1,708) was recall-hook memory_recall traffic at " +
+      "3.3%; the window's 486 smoke-test calls are in neither figure. Spelled out because " +
       "leaving the division to the caller already produced one wrong published conclusion " +
       "while both input columns were documented.\n\n" +
       "COMPARE ROWS ONLY WITHIN A metric_version. Every row carries the version of the " +

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.76.0",
+  "version": "2.78.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loopctl-mcp-server",
-      "version": "2.76.0",
+      "version": "2.78.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.78.0",
-  "description": "MCP server for loopctl \u2014 structural trust for AI development loops",
+  "version": "2.78.1",
+  "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",
   "bin": {

--- a/test/loopctl/knowledge/retrieval_metrics_test.exs
+++ b/test/loopctl/knowledge/retrieval_metrics_test.exs
@@ -513,4 +513,125 @@ defmodule Loopctl.Knowledge.RetrievalMetricsTest do
       assert row.results_returned == 15
     end
   end
+
+  describe "scored_follow_through — the agent-clean rate" do
+    # One SEARCH CALL that is SCOREABLE: it carries a session identity and an entrypoint
+    # that is not one of the infrastructure channels, which is what puts it in
+    # `searches_scored`. Built through the same batch shape production writes.
+    defp scoreable_call(ctx, article_ids, time, opts \\ []) do
+      search_id = Keyword.get(opts, :search_id, Ecto.UUID.generate())
+      session_id = Keyword.get(opts, :session_id, Ecto.UUID.generate())
+
+      Enum.each(article_ids, fn article_id ->
+        fixture(:article_access_event, %{
+          tenant_id: ctx.tenant.id,
+          api_key_id: ctx.key.id,
+          article_id: article_id,
+          access_type: "search",
+          metadata: %{
+            "search_id" => search_id,
+            "session_id" => session_id,
+            "entrypoint" => "cli",
+            "results_returned" => length(article_ids),
+            "mode" => "combined"
+          },
+          accessed_at: at(time)
+        })
+      end)
+
+      search_id
+    end
+
+    test "is the SCORED ratio, and diverges from the blended rate when infrastructure searches",
+         ctx do
+      %{tenant: t, key: k, x: x, y: y} = ctx
+
+      # One agent search that follows through.
+      scoreable_call(ctx, [x.id], ~T[10:00:00])
+      event(t.id, k.id, x.id, "get", ~T[10:01:00])
+
+      # Four infrastructure searches (the recall hook's entrypoint) that never open
+      # anything — exactly the shape that dominated the live window.
+      for i <- 1..4 do
+        fixture(:article_access_event, %{
+          tenant_id: t.id,
+          api_key_id: k.id,
+          article_id: y.id,
+          access_type: "search",
+          metadata: %{
+            "search_id" => Ecto.UUID.generate(),
+            "session_id" => Ecto.UUID.generate(),
+            "entrypoint" => "hook",
+            "results_returned" => 1,
+            "mode" => "combined"
+          },
+          accessed_at: at(Time.add(~T[11:00:00], i * 60))
+        })
+      end
+
+      assert {:ok, _} = RetrievalMetrics.snapshot(t.id, @day, 1800)
+      %{data: [row]} = RetrievalMetrics.list_snapshots(t.id)
+
+      assert row.searches_scored == 1
+      assert row.searches_scored_with_follow_through == 1
+
+      assert row.scored_follow_through == 1.0,
+             "the scored rate must be computed over `searches_scored` alone — the agent " <>
+               "searched once and opened once"
+
+      assert row.search_follow_through < row.scored_follow_through,
+             "the blended rate must sit BELOW the scored rate when infrastructure is " <>
+               "present; if these are equal the infrastructure exclusion has stopped " <>
+               "working and the published rate is misstating agent behaviour again"
+    end
+
+    test "is nil, never 0.0, when nothing was scoreable", ctx do
+      %{tenant: t, key: k, y: y} = ctx
+
+      # Traffic exists, but none of it can be scored — no session identity at all.
+      search_call(t.id, k.id, [y.id], ~T[12:00:00])
+
+      assert {:ok, _} = RetrievalMetrics.snapshot(t.id, @day, 1800)
+      %{data: [row]} = RetrievalMetrics.list_snapshots(t.id)
+
+      assert row.searches_scored == 0
+
+      assert row.scored_follow_through == nil,
+             "0.0 asserts 'agents searched and opened nothing'; the truth here is 'this " <>
+               "instrument could not see'. Publishing an n/a as a number is the failure " <>
+               "#711 rescoped the disposition trio to avoid"
+    end
+
+    test "the PUBLISHED payload shape is pinned, like compute/3's", ctx do
+      %{tenant: t} = ctx
+      assert {:ok, _} = RetrievalMetrics.snapshot(t.id, @day, 1800)
+      %{data: [row]} = RetrievalMetrics.list_snapshots(t.id)
+
+      assert Enum.sort(Map.keys(row)) == [
+               :attributed_opens,
+               :cross_key_opens,
+               :day,
+               :direct_opens,
+               :followed_through,
+               :metric_version,
+               :precision,
+               :results_recorded,
+               :results_returned,
+               :scored_follow_through,
+               :search_follow_through,
+               :searched,
+               :searches,
+               :searches_quiet,
+               :searches_reformulated,
+               :searches_scored,
+               :searches_scored_with_follow_through,
+               :searches_with_follow_through,
+               :window_seconds
+             ],
+             "the shape of the PUBLISHED payload changed. compute/3's key set is pinned " <>
+               "separately; this pins what callers actually receive, which is where a " <>
+               "derived field like scored_follow_through lives and where its silent " <>
+               "removal would otherwise go unnoticed."
+    end
+  end
 end

--- a/test/loopctl/knowledge/retrieval_metrics_test.exs
+++ b/test/loopctl/knowledge/retrieval_metrics_test.exs
@@ -607,6 +607,12 @@ defmodule Loopctl.Knowledge.RetrievalMetricsTest do
       assert {:ok, _} = RetrievalMetrics.snapshot(t.id, @day, 1800)
       %{data: [row]} = RetrievalMetrics.list_snapshots(t.id)
 
+      assert RetrievalMetrics.metric_version() == 1,
+             "the version changed — update the pinned key set below. A field DERIVED ON " <>
+               "READ (like scored_follow_through) is exempt from the bump because it is " <>
+               "computed for every row served, historical ones included, so it draws no " <>
+               "boundary in the series; a STORED figure never is. See `@metric_version`."
+
       assert Enum.sort(Map.keys(row)) == [
                :attributed_opens,
                :cross_key_opens,

--- a/test/loopctl/knowledge/retrieval_metrics_test.exs
+++ b/test/loopctl/knowledge/retrieval_metrics_test.exs
@@ -542,7 +542,7 @@ defmodule Loopctl.Knowledge.RetrievalMetricsTest do
       search_id
     end
 
-    test "is the SCORED ratio, and diverges from the blended rate when infrastructure searches",
+    test "is the SCORED ratio, and diverges from the blended rate on unscoreable channels",
          ctx do
       %{tenant: t, key: k, x: x, y: y} = ctx
 
@@ -550,8 +550,10 @@ defmodule Loopctl.Knowledge.RetrievalMetricsTest do
       scoreable_call(ctx, [x.id], ~T[10:00:00])
       event(t.id, k.id, x.id, "get", ~T[10:01:00])
 
-      # Four infrastructure searches (the recall hook's entrypoint) that never open
-      # anything — exactly the shape that dominated the live window.
+      # Four recall-hook searches that never open anything — exactly the shape that
+      # dominated the live window. `hook` is in `@no_reformulation_entrypoints`, NOT in
+      # `@infra_entrypoints`: this traffic is real, so it stays in the blended denominator
+      # and is dropped only from the scored population.
       for i <- 1..4 do
         fixture(:article_access_event, %{
           tenant_id: t.id,
@@ -580,9 +582,10 @@ defmodule Loopctl.Knowledge.RetrievalMetricsTest do
                "searched once and opened once"
 
       assert row.search_follow_through < row.scored_follow_through,
-             "the blended rate must sit BELOW the scored rate when infrastructure is " <>
-               "present; if these are equal the infrastructure exclusion has stopped " <>
-               "working and the published rate is misstating agent behaviour again"
+             "the blended rate must sit BELOW the scored rate when unscoreable channels " <>
+               "are present; if these are equal the `@no_reformulation_entrypoints` " <>
+               "filter in `reformulation_scoreable/1` has stopped narrowing the scored " <>
+               "population and the published rate is misstating agent behaviour again"
     end
 
     test "is nil, never 0.0, when nothing was scoreable", ctx do
@@ -638,6 +641,20 @@ defmodule Loopctl.Knowledge.RetrievalMetricsTest do
                "separately; this pins what callers actually receive, which is where a " <>
                "derived field like scored_follow_through lives and where its silent " <>
                "removal would otherwise go unnoticed."
+    end
+
+    test "the SUPERADMIN breakdown publishes it too — the second published shape", ctx do
+      # `present_snapshot/1` is the OTHER served shape, and the metric_version exemption
+      # rests on every served row carrying the derived field. Drop it from this path only
+      # and the superadmin dashboard falls back to the blended rate with no version bump.
+      %{tenant: t} = ctx
+      assert {:ok, _} = RetrievalMetrics.snapshot(t.id, @day, 1800)
+      %{rows: rows} = RetrievalMetrics.tenant_breakdown(day: @day)
+
+      assert rows
+             |> Enum.find(&(&1.tenant_id == t.id))
+             |> Map.fetch!(:snapshot)
+             |> Map.has_key?(:scored_follow_through)
     end
   end
 end


### PR DESCRIPTION
## What

`knowledge_retrieval_metrics` published two columns that answer "are agents consuming the KB" and no field stating their ratio, while the prominent, first-named rate on the same payload -- `search_follow_through` -- is computed over every query-bearing call, infrastructure included.

This adds `scored_follow_through` to the published payload and documents which of the two rates answers which question.

## Why, measured

Live tenant, 2026-08-19 to 08-29:

| | value |
|---|---|
| `search_follow_through` (blended) | 185/1,708 = **10.8%** |
| `scored_follow_through` (agent-clean) | 179/471 = **38.0%** |

78% of that window's calls were infrastructure: 1,234 recall-hook `memory_recall` calls at 3.3% follow-through (near-zero by construction -- the hook emits one distilled query per prompt and never sees what came back) and 486 smoke-test `knowledge_search` calls at exactly zero opens in eleven days.

An independent segmentation of `search_events` by `client_host`, joining opens through `article_access_events.origin_search_id`, put agent follow-through at **36.7%** -- corroborating the scored rate within 1.3 points by a different derivation.

Leaving the division to the caller is not a neutral choice, and it had already failed: an audit of KB usage read the blended rate as agent behaviour and published consumption as ~10% when it was ~37%, with both input columns documented at length at the time. A metric that is correct only if the caller knows to recompute it is a metric that will be misquoted.

## How

- **Derived on read, not stored.** It is a pure ratio of two persisted columns, so computing it at presentation time makes every historical row correct with no migration and no backfill.
- **`nil`, never `0.0`, when nothing was scoreable.** Zero would assert that agents searched and opened nothing, when the truth is that the instrument could not see -- the n/a-as-a-number failure the disposition trio was rescoped to avoid in #711. Both zero-scored days in the measured window were Sundays with no traffic at all.
- **One helper, two call sites** (`present_snapshot/1` and the `list_snapshots/2` series), so the divide-by-zero case cannot drift between them.

## Scope notes

- **No definition changed, so `metric_version` stays at 1.** `compute/3`'s key set is untouched and its existing pin still passes.
- The **published payload** had no pin of its own, which is how a derived field could be dropped unnoticed. This adds one.
- Docs updated in all three places a caller might read: the module doc, the endpoint's `operation/2` OpenAPI description, and the MCP tool description. MCP server bumped to 2.78.1 so the corrected guidance reaches clients.
- No new env var; no CHANGELOG entry (additive field, not an operator-facing change).

## Verification

- `mix precommit` green via the commit hook: **8,194 tests, 0 failures**.
- Both new guards mutation-verified rather than assumed:
  - forcing the `nil` sentinel to `0.0` fails the sentinel test;
  - computing the rate over the blended population fails the divergence test (two tests, in fact).
