### PR TITLE
Retry the Hex install instead of failing the run on one hex.pm timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,28 +191,32 @@ jobs:
       #
       # — which is exactly how a three-file docs change went red on 2026-09-02.
       #
-      # The fix is to stop asking. setup-beam no longer installs either archive
-      # (install-hex / install-rebar above) and this step installs them only
-      # `--if-missing`, with retries. On the persistent self-hosted runners
-      # MIX_HOME survives between jobs — infra's ci-runner-pool.sh gives each
-      # pool slot a per-repo MIX_HOME — so the archives are already on disk and
-      # this step makes no network call at all. On an ephemeral hosted runner it
-      # still downloads once, but a transient failure now costs a retry instead
-      # of the whole run.
+      # setup-beam no longer installs either archive (install-hex /
+      # install-rebar above); this step does, with three attempts and a backoff
+      # between them. The download still happens on every job, and that is the
+      # point: what was missing was never the caching, it was the retry.
       #
-      # CAVEAT: --if-missing never upgrades. If an ELIXIR_VERSION bump ever needs
-      # a newer Hex, the stale archive has to be cleared out of the slot's
-      # MIX_HOME on the runner host; nothing here will do it for you.
+      # DELIBERATELY NOT --if-missing, even though the self-hosted runners keep
+      # MIX_HOME between jobs and it would skip the download outright. `mix
+      # local.hex --if-missing` tests `Code.ensure_loaded?(Hex)` and nothing
+      # else -- no version, no checksum -- and `mix local.rebar --if-missing` is
+      # a bare File.exists?. This unconditional install is the ONLY thing that
+      # ever overwrites those files, so skipping it converts a per-job,
+      # TLS-verified, sha512-checked refresh into an artifact written once and
+      # trusted forever, on a host where every repo's jobs run as one uid and a
+      # cancelled job can leave a half-unpacked archive that satisfies the check
+      # exactly as well as a hostile one. Two seconds a job buys that back.
       - name: Ensure hex and rebar
+        timeout-minutes: 5
         run: |
           for tool in hex rebar; do
             installed=false
             for attempt in 1 2 3; do
-              if mix local.$tool --if-missing --force; then
+              if mix local.$tool --force; then
                 installed=true
                 break
               fi
-              sleep $((attempt * 10))
+              [ "$attempt" = 3 ] || sleep $((attempt * 10))
             done
             if [ "$installed" != true ]; then
               echo "mix local.$tool failed after 3 attempts" >&2
@@ -369,15 +373,16 @@ jobs:
       # Same reason as the first job: setup-beam's hex install is a per-job
       # hex.pm dependency, so install only what is missing, and retry.
       - name: Ensure hex and rebar
+        timeout-minutes: 5
         run: |
           for tool in hex rebar; do
             installed=false
             for attempt in 1 2 3; do
-              if mix local.$tool --if-missing --force; then
+              if mix local.$tool --force; then
                 installed=true
                 break
               fi
-              sleep $((attempt * 10))
+              [ "$attempt" = 3 ] || sleep $((attempt * 10))
             done
             if [ "$installed" != true ]; then
               echo "mix local.$tool failed after 3 attempts" >&2
@@ -560,15 +565,16 @@ jobs:
       # Same reason as the first job: setup-beam's hex install is a per-job
       # hex.pm dependency, so install only what is missing, and retry.
       - name: Ensure hex and rebar
+        timeout-minutes: 5
         run: |
           for tool in hex rebar; do
             installed=false
             for attempt in 1 2 3; do
-              if mix local.$tool --if-missing --force; then
+              if mix local.$tool --force; then
                 installed=true
                 break
               fi
-              sleep $((attempt * 10))
+              [ "$attempt" = 3 ] || sleep $((attempt * 10))
             done
             if [ "$installed" != true ]; then
               echo "mix local.$tool failed after 3 attempts" >&2
@@ -766,15 +772,16 @@ jobs:
       # Same reason as the first job: setup-beam's hex install is a per-job
       # hex.pm dependency, so install only what is missing, and retry.
       - name: Ensure hex and rebar
+        timeout-minutes: 5
         run: |
           for tool in hex rebar; do
             installed=false
             for attempt in 1 2 3; do
