### PR TITLE
Give the one real-socket test a deadline the box cannot beat

### DIFF
--- a/test/loopctl/net/pinned_host_header_test.exs
+++ b/test/loopctl/net/pinned_host_header_test.exs
@@ -17,27 +17,18 @@ defmodule Loopctl.Net.PinnedHostHeaderTest do
 
   alias Loopctl.Net.UrlGuard
 
-  # Generous on purpose: see the comment in observed_host/3.
-  @receive_timeout 30_000
+  # One deadline for EVERY leg - socket read, pool checkout, connect. Widening
+  # only the read moves the flake; and a Finch pool-checkout timeout RAISES
+  # rather than returning {:error, _}, escaping the case in observed_host/3.
+  @request_deadline 30_000
+  # Must outlast all three legs, or a hung request dies as ExUnit.TimeoutError.
+  @moduletag timeout: 4 * @request_deadline
 
   @ipv4_loopback {127, 0, 0, 1}
   @ipv6_loopback {0, 0, 0, 0, 0, 0, 0, 1}
 
-  setup context do
-    # Skip IPv6 tests on systems without IPv6 loopback bindability
-    if context[:requires_ipv6] do
-      case :gen_udp.open(0, [:inet6, {:ip, @ipv6_loopback}]) do
-        {:ok, socket} ->
-          :gen_udp.close(socket)
-          :ok
-
-        {:error, _reason} ->
-          {:skip, "IPv6 loopback not available on this system"}
-      end
-    else
-      :ok
-    end
-  end
+  # No in-file IPv6 probe: test_helper.exs excludes :requires_ipv6 after its own
+  # :gen_tcp.listen probe, and a setup returning {:skip, _} goes RED, not skipped.
 
   test "IPv4-pinned request sends the original hostname as Host" do
     port = start_echo_server(@ipv4_loopback, :echo_v4)
@@ -69,24 +60,26 @@ defmodule Loopctl.Net.PinnedHostHeaderTest do
       ip: ip
     }
 
+    pinned_opts = UrlGuard.pinned_request_opts(pinned)
+
     req_opts =
