### PR TITLE
Stop import_stories payload_path disclosing or uploading non-payload files

### DIFF
--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.91.1 — 2026-09-12 (payload_path no longer discloses or uploads files that are not a payload)
+
+### Security
+
+- **`import_stories` `payload_path` could disclose file content.** A path to a non-JSON file
+  (for example `/etc/passwd`) made `JSON.parse` throw, and the error was returned verbatim —
+  V8's SyntaxError quotes the start of the file. A valid JSON file that was not an import
+  payload (a credentials file) was POSTed to the import endpoint. Reported by Artyom Lobanov
+  (@Morendais). `payload_path` now:
+  - must end in `.json`, checked on the path and on its realpath, so a `.json` symlink cannot
+    point at another file or into `/proc`, `/dev` or `/sys`;
+  - reports a parse failure as "is not valid JSON" and an fs failure by its error code only,
+    never the underlying message;
+  - must hold an object with an `epics` array, or it is refused before anything is sent.
+
 ## 2.89.0 — 2026-09-06 (a deduplicated create says whether it threw your payload away)
 
 ### Changed

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -43,6 +43,7 @@ import {
   GENERATED_TOOL_PREFIX,
 } from "./lib/generated-tools.js";
 import { createHandoff } from "./lib/handoff.js";
+import { readPayloadFile } from "./lib/payload-path.js";
 
 // Single source of truth for the server version: the package.json this file
 // ships with (npm always includes package.json in the published tarball).