-              if mix local.$tool --if-missing --force; then
+              if mix local.$tool --force; then
                 installed=true
                 break
               fi
-              sleep $((attempt * 10))
+              [ "$attempt" = 3 ] || sleep $((attempt * 10))
             done
             if [ "$installed" != true ]; then
               echo "mix local.$tool failed after 3 attempts" >&2
@@ -853,15 +860,16 @@ jobs:
       # Same reason as the first job: setup-beam's hex install is a per-job
       # hex.pm dependency, so install only what is missing, and retry.
       - name: Ensure hex and rebar
+        timeout-minutes: 5
         run: |
           for tool in hex rebar; do
             installed=false
             for attempt in 1 2 3; do
-              if mix local.$tool --if-missing --force; then
+              if mix local.$tool --force; then
                 installed=true
                 break
               fi
-              sleep $((attempt * 10))
+              [ "$attempt" = 3 ] || sleep $((attempt * 10))
             done
             if [ "$installed" != true ]; then
               echo "mix local.$tool failed after 3 attempts" >&2
@@ -922,15 +930,16 @@ jobs:
       # Same reason as the first job: setup-beam's hex install is a per-job
       # hex.pm dependency, so install only what is missing, and retry.
       - name: Ensure hex and rebar
+        timeout-minutes: 5
         run: |
           for tool in hex rebar; do
             installed=false
             for attempt in 1 2 3; do
-              if mix local.$tool --if-missing --force; then
+              if mix local.$tool --force; then
                 installed=true
                 break
               fi
-              sleep $((attempt * 10))
+              [ "$attempt" = 3 ] || sleep $((attempt * 10))
             done
             if [ "$installed" != true ]; then
               echo "mix local.$tool failed after 3 attempts" >&2
@@ -1059,15 +1068,16 @@ jobs:
       # Same reason as the first job: setup-beam's hex install is a per-job
       # hex.pm dependency, so install only what is missing, and retry.
       - name: Ensure hex and rebar
+        timeout-minutes: 5
         run: |
           for tool in hex rebar; do
             installed=false
             for attempt in 1 2 3; do
-              if mix local.$tool --if-missing --force; then
+              if mix local.$tool --force; then
                 installed=true
                 break
               fi
-              sleep $((attempt * 10))
+              [ "$attempt" = 3 ] || sleep $((attempt * 10))
             done
             if [ "$installed" != true ]; then
               echo "mix local.$tool failed after 3 attempts" >&2
@@ -1346,15 +1356,16 @@ jobs:
       # Same reason as the first job: setup-beam's hex install is a per-job
       # hex.pm dependency, so install only what is missing, and retry.
       - name: Ensure hex and rebar
+        timeout-minutes: 5
         run: |
           for tool in hex rebar; do
             installed=false
             for attempt in 1 2 3; do
-              if mix local.$tool --if-missing --force; then
+              if mix local.$tool --force; then
                 installed=true
                 break
               fi
-              sleep $((attempt * 10))
+              [ "$attempt" = 3 ] || sleep $((attempt * 10))
             done
             if [ "$installed" != true ]; then
               echo "mix local.$tool failed after 3 attempts" >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,47 @@ jobs:
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
+          install-hex: false
+          install-rebar: false
+
+      # hex.pm is a hard dependency of every setup-beam step: the action runs
+      # `mix local.hex` on EVERY job, its default mirror list holds a single
+      # entry (https://builds.hex.pm), and Mix gives up after 60 seconds. So one
+      # bad minute on hex.pm fails a run before a line of code is compiled:
+      #
+      #   ** (Mix) request timed out after 60000ms
+      #   Could not mix hex from any hex.pm mirror
+      #
+      # — which is exactly how a three-file docs change went red on 2026-09-02.
+      #
+      # The fix is to stop asking. setup-beam no longer installs either archive
+      # (install-hex / install-rebar above) and this step installs them only
+      # `--if-missing`, with retries. On the persistent self-hosted runners
+      # MIX_HOME survives between jobs — infra's ci-runner-pool.sh gives each
+      # pool slot a per-repo MIX_HOME — so the archives are already on disk and
+      # this step makes no network call at all. On an ephemeral hosted runner it
+      # still downloads once, but a transient failure now costs a retry instead
+      # of the whole run.
+      #
+      # CAVEAT: --if-missing never upgrades. If an ELIXIR_VERSION bump ever needs
+      # a newer Hex, the stale archive has to be cleared out of the slot's
+      # MIX_HOME on the runner host; nothing here will do it for you.
+      - name: Ensure hex and rebar
+        run: |
+          for tool in hex rebar; do
+            installed=false
+            for attempt in 1 2 3; do
+              if mix local.$tool --if-missing --force; then
+                installed=true
+                break
+              fi
+              sleep $((attempt * 10))
+            done
+            if [ "$installed" != true ]; then
+              echo "mix local.$tool failed after 3 attempts" >&2
+              exit 1
+            fi
+          done
 
       - name: Install dependencies
         run: mix deps.get
