### PR TITLE
Give the other real-socket test the same deadline and the same words

### DIFF
--- a/test/loopctl_web/endpoint_websocket_test.exs
+++ b/test/loopctl_web/endpoint_websocket_test.exs
@@ -8,6 +8,23 @@ defmodule LoopctlWeb.EndpointWebsocketTest do
 
   @cap 64_000
 
+  # One deadline for every blocking :gen_tcp leg here - the connect and both
+  # recvs. The sibling real-socket test, pinned_host_header_test.exs, measured
+  # this exact class: a 2s budget flaked the commit gate at load 36.9 on a
+  # 16-thread box, and hammering that round-trip 400x under deliberate BEAM
+  # scheduler starvation reproduced it 16/400. Nothing this file asserts is
+  # timing-dependent - it asserts a close code - so a slow loopback carries no
+  # information about the code under test, and 5s was simply exposure.
+  @deadline 30_000
+
+  # A backstop so the flunk diagnostics below print instead of an
+  # ExUnit.TimeoutError swallowing them. It only has to outlast ONE leg.
+  @suite_deadline 4 * @deadline
+  if @suite_deadline <= @deadline,
+    do: raise("@suite_deadline must outlast one leg's @deadline")
+
+  @moduletag timeout: @suite_deadline
+
   describe "endpoint websocket configuration" do
     test "the endpoint carries the fragmented-message cap (regression guard)" do
       ws_opts = LoopctlWeb.Endpoint.config(:http)[:websocket_options]
@@ -72,7 +89,7 @@ defmodule LoopctlWeb.EndpointWebsocketTest do
       :ok = :gen_tcp.send(sock, client_frame(0x1, false, half))
       :ok = :gen_tcp.send(sock, client_frame(0x0, true, half))
 
-      assert {:ok, resp} = :gen_tcp.recv(sock, 0, 5000)
+      resp = recv!(sock, "the close frame for the oversize fragmented message")
       # Server -> client close frame is unmasked: <<0x88, len, code::16, reason>>.
       assert <<0x88, _len, code::16, _reason::binary>> = resp
       assert code == 1009
@@ -84,8 +101,22 @@ defmodule LoopctlWeb.EndpointWebsocketTest do
   # --- raw websocket client helpers ---
 
   defp ws_handshake(port) do
-    {:ok, sock} =
-      :gen_tcp.connect(~c"127.0.0.1", port, [:binary, active: false, packet: :raw], 5000)
+    # A bare match here reported a starved-box timeout as an unexplained
+    # MatchError with the reason discarded, which is what makes this class of
+    # flake cost a diagnosis instead of being read off the log.
+    sock =
+      case :gen_tcp.connect(
+             ~c"127.0.0.1",
+             port,
+             [:binary, active: false, packet: :raw],
+             @deadline
+           ) do
+        {:ok, sock} ->
+          sock
+
+        {:error, reason} ->
+          flunk("never connected to the test server on port #{port}: #{inspect(reason)}")
+      end
 
     key = Base.encode64(:crypto.strong_rand_bytes(16))
 
@@ -98,9 +129,19 @@ defmodule LoopctlWeb.EndpointWebsocketTest do
         "Sec-WebSocket-Version: 13\r\n\r\n"
 
     :ok = :gen_tcp.send(sock, req)
-    {:ok, resp} = :gen_tcp.recv(sock, 0, 5000)
+    resp = recv!(sock, "the 101 handshake response")
     assert resp =~ "101 Switching Protocols"
     sock
+  end
+
+  # inspect/1, not :inet.format_error/1: a recv reason is :timeout or :closed as
+  # often as it is a POSIX atom, and format_error renders those as
+  # "unknown POSIX error".
+  defp recv!(sock, what) do
+    case :gen_tcp.recv(sock, 0, @deadline) do
+      {:ok, resp} -> resp
+      {:error, reason} -> flunk("never received #{what}: #{inspect(reason)}")
+    end
   end
 
   # Build a masked client frame (clients MUST mask, RFC6455§5.3).


### PR DESCRIPTION
## Why this branch exists

The enhanced review on #788 returned two out-of-scope findings, both in this file, both the same defect class as the one #788 fixed. Out-of-scope means wrong branch, not lower severity: it is a finite, already-verified list, so it gets fixed here rather than filed. Per the workflow's own chain rule, no second review run is launched on this branch, and fixing the list consumes no chain hop.

## The defect

`test/loopctl_web/endpoint_websocket_test.exs` carries `@describetag :websocket_transport`, which `test_helper.exs` does not exclude, so it runs on every `mix test` and every commit gate. Three blocking `:gen_tcp` legs had a 5-second deadline bound with a bare match:

| line | leg |
|---|---|
| `:87-88` | `:gen_tcp.connect(..., 5000)` under `{:ok, sock} =` |
| `:101` | `:gen_tcp.recv(sock, 0, 5000)` under `{:ok, resp} =`, inside the shared handshake helper |
| `:75` | `assert {:ok, resp} = :gen_tcp.recv(sock, 0, 5000)` for the close frame |

Under the BEAM scheduler starvation measured on #788 — 16 failures in 400 pinned round-trips at a 2s budget — each of these reports itself as an unexplained `MatchError` with the transport reason discarded. That is exactly what cost the diagnosis last time.

## The change

One named `@deadline` of 30s across all three legs. Nothing this file asserts is timing-dependent, it asserts a 1009 close code, so a slow loopback response carries no information about the code under test.

The two recvs collapse into a single `recv!/2` helper rather than two case blocks, so a third caller cannot reintroduce the bare match. A `@suite_deadline` backstop, guarded at compile time so it can never be set below the leg it backstops, keeps an ExUnit timeout from swallowing the new diagnostics.

`inspect/1` on the reason rather than `:inet.format_error/1`: a recv reason is `:timeout` or `:closed` as often as it is a POSIX atom, and `format_error` renders those as "unknown POSIX error".

## Falsifiability

Three new branches, three mutations, each exit 0 — red under the mutation, green without:

    --old '~c"127.0.0.1",' --new '~c"203.0.113.7",'
      never connected to the test server on port 44185: :timeout

    --old ':gen_tcp.recv(sock, 0, @deadline)' --new ':gen_tcp.recv(sock, 0, 0)'
      never received the 101 handshake response: :timeout

    --old '@suite_deadline 4 * @deadline' --new '@suite_deadline 1 * @deadline'
      compile error, must outlast one leg's deadline

Commit gate green: 8437 tests, 0 failures.