@@ -967,13 +968,7 @@ async function importStories({ project_id, payload, payload_path, merge }) {
 
 // Reads JSON payload from either an inline object or an absolute file path.
 // Returns the object on success, or an { error, body } shape on failure.
-//
-// Security: `payload_path` is read with the MCP process's filesystem
-// privileges. Because agents can set this argument via prompt injection,
-// we validate aggressively:
-//   * require absolute path
-//   * reject /proc, /dev, /sys (pseudo-filesystems that could DoS or leak)
-//   * stat first and cap at 5 MiB (server also enforces a body size limit)
+// The file path is validated in lib/payload-path.js (see its security notes).
 async function resolvePayload(inline, payloadPath) {
   if (inline && typeof inline === "object") return inline;
   if (!payloadPath) {
@@ -983,53 +978,7 @@ async function resolvePayload(inline, payloadPath) {
       body: "Must provide either `payload` (object) or `payload_path` (absolute JSON file path).",
     };
   }
-
-  const nodePath = await import("node:path");
-  if (!nodePath.isAbsolute(payloadPath)) {
-    return {
-      error: true,
-      status: 0,
-      body: `payload_path must be absolute (got '${payloadPath}').`,
-    };
-  }
-
-  const blockedPrefixes = ["/proc/", "/dev/", "/sys/", "/proc", "/dev", "/sys"];
-  if (blockedPrefixes.some((p) => payloadPath === p.replace(/\/$/, "") || payloadPath.startsWith(p))) {
-    return {
-      error: true,
-      status: 0,
-      body: `payload_path refused: '${payloadPath}' targets a pseudo-filesystem path.`,
-    };
-  }
-
-  const MAX_PAYLOAD_BYTES = 5 * 1024 * 1024;
-  const fs = await import("node:fs/promises");
-
-  try {
-    const stat = await fs.stat(payloadPath);
-    if (!stat.isFile()) {
-      return {
-        error: true,
-        status: 0,
-        body: `payload_path '${payloadPath}' is not a regular file.`,
-      };
-    }
-    if (stat.size > MAX_PAYLOAD_BYTES) {
-      return {
-        error: true,
-        status: 0,
-        body: `payload_path '${payloadPath}' is ${stat.size} bytes, exceeds max ${MAX_PAYLOAD_BYTES}.`,
-      };
-    }
-    const raw = await fs.readFile(payloadPath, "utf8");
-    return JSON.parse(raw);
-  } catch (err) {
-    return {
-      error: true,
-      status: 0,
-      body: `Could not read payload_path '${payloadPath}': ${err.message}`,
-    };
-  }
+  return readPayloadFile(payloadPath);
 }
 
 // --- Story Tools ---
@@ -3927,7 +3876,7 @@ const TOOLS = [
         payload_path: {
           type: "string",
           description:
-            "Absolute path to a JSON file with the import payload. Avoids inline size limits for large epics. Ignored if `payload` is also passed.",
+            "Absolute path to a .json file holding the import payload (an object with an `epics` array). Avoids inline size limits for large epics. Ignored if `payload` is also passed.",
         },
         merge: {
           type: "boolean",

--- a/mcp-server/lib/payload-path.js
+++ b/mcp-server/lib/payload-path.js
@@ -1,8 +1,10 @@
 // Reads an import_stories payload from an absolute file path.
 //
 // Security: `payload_path` is read with the MCP process's filesystem privileges and an
-// agent can set it via prompt injection, so a hostile path must learn NOTHING about a file
-// that is not an import payload, and such a file must never be uploaded:
+// agent can set it via prompt injection, so no file CONTENT is ever returned, and a file
+// that is not an import payload is never uploaded. The refusals still say which check
+// failed (missing, not a file, too large, not JSON, wrong shape) for a .json path; that
+// is metadata an agent needs to fix its own call, not content:
 //   * require an absolute path ending in .json, checked on the path AND on its realpath,
 //     so a symlink named x.json cannot point at /etc/passwd or /proc
 //   * reject /proc, /dev, /sys (pseudo-filesystems that could DoS or leak)
@@ -69,7 +71,7 @@ export async function readPayloadFile(payloadPath, { fs = defaultFs } = {}) {
     }
     if (stat.size > MAX_PAYLOAD_BYTES) {
       return refuse(
-        `payload_path '${payloadPath}' is ${stat.size} bytes, exceeds max ${MAX_PAYLOAD_BYTES}.`,
+        `payload_path '${payloadPath}' exceeds max ${MAX_PAYLOAD_BYTES} bytes.`,
       );
     }
     raw = await fs.readFile(realPath, "utf8");

--- a/mcp-server/lib/payload-path.js
+++ b/mcp-server/lib/payload-path.js
@@ -1,0 +1,94 @@
+// Reads an import_stories payload from an absolute file path.
+//
+// Security: `payload_path` is read with the MCP process's filesystem privileges and an
+// agent can set it via prompt injection, so a hostile path must learn NOTHING about a file
+// that is not an import payload, and such a file must never be uploaded:
+//   * require an absolute path ending in .json, checked on the path AND on its realpath,
+//     so a symlink named x.json cannot point at /etc/passwd or /proc
+//   * reject /proc, /dev, /sys (pseudo-filesystems that could DoS or leak)
+//   * stat first and cap at 5 MiB (server also enforces a body size limit)
+//   * never echo a JSON.parse or fs error message: V8's SyntaxError quotes the file's
+//     content ("root:x:0:0"... is not valid JSON), so only err.code is reported
+//   * require the Epic 12 import shape (an object with an `epics` array) before returning,
+//     so a valid JSON file that is not a payload (a credentials file) is never POSTed
+//
+// Returns the parsed payload on success, or an { error, status, body } shape on failure.
+
+import nodePath from "node:path";
+import defaultFs from "node:fs/promises";
+
+export const MAX_PAYLOAD_BYTES = 5 * 1024 * 1024;
+
+const BLOCKED_ROOTS = ["/proc", "/dev", "/sys"];
+
+function refuse(body) {
+  return { error: true, status: 0, body };
+}
+
+function isBlocked(p) {
+  return BLOCKED_ROOTS.some((root) => p === root || p.startsWith(root + "/"));
+}
+
+function hasJsonExtension(p) {
+  return nodePath.extname(p).toLowerCase() === ".json";
+}
+
+export async function readPayloadFile(payloadPath, { fs = defaultFs } = {}) {
+  if (typeof payloadPath !== "string" || !nodePath.isAbsolute(payloadPath)) {
+    return refuse(`payload_path must be absolute (got '${payloadPath}').`);
+  }
+
+  if (isBlocked(nodePath.resolve(payloadPath))) {
+    return refuse(`payload_path refused: '${payloadPath}' targets a pseudo-filesystem path.`);
+  }
+
+  if (!hasJsonExtension(payloadPath)) {
+    return refuse(`payload_path refused: '${payloadPath}' must be a .json file.`);
+  }
+
+  let realPath;
+  try {
+    realPath = await fs.realpath(payloadPath);
+  } catch (err) {
+    return refuse(`Could not read payload_path '${payloadPath}' (${err.code || "error"}).`);
+  }
+
+  if (isBlocked(realPath)) {
+    return refuse(`payload_path refused: '${payloadPath}' targets a pseudo-filesystem path.`);
+  }
+
+  if (!hasJsonExtension(realPath)) {
+    return refuse(`payload_path refused: '${payloadPath}' must be a .json file.`);
+  }
+
+  let raw;
+  try {
+    const stat = await fs.stat(realPath);
+    if (!stat.isFile()) {
+      return refuse(`payload_path '${payloadPath}' is not a regular file.`);
+    }
+    if (stat.size > MAX_PAYLOAD_BYTES) {
+      return refuse(
+        `payload_path '${payloadPath}' is ${stat.size} bytes, exceeds max ${MAX_PAYLOAD_BYTES}.`,
+      );
+    }
+    raw = await fs.readFile(realPath, "utf8");
+  } catch (err) {
+    return refuse(`Could not read payload_path '${payloadPath}' (${err.code || "error"}).`);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return refuse(`payload_path '${payloadPath}' is not valid JSON.`);
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed) || !Array.isArray(parsed.epics)) {
+    return refuse(
+      `payload_path '${payloadPath}' is not an import payload (expected an object with an "epics" array).`,
+    );
+  }
+
+  return parsed;
+}

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.91.0",
+  "version": "2.91.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loopctl-mcp-server",
-      "version": "2.91.0",
+      "version": "2.91.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.91.0",
+  "version": "2.91.1",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/mcp-server/test/payload_path.test.js
+++ b/mcp-server/test/payload_path.test.js
@@ -33,7 +33,7 @@ before(() => {
   writeFileSync(at("creds.json"), JSON.stringify({ token: "SECRET-MARKER" }));
   writeFileSync(at("array.json"), JSON.stringify([{ epics: [] }]));
   symlinkSync(at("passwd"), at("link-to-passwd.json"));
-  symlinkSync("/proc/self/environ", at("link-to-proc.json"));
+  symlinkSync("/dev/null", at("link-to-dev.json"));
   mkdirSync(at("dir.json"));
 });
 
@@ -89,8 +89,8 @@ describe("payload_path never discloses or uploads a non-payload file", () => {
     assert.match(result.body, /must be a \.json file/);
   });
 
-  test("a .json symlink into /proc is refused as a pseudo-filesystem", async () => {
-    const result = await readPayloadFile(at("link-to-proc.json"));
+  test("a .json symlink into /dev is refused as a pseudo-filesystem", async () => {
+    const result = await readPayloadFile(at("link-to-dev.json"));
     assertRefusedWithoutLeak(result);
     assert.match(result.body, /pseudo-filesystem/);
   });

--- a/mcp-server/test/payload_path.test.js
+++ b/mcp-server/test/payload_path.test.js
@@ -1,0 +1,133 @@
+/**
+ * Tests for import_stories `payload_path` reading (lib/payload-path.js).
+ *
+ * Regression for a reported disclosure: a hostile payload_path such as /etc/passwd made
+ * JSON.parse throw, and the SyntaxError message (which quotes the file's content) was
+ * echoed back to the caller. A valid non-payload JSON file (credentials) was uploaded.
+ *
+ * Runs the REAL reader against real files in a temp dir; the last block source-scans
+ * index.js so the wiring cannot drift from the logic.
+ *
+ * Run: node --test test/*.test.js
+ */
+
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, symlinkSync, mkdirSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import { readPayloadFile } from "../lib/payload-path.js";
+
+const SECRET = "root:x:0:0:SECRET-MARKER";
+
+let dir;
+const at = (name) => path.join(dir, name);
+
+before(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "payload-path-"));
+  writeFileSync(at("stories.json"), JSON.stringify({ epics: [{ number: 1, stories: [] }] }));
+  writeFileSync(at("passwd"), `${SECRET}\n`);
+  writeFileSync(at("garbage.json"), `${SECRET}\n`);
+  writeFileSync(at("creds.json"), JSON.stringify({ token: "SECRET-MARKER" }));
+  writeFileSync(at("array.json"), JSON.stringify([{ epics: [] }]));
+  symlinkSync(at("passwd"), at("link-to-passwd.json"));
+  symlinkSync("/proc/self/environ", at("link-to-proc.json"));
+  mkdirSync(at("dir.json"));
+});
+
+after(() => rmSync(dir, { recursive: true, force: true }));
+
+function assertRefusedWithoutLeak(result) {
+  assert.equal(result.error, true);
+  assert.equal(result.status, 0);
+  assert.ok(!result.body.includes("SECRET-MARKER"), `body leaked file content: ${result.body}`);
+  assert.ok(!result.body.includes("Unexpected token"), `body echoed a parser message: ${result.body}`);
+}
+
+describe("payload_path accepts a real import payload", () => {
+  test("returns the parsed object", async () => {
+    const result = await readPayloadFile(at("stories.json"));
+    assert.deepEqual(result, { epics: [{ number: 1, stories: [] }] });
+  });
+});
+
+describe("payload_path never discloses or uploads a non-payload file", () => {
+  test("a non-JSON file with no .json extension is refused before it is read", async () => {
+    let read = false;
+    const fs = { realpath: async () => { read = true; }, stat: async () => { read = true; }, readFile: async () => { read = true; } };
+    const result = await readPayloadFile(at("passwd"), { fs });
+    assertRefusedWithoutLeak(result);
+    assert.match(result.body, /must be a \.json file/);
+    assert.equal(read, false);
+  });
+
+  test("/etc/passwd is refused without echoing content", async () => {
+    assertRefusedWithoutLeak(await readPayloadFile("/etc/passwd"));
+  });
+
+  test("a .json file that does not parse reports 'not valid JSON' and no content", async () => {
+    const result = await readPayloadFile(at("garbage.json"));
+    assertRefusedWithoutLeak(result);
+    assert.match(result.body, /is not valid JSON\.$/);
+  });
+
+  test("valid JSON without an epics array is refused, so it is never POSTed", async () => {
+    const result = await readPayloadFile(at("creds.json"));
+    assertRefusedWithoutLeak(result);
+    assert.match(result.body, /not an import payload/);
+  });
+
+  test("a top-level array is refused", async () => {
+    assertRefusedWithoutLeak(await readPayloadFile(at("array.json")));
+  });
+
+  test("a .json symlink to a non-.json file is refused on its realpath", async () => {
+    const result = await readPayloadFile(at("link-to-passwd.json"));
+    assertRefusedWithoutLeak(result);
+    assert.match(result.body, /must be a \.json file/);
+  });
+
+  test("a .json symlink into /proc is refused as a pseudo-filesystem", async () => {
+    const result = await readPayloadFile(at("link-to-proc.json"));
+    assertRefusedWithoutLeak(result);
+    assert.match(result.body, /pseudo-filesystem/);
+  });
+
+  test("a lexical /proc path is refused", async () => {
+    assert.match((await readPayloadFile("/proc/self/environ.json")).body, /pseudo-filesystem/);
+    assert.match((await readPayloadFile("/sys/../proc/x.json")).body, /pseudo-filesystem/);
+  });
+
+  test("a directory is refused", async () => {
+    assert.match((await readPayloadFile(at("dir.json"))).body, /not a regular file/);
+  });
+
+  test("a missing file reports only the error code", async () => {
+    const result = await readPayloadFile(at("nope.json"));
+    assertRefusedWithoutLeak(result);
+    assert.match(result.body, /\(ENOENT\)\.$/);
+  });
+
+  test("a relative path is refused", async () => {
+    assert.match((await readPayloadFile("stories.json")).body, /must be absolute/);
+  });
+});
+
+describe("index.js wiring", () => {
+  const src = readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "index.js"),
+    "utf8",
+  );
+
+  test("imports readPayloadFile and delegates payload_path to it", () => {
+    assert.match(src, /import \{ readPayloadFile \} from "\.\/lib\/payload-path\.js";/);
+    assert.match(src, /return readPayloadFile\(payloadPath\);/);
+  });
+
+  test("index.js no longer reads payload_path itself or echoes err.message for it", () => {
+    assert.ok(!/Could not read payload_path '\$\{payloadPath\}': \$\{err\.message\}/.test(src));
+    assert.ok(!/fs\.readFile\(payloadPath/.test(src));
+  });
+});