@@ -322,6 +363,27 @@ jobs:
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
+          install-hex: false
+          install-rebar: false
+
+      # Same reason as the first job: setup-beam's hex install is a per-job
+      # hex.pm dependency, so install only what is missing, and retry.
+      - name: Ensure hex and rebar
+        run: |
+          for tool in hex rebar; do
+            installed=false
+            for attempt in 1 2 3; do
+              if mix local.$tool --if-missing --force; then
+                installed=true
+                break
+              fi
+              sleep $((attempt * 10))
+            done
+            if [ "$installed" != true ]; then
+              echo "mix local.$tool failed after 3 attempts" >&2
+              exit 1
+            fi
+          done
 
       - name: Install dependencies
         run: mix deps.get
@@ -492,6 +554,27 @@ jobs:
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
+          install-hex: false
+          install-rebar: false
+
+      # Same reason as the first job: setup-beam's hex install is a per-job
+      # hex.pm dependency, so install only what is missing, and retry.
+      - name: Ensure hex and rebar
+        run: |
+          for tool in hex rebar; do
+            installed=false
+            for attempt in 1 2 3; do
+              if mix local.$tool --if-missing --force; then
+                installed=true
+                break
+              fi
+              sleep $((attempt * 10))
+            done
+            if [ "$installed" != true ]; then
+              echo "mix local.$tool failed after 3 attempts" >&2
+              exit 1
+            fi
+          done
 
       - name: Install dependencies
         run: mix deps.get
@@ -677,6 +760,27 @@ jobs:
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
+          install-hex: false
+          install-rebar: false
+
+      # Same reason as the first job: setup-beam's hex install is a per-job
+      # hex.pm dependency, so install only what is missing, and retry.
+      - name: Ensure hex and rebar
+        run: |
+          for tool in hex rebar; do
+            installed=false
+            for attempt in 1 2 3; do
+              if mix local.$tool --if-missing --force; then
+                installed=true
+                break
+              fi
+              sleep $((attempt * 10))
+            done
+            if [ "$installed" != true ]; then
+              echo "mix local.$tool failed after 3 attempts" >&2
+              exit 1
+            fi
+          done
 
       - name: Install dependencies
         run: mix deps.get
@@ -743,6 +847,27 @@ jobs:
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
+          install-hex: false
+          install-rebar: false
+
+      # Same reason as the first job: setup-beam's hex install is a per-job
+      # hex.pm dependency, so install only what is missing, and retry.
+      - name: Ensure hex and rebar
+        run: |
+          for tool in hex rebar; do
+            installed=false
+            for attempt in 1 2 3; do
+              if mix local.$tool --if-missing --force; then
+                installed=true
+                break
+              fi
+              sleep $((attempt * 10))
+            done
+            if [ "$installed" != true ]; then
+              echo "mix local.$tool failed after 3 attempts" >&2
+              exit 1
+            fi
+          done
 
       - name: Cache Dialyzer PLT
         uses: actions/cache@v4
@@ -791,6 +916,27 @@ jobs:
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
+          install-hex: false
+          install-rebar: false
+
+      # Same reason as the first job: setup-beam's hex install is a per-job
+      # hex.pm dependency, so install only what is missing, and retry.
+      - name: Ensure hex and rebar
+        run: |
+          for tool in hex rebar; do
+            installed=false
+            for attempt in 1 2 3; do
+              if mix local.$tool --if-missing --force; then
+                installed=true
+                break
+              fi
+              sleep $((attempt * 10))
+            done
+            if [ "$installed" != true ]; then
+              echo "mix local.$tool failed after 3 attempts" >&2
+              exit 1
+            fi
+          done
 
       - name: Restore dependencies cache
         uses: actions/cache@v4