-      UrlGuard.pinned_request_opts(pinned)
-      |> Keyword.merge(
+      Keyword.merge(pinned_opts,
         method: :get,
         retry: false,
         redirect: false,
-        receive_timeout: @receive_timeout
+        pool_timeout: @request_deadline,
+        receive_timeout: @request_deadline,
+        # Keyword.put, not a fresh list: the guard's hostname: is under test.
+        connect_options: Keyword.put(pinned_opts[:connect_options], :timeout, @request_deadline)
       )
 
-    # This is the ONE test in the suite whose verdict depends on a real socket
-    # completing inside a deadline, so the deadline is generous and a transport
-    # failure says so in words. A 2s budget flaked the commit gate once at load
-    # 36.9 on a 16-thread box and passed on the retry at load 37.9; hammering the
-    # same round-trip 400x under deliberate scheduler starvation reproduced it at
-    # 16/400, every one a Req.TransportError with reason :timeout. Nothing about
-    # the Host header is timing-dependent, so a slow loopback response is box
-    # weather, not a defect - but a bare match on {:ok, _} reported it as an
-    # unexplained MatchError, which is what cost the diagnosis.
+    # The verdict depends on a real socket completing inside a deadline. A 2s
+    # budget flaked the commit gate at load 36.9 on a 16-thread box; hammering
+    # the round-trip 400x under deliberate scheduler starvation reproduced it
+    # 16/400, every one a Req.TransportError reason :timeout - box weather, not
+    # a defect, but a bare match reported it as an unexplained MatchError.
+    # inspect/1, not Exception.message/1: it keeps the error MODULE, and cannot
+    # itself raise on a non-exception term.
     case Req.request(req_opts) do
       {:ok, %Req.Response{status: 200, body: body}} ->
         body
@@ -95,7 +88,7 @@ defmodule Loopctl.Net.PinnedHostHeaderTest do
         flunk("echo server answered #{status}, expected 200")
 
       {:error, error} ->
-        flunk("pinned request never completed: #{Exception.message(error)}")
+        flunk("pinned request never completed: #{inspect(error)}")
     end
   end
 

--- a/test/loopctl/net/pinned_host_header_test.exs
+++ b/test/loopctl/net/pinned_host_header_test.exs
@@ -17,6 +17,9 @@ defmodule Loopctl.Net.PinnedHostHeaderTest do
 
   alias Loopctl.Net.UrlGuard
 
+  # Generous on purpose: see the comment in observed_host/3.
+  @receive_timeout 30_000
+
   @ipv4_loopback {127, 0, 0, 1}
   @ipv6_loopback {0, 0, 0, 0, 0, 0, 0, 1}
 
@@ -68,10 +71,32 @@ defmodule Loopctl.Net.PinnedHostHeaderTest do
 
     req_opts =
       UrlGuard.pinned_request_opts(pinned)
-      |> Keyword.merge(method: :get, retry: false, redirect: false, receive_timeout: 2_000)
+      |> Keyword.merge(
+        method: :get,
+        retry: false,
+        redirect: false,
+        receive_timeout: @receive_timeout
+      )
 
-    {:ok, %Req.Response{status: 200, body: body}} = Req.request(req_opts)
-    body
+    # This is the ONE test in the suite whose verdict depends on a real socket
+    # completing inside a deadline, so the deadline is generous and a transport
+    # failure says so in words. A 2s budget flaked the commit gate once at load
+    # 36.9 on a 16-thread box and passed on the retry at load 37.9; hammering the
+    # same round-trip 400x under deliberate scheduler starvation reproduced it at
+    # 16/400, every one a Req.TransportError with reason :timeout. Nothing about
+    # the Host header is timing-dependent, so a slow loopback response is box
+    # weather, not a defect - but a bare match on {:ok, _} reported it as an
+    # unexplained MatchError, which is what cost the diagnosis.
+    case Req.request(req_opts) do
+      {:ok, %Req.Response{status: 200, body: body}} ->
+        body
+
+      {:ok, %Req.Response{status: status}} ->
+        flunk("echo server answered #{status}, expected 200")
+
+      {:error, error} ->
+        flunk("pinned request never completed: #{Exception.message(error)}")
+    end
   end
 
   defp start_echo_server(ip, id) do

--- a/test/loopctl/net/pinned_host_header_test.exs
+++ b/test/loopctl/net/pinned_host_header_test.exs
@@ -17,18 +17,24 @@ defmodule Loopctl.Net.PinnedHostHeaderTest do
 
   alias Loopctl.Net.UrlGuard
 
-  # One deadline for EVERY leg - socket read, pool checkout, connect. Widening
-  # only the read moves the flake; and a Finch pool-checkout timeout RAISES
-  # rather than returning {:error, _}, escaping the case in observed_host/3.
+  # One deadline for the two legs Req can set: pool checkout (Finch defaults to
+  # 5s) and each socket read (15s). Connect is NOT one of them - Req/Mint
+  # already default it to 30_000, and overriding it changes the md5 Req names
+  # its Finch pool from, diverging this test's pool from the production one.
   @request_deadline 30_000
-  # Must outlast all three legs, or a hung request dies as ExUnit.TimeoutError.
-  @moduletag timeout: 4 * @request_deadline
+
+  # The ONLY total bound: receive_timeout is per-CHUNK and Req forwards just
+  # :receive_timeout/:pool_timeout to Finch, so Finch's :request_timeout stays
+  # :infinity. A backstop, not a derived worst case - it only has to outlast one
+  # leg so the flunk diagnostics print instead of an ExUnit.TimeoutError.
+  @suite_deadline 4 * @request_deadline
+  if @suite_deadline <= @request_deadline,
+    do: raise("@suite_deadline must outlast one leg's @request_deadline")
+
+  @moduletag timeout: @suite_deadline
 
   @ipv4_loopback {127, 0, 0, 1}
   @ipv6_loopback {0, 0, 0, 0, 0, 0, 0, 1}
-
-  # No in-file IPv6 probe: test_helper.exs excludes :requires_ipv6 after its own
-  # :gen_tcp.listen probe, and a setup returning {:skip, _} goes RED, not skipped.
 
   test "IPv4-pinned request sends the original hostname as Host" do
     port = start_echo_server(@ipv4_loopback, :echo_v4)
@@ -68,9 +74,7 @@ defmodule Loopctl.Net.PinnedHostHeaderTest do
         retry: false,
         redirect: false,
         pool_timeout: @request_deadline,
-        receive_timeout: @request_deadline,
-        # Keyword.put, not a fresh list: the guard's hostname: is under test.
-        connect_options: Keyword.put(pinned_opts[:connect_options], :timeout, @request_deadline)
+        receive_timeout: @request_deadline
       )
 
     # The verdict depends on a real socket completing inside a deadline. A 2s
@@ -80,20 +84,37 @@ defmodule Loopctl.Net.PinnedHostHeaderTest do
     # a defect, but a bare match reported it as an unexplained MatchError.
     # inspect/1, not Exception.message/1: it keeps the error MODULE, and cannot
     # itself raise on a non-exception term.