### PR DESCRIPTION
## Problem

Reported by email by Artyom Lobanov (@Morendais) against loopctl-mcp-server 2.91.0, and verified here.

- `import_stories` with `payload_path` pointing at a non-JSON file (e.g. `/etc/passwd`) made `JSON.parse` throw, and `err.message` was returned to the caller. V8's SyntaxError quotes the start of the file: `Unexpected token 'r', "root:x:0:0"... is not valid JSON`.
- A valid JSON file that was not an import payload (a credentials file) was POSTed to `/api/v1/projects/:id/import`.

Low severity (local stdio tool; the caller is an agent that usually already has file access), but real.

## Fix

`resolvePayload`'s file branch moves to `mcp-server/lib/payload-path.js` (`readPayloadFile`):

- path must be absolute and end in `.json`, checked on the path AND its realpath, so a `.json` symlink cannot point at another file;
- `/proc`, `/dev`, `/sys` re-checked on the realpath;
- parse failure reports "is not valid JSON"; fs failures report only `err.code`;
- the parsed value must be an object with an `epics` array (the Epic 12 shape `ImportExport` reads) or nothing is sent.

Not adopted: the report's `process.cwd()` containment. An MCP server's cwd is wherever the client launched it, so it would refuse the `/tmp` and scratchpad payload files agents legitimately write.

Bumps to 2.91.1 (autopublish on merge), CHANGELOG entry credits the reporter.

## Verification

- `npm test`: 495 pass, 0 fail (14 new in `test/payload_path.test.js`, real temp files incl. symlinks).
- Mutation-tested with `bin/mutate.sh`, all exit 0 (check went red): echoing raw content on parse failure; removing the realpath `.json` check; removing the `epics` shape check; and the WIRING, `index.js` reverted to a direct `readFile` + `JSON.parse`.
- Pre-push e2e: 26 tests, 0 failures.

Review gate: `/code-review high` running.