@@ -907,6 +1053,27 @@ jobs:
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
+          install-hex: false
+          install-rebar: false
+
+      # Same reason as the first job: setup-beam's hex install is a per-job
+      # hex.pm dependency, so install only what is missing, and retry.
+      - name: Ensure hex and rebar
+        run: |
+          for tool in hex rebar; do
+            installed=false
+            for attempt in 1 2 3; do
+              if mix local.$tool --if-missing --force; then
+                installed=true
+                break
+              fi
+              sleep $((attempt * 10))
+            done
+            if [ "$installed" != true ]; then
+              echo "mix local.$tool failed after 3 attempts" >&2
+              exit 1
+            fi
+          done
 
       - name: Restore dependencies cache
         uses: actions/cache@v4
@@ -1173,6 +1340,27 @@ jobs:
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
+          install-hex: false
+          install-rebar: false
+
+      # Same reason as the first job: setup-beam's hex install is a per-job
+      # hex.pm dependency, so install only what is missing, and retry.
+      - name: Ensure hex and rebar
+        run: |
+          for tool in hex rebar; do
+            installed=false
+            for attempt in 1 2 3; do
+              if mix local.$tool --if-missing --force; then
+                installed=true
+                break
+              fi
+              sleep $((attempt * 10))
+            done
+            if [ "$installed" != true ]; then
+              echo "mix local.$tool failed after 3 attempts" >&2
+              exit 1
+            fi
+          done
 
       - name: Install dependencies
         run: mix deps.get


### PR DESCRIPTION
## What broke

`Set up Elixir` failed on a three-file docs change, before a single test ran:

```
** (Mix) request timed out after 60000ms
Could not mix hex from any hex.pm mirror
```

`erlef/setup-beam` runs `mix local.hex` and `mix local.rebar` on **every job**. Its default `hexpm-mirrors` list holds exactly one entry (`https://builds.hex.pm`) and Mix gives up after 60 seconds, so there is **no retry anywhere in that path** — one bad minute on hex.pm takes the run down regardless of what changed. Every repo running `setup-beam` has the same exposure.

## What this does

- `install-hex: false` / `install-rebar: false` on every `setup-beam` step.
- A new `Ensure hex and rebar` step running `mix local.<tool> --force`: three attempts, 10s then 20s backoff, `timeout-minutes: 5`.

The download still happens on every job. That is deliberate: what was missing here was never caching, it was the retry.

## What it deliberately does not do

The first version of this branch used `--if-missing`, which on the persistent self-hosted runners would have skipped the download entirely — `infra`'s `ci-runner-pool.sh` gives each pool slot a per-repo `MIX_HOME` that survives between jobs. Adversarial review killed that, and it was right:

- `mix local.hex --if-missing` tests `Code.ensure_loaded?(Hex)` and nothing else — no version, no checksum (`mix/tasks/local.hex.ex:51-60`). `mix local.rebar --if-missing` is a bare `File.exists?` (`local.rebar.ex:129-133`). Verified in the Elixir source for both 1.18.4 and 1.19.5.
- That unconditional install is the **only** thing on those hosts that ever overwrites the archive. `MIX_HOME` sits outside the workspace, so neither `git clean -ffdx` nor `git reset --hard` reaches it, and every repo's jobs run as the same `github-runner` uid.
- So skipping it converts a per-job, TLS-verified, sha512-checked refresh into an artifact written once and trusted indefinitely — and a job cancelled mid-unpack (routine, given `cancel-in-progress`) leaves a partial archive that satisfies the check exactly as well as a hostile one.

Two seconds a job is the price of not having that. The rationale is in the workflow comment so it does not get reintroduced.

## Verification

- The retry loop was exercised under `bash -e` — the shell Actions uses — with a `mix` stub that always fails: three attempts, then `exit 1`; happy path exits 0.
- Every workflow file parses; `git diff` against the base has zero removed lines.
- Measured on the self-hosted jobs: `Ensure hex and rebar` completes in 0-1s.