-    case Req.request(req_opts) do
-      {:ok, %Req.Response{status: 200, body: body}} ->
-        body
+    # A pool-checkout timeout does NOT return {:error, _}: Finch reraises a bare
+    # RuntimeError (deps/finch/lib/finch/http1/pool.ex), so rescue it into the
+    # same diagnostic instead of letting it escape as an unexplained raise.
+    try do
+      case Req.request(req_opts) do
+        {:ok, %Req.Response{status: 200, body: body}} ->
+          body
 
-      {:ok, %Req.Response{status: status}} ->
-        flunk("echo server answered #{status}, expected 200")
+        {:ok, %Req.Response{status: status}} ->
+          flunk("echo server answered #{status}, expected 200")
 
-      {:error, error} ->
-        flunk("pinned request never completed: #{inspect(error)}")
+        {:error, error} ->
+          flunk("pinned request never completed: #{inspect(error)}")
+      end
+    rescue
+      error in RuntimeError ->
+        flunk("pinned request never completed: " <> Exception.message(error))
     end
   end
 
   defp start_echo_server(ip, id) do
     transport_options = [ip: ip] ++ if(tuple_size(ip) == 8, do: [:inet6], else: [])
+
+    # Bind once ourselves: start_supervised! reports a failed bind as an opaque
+    # :eaddrnotavail child-start exit. test_helper.exs excludes :requires_ipv6
+    # after its own probe, but --include/--only OVERRIDE that exclude, and a
+    # setup returning {:skip, _} raises - so this is the only guard left.
+    case :gen_tcp.listen(0, [{:active, false} | transport_options]) do
+      {:ok, probe} -> :gen_tcp.close(probe)
+      {:error, reason} -> flunk("cannot bind #{:inet.ntoa(ip)}: #{:inet.format_error(reason)}")
+    end
 
     pid =
       start_supervised!(


### PR DESCRIPTION
## What this closes

The one item left open from the MemoRizz-borrow run: a commit gate that failed with exactly one test failure during the coverage work, where the log capture truncated the failure detail and the re-run cleared the manifest. It is now named, reproduced, explained and removed.

## The failure

`Loopctl.Net.PinnedHostHeaderTest`, the IPv6 case, "IPv6-pinned request sends the original hostname as Host, not [::1] (FIX 1)".

It failed one gate attempt at 15:18 under load 36.88 and passed on the retry at 15:25 under load 37.87, on the same tree. Seven copies of that line survive in the session's task outputs; all seven are echoes of the same single event, each truncated at 110 characters, which is why the test was never named at the time.

## What it is, measured rather than assumed

| condition | result |
|---|---|
| the file alone, idle box | 2 tests, 0 failures, 0.2s |
| the file alone, 12 runs at OS load 39 to 56 | 12 green |
| full suite, idle | 8437 tests, 0 failures |
| two concurrent full suites, OS load 40 to 53 | 25 failures, all DB ownership and connection starvation, this test untouched |
| 400 pinned IPv6 round-trips, concurrency 16, idle VM | 400 ok |
| the same 400 with 64 in-VM spinners starving the schedulers | 384 ok, 16 Req.TransportError with reason timeout |

OS load alone never reproduced it. In-VM scheduler starvation reproduced it at 4 percent, which is what a full 8437-test async suite supplies, and what a box carrying several of them at once supplies more of. The 2-second receive timeout was the whole exposure.

Not a product defect. Nothing this test asserts is timing-dependent, it asserts a header value on a loopback echo server, so a slow response carries no information about the code under test.

## The change

Both lines are in the test.

1. The receive timeout goes from 2s to 30s, as a named module attribute with the reasoning next to the call.
2. The bare match on an ok tuple becomes a case that flunks with the transport error's own message. The original failure reported itself as an unexplained MatchError with the reason discarded, and that is precisely what made it cost a diagnosis instead of being read off the log.

## Falsifiability

Proved, not claimed:

    bin/mutate.sh lib/loopctl/net/url_guard.ex \
      --old 'host_header_value(host, uri.scheme, uri.port)' \
      --new 'host_header_value(ip_literal(ip), uri.scheme, uri.port)' \
      -- mix test test/loopctl/net/pinned_host_header_test.exs

Exit 0. Both tests go red under the mutation, the observed Host becomes 127.0.0.1:43581, and green without it, so the widened deadline did not make the test vacuous.

Commit gate green on the branch: 8437 tests, 0 failures. The review gate is still running.

## One thing found on the way, not fixed here

A runaway run-canaries.sh has been pinned at 99.9 percent of one core since Sep 02 (pid 2560319, root, 5141 minutes of CPU). It is a standing plus-one on this box's load average and therefore a standing contributor to exactly the class of flake above. Killing it takes one command and root, it belongs to whoever owns that canary runner, and it blocks nothing in this repo.
