### PR TITLE
Runner contract, authenticated runner channel and Presence pool (#801)

### DIFF
--- a/lib/loopctl/api_spec/runner_contract.ex
+++ b/lib/loopctl/api_spec/runner_contract.ex
@@ -15,13 +15,14 @@ defmodule Loopctl.ApiSpec.RunnerContract do
   - socket: `wss://<host>/runner/socket/websocket?vsn=2.0.0`
   - credential: header `x-loopctl-runner-token: <raw runner key>`. Never a query
     parameter — a URL is logged by every proxy on the path.
-  - topic: `"runners"`, joined with a `RunnerJoin` payload.
+  - topic: `"runner:<runner_id>"` — the id returned by `POST /api/v1/runners` — joined
+    with a `RunnerJoin` payload. A runner may join only its own topic.
 
   ## Messages
 
   | direction | event | schema |
   |---|---|---|
-  | runner -> control | `phx_join` on `"runners"` | `RunnerJoin` |
+  | runner -> control | `phx_join` on `"runner:<runner_id>"` | `RunnerJoin` |
   | runner -> control | `"status"` | `RunnerStatus` |
   | control -> runner | `"dispatch"` | `RunnerDispatch` (declared; emitted from #803) |
   | runner -> control | trace upload | `RunnerTraceEvent` (declared; shipped from #803) |
@@ -314,7 +315,7 @@ defmodule Loopctl.ApiSpec.RunnerContract do
       "x-connection" => %{
         "socket_path" => "/runner/socket/websocket",
         "credential_header" => "x-loopctl-runner-token",
-        "topic" => "runners",
+        "topic" => "runner:{runner_id}",
         "events" => %{
           "join" => "RunnerJoin",
           "status" => "RunnerStatus",

--- a/lib/loopctl/api_spec/runner_contract.ex
+++ b/lib/loopctl/api_spec/runner_contract.ex
@@ -257,7 +257,7 @@ defmodule Loopctl.ApiSpec.RunnerContract do
   def cast_join(payload) do
     with {:ok, cast} <- cast(payload, RunnerJoin.schema()),
          :ok <- supported_version(cast.contract_version) do
-      {:ok, Map.take(cast, Map.keys(RunnerJoin.schema().properties))}
+      {:ok, known_fields(cast, RunnerJoin.schema())}
     end
   end
 
@@ -265,12 +265,22 @@ defmodule Loopctl.ApiSpec.RunnerContract do
   @spec cast_status(term()) :: {:ok, map()} | {:error, term()}
   def cast_status(payload) do
     with {:ok, cast} <- cast(payload, RunnerStatus.schema()) do
-      case Map.take(cast, Map.keys(RunnerStatus.schema().properties)) do
+      case known_fields(cast, RunnerStatus.schema()) do
         empty when map_size(empty) == 0 -> {:error, {:invalid, ["no known status field"]}}
         known -> {:ok, known}
       end
     end
   end
+
+  # OpenApiSpex keeps undeclared keys on an object, at every depth. Drop them at every
+  # depth too, so nothing the contract does not declare reaches Presence.
+  defp known_fields(map, %Schema{type: :object, properties: props}) when is_map(map) do
+    for {key, sub} <- props, Map.has_key?(map, key), into: %{} do
+      {key, known_fields(Map.fetch!(map, key), sub)}
+    end
+  end
+
+  defp known_fields(value, _schema), do: value
 
   defp cast(payload, schema) when is_map(payload) do
     case OpenApiSpex.Cast.cast(schema, payload) do

--- a/lib/loopctl/api_spec/runner_contract.ex
+++ b/lib/loopctl/api_spec/runner_contract.ex
@@ -1,0 +1,371 @@
+defmodule Loopctl.ApiSpec.RunnerContract do
+  @moduledoc """
+  The versioned wire contract between loopctl and a runner (issue #801).
+
+  A runner is a dev machine that connects outbound over `LoopctlWeb.RunnerSocket`. This
+  module is the ONE declaration of every message on that connection. The same schemas
+  VALIDATE inbound messages (`cast_join/1`, `cast_status/1`) and are EXPORTED as JSON
+  Schema to `priv/runner_contract/v<major>.json` (`mix loopctl.runner_contract`), which
+  `mkreyman/loopctl-runner` vendors. A test fails when the checked-in export drifts from
+  these declarations, so the file a runner builds against is always the file loopctl
+  enforces.
+
+  ## Connection
+
+  - socket: `wss://<host>/runner/socket/websocket?vsn=2.0.0`
+  - credential: header `x-loopctl-runner-token: <raw runner key>`. Never a query
+    parameter — a URL is logged by every proxy on the path.
+  - topic: `"runners"`, joined with a `RunnerJoin` payload.
+
+  ## Messages
+
+  | direction | event | schema |
+  |---|---|---|
+  | runner -> control | `phx_join` on `"runners"` | `RunnerJoin` |
+  | runner -> control | `"status"` | `RunnerStatus` |
+  | control -> runner | `"dispatch"` | `RunnerDispatch` (declared; emitted from #803) |
+  | runner -> control | trace upload | `RunnerTraceEvent` (declared; shipped from #803) |
+
+  ## Versioning
+
+  `version/0` is semver. A runner sends its `contract_version` on join; the join is
+  refused unless the MAJOR matches. Minor versions only ADD optional fields, so an
+  older server ignores fields it does not declare rather than refusing them, and a
+  runner must do the same with a newer server's pushes.
+  """
+
+  require OpenApiSpex
+
+  alias OpenApiSpex.Schema
+
+  @version "1.0.0"
+  @major 1
+
+  defmodule RunnerSample do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(
+      %{
+        title: "RunnerSample",
+        description:
+          "A self-measured health sample. Connected is not able-to-build: a wedged " <>
+            "machine still answers heartbeats, so the control plane treats a stale " <>
+            "sample as a breached threshold.",
+        type: :object,
+        required: [:sampled_at, :loadavg_1m, :free_ram_mb, :free_disk_mb],
+        properties: %{
+          sampled_at: %Schema{type: :string, format: :"date-time"},
+          loadavg_1m: %Schema{type: :number, minimum: 0},
+          free_ram_mb: %Schema{type: :integer, minimum: 0},
+          free_disk_mb: %Schema{type: :integer, minimum: 0},
+          last_build_at: %Schema{
+            type: :string,
+            format: :"date-time",
+            nullable: true,
+            description: "When this machine last completed a build successfully."
+          }
+        }
+      },
+      struct?: false
+    )
+  end
+
+  defmodule RunnerJoin do
+    @moduledoc false
+    require OpenApiSpex
+
+    alias Loopctl.ApiSpec.RunnerContract.RunnerSample
+
+    OpenApiSpex.schema(
+      %{
+        title: "RunnerJoin",
+        description: "The payload a runner joins the `runners` topic with.",
+        type: :object,
+        required: [
+          :contract_version,
+          :machine,
+          :cores,
+          :memory_mb,
+          :repos,
+          :max_sessions,
+          :in_flight,
+          :draining
+        ],
+        properties: %{
+          contract_version: %Schema{
+            type: :string,
+            pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+            description: "The contract version the runner was built against (semver)."
+          },
+          machine: %Schema{
+            type: :string,
+            pattern: "^[a-z0-9][a-z0-9._-]{0,62}$",
+            description: "The machine name the runner was enrolled under. Must match exactly."
+          },
+          cores: %Schema{type: :integer, minimum: 1, maximum: 1024},
+          memory_mb: %Schema{type: :integer, minimum: 1},
+          repos: %Schema{
+            type: :array,
+            maxItems: 50,
+            items: %Schema{
+              type: :string,
+              pattern: "^[A-Za-z0-9_.-]{1,100}/[A-Za-z0-9_.-]{1,100}$"
+            },
+            description: "GitHub `owner/repo` checkouts this runner can work in."
+          },
+          max_sessions: %Schema{
+            type: :integer,
+            minimum: 0,
+            maximum: 64,
+            description: "Concurrent sessions this machine accepts. Advisory; see in_flight."
+          },
+          in_flight: %Schema{
+            type: :integer,
+            minimum: 0,
+            description:
+              "Sessions running now, as the runner counts them. A hint: capacity is " <>
+                "reserved in Postgres, never read off Presence."
+          },
+          draining: %Schema{
+            type: :boolean,
+            description: "True when the runner accepts no new dispatches."
+          },
+          sample: RunnerSample.schema()
+        }
+      },
+      struct?: false
+    )
+  end
+
+  defmodule RunnerStatus do
+    @moduledoc false
+    require OpenApiSpex
+
+    alias Loopctl.ApiSpec.RunnerContract.RunnerSample
+
+    OpenApiSpex.schema(
+      %{
+        title: "RunnerStatus",
+        description:
+          "A runner's periodic update, pushed as the `status` event. Any subset of the " <>
+            "fields; at least one.",
+        type: :object,
+        minProperties: 1,
+        properties: %{
+          in_flight: %Schema{type: :integer, minimum: 0},
+          draining: %Schema{type: :boolean},
+          sample: RunnerSample.schema()
+        }
+      },
+      struct?: false
+    )
+  end
+
+  defmodule RunnerDispatch do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(
+      %{
+        title: "RunnerDispatch",
+        description:
+          "Control pushes `dispatch` to start a session. The runner validates it against " <>
+            "its LOCAL allow-list (repos, branch prefixes, wall clock, token budget) and " <>
+            "refuses by default: a dispatch is a prompt executed as the machine's user. " <>
+            "Declared in contract v1; emitted from #803.",
+        type: :object,
+        required: [
+          :dispatch_id,
+          :story_id,
+          :kind,
+          :repo,
+          :base_branch,
+          :branch,
+          :claim_epoch,
+          :wall_clock_seconds,
+          :max_turns
+        ],
+        properties: %{
+          dispatch_id: %Schema{type: :string, format: :uuid},
+          story_id: %Schema{type: :string, format: :uuid},
+          kind: %Schema{type: :string, enum: ["triage", "implement"]},
+          repo: %Schema{type: :string, pattern: "^[A-Za-z0-9_.-]{1,100}/[A-Za-z0-9_.-]{1,100}$"},
+          base_branch: %Schema{type: :string, minLength: 1, maxLength: 255},
+          branch: %Schema{type: :string, minLength: 1, maxLength: 255},
+          claim_epoch: %Schema{
+            type: :integer,
+            minimum: 0,
+            description:
+              "Echoed on every runner-to-control message about this dispatch. Bumped on " <>
+                "reclaim, so a resurrected session's writes are rejected."
+          },
+          wall_clock_seconds: %Schema{type: :integer, minimum: 1},
+          max_turns: %Schema{type: :integer, minimum: 1},
+          token_budget: %Schema{type: :integer, minimum: 1, nullable: true}
+        }
+      },
+      struct?: false
+    )
+  end
+
+  defmodule RunnerTraceEvent do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(
+      %{
+        title: "RunnerTraceEvent",
+        description:
+          "One line of a run's NDJSON trace. The on-disk file is the source of truth: " <>
+            "the runner ships `(run_id, seq)`, the server ACKs the last contiguous seq and " <>
+            "dedups on the pair, and the runner resumes from that offset on rejoin. " <>
+            "`parent` is REQUIRED on every event (null only for the root) so the agent " <>
+            "tree can be rebuilt by query.",
+        type: :object,
+        required: [:run_id, :seq, :event_id, :parent, :ts, :type],
+        properties: %{
+          run_id: %Schema{type: :string, format: :uuid},
+          seq: %Schema{type: :integer, minimum: 0},
+          event_id: %Schema{type: :string, minLength: 1, maxLength: 128},
+          parent: %Schema{type: :string, minLength: 1, maxLength: 128, nullable: true},
+          ts: %Schema{type: :string, format: :"date-time"},
+          type: %Schema{type: :string, minLength: 1, maxLength: 64},
+          data: %Schema{type: :object, additionalProperties: true}
+        }
+      },
+      struct?: false
+    )
+  end
+
+  @schemas [RunnerJoin, RunnerStatus, RunnerSample, RunnerDispatch, RunnerTraceEvent]
+
+  @doc "The contract version loopctl speaks (semver)."
+  @spec version() :: String.t()
+  def version, do: @version
+
+  @doc "The schema modules the contract declares."
+  @spec schema_modules() :: [module()]
+  def schema_modules, do: @schemas
+
+  @doc """
+  Validates a join payload. Returns the known fields only, with atom keys, or
+  `{:error, reason}` where reason is `{:invalid, messages}` or
+  `{:unsupported_contract_version, sent, speaks}`.
+  """
+  @spec cast_join(term()) :: {:ok, map()} | {:error, term()}
+  def cast_join(payload) do
+    with {:ok, cast} <- cast(payload, RunnerJoin.schema()),
+         :ok <- supported_version(cast.contract_version) do
+      {:ok, Map.take(cast, Map.keys(RunnerJoin.schema().properties))}
+    end
+  end
+
+  @doc "Validates a `status` payload. Returns the known fields only, with atom keys."
+  @spec cast_status(term()) :: {:ok, map()} | {:error, term()}
+  def cast_status(payload) do
+    with {:ok, cast} <- cast(payload, RunnerStatus.schema()) do
+      case Map.take(cast, Map.keys(RunnerStatus.schema().properties)) do
+        empty when map_size(empty) == 0 -> {:error, {:invalid, ["no known status field"]}}
+        known -> {:ok, known}
+      end
+    end
+  end
+
+  defp cast(payload, schema) when is_map(payload) do
+    case OpenApiSpex.Cast.cast(schema, payload) do
+      {:ok, cast} -> {:ok, cast}
+      {:error, errors} -> {:error, {:invalid, Enum.map(errors, &to_string/1)}}
+    end
+  end
+
+  defp cast(_payload, _schema), do: {:error, {:invalid, ["payload must be an object"]}}
+
+  defp supported_version(sent) do
+    case String.split(sent, ".") do
+      [major | _] when major == unquote(Integer.to_string(@major)) -> :ok
+      _ -> {:error, {:unsupported_contract_version, sent, @version}}
+    end
+  end
+
+  @doc """
+  The contract as a JSON Schema document (2020-12), the shape written to
+  `priv/runner_contract/v<major>.json`.
+  """
+  @spec json_schema() :: map()
+  def json_schema do
+    defs = Map.new(@schemas, fn mod -> {mod.schema().title, schema_to_map(mod.schema())} end)
+
+    %{
+      "$schema" => "https://json-schema.org/draft/2020-12/schema",
+      "$id" => "https://loopctl.com/runner_contract/v#{@major}.json",
+      "title" => "loopctl runner contract",
+      "x-contract-version" => @version,
+      "x-connection" => %{
+        "socket_path" => "/runner/socket/websocket",
+        "credential_header" => "x-loopctl-runner-token",
+        "topic" => "runners",
+        "events" => %{
+          "join" => "RunnerJoin",
+          "status" => "RunnerStatus",
+          "dispatch" => "RunnerDispatch",
+          "trace_event" => "RunnerTraceEvent"
+        }
+      },
+      "$defs" => defs
+    }
+  end
+
+  @doc "The export path for the current major version, relative to the app root."
+  @spec export_path() :: String.t()
+  def export_path, do: "priv/runner_contract/v#{@major}.json"
+
+  @doc "The export encoded as it is checked in: pretty JSON with sorted keys and a newline."
+  @spec encoded_json_schema() :: String.t()
+  def encoded_json_schema do
+    json_schema()
+    |> sort_keys()
+    |> Jason.encode!(pretty: true)
+    |> Kernel.<>("\n")
+  end
+
+  defp sort_keys(map) when is_map(map) do
+    map
+    |> Enum.sort_by(fn {k, _} -> to_string(k) end)
+    |> Enum.map(fn {k, v} -> {to_string(k), sort_keys(v)} end)
+    |> Jason.OrderedObject.new()
+  end
+
+  defp sort_keys(list) when is_list(list), do: Enum.map(list, &sort_keys/1)
+  defp sort_keys(other), do: other
+
+  # OpenApiSpex nullable -> JSON Schema 2020-12 type union. Nested schemas are inlined
+  # (`RunnerSample` inside `RunnerJoin`), because `OpenApiSpex.Cast` cannot resolve a
+  # module reference without a full spec, and validation must use these exact structs.
+  defp schema_to_map(%Schema{} = schema) do
+    base =
+      [
+        description: schema.description,
+        pattern: schema.pattern,
+        format: schema.format && to_string(schema.format),
+        minimum: schema.minimum,
+        maximum: schema.maximum,
+        minLength: schema.minLength,
+        maxLength: schema.maxLength,
+        maxItems: schema.maxItems,
+        minProperties: schema.minProperties,
+        enum: schema.enum,
+        required: schema.required && Enum.map(schema.required, &to_string/1),
+        additionalProperties: schema.additionalProperties,
+        items: schema.items && schema_to_map(schema.items),
+        properties:
+          schema.properties &&
+            Map.new(schema.properties, fn {k, v} -> {to_string(k), schema_to_map(v)} end)
+      ]
+      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+      |> Map.new(fn {k, v} -> {to_string(k), v} end)
+
+    type = to_string(schema.type)
+    Map.put(base, "type", if(schema.nullable, do: [type, "null"], else: type))
+  end
+end

--- a/lib/loopctl/api_spec/runner_contract.ex
+++ b/lib/loopctl/api_spec/runner_contract.ex
@@ -81,7 +81,7 @@ defmodule Loopctl.ApiSpec.RunnerContract do
     OpenApiSpex.schema(
       %{
         title: "RunnerJoin",
-        description: "The payload a runner joins the `runners` topic with.",
+        description: "The payload a runner joins its own `runner:<runner_id>` topic with.",
         type: :object,
         required: [
           :contract_version,

--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -76,6 +76,9 @@ defmodule Loopctl.Application do
       Loopctl.SystemConfig.CachePrimer,
       {DNSCluster, query: Application.get_env(:loopctl, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: Loopctl.PubSub},
+      # Issue #801: the runner pool. Its tracker needs PubSub and must be up before
+      # the Endpoint accepts a runner socket.
+      Loopctl.Runners.Presence,
       # Bridges tenant audit-key cache invalidations BETWEEN nodes. The ETS table
       # itself is created above by `TenantKeys.init_cache/0`; this child only
       # subscribes to the invalidate topic, so it needs PubSub and nothing else.

--- a/lib/loopctl/runners.ex
+++ b/lib/loopctl/runners.ex
@@ -18,7 +18,10 @@ defmodule Loopctl.Runners do
   Revocation is central (`revoke_runner/3`): it revokes the key and the row in one
   transaction, busts the key cache after commit, and notifies the live channel, which
   disconnects its socket. A key revoked by any other route (`DELETE /api/v1/api_keys/:id`,
-  expiry, tenant suspension) is caught by the channel's periodic `authorized?/2` recheck.
+  expiry, tenant suspension) is caught by the channel's periodic `authorized?/2` recheck
+  and by the same read on every join. A database trigger revokes the runner row with its
+  key, so the registry never lists a machine whose credential is gone, and a runner's key
+  cannot be rotated through `/api/v1/api_keys`: rotation is revoke plus re-enroll.
 
   ## Pool
 
@@ -200,6 +203,14 @@ defmodule Loopctl.Runners do
       {:error, _step, reason, _} ->
         {:error, reason}
     end
+  end
+
+  @doc "Whether `api_key_id` is the credential of a runner (active or revoked)."
+  @spec runner_key?(Ecto.UUID.t(), Ecto.UUID.t()) :: boolean()
+  def runner_key?(tenant_id, api_key_id) when is_binary(tenant_id) and is_binary(api_key_id) do
+    AdminRepo.exists?(
+      from r in Runner, where: r.tenant_id == ^tenant_id and r.api_key_id == ^api_key_id
+    )
   end
 
   @doc """

--- a/lib/loopctl/runners.ex
+++ b/lib/loopctl/runners.ex
@@ -1,0 +1,274 @@
+defmodule Loopctl.Runners do
+  @moduledoc """
+  The runner registry and pool of the agent delivery loop (issue #801).
+
+  A **runner** is a dev machine that connects OUTBOUND to loopctl as a Phoenix Channel
+  client (`LoopctlWeb.RunnerSocket`). It never joins loopctl's BEAM cluster: a dev
+  machine inside the production cluster would reach every process over `:erpc`, so a
+  compromised laptop would be a compromised control plane.
+
+  ## Credential
+
+  A runner authenticates with an ordinary `api_keys` row (role `:agent`) bound to one
+  machine name by a `Loopctl.Runners.Runner` row. Resolution goes through
+  `Auth.verify_api_key/1` — the same function `LoopctlWeb.Plugs.ResolveApiKey` calls —
+  so the revocation cache, expiry and tenant suspension apply to the socket exactly as
+  they apply to a REST request. A key with no active runner row cannot open the socket.
+
+  Revocation is central (`revoke_runner/3`): it revokes the key and the row in one
+  transaction, busts the key cache after commit, and notifies the live channel, which
+  disconnects its socket. A key revoked by any other route (`DELETE /api/v1/api_keys/:id`,
+  expiry, tenant suspension) is caught by the channel's periodic `authorized?/2` recheck.
+
+  ## Pool
+
+  `Loopctl.Runners.Presence` tracks each joined runner under a TENANT-SCOPED topic,
+  `pool_topic/1`. The design names the topic `"runners"`; that is the topic a runner
+  JOINS, but the Presence set is kept per tenant so one tenant's machines are never
+  visible to another. `pool/1` is the read.
+
+  Presence is a liveness hint, never a scheduler: it has no compare-and-set, so capacity
+  must be reserved in Postgres when dispatch arrives (design §7). And it converges only
+  across a CLUSTER — on a second, unclustered machine a runner tracked on node A is
+  invisible on node B. `Loopctl.ClusterReadiness` warns when that happens.
+  """
+
+  import Ecto.Query
+
+  alias Ecto.Multi
+  alias Loopctl.AdminRepo
+  alias Loopctl.AuditChain
+  alias Loopctl.Auth
+  alias Loopctl.Auth.ApiKey
+  alias Loopctl.Runners.Presence
+  alias Loopctl.Runners.Runner
+  alias Loopctl.Tenants.Tenant
+
+  @doc "The tenant-scoped Presence topic a runner is tracked under."
+  @spec pool_topic(Ecto.UUID.t()) :: String.t()
+  def pool_topic(tenant_id) when is_binary(tenant_id), do: "runners:" <> tenant_id
+
+  @doc "The PubSub topic a runner's live channel listens on for its own revocation."
+  @spec revocation_topic(Ecto.UUID.t()) :: String.t()
+  def revocation_topic(runner_id) when is_binary(runner_id), do: "runner_revocation:" <> runner_id
+
+  @doc """
+  The joined runners of a tenant, as `Phoenix.Presence.list/1` returns them: a map of
+  machine name to `%{metas: [meta, ...]}`. More than one meta under a name means more
+  than one live socket is using that runner's credential.
+  """
+  @spec pool(Ecto.UUID.t()) :: map()
+  def pool(tenant_id) when is_binary(tenant_id), do: Presence.list(pool_topic(tenant_id))
+
+  @doc """
+  Enrolls a machine as a runner: mints its `:agent` API key and binds it to `name` in
+  one transaction, and records the enrollment on the audit chain.
+
+  Returns `{:ok, %{runner: runner, raw_key: raw_key}}`. The raw key is returned once
+  and never stored.
+
+  ## Options
+
+  - `:actor_lineage` — the enrolling caller's dispatch lineage, for the audit entry.
+  """
+  @spec enroll_runner(Ecto.UUID.t(), map(), keyword()) ::
+          {:ok, %{runner: Runner.t(), raw_key: String.t()}}
+          | {:error, Ecto.Changeset.t() | term()}
+  def enroll_runner(tenant_id, attrs, opts \\ []) when is_binary(tenant_id) do
+    name = Map.get(attrs, :name) || Map.get(attrs, "name")
+    changeset = Runner.create_changeset(%Runner{tenant_id: tenant_id}, %{name: name})
+
+    if changeset.valid? do
+      do_enroll(tenant_id, changeset, opts)
+    else
+      {:error, changeset}
+    end
+  end
+
+  defp do_enroll(tenant_id, changeset, opts) do
+    name = Ecto.Changeset.get_field(changeset, :name)
+
+    multi =
+      Multi.new()
+      |> Multi.run(:mint_key, fn _repo, _ ->
+        Auth.generate_api_key(%{tenant_id: tenant_id, name: "runner:" <> name, role: :agent})
+      end)
+      |> Multi.run(:runner, fn _repo, %{mint_key: {_raw, api_key}} ->
+        changeset
+        |> Ecto.Changeset.put_change(:api_key_id, api_key.id)
+        |> AdminRepo.insert()
+      end)
+      |> Multi.run(:audit, fn _repo, %{runner: runner, mint_key: {_raw, api_key}} ->
+        AuditChain.append(tenant_id, %{
+          action: "runner_enrolled",
+          actor_lineage: Keyword.get(opts, :actor_lineage, []),
+          entity_type: "runner",
+          entity_id: runner.id,
+          payload: %{"name" => runner.name, "api_key_id" => api_key.id}
+        })
+      end)
+
+    case AdminRepo.transaction(multi) do
+      {:ok, %{runner: runner, mint_key: {raw_key, _api_key}}} ->
+        {:ok, %{runner: runner, raw_key: raw_key}}
+
+      {:error, _step, reason, _} ->
+        {:error, reason}
+    end
+  end
+
+  @doc "Lists a tenant's runners, newest first. Pass `include_revoked: true` for all."
+  @spec list_runners(Ecto.UUID.t(), keyword()) :: [Runner.t()]
+  def list_runners(tenant_id, opts \\ []) when is_binary(tenant_id) do
+    query =
+      from r in Runner,
+        where: r.tenant_id == ^tenant_id,
+        order_by: [desc: r.inserted_at]
+
+    query =
+      if Keyword.get(opts, :include_revoked, false),
+        do: query,
+        else: where(query, [r], is_nil(r.revoked_at))
+
+    AdminRepo.all(query)
+  end
+
+  @doc "Gets one runner of a tenant."
+  @spec get_runner(Ecto.UUID.t(), Ecto.UUID.t()) :: {:ok, Runner.t()} | {:error, :not_found}
+  def get_runner(tenant_id, runner_id) when is_binary(tenant_id) do
+    with {:ok, id} <- Ecto.UUID.cast(runner_id),
+         %Runner{} = runner <- AdminRepo.get_by(Runner, id: id, tenant_id: tenant_id) do
+      {:ok, runner}
+    else
+      _ -> {:error, :not_found}
+    end
+  end
+
+  @doc """
+  Revokes a runner: its row and its API key in one transaction, then busts the key
+  cache and tells the live channel, which disconnects its socket.
+
+  Idempotent: revoking an already-revoked runner returns it unchanged.
+  """
+  @spec revoke_runner(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
+          {:ok, Runner.t()} | {:error, :not_found | term()}
+  def revoke_runner(tenant_id, runner_id, opts \\ []) when is_binary(tenant_id) do
+    case get_runner(tenant_id, runner_id) do
+      {:ok, %Runner{revoked_at: nil} = runner} -> do_revoke(tenant_id, runner, opts)
+      {:ok, %Runner{} = already_revoked} -> {:ok, already_revoked}
+      error -> error
+    end
+  end
+
+  defp do_revoke(tenant_id, runner, opts) do
+    now = DateTime.utc_now()
+
+    multi =
+      Multi.new()
+      |> Multi.update(:runner, Runner.revoke_changeset(runner, now))
+      |> Multi.run(:revoke_key, fn _repo, _ ->
+        # Select the hash back from the revoke itself so the post-commit cache bust
+        # needs no second AdminRepo round-trip (the dispatch-revoke pattern).
+        {_count, key_hashes} =
+          from(k in ApiKey,
+            where: k.id == ^runner.api_key_id and k.tenant_id == ^tenant_id,
+            where: is_nil(k.revoked_at),
+            select: k.key_hash
+          )
+          |> AdminRepo.update_all(set: [revoked_at: now])
+
+        {:ok, key_hashes}
+      end)
+      |> Multi.run(:audit, fn _repo, _ ->
+        AuditChain.append(tenant_id, %{
+          action: "runner_revoked",
+          actor_lineage: Keyword.get(opts, :actor_lineage, []),
+          entity_type: "runner",
+          entity_id: runner.id,
+          payload: %{"name" => runner.name, "api_key_id" => runner.api_key_id}
+        })
+      end)
+
+    case AdminRepo.transaction(multi) do
+      {:ok, %{runner: revoked, revoke_key: key_hashes}} ->
+        # AFTER commit: a bust before commit lets a concurrent verify re-cache the
+        # still-unrevoked row.
+        Auth.invalidate_key_cache_by_hashes(key_hashes)
+        Phoenix.PubSub.broadcast(Loopctl.PubSub, revocation_topic(revoked.id), :runner_revoked)
+        {:ok, revoked}
+
+      {:error, _step, reason, _} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Authenticates a runner credential presented on the runner socket.
+
+  Returns `{:ok, %{runner: runner, api_key: api_key}}`, or `{:error, reason}` where
+  reason is one of `:invalid_token`, `:tenant_inactive`, `:not_a_runner` or
+  `:runner_revoked`. The reason is for the server log; the socket answers every
+  failure identically.
+  """
+  @spec authenticate(term()) ::
+          {:ok, %{runner: Runner.t(), api_key: ApiKey.t()}}
+          | {:error, :invalid_token | :tenant_inactive | :not_a_runner | :runner_revoked}
+  def authenticate(raw_token) when is_binary(raw_token) and raw_token != "" do
+    with {:ok, api_key} <- verify(raw_token),
+         :ok <- tenant_active(api_key.tenant),
+         {:ok, runner} <- runner_for_key(api_key) do
+      {:ok, %{runner: runner, api_key: api_key}}
+    end
+  end
+
+  def authenticate(_raw_token), do: {:error, :invalid_token}
+
+  defp verify(raw_token) do
+    case Auth.verify_api_key(raw_token) do
+      {:ok, %ApiKey{tenant_id: tenant_id, role: :agent} = api_key} when is_binary(tenant_id) ->
+        {:ok, api_key}
+
+      {:ok, %ApiKey{}} ->
+        {:error, :not_a_runner}
+
+      {:error, _} ->
+        {:error, :invalid_token}
+    end
+  end
+
+  defp tenant_active(%Tenant{status: :active}), do: :ok
+  defp tenant_active(_tenant), do: {:error, :tenant_inactive}
+
+  defp runner_for_key(%ApiKey{id: key_id, tenant_id: tenant_id}) do
+    case AdminRepo.get_by(Runner, api_key_id: key_id, tenant_id: tenant_id) do
+      nil -> {:error, :not_a_runner}
+      %Runner{revoked_at: nil} = runner -> {:ok, runner}
+      %Runner{} -> {:error, :runner_revoked}
+    end
+  end
+
+  @doc """
+  Whether a connected runner is still allowed to be connected: its row is not revoked,
+  its key is neither revoked nor expired, and its tenant is active. One query.
+
+  This is the backstop for every revocation that does not go through `revoke_runner/3`.
+  """
+  @spec authorized?(Ecto.UUID.t(), Ecto.UUID.t()) :: boolean()
+  def authorized?(tenant_id, runner_id) when is_binary(tenant_id) and is_binary(runner_id) do
+    now = DateTime.utc_now()
+
+    query =
+      from r in Runner,
+        join: k in ApiKey,
+        on: k.id == r.api_key_id and k.tenant_id == r.tenant_id,
+        join: t in Tenant,
+        on: t.id == r.tenant_id,
+        where: r.id == ^runner_id and r.tenant_id == ^tenant_id,
+        where: is_nil(r.revoked_at) and is_nil(k.revoked_at),
+        where: is_nil(k.expires_at) or k.expires_at > ^now,
+        where: t.status == :active,
+        select: true
+
+    AdminRepo.exists?(query)
+  end
+end

--- a/lib/loopctl/runners.ex
+++ b/lib/loopctl/runners.ex
@@ -26,9 +26,9 @@ defmodule Loopctl.Runners do
   ## Pool
 
   `Loopctl.Runners.Presence` tracks each joined runner under a TENANT-SCOPED topic,
-  `pool_topic/1`. The design names the topic `"runners"`; that is the topic a runner
-  JOINS, but the Presence set is kept per tenant so one tenant's machines are never
-  visible to another. `pool/1` is the read.
+  `pool_topic/1`, so one tenant's machines are never visible to another. A runner JOINS
+  its own topic, `runner:<runner_id>` (the design's single `"runners"` topic would carry
+  a broadcast to every tenant's machines). `pool/1` is the read.
 
   Presence is a liveness hint, never a scheduler: it has no compare-and-set, so capacity
   must be reserved in Postgres when dispatch arrives (design §7). And it converges only
@@ -41,6 +41,7 @@ defmodule Loopctl.Runners do
   alias Ecto.Multi
   alias Loopctl.AdminRepo
   alias Loopctl.AuditChain
+  alias Loopctl.AuditChain.Entry, as: AuditEntry
   alias Loopctl.Auth
   alias Loopctl.Auth.ApiKey
   alias Loopctl.Runners.Presence
@@ -151,45 +152,39 @@ defmodule Loopctl.Runners do
   Revokes a runner: its row and its API key in one transaction, then busts the key
   cache and tells the live channel, which disconnects its socket.
 
-  Idempotent: revoking an already-revoked runner returns it unchanged.
+  The row is locked inside the transaction, so concurrent revokes serialize and exactly
+  one writes `revoked_at` and the `runner_revoked` audit entry. A runner whose row the
+  `runners_revoke_with_api_key` trigger already revoked (its key was revoked through
+  `/api/v1/api_keys`) still gets its audit entry, once, and its live socket is still told
+  — so calling this after a key revoke is never a silent no-op. Idempotent otherwise.
   """
   @spec revoke_runner(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
           {:ok, Runner.t()} | {:error, :not_found | term()}
   def revoke_runner(tenant_id, runner_id, opts \\ []) when is_binary(tenant_id) do
-    case get_runner(tenant_id, runner_id) do
-      {:ok, %Runner{revoked_at: nil} = runner} -> do_revoke(tenant_id, runner, opts)
-      {:ok, %Runner{} = already_revoked} -> {:ok, already_revoked}
-      error -> error
+    with {:ok, id} <- cast_id(runner_id) do
+      do_revoke(tenant_id, id, opts)
     end
   end
 
-  defp do_revoke(tenant_id, runner, opts) do
+  defp cast_id(runner_id) do
+    case Ecto.UUID.cast(runner_id) do
+      {:ok, id} -> {:ok, id}
+      :error -> {:error, :not_found}
+    end
+  end
+
+  defp do_revoke(tenant_id, runner_id, opts) do
     now = DateTime.utc_now()
 
     multi =
       Multi.new()
-      |> Multi.update(:runner, Runner.revoke_changeset(runner, now))
-      |> Multi.run(:revoke_key, fn _repo, _ ->
-        # Select the hash back from the revoke itself so the post-commit cache bust
-        # needs no second AdminRepo round-trip (the dispatch-revoke pattern).
-        {_count, key_hashes} =
-          from(k in ApiKey,
-            where: k.id == ^runner.api_key_id and k.tenant_id == ^tenant_id,
-            where: is_nil(k.revoked_at),
-            select: k.key_hash
-          )
-          |> AdminRepo.update_all(set: [revoked_at: now])
-
-        {:ok, key_hashes}
+      |> Multi.run(:locked, fn _repo, _ -> lock_runner(tenant_id, runner_id) end)
+      |> Multi.run(:runner, fn _repo, %{locked: runner} -> mark_revoked(runner, now) end)
+      |> Multi.run(:revoke_key, fn _repo, %{runner: runner} ->
+        revoke_runner_key(tenant_id, runner, now)
       end)
-      |> Multi.run(:audit, fn _repo, _ ->
-        AuditChain.append(tenant_id, %{
-          action: "runner_revoked",
-          actor_lineage: Keyword.get(opts, :actor_lineage, []),
-          entity_type: "runner",
-          entity_id: runner.id,
-          payload: %{"name" => runner.name, "api_key_id" => runner.api_key_id}
-        })
+      |> Multi.run(:audit, fn _repo, %{runner: runner} ->
+        audit_revocation_once(tenant_id, runner, opts)
       end)
 
     case AdminRepo.transaction(multi) do
@@ -203,6 +198,63 @@ defmodule Loopctl.Runners do
       {:error, _step, reason, _} ->
         {:error, reason}
     end
+  end
+
+  defp lock_runner(tenant_id, runner_id) do
+    query =
+      from r in Runner,
+        where: r.id == ^runner_id and r.tenant_id == ^tenant_id,
+        lock: "FOR UPDATE"
+
+    case AdminRepo.one(query) do
+      nil -> {:error, :not_found}
+      runner -> {:ok, runner}
+    end
+  end
+
+  # An already-revoked row (the api key trigger got there first) passes through, so
+  # its audit entry and its live-channel notice still happen.
+  defp mark_revoked(%Runner{revoked_at: nil} = runner, now),
+    do: AdminRepo.update(Runner.revoke_changeset(runner, now))
+
+  defp mark_revoked(%Runner{} = runner, _now), do: {:ok, runner}
+
+  # Selects the hash back from the revoke itself so the post-commit cache bust needs no
+  # second AdminRepo round-trip (the dispatch-revoke pattern). A no-op when the key was
+  # revoked first.
+  defp revoke_runner_key(tenant_id, runner, now) do
+    {_count, key_hashes} =
+      from(k in ApiKey,
+        where: k.id == ^runner.api_key_id and k.tenant_id == ^tenant_id,
+        where: is_nil(k.revoked_at),
+        select: k.key_hash
+      )
+      |> AdminRepo.update_all(set: [revoked_at: now])
+
+    {:ok, key_hashes}
+  end
+
+  # Under the row lock, so two callers cannot both find no entry and both write one.
+  defp audit_revocation_once(tenant_id, runner, opts) do
+    if revocation_audited?(tenant_id, runner.id) do
+      {:ok, :already_audited}
+    else
+      AuditChain.append(tenant_id, %{
+        action: "runner_revoked",
+        actor_lineage: Keyword.get(opts, :actor_lineage, []),
+        entity_type: "runner",
+        entity_id: runner.id,
+        payload: %{"name" => runner.name, "api_key_id" => runner.api_key_id}
+      })
+    end
+  end
+
+  defp revocation_audited?(tenant_id, runner_id) do
+    AdminRepo.exists?(
+      from e in AuditEntry,
+        where: e.tenant_id == ^tenant_id and e.action == "runner_revoked",
+        where: e.entity_type == "runner" and e.entity_id == ^runner_id
+    )
   end
 
   @doc "Whether `api_key_id` is the credential of a runner (active or revoked)."

--- a/lib/loopctl/runners.ex
+++ b/lib/loopctl/runners.ex
@@ -152,7 +152,9 @@ defmodule Loopctl.Runners do
   Revokes a runner: its row and its API key in one transaction, then busts the key
   cache and tells the live channel, which disconnects its socket.
 
-  The row is locked inside the transaction, so concurrent revokes serialize and exactly
+  The key row and then the runner row are locked inside the transaction — the order the
+  api_keys revoke path takes them in, so the two paths cannot deadlock — and concurrent
+  revokes serialize and exactly
   one writes `revoked_at` and the `runner_revoked` audit entry. A runner whose row the
   `runners_revoke_with_api_key` trigger already revoked (its key was revoked through
   `/api/v1/api_keys`) still gets its audit entry, once, and its live socket is still told
@@ -200,15 +202,29 @@ defmodule Loopctl.Runners do
     end
   end
 
+  # Locks the api key BEFORE the runner row. `DELETE /api/v1/api_keys/:id` takes them in
+  # that order (the key row, then the `runners_revoke_with_api_key` trigger's update of the
+  # runner row), so the opposite order here would let the two revoke paths deadlock. The
+  # unlocked pre-read only learns `api_key_id`, which never changes after enrollment.
   defp lock_runner(tenant_id, runner_id) do
-    query =
-      from r in Runner,
-        where: r.id == ^runner_id and r.tenant_id == ^tenant_id,
-        lock: "FOR UPDATE"
-
-    case AdminRepo.one(query) do
+    with %Runner{api_key_id: key_id} <-
+           AdminRepo.get_by(Runner, id: runner_id, tenant_id: tenant_id),
+         _key_id <-
+           AdminRepo.one(
+             from k in ApiKey,
+               where: k.id == ^key_id and k.tenant_id == ^tenant_id,
+               lock: "FOR UPDATE",
+               select: k.id
+           ),
+         %Runner{} = runner <-
+           AdminRepo.one(
+             from r in Runner,
+               where: r.id == ^runner_id and r.tenant_id == ^tenant_id,
+               lock: "FOR UPDATE"
+           ) do
+      {:ok, runner}
+    else
       nil -> {:error, :not_found}
-      runner -> {:ok, runner}
     end
   end
 

--- a/lib/loopctl/runners/presence.ex
+++ b/lib/loopctl/runners/presence.ex
@@ -1,0 +1,24 @@
+defmodule Loopctl.Runners.Presence do
+  @moduledoc """
+  Presence for the runner pool (issue #801).
+
+  A runner's entry is tracked against its channel process, so it disappears when that
+  process exits — a killed runner, a dropped socket, a revoked credential. That IS the
+  liveness design: no TTL, no sweeper, no `last_seen_at` row to go stale.
+
+  Read it through `Loopctl.Runners.pool/1`, which applies the tenant-scoped topic.
+
+  Two limits a caller must not forget (design §7):
+
+  - **Liveness hint, not a scheduler.** Presence is an eventually-consistent CRDT with no
+    compare-and-set; two readers can both see `in_flight: 0` and both dispatch to the
+    same runner. Reserve capacity in Postgres.
+  - **It converges only within a cluster.** loopctl runs single-node today. If Fly starts
+    a second machine without `DNS_CLUSTER_QUERY`, a runner tracked on node A is invisible
+    on node B for as long as its socket lives.
+  """
+
+  use Phoenix.Presence,
+    otp_app: :loopctl,
+    pubsub_server: Loopctl.PubSub
+end

--- a/lib/loopctl/runners/runner.ex
+++ b/lib/loopctl/runners/runner.ex
@@ -1,0 +1,74 @@
+defmodule Loopctl.Runners.Runner do
+  @moduledoc """
+  Schema for the `runners` table — the enrolled machines of the agent delivery loop
+  (issue #801).
+
+  A runner row binds ONE `api_keys` row to ONE machine name. The key is the credential;
+  this row is what makes it a RUNNER credential. `LoopctlWeb.RunnerSocket` refuses a
+  key with no active row here, and `LoopctlWeb.RunnerChannel` refuses a join whose
+  declared machine name is not this row's `name` — so a token enrolled for `minis`
+  cannot appear in the pool as `mac-mini`.
+
+  The row carries no liveness. Presence does, and it dies with the socket.
+
+  ## Trust boundary
+
+  `tenant_id`, `api_key_id` and `revoked_at` are set programmatically in
+  `Loopctl.Runners`, never via `cast/3`. `name` is the only caller-supplied field.
+
+  ## Isolation
+
+  `AdminRepo` plus an explicit `tenant_id` predicate in every `Loopctl.Runners` query,
+  the same convention as `Loopctl.Coordination`. RLS is ENABLED on the table as
+  defense-in-depth.
+  """
+
+  use Loopctl.Schema
+
+  @type t :: %__MODULE__{}
+
+  # A hostname-shaped label: it is echoed into Presence keys, logs and the audit
+  # chain, so it is bounded and has no whitespace or path characters. Mirrored by the
+  # `runners_name_shape` CHECK constraint.
+  @name_format ~r/^[a-z0-9][a-z0-9._-]{0,62}$/
+
+  @derive {Jason.Encoder, only: [:id, :name, :revoked_at, :inserted_at, :updated_at]}
+
+  schema "runners" do
+    tenant_field()
+    field :api_key_id, :binary_id
+    field :name, :string
+    field :revoked_at, :utc_datetime_usec
+
+    timestamps()
+  end
+
+  @doc "The machine-name format a runner is enrolled under."
+  @spec name_format() :: Regex.t()
+  def name_format, do: @name_format
+
+  @doc """
+  Changeset for enrolling a runner. `tenant_id` and `api_key_id` must already be set
+  on the struct.
+  """
+  @spec create_changeset(t(), map()) :: Ecto.Changeset.t()
+  def create_changeset(%__MODULE__{} = runner, attrs) do
+    runner
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+    |> validate_format(:name, @name_format,
+      message: "must be lowercase letters, digits, '.', '_' or '-', starting alphanumeric"
+    )
+    |> check_constraint(:name, name: :runners_name_shape)
+    |> unique_constraint(:name,
+      name: :runners_active_name_uidx,
+      message: "an active runner already uses this name"
+    )
+  end
+
+  @doc "Changeset that revokes a runner."
+  @spec revoke_changeset(t(), DateTime.t()) :: Ecto.Changeset.t()
+  def revoke_changeset(%__MODULE__{} = runner, now) do
+    change(runner, revoked_at: now)
+  end
+end

--- a/lib/loopctl/tenants/tier_capabilities.ex
+++ b/lib/loopctl/tenants/tier_capabilities.ex
@@ -103,6 +103,10 @@ defmodule Loopctl.Tenants.TierCapabilities do
     {:dispatch, :human_anchored,
      "Minting per-dispatch ephemeral keys and lineage paths (L4). Reading your own " <>
        "dispatches stays open."},
+    {:runner_pool, :human_anchored,
+     "Enrolling and revoking agent delivery loop runners (#801): a runner is a machine " <>
+       "that executes dispatched sessions, so admitting one is an execution root. Listing " <>
+       "enrolled runners stays open."},
     {:token_budgets, :human_anchored,
      "RECORDING token usage (POST /api/v1/token-usage — the per-dispatch usage report " <>
        "agents emit at end of work), correcting/deleting usage records, token budgets, " <>
@@ -153,6 +157,7 @@ defmodule Loopctl.Tenants.TierCapabilities do
       "LoopctlWeb.TenantController"
     ],
     dispatch: ["LoopctlWeb.DispatchController"],
+    runner_pool: ["LoopctlWeb.RunnerController"],
     token_budgets: [
       "LoopctlWeb.TokenBudgetController",
       "LoopctlWeb.TokenUsageController",

--- a/lib/loopctl_web/controllers/api_key_controller.ex
+++ b/lib/loopctl_web/controllers/api_key_controller.ex
@@ -80,6 +80,7 @@ defmodule LoopctlWeb.ApiKeyController do
     summary: "Rotate API key",
     description:
       "Creates a new key with the same name/role and sets a grace period on the old key. " <>
+        "A runner's key cannot be rotated here (422): revoke and re-enroll the runner. " <>
         "Like `create`, this mints a raw key that belongs to no dispatch lineage, so a " <>
         "caller whose own key carries a lineage is refused with 403 " <>
         "`api_key_mint_forbidden`.",
@@ -166,6 +167,7 @@ defmodule LoopctlWeb.ApiKeyController do
 
     with {:ok, old_key} <- Auth.get_api_key(tenant.id, key_id),
          :ok <- validate_not_revoked(old_key),
+         :ok <- validate_not_runner_key(tenant.id, old_key),
          {:ok, {raw_key, new_key, updated_old}} <- do_rotate_key(tenant, old_key, grace_hours) do
       conn
       |> put_status(:created)
@@ -218,6 +220,19 @@ defmodule LoopctlWeb.ApiKeyController do
     # the HTTP-scoped changeset here so the context layer refuses a superadmin key
     # on every path regardless of how `role` was derived.
     Auth.generate_api_key(attrs, changeset: :http)
+  end
+
+  # Issue #801: a runner row binds exactly ONE key. Rotation would mint a replacement no
+  # runner row names (refused at the runner socket) and put the bound key on an expiry, so
+  # the machine would drop out of the pool when the grace period ended with nothing saying
+  # why. A runner is rotated by revoking it and enrolling it again.
+  defp validate_not_runner_key(tenant_id, api_key) do
+    if Loopctl.Runners.runner_key?(tenant_id, api_key.id),
+      do:
+        {:error, :unprocessable_entity,
+         "This key belongs to a runner. Rotate it with DELETE /api/v1/runners/:id and " <>
+           "POST /api/v1/runners."},
+      else: :ok
   end
 
   defp do_rotate_key(tenant, old_key, grace_hours) do

--- a/lib/loopctl_web/controllers/runner_controller.ex
+++ b/lib/loopctl_web/controllers/runner_controller.ex
@@ -1,0 +1,170 @@
+defmodule LoopctlWeb.RunnerController do
+  @moduledoc """
+  Enroll, list and revoke the runners of the agent delivery loop (issue #801).
+
+  All actions require `user` role, and the writes require a human-anchored tenant
+  (`RequireHumanAnchor`, surface `:runner_pool`): a runner executes dispatched sessions
+  as its machine's user, so an agent-rooted tenant may not admit one for itself.
+
+  Enrollment MINTS a credential — a plain API key that
+  belongs to no dispatch lineage — so it carries the same lineage ceiling as
+  `POST /api/v1/api_keys`: a caller whose own key a dispatch minted is refused with
+  `403 api_key_mint_forbidden` (`LoopctlWeb.Plugs.RequireUnlineagedCaller`).
+
+  A runner's credential counts toward the tenant's `max_api_keys` limit, because it is
+  one.
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Auth
+  alias Loopctl.Dispatches
+  alias Loopctl.Runners
+  alias Loopctl.Runners.Runner
+  alias Loopctl.Tenants
+  alias OpenApiSpex.Schema
+
+  action_fallback LoopctlWeb.FallbackController
+
+  plug LoopctlWeb.Plugs.RequireRole, role: :user
+  plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:create, :delete]
+  plug LoopctlWeb.Plugs.RequireUnlineagedCaller when action in [:create]
+
+  tags(["Runners"])
+
+  @runner_schema %Schema{
+    type: :object,
+    required: [:id, :name, :revoked_at, :inserted_at],
+    properties: %{
+      id: %Schema{type: :string, format: :uuid},
+      name: %Schema{type: :string, pattern: Runner.name_format().source},
+      revoked_at: %Schema{type: :string, format: :"date-time", nullable: true},
+      inserted_at: %Schema{type: :string, format: :"date-time"},
+      updated_at: %Schema{type: :string, format: :"date-time"}
+    }
+  }
+
+  operation(:create,
+    summary: "Enroll a runner",
+    description:
+      "Enrolls a dev machine as a runner and returns its credential ONCE, as `token`. The " <>
+        "runner presents it in the `x-loopctl-runner-token` header when it connects to " <>
+        "`/runner/socket/websocket`, and joins the `runners` topic under exactly this " <>
+        "`name`. The wire contract is `priv/runner_contract/v1.json`. Requires user role; " <>
+        "a caller whose key was minted by a dispatch is refused with 403 " <>
+        "`api_key_mint_forbidden`. 422 when the name is malformed, already used by an " <>
+        "active runner, or the tenant is at its API key limit.",
+    request_body:
+      {"Runner", "application/json",
+       %Schema{
+         type: :object,
+         required: [:name],
+         properties: %{
+           name: %Schema{
+             type: :string,
+             pattern: Runner.name_format().source,
+             description: "The machine name, e.g. `minis`."
+           }
+         }
+       }},
+    responses: %{
+      201 =>
+        {"Runner enrolled", "application/json",
+         %Schema{
+           type: :object,
+           required: [:runner, :token],
+           properties: %{
+             runner: @runner_schema,
+             token: %Schema{type: :string, description: "The raw credential. Shown once."}
+           }
+         }},
+      403 => {"Forbidden", "application/json", Schemas.ErrorResponse},
+      422 => {"Validation error", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:index,
+    summary: "List runners",
+    description:
+      "Lists the tenant's enrolled runners. Enrollment only: whether a runner is CONNECTED " <>
+        "is Presence, not a row. Pass `include_revoked=true` for revoked ones too.",
+    parameters: [
+      include_revoked: [in: :query, type: :boolean, description: "Include revoked runners"]
+    ],
+    responses: %{
+      200 =>
+        {"Runners", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{runners: %Schema{type: :array, items: @runner_schema}}
+         }},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:delete,
+    summary: "Revoke a runner",
+    description:
+      "Revokes the runner and its credential in one transaction and disconnects its live " <>
+        "socket, which removes it from the pool. Idempotent. Requires user role.",
+    parameters: [id: [in: :path, type: :string, description: "Runner UUID"]],
+    responses: %{
+      200 =>
+        {"Runner revoked", "application/json",
+         %Schema{type: :object, properties: %{runner: @runner_schema}}},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc "POST /api/v1/runners"
+  def create(conn, params) do
+    tenant = conn.assigns.current_tenant
+
+    with :ok <- validate_key_limit(tenant),
+         {:ok, %{runner: runner, raw_key: raw_key}} <-
+           Runners.enroll_runner(tenant.id, %{name: params["name"]},
+             actor_lineage: actor_lineage(conn)
+           ) do
+      conn
+      |> put_status(:created)
+      |> json(%{runner: runner, token: raw_key})
+    end
+  end
+
+  @doc "GET /api/v1/runners"
+  def index(conn, params) do
+    tenant = conn.assigns.current_tenant
+    include_revoked = params["include_revoked"] == "true"
+
+    json(conn, %{runners: Runners.list_runners(tenant.id, include_revoked: include_revoked)})
+  end
+
+  @doc "DELETE /api/v1/runners/:id"
+  def delete(conn, %{"id" => runner_id}) do
+    tenant = conn.assigns.current_tenant
+
+    with {:ok, runner} <-
+           Runners.revoke_runner(tenant.id, runner_id, actor_lineage: actor_lineage(conn)) do
+      json(conn, %{runner: runner})
+    end
+  end
+
+  defp validate_key_limit(tenant) do
+    max_keys = Tenants.get_tenant_settings(tenant, "max_api_keys", 100)
+
+    if Auth.count_api_keys(tenant.id) >= max_keys do
+      {:error, :unprocessable_entity, "API key limit reached (max: #{max_keys})"}
+    else
+      :ok
+    end
+  end
+
+  defp actor_lineage(conn) do
+    api_key = conn.assigns.current_api_key
+    Dispatches.lineage_for_api_key(api_key.tenant_id, api_key.id)
+  end
+end

--- a/lib/loopctl_web/controllers/runner_controller.ex
+++ b/lib/loopctl_web/controllers/runner_controller.ex
@@ -51,8 +51,8 @@ defmodule LoopctlWeb.RunnerController do
     description:
       "Enrolls a dev machine as a runner and returns its credential ONCE, as `token`. The " <>
         "runner presents it in the `x-loopctl-runner-token` header when it connects to " <>
-        "`/runner/socket/websocket`, and joins the `runners` topic under exactly this " <>
-        "`name`. The wire contract is `priv/runner_contract/v1.json`. Requires user role; " <>
+        "`/runner/socket/websocket`, and joins the topic `runner:<runner.id>` declaring " <>
+        "exactly this `name`. The wire contract is `priv/runner_contract/v1.json`. Requires user role; " <>
         "a caller whose key was minted by a dispatch is refused with 403 " <>
         "`api_key_mint_forbidden`. 422 when the name is malformed, already used by an " <>
         "active runner, or the tenant is at its API key limit.",

--- a/lib/loopctl_web/endpoint.ex
+++ b/lib/loopctl_web/endpoint.ex
@@ -53,6 +53,15 @@ defmodule LoopctlWeb.Endpoint do
     websocket: [connect_info: [session: @session_options], max_frame_size: 64_000],
     longpoll: [connect_info: [session: @session_options]]
 
+  # Issue #801: the runner socket. Runners are non-browser clients that dial OUT to
+  # loopctl; they are never BEAM cluster peers. The credential arrives in the
+  # `x-loopctl-runner-token` header (hence `:x_headers`), never in the URL. No longpoll:
+  # a runner holds one long-lived websocket, and a second transport is a second surface
+  # for nothing. The frame cap matches `/live` — no runner message is near 64 KB.
+  socket "/runner/socket", LoopctlWeb.RunnerSocket,
+    websocket: [connect_info: [:peer_data, :x_headers], max_frame_size: 64_000],
+    longpoll: false
+
   # Serve at "/" the static files from "priv/static" directory.
   #
   # When code reloading is disabled (e.g., in production),

--- a/lib/loopctl_web/endpoint.ex
+++ b/lib/loopctl_web/endpoint.ex
@@ -2,6 +2,10 @@ defmodule LoopctlWeb.Endpoint do
   require Logger
   use Phoenix.Endpoint, otp_app: :loopctl
 
+  # Issue #801: must be registered AFTER `use Phoenix.Endpoint`, so it wraps the endpoint's
+  # `call/2` and stamps the trusted client IP before socket dispatch. See the module.
+  @before_compile LoopctlWeb.RunnerClientIp
+
   # The session is stored in the cookie. It is BOTH signed (tamper-proof) and now
   # ENCRYPTED (`encryption_salt`, a value distinct from `signing_salt`) so the
   # signup-flow payload it carries — the client IP handed to `SignupLive` through

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -329,6 +329,9 @@ defmodule LoopctlWeb.Router do
     resources "/api_keys", ApiKeyController, only: [:create, :index, :delete]
     post "/api_keys/:id/rotate", ApiKeyController, :rotate
 
+    # Issue #801 — runner enrollment for the agent delivery loop
+    resources "/runners", RunnerController, only: [:create, :index, :delete]
+
     # Audit log
     get "/audit", AuditController, :index
 

--- a/lib/loopctl_web/runner_channel.ex
+++ b/lib/loopctl_web/runner_channel.ex
@@ -2,8 +2,8 @@ defmodule LoopctlWeb.RunnerChannel do
   @moduledoc """
   The `"runners"` channel: a runner joins it to enter its tenant's pool (issue #801).
 
-  The socket has already authenticated the credential (`LoopctlWeb.RunnerSocket`). The
-  join validates the payload against `Loopctl.ApiSpec.RunnerContract.RunnerJoin`,
+  The socket authenticated the credential at connect (`LoopctlWeb.RunnerSocket`). Every
+  join re-reads `Runners.authorized?/2`, validates the payload against `Loopctl.ApiSpec.RunnerContract.RunnerJoin`,
   refuses a declared machine name that is not the enrolled one, and tracks the runner
   in `Loopctl.Runners.Presence` under the tenant-scoped `Runners.pool_topic/1`.
 
@@ -43,8 +43,15 @@ defmodule LoopctlWeb.RunnerChannel do
 
   @impl true
   def join("runners", payload, socket) do
-    with {:ok, meta} <- RunnerContract.cast_join(payload),
-         :ok <- enrolled_machine(meta, socket.assigns.runner) do
+    %{runner: runner, tenant_id: tenant_id} = socket.assigns
+
+    # Subscribe BEFORE the authorization read: a revoke committing between the two is
+    # then either seen by the read or delivered to this process, never lost.
+    :ok = Phoenix.PubSub.subscribe(Loopctl.PubSub, Runners.revocation_topic(runner.id))
+
+    with :ok <- still_authorized(tenant_id, runner),
+         {:ok, meta} <- RunnerContract.cast_join(payload),
+         :ok <- enrolled_machine(meta, runner) do
       send(self(), :after_join)
 
       {:ok, %{contract_version: RunnerContract.version()},
@@ -61,8 +68,6 @@ defmodule LoopctlWeb.RunnerChannel do
   @impl true
   def handle_info(:after_join, socket) do
     %{runner: runner, tenant_id: tenant_id, meta: meta} = socket.assigns
-
-    :ok = Phoenix.PubSub.subscribe(Loopctl.PubSub, Runners.revocation_topic(runner.id))
 
     {:ok, _ref} =
       Presence.track(
@@ -120,6 +125,13 @@ defmodule LoopctlWeb.RunnerChannel do
   def handle_in(_event, _payload, socket),
     do: {:reply, {:error, %{reason: "unknown_event"}}, socket}
 
+  # The socket authenticated once, at connect. A join can come much later — a runner can
+  # leave and rejoin on the same connection — so every join re-reads authorization, or a
+  # revoked runner could re-enter the pool faster than the periodic recheck fires.
+  defp still_authorized(tenant_id, runner) do
+    if Runners.authorized?(tenant_id, runner.id), do: :ok, else: {:error, :not_authorized}
+  end
+
   defp enrolled_machine(%{machine: machine}, %{name: machine}), do: :ok
 
   defp enrolled_machine(%{machine: declared}, _runner),
@@ -149,6 +161,8 @@ defmodule LoopctlWeb.RunnerChannel do
 
     {:stop, {:shutdown, reason}, socket}
   end
+
+  defp join_error(:not_authorized), do: %{reason: "not_authorized"}
 
   defp join_error({:invalid, messages}), do: %{reason: "invalid_payload", details: messages}
 

--- a/lib/loopctl_web/runner_channel.ex
+++ b/lib/loopctl_web/runner_channel.ex
@@ -1,0 +1,160 @@
+defmodule LoopctlWeb.RunnerChannel do
+  @moduledoc """
+  The `"runners"` channel: a runner joins it to enter its tenant's pool (issue #801).
+
+  The socket has already authenticated the credential (`LoopctlWeb.RunnerSocket`). The
+  join validates the payload against `Loopctl.ApiSpec.RunnerContract.RunnerJoin`,
+  refuses a declared machine name that is not the enrolled one, and tracks the runner
+  in `Loopctl.Runners.Presence` under the tenant-scoped `Runners.pool_topic/1`.
+
+  The runner never receives the pool: it is not subscribed to the presence topic, so
+  one machine learns nothing about another's topology.
+
+  ## Leaving the pool
+
+  The Presence entry is tracked against this process, so it is removed whenever the
+  process exits — the runner is killed, its socket drops, or this channel stops. There
+  is no sweeper. Revocation stops it two ways:
+
+  - `Runners.revoke_runner/3` broadcasts on `Runners.revocation_topic/1`; this channel
+    disconnects the socket at once.
+  - every `@recheck_interval_ms` it re-reads `Runners.authorized?/2`, which catches a
+    key revoked through `DELETE /api/v1/api_keys/:id`, an expired key and a suspended
+    tenant. That is the upper bound on how long such a revocation takes to bite.
+
+  ## Status
+
+  `"status"` updates the runner's Presence meta (`RunnerStatus`). Updates closer
+  together than `@min_status_interval_ms` are refused with `rate_limited`, because each
+  one is a Presence diff broadcast across the PubSub.
+  """
+
+  use LoopctlWeb, :channel
+
+  require Logger
+
+  alias Loopctl.ApiSpec.RunnerContract
+  alias Loopctl.Runners
+  alias Loopctl.Runners.Presence
+  alias LoopctlWeb.RunnerSocket
+
+  @recheck_interval_ms 30_000
+  @min_status_interval_ms 1_000
+
+  @impl true
+  def join("runners", payload, socket) do
+    with {:ok, meta} <- RunnerContract.cast_join(payload),
+         :ok <- enrolled_machine(meta, socket.assigns.runner) do
+      send(self(), :after_join)
+
+      {:ok, %{contract_version: RunnerContract.version()},
+       socket
+       |> assign(:meta, Map.put(meta, :joined_at, DateTime.utc_now()))
+       |> assign(:last_status_at, :never)}
+    else
+      {:error, reason} -> {:error, join_error(reason)}
+    end
+  end
+
+  def join(_topic, _payload, _socket), do: {:error, %{reason: "unknown_topic"}}
+
+  @impl true
+  def handle_info(:after_join, socket) do
+    %{runner: runner, tenant_id: tenant_id, meta: meta} = socket.assigns
+
+    :ok = Phoenix.PubSub.subscribe(Loopctl.PubSub, Runners.revocation_topic(runner.id))
+
+    {:ok, _ref} =
+      Presence.track(
+        self(),
+        Runners.pool_topic(tenant_id),
+        runner.name,
+        presence_meta(meta, runner)
+      )
+
+    schedule_recheck()
+    {:noreply, socket}
+  end
+
+  def handle_info(:runner_revoked, socket), do: disconnect(socket, :runner_revoked)
+
+  def handle_info(:recheck, socket) do
+    %{runner: runner, tenant_id: tenant_id} = socket.assigns
+
+    if Runners.authorized?(tenant_id, runner.id) do
+      schedule_recheck()
+      {:noreply, socket}
+    else
+      disconnect(socket, :no_longer_authorized)
+    end
+  end
+
+  @impl true
+  def handle_in("status", payload, socket) do
+    now = System.monotonic_time(:millisecond)
+
+    with :ok <- status_interval_ok(socket.assigns.last_status_at, now),
+         {:ok, status} <- RunnerContract.cast_status(payload) do
+      %{runner: runner, tenant_id: tenant_id, meta: meta} = socket.assigns
+      meta = Map.merge(meta, status)
+
+      {:ok, _ref} =
+        Presence.update(
+          self(),
+          Runners.pool_topic(tenant_id),
+          runner.name,
+          presence_meta(meta, runner)
+        )
+
+      {:reply, :ok, socket |> assign(:meta, meta) |> assign(:last_status_at, now)}
+    else
+      {:error, :rate_limited} ->
+        {:reply, {:error, %{reason: "rate_limited", min_interval_ms: @min_status_interval_ms}},
+         socket}
+
+      {:error, reason} ->
+        {:reply, {:error, join_error(reason)}, socket}
+    end
+  end
+
+  def handle_in(_event, _payload, socket),
+    do: {:reply, {:error, %{reason: "unknown_event"}}, socket}
+
+  defp enrolled_machine(%{machine: machine}, %{name: machine}), do: :ok
+
+  defp enrolled_machine(%{machine: declared}, _runner),
+    do: {:error, {:machine_mismatch, declared}}
+
+  # `:never` rather than 0: monotonic time is negative on a fresh VM, so a 0 sentinel
+  # would refuse the first update.
+  defp status_interval_ok(:never, _now), do: :ok
+
+  defp status_interval_ok(last, now) when now - last >= @min_status_interval_ms, do: :ok
+  defp status_interval_ok(_last, _now), do: {:error, :rate_limited}
+
+  defp presence_meta(meta, runner), do: Map.put(meta, :runner_id, runner.id)
+
+  defp schedule_recheck, do: Process.send_after(self(), :recheck, @recheck_interval_ms)
+
+  # Disconnecting the SOCKET (not just stopping this channel) keeps a revoked runner from
+  # simply rejoining the topic on the connection it already has.
+  defp disconnect(socket, reason) do
+    Logger.info("runner #{socket.assigns.runner.id} disconnected: #{inspect(reason)}")
+
+    LoopctlWeb.Endpoint.broadcast(
+      RunnerSocket.socket_id(socket.assigns.runner.id),
+      "disconnect",
+      %{}
+    )
+
+    {:stop, {:shutdown, reason}, socket}
+  end
+
+  defp join_error({:invalid, messages}), do: %{reason: "invalid_payload", details: messages}
+
+  defp join_error({:unsupported_contract_version, sent, speaks}),
+    do: %{reason: "unsupported_contract_version", sent: sent, supported: speaks}
+
+  defp join_error({:machine_mismatch, declared}),
+    do: %{reason: "machine_mismatch", declared: declared}
+end

--- a/lib/loopctl_web/runner_channel.ex
+++ b/lib/loopctl_web/runner_channel.ex
@@ -1,6 +1,7 @@
 defmodule LoopctlWeb.RunnerChannel do
   @moduledoc """
-  The `"runners"` channel: a runner joins it to enter its tenant's pool (issue #801).
+  The runner channel: a runner joins its own topic, `"runner:<runner_id>"`, to enter its
+  tenant's pool (issue #801). A join on any other runner's topic is refused.
 
   The socket authenticated the credential at connect (`LoopctlWeb.RunnerSocket`). Every
   join re-reads `Runners.authorized?/2`, validates the payload against `Loopctl.ApiSpec.RunnerContract.RunnerJoin`,
@@ -40,16 +41,19 @@ defmodule LoopctlWeb.RunnerChannel do
 
   @recheck_interval_ms 30_000
   @min_status_interval_ms 1_000
+  @join_window_ms 60_000
+  @max_joins 30
 
   @impl true
-  def join("runners", payload, socket) do
-    %{runner: runner, tenant_id: tenant_id} = socket.assigns
+  def join("runner:" <> runner_id, payload, %{assigns: %{runner: %{id: runner_id}}} = socket) do
+    %{runner: runner} = socket.assigns
 
     # Subscribe BEFORE the authorization read: a revoke committing between the two is
     # then either seen by the read or delivered to this process, never lost.
     :ok = Phoenix.PubSub.subscribe(Loopctl.PubSub, Runners.revocation_topic(runner.id))
 
-    with :ok <- still_authorized(tenant_id, runner),
+    with :ok <- join_rate_ok(runner),
+         :ok <- still_authorized(socket),
          {:ok, meta} <- RunnerContract.cast_join(payload),
          :ok <- enrolled_machine(meta, runner) do
       send(self(), :after_join)
@@ -63,6 +67,7 @@ defmodule LoopctlWeb.RunnerChannel do
     end
   end
 
+  def join("runner:" <> _other, _payload, _socket), do: {:error, %{reason: "forbidden_topic"}}
   def join(_topic, _payload, _socket), do: {:error, %{reason: "unknown_topic"}}
 
   @impl true
@@ -128,8 +133,26 @@ defmodule LoopctlWeb.RunnerChannel do
   # The socket authenticated once, at connect. A join can come much later — a runner can
   # leave and rejoin on the same connection — so every join re-reads authorization, or a
   # revoked runner could re-enter the pool faster than the periodic recheck fires.
-  defp still_authorized(tenant_id, runner) do
-    if Runners.authorized?(tenant_id, runner.id), do: :ok, else: {:error, :not_authorized}
+  #
+  # A refusal also DISCONNECTS the socket: an unauthorized runner has no use for the
+  # connection it still holds, and every further join would be another read.
+  defp still_authorized(%{assigns: %{runner: runner, tenant_id: tenant_id}}) do
+    if Runners.authorized?(tenant_id, runner.id) do
+      :ok
+    else
+      LoopctlWeb.Endpoint.broadcast(RunnerSocket.socket_id(runner.id), "disconnect", %{})
+      {:error, :not_authorized}
+    end
+  end
+
+  # Every join costs an authorization read on AdminRepo and a Presence leave/join
+  # broadcast, and each rejoin starts a fresh channel process whose status interval has
+  # never fired. So joins are budgeted per runner, before any of that, on the shared
+  # limiter (fail-CLOSED: a limiter fault refuses the join and the runner retries).
+  defp join_rate_ok(runner) do
+    if Loopctl.RateLimiter.gate_ok?("runner_join:" <> runner.id, @join_window_ms, @max_joins),
+      do: :ok,
+      else: {:error, :join_rate_limited}
   end
 
   defp enrolled_machine(%{machine: machine}, %{name: machine}), do: :ok
@@ -163,6 +186,9 @@ defmodule LoopctlWeb.RunnerChannel do
   end
 
   defp join_error(:not_authorized), do: %{reason: "not_authorized"}
+
+  defp join_error(:join_rate_limited),
+    do: %{reason: "rate_limited", max_joins: @max_joins, window_ms: @join_window_ms}
 
   defp join_error({:invalid, messages}), do: %{reason: "invalid_payload", details: messages}
 

--- a/lib/loopctl_web/runner_client_ip.ex
+++ b/lib/loopctl_web/runner_client_ip.ex
@@ -1,0 +1,51 @@
+defmodule LoopctlWeb.RunnerClientIp do
+  @moduledoc """
+  Hands the runner socket the TRUSTED client IP (issue #801).
+
+  A Phoenix socket is dispatched by `plug :socket_dispatch`, which `use Phoenix.Endpoint`
+  installs AHEAD of every plug the endpoint declares — so `LoopctlWeb.Plugs.ClientIp`
+  has not run, and `connect_info` offers only `:x_headers` (headers starting `x-`) and
+  the TCP peer. Neither is the client on Fly: `fly-client-ip` is not an `x-` header, the
+  peer is the proxy, and the rightmost `x-forwarded-for` entry is Fly's own app IP
+  (`Loopctl.RemoteIp`). Keying the connect throttle on any of those collapses every
+  tenant's runners into one fail-closed bucket.
+
+  So the endpoint wraps its own `call/2` (`__before_compile__/1`, registered after
+  `use Phoenix.Endpoint`, so it runs before socket dispatch) and, for runner-socket paths
+  only, replaces any client-supplied `#{"x-loopctl-client-ip"}` with the address
+  `Loopctl.RemoteIp.from/1` resolves — `fly-client-ip` first. A client cannot set the
+  header: every inbound copy is removed before the trusted one is written.
+  """
+
+  alias Plug.Conn
+
+  @header "x-loopctl-client-ip"
+
+  @doc "The header the trusted client IP is written to."
+  @spec header() :: String.t()
+  def header, do: @header
+
+  defmacro __before_compile__(_env) do
+    quote do
+      defoverridable call: 2
+
+      def call(conn, opts), do: super(LoopctlWeb.RunnerClientIp.stamp(conn), opts)
+    end
+  end
+
+  @doc """
+  Strips every inbound copy of the header and, on a runner-socket path, writes the
+  resolved client IP. Other paths are returned untouched.
+  """
+  @spec stamp(Conn.t()) :: Conn.t()
+  def stamp(%Conn{path_info: ["runner", "socket" | _]} = conn) do
+    headers = Enum.reject(conn.req_headers, fn {name, _} -> name == @header end)
+
+    case Loopctl.RemoteIp.string_from(headers) do
+      nil -> %{conn | req_headers: headers}
+      ip -> %{conn | req_headers: [{@header, ip} | headers]}
+    end
+  end
+
+  def stamp(%Conn{} = conn), do: conn
+end

--- a/lib/loopctl_web/runner_socket.ex
+++ b/lib/loopctl_web/runner_socket.ex
@@ -41,7 +41,10 @@ defmodule LoopctlWeb.RunnerSocket do
   @throttle_window_ms 60_000
   @throttle_max_per_ip 3_000
 
-  channel "runners", LoopctlWeb.RunnerChannel
+  # One topic PER RUNNER, `runner:<runner_id>`. Phoenix subscribes a channel to its join
+  # topic, so a shared literal topic would carry any broadcast on it to every tenant's
+  # machines — and a `dispatch` is a prompt executed as that machine's user.
+  channel "runner:*", LoopctlWeb.RunnerChannel
 
   @doc "The header a runner presents its credential in."
   @spec token_header() :: String.t()

--- a/lib/loopctl_web/runner_socket.ex
+++ b/lib/loopctl_web/runner_socket.ex
@@ -1,0 +1,118 @@
+defmodule LoopctlWeb.RunnerSocket do
+  @moduledoc """
+  The authenticated socket runners connect to (issue #801).
+
+  A runner is a CLIENT, never a BEAM cluster peer: it dials out to
+  `/runner/socket/websocket` and presents its credential in the
+  `x-loopctl-runner-token` header. The credential is never read from connect params,
+  because a query string is logged by every proxy between the runner and loopctl.
+
+  ## Not a bypass of the HTTP security pipeline
+
+  A socket does not run the router's plugs, so `connect/3` re-applies the parts that
+  carry security weight, through the same functions:
+
+  - `AuthPathThrottle`'s per-IP, fail-CLOSED ceiling (`Loopctl.RateLimiter.gate_ok?/3`,
+    same `auth_ip:` bucket), counted BEFORE the key is resolved, so a flood of bad
+    tokens cannot turn into unbounded `api_keys` lookups on the AdminRepo pool;
+  - `ResolveApiKey`'s resolution (`Auth.verify_api_key/1`: revocation cache, expiry)
+    and its refusal of a non-active tenant, via `Loopctl.Runners.authenticate/1`;
+  - plus the runner-specific rule: the key must be bound to an active runner row.
+
+  `SetTenant` has no equivalent here on purpose. It writes the RLS tenant into the
+  process dictionary of the REQUEST process; a channel is a different, long-lived
+  process, and every context call it makes passes `tenant_id` explicitly. The witness
+  header and `CheckCustodyHalt` are not applied: the socket carries no audit-chain read
+  and no custody operation. Dispatch (#803) will, and must add the halt check there.
+
+  Every refusal answers identically (HTTP 403); the reason goes to the server log only.
+  """
+
+  use Phoenix.Socket
+
+  require Logger
+
+  alias Loopctl.RemoteIp
+  alias Loopctl.Runners
+
+  @token_header "x-loopctl-runner-token"
+  @throttle_window_ms 60_000
+  @throttle_max_per_ip 3_000
+
+  channel "runners", LoopctlWeb.RunnerChannel
+
+  @doc "The header a runner presents its credential in."
+  @spec token_header() :: String.t()
+  def token_header, do: @token_header
+
+  @impl true
+  def connect(_params, socket, connect_info) do
+    with :ok <- throttle(connect_info),
+         {:ok, token} <- fetch_token(connect_info),
+         {:ok, %{runner: runner, api_key: api_key}} <- Runners.authenticate(token) do
+      {:ok,
+       socket
+       |> assign(:runner, runner)
+       |> assign(:tenant_id, runner.tenant_id)
+       |> assign(:api_key_id, api_key.id)}
+    else
+      {:error, reason} ->
+        Logger.info("runner socket refused: #{inspect(reason)}")
+        :error
+    end
+  end
+
+  @impl true
+  def id(socket), do: socket_id(socket.assigns.runner.id)
+
+  @doc "The socket id a runner's connection is registered under, for disconnects."
+  @spec socket_id(Ecto.UUID.t()) :: String.t()
+  def socket_id(runner_id), do: "runner_socket:" <> runner_id
+
+  defp fetch_token(connect_info) do
+    headers = Map.get(connect_info, :x_headers, [])
+
+    case for({@token_header, value} <- headers, do: String.trim(value)) do
+      [token] when token != "" -> {:ok, token}
+      [] -> {:error, :missing_token}
+      _ -> {:error, :ambiguous_token}
+    end
+  end
+
+  # Mirrors `LoopctlWeb.Plugs.AuthPathThrottle`: the same fail-CLOSED gate, the same
+  # bucket and ceiling, and the same skip when no stable client IP resolves (keying a
+  # shared bucket on a proxy IP would collapse every client onto one budget).
+  defp throttle(connect_info) do
+    case RemoteIp.bucket_key_tagged(client_ip(connect_info)) do
+      {:client, ip} ->
+        {window_ms, ceiling} = throttle_limits()
+
+        if Loopctl.RateLimiter.gate_ok?("auth_ip:#{ip}", window_ms, ceiling),
+          do: :ok,
+          else: {:error, :throttled}
+
+      {:unresolved, _reason} ->
+        :ok
+    end
+  end
+
+  # The plug's own configuration, so one `AUTH_THROTTLE_*` knob tunes both paths.
+  defp throttle_limits do
+    config = Application.get_env(:loopctl, LoopctlWeb.Plugs.AuthPathThrottle, [])
+
+    {positive_int(config[:window_ms], @throttle_window_ms),
+     positive_int(config[:max_requests_per_ip], @throttle_max_per_ip)}
+  end
+
+  defp positive_int(value, _default) when is_integer(value) and value > 0, do: value
+  defp positive_int(_value, default), do: default
+
+  defp client_ip(connect_info) do
+    forwarded = RemoteIp.from(Map.get(connect_info, :x_headers, []))
+
+    case {forwarded, Map.get(connect_info, :peer_data)} do
+      {nil, %{address: address}} -> address
+      {forwarded, _} -> forwarded
+    end
+  end
+end

--- a/lib/loopctl_web/runner_socket.ex
+++ b/lib/loopctl_web/runner_socket.ex
@@ -13,8 +13,10 @@ defmodule LoopctlWeb.RunnerSocket do
   carry security weight, through the same functions:
 
   - `AuthPathThrottle`'s per-IP, fail-CLOSED ceiling (`Loopctl.RateLimiter.gate_ok?/3`,
-    same `auth_ip:` bucket), counted BEFORE the key is resolved, so a flood of bad
-    tokens cannot turn into unbounded `api_keys` lookups on the AdminRepo pool;
+    same `auth_ip:` bucket and config), counted BEFORE the key is resolved, so a flood
+    of bad tokens cannot turn into unbounded `api_keys` lookups on the AdminRepo pool.
+    The IP is the one `LoopctlWeb.RunnerClientIp` resolved from `fly-client-ip` ahead
+    of socket dispatch — the plug pipeline has not run yet at this point;
   - `ResolveApiKey`'s resolution (`Auth.verify_api_key/1`: revocation cache, expiry)
     and its refusal of a non-active tenant, via `Loopctl.Runners.authenticate/1`;
   - plus the runner-specific rule: the key must be bound to an active runner row.
@@ -107,12 +109,20 @@ defmodule LoopctlWeb.RunnerSocket do
   defp positive_int(value, _default) when is_integer(value) and value > 0, do: value
   defp positive_int(_value, default), do: default
 
+  # The address `LoopctlWeb.RunnerClientIp` stamped from `fly-client-ip` before dispatch,
+  # never a header the client chose. Without one (off-Fly, no forwarding header) the TCP
+  # peer is the client; a proxy peer resolves as unresolved and skips the gate.
   defp client_ip(connect_info) do
-    forwarded = RemoteIp.from(Map.get(connect_info, :x_headers, []))
+    stamped =
+      for {name, value} <- Map.get(connect_info, :x_headers, []),
+          name == LoopctlWeb.RunnerClientIp.header(),
+          {:ok, addr} <- [:inet.parse_address(String.to_charlist(value))],
+          do: addr
 
-    case {forwarded, Map.get(connect_info, :peer_data)} do
-      {nil, %{address: address}} -> address
-      {forwarded, _} -> forwarded
+    case {stamped, Map.get(connect_info, :peer_data)} do
+      {[addr | _], _} -> addr
+      {[], %{address: address}} -> address
+      {[], _} -> nil
     end
   end
 end

--- a/lib/mix/tasks/loopctl.runner_contract.ex
+++ b/lib/mix/tasks/loopctl.runner_contract.ex
@@ -1,0 +1,28 @@
+defmodule Mix.Tasks.Loopctl.RunnerContract do
+  @shortdoc "Writes the runner wire contract to priv/runner_contract/"
+
+  @moduledoc """
+  Writes `Loopctl.ApiSpec.RunnerContract` as JSON Schema to
+  `priv/runner_contract/v<major>.json`, the file `mkreyman/loopctl-runner` vendors.
+
+      mix loopctl.runner_contract
+
+  Run it after changing any schema in that module. The checked-in file is compared
+  against the declarations by `test/loopctl/api_spec/runner_contract_test.exs`, so a
+  forgotten run fails the build rather than shipping a contract loopctl does not enforce.
+  """
+
+  use Mix.Task
+
+  alias Loopctl.ApiSpec.RunnerContract
+
+  @impl Mix.Task
+  def run(_args) do
+    Mix.Task.run("compile")
+
+    path = RunnerContract.export_path()
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, RunnerContract.encoded_json_schema())
+    Mix.shell().info("wrote #{path} (contract #{RunnerContract.version()})")
+  end
+end

--- a/priv/repo/migrations/20260912210000_create_runners.exs
+++ b/priv/repo/migrations/20260912210000_create_runners.exs
@@ -43,5 +43,35 @@ defmodule Loopctl.Repo.Migrations.CreateRunners do
            )
 
     enable_rls(:runners)
+
+    # A runner row must never outlive its credential. `api_keys.revoked_at` is written by
+    # more than one route (`DELETE /api/v1/api_keys/:id`, dispatch revocation, direct
+    # `update_all`s), so the cascade is a trigger rather than a call each route has to
+    # remember: otherwise `GET /api/v1/runners` lists a machine that can never connect,
+    # and re-enrolling the name 422s against the active-name index.
+    execute(
+      """
+      CREATE FUNCTION runners_revoke_with_api_key() RETURNS trigger AS $$
+      BEGIN
+        UPDATE runners
+           SET revoked_at = NEW.revoked_at, updated_at = NEW.revoked_at
+         WHERE api_key_id = NEW.id AND revoked_at IS NULL;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql
+      """,
+      "DROP FUNCTION runners_revoke_with_api_key()"
+    )
+
+    execute(
+      """
+      CREATE TRIGGER runners_revoke_with_api_key
+        AFTER UPDATE OF revoked_at ON api_keys
+        FOR EACH ROW
+        WHEN (OLD.revoked_at IS NULL AND NEW.revoked_at IS NOT NULL)
+        EXECUTE FUNCTION runners_revoke_with_api_key()
+      """,
+      "DROP TRIGGER runners_revoke_with_api_key ON api_keys"
+    )
   end
 end

--- a/priv/repo/migrations/20260912210000_create_runners.exs
+++ b/priv/repo/migrations/20260912210000_create_runners.exs
@@ -1,0 +1,47 @@
+defmodule Loopctl.Repo.Migrations.CreateRunners do
+  use Ecto.Migration
+  import Loopctl.Repo.RlsHelpers
+
+  # Issue #801: the machine registry behind the runner channel.
+  #
+  # A runner is a dev machine that connects OUTBOUND to loopctl over an authenticated
+  # Phoenix Channel. Its credential is an ordinary `api_keys` row, so resolution,
+  # the revocation cache and tenant suspension all go through `Auth.verify_api_key/1`
+  # exactly as a REST request does. This table binds that key to ONE machine name:
+  # a key that has no row here cannot open the runner socket, and a runner cannot join
+  # under a machine name other than the one it was enrolled as.
+  #
+  # Liveness is NOT stored here. Presence carries it and dies with the socket, so
+  # there is no `last_seen_at` column to go stale and nothing to sweep.
+  #
+  # The name is unique among ACTIVE runners only, so a revoked machine can be
+  # re-enrolled under the same name with a fresh key.
+  def change do
+    create table(:runners, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :tenant_id, references(:tenants, type: :binary_id, on_delete: :delete_all), null: false
+
+      add :api_key_id, references(:api_keys, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      add :name, :text, null: false
+      add :revoked_at, :utc_datetime_usec, null: true
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:runners, [:api_key_id], name: :runners_api_key_uidx)
+
+    create unique_index(:runners, [:tenant_id, :name],
+             where: "revoked_at IS NULL",
+             name: :runners_active_name_uidx
+           )
+
+    create constraint(:runners, :runners_name_shape,
+             check: "name ~ '^[a-z0-9][a-z0-9._-]{0,62}$'"
+           )
+
+    enable_rls(:runners)
+  end
+end

--- a/priv/runner_contract/v1.json
+++ b/priv/runner_contract/v1.json
@@ -1,0 +1,314 @@
+{
+  "$defs": {
+    "RunnerDispatch": {
+      "description": "Control pushes `dispatch` to start a session. The runner validates it against its LOCAL allow-list (repos, branch prefixes, wall clock, token budget) and refuses by default: a dispatch is a prompt executed as the machine's user. Declared in contract v1; emitted from #803.",
+      "properties": {
+        "base_branch": {
+          "maxLength": 255,
+          "minLength": 1,
+          "type": "string"
+        },
+        "branch": {
+          "maxLength": 255,
+          "minLength": 1,
+          "type": "string"
+        },
+        "claim_epoch": {
+          "description": "Echoed on every runner-to-control message about this dispatch. Bumped on reclaim, so a resurrected session's writes are rejected.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "dispatch_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "triage",
+            "implement"
+          ],
+          "type": "string"
+        },
+        "max_turns": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "repo": {
+          "pattern": "^[A-Za-z0-9_.-]{1,100}/[A-Za-z0-9_.-]{1,100}$",
+          "type": "string"
+        },
+        "story_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "token_budget": {
+          "minimum": 1,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "wall_clock_seconds": {
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "dispatch_id",
+        "story_id",
+        "kind",
+        "repo",
+        "base_branch",
+        "branch",
+        "claim_epoch",
+        "wall_clock_seconds",
+        "max_turns"
+      ],
+      "type": "object"
+    },
+    "RunnerJoin": {
+      "description": "The payload a runner joins the `runners` topic with.",
+      "properties": {
+        "contract_version": {
+          "description": "The contract version the runner was built against (semver).",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+          "type": "string"
+        },
+        "cores": {
+          "maximum": 1024,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "draining": {
+          "description": "True when the runner accepts no new dispatches.",
+          "type": "boolean"
+        },
+        "in_flight": {
+          "description": "Sessions running now, as the runner counts them. A hint: capacity is reserved in Postgres, never read off Presence.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "machine": {
+          "description": "The machine name the runner was enrolled under. Must match exactly.",
+          "pattern": "^[a-z0-9][a-z0-9._-]{0,62}$",
+          "type": "string"
+        },
+        "max_sessions": {
+          "description": "Concurrent sessions this machine accepts. Advisory; see in_flight.",
+          "maximum": 64,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "memory_mb": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "repos": {
+          "description": "GitHub `owner/repo` checkouts this runner can work in.",
+          "items": {
+            "pattern": "^[A-Za-z0-9_.-]{1,100}/[A-Za-z0-9_.-]{1,100}$",
+            "type": "string"
+          },
+          "maxItems": 50,
+          "type": "array"
+        },
+        "sample": {
+          "description": "A self-measured health sample. Connected is not able-to-build: a wedged machine still answers heartbeats, so the control plane treats a stale sample as a breached threshold.",
+          "properties": {
+            "free_disk_mb": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "free_ram_mb": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "last_build_at": {
+              "description": "When this machine last completed a build successfully.",
+              "format": "date-time",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "loadavg_1m": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "sampled_at": {
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          "required": [
+            "sampled_at",
+            "loadavg_1m",
+            "free_ram_mb",
+            "free_disk_mb"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "contract_version",
+        "machine",
+        "cores",
+        "memory_mb",
+        "repos",
+        "max_sessions",
+        "in_flight",
+        "draining"
+      ],
+      "type": "object"
+    },
+    "RunnerSample": {
+      "description": "A self-measured health sample. Connected is not able-to-build: a wedged machine still answers heartbeats, so the control plane treats a stale sample as a breached threshold.",
+      "properties": {
+        "free_disk_mb": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "free_ram_mb": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "last_build_at": {
+          "description": "When this machine last completed a build successfully.",
+          "format": "date-time",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "loadavg_1m": {
+          "minimum": 0,
+          "type": "number"
+        },
+        "sampled_at": {
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "required": [
+        "sampled_at",
+        "loadavg_1m",
+        "free_ram_mb",
+        "free_disk_mb"
+      ],
+      "type": "object"
+    },
+    "RunnerStatus": {
+      "description": "A runner's periodic update, pushed as the `status` event. Any subset of the fields; at least one.",
+      "minProperties": 1,
+      "properties": {
+        "draining": {
+          "type": "boolean"
+        },
+        "in_flight": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "sample": {
+          "description": "A self-measured health sample. Connected is not able-to-build: a wedged machine still answers heartbeats, so the control plane treats a stale sample as a breached threshold.",
+          "properties": {
+            "free_disk_mb": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "free_ram_mb": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "last_build_at": {
+              "description": "When this machine last completed a build successfully.",
+              "format": "date-time",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "loadavg_1m": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "sampled_at": {
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          "required": [
+            "sampled_at",
+            "loadavg_1m",
+            "free_ram_mb",
+            "free_disk_mb"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "RunnerTraceEvent": {
+      "description": "One line of a run's NDJSON trace. The on-disk file is the source of truth: the runner ships `(run_id, seq)`, the server ACKs the last contiguous seq and dedups on the pair, and the runner resumes from that offset on rejoin. `parent` is REQUIRED on every event (null only for the root) so the agent tree can be rebuilt by query.",
+      "properties": {
+        "data": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "event_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "type": "string"
+        },
+        "parent": {
+          "maxLength": 128,
+          "minLength": 1,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "run_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "seq": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "ts": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "type": {
+          "maxLength": 64,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "run_id",
+        "seq",
+        "event_id",
+        "parent",
+        "ts",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://loopctl.com/runner_contract/v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "loopctl runner contract",
+  "x-connection": {
+    "credential_header": "x-loopctl-runner-token",
+    "events": {
+      "dispatch": "RunnerDispatch",
+      "join": "RunnerJoin",
+      "status": "RunnerStatus",
+      "trace_event": "RunnerTraceEvent"
+    },
+    "socket_path": "/runner/socket/websocket",
+    "topic": "runners"
+  },
+  "x-contract-version": "1.0.0"
+}

--- a/priv/runner_contract/v1.json
+++ b/priv/runner_contract/v1.json
@@ -308,7 +308,7 @@
       "trace_event": "RunnerTraceEvent"
     },
     "socket_path": "/runner/socket/websocket",
-    "topic": "runners"
+    "topic": "runner:{runner_id}"
   },
   "x-contract-version": "1.0.0"
 }

--- a/priv/runner_contract/v1.json
+++ b/priv/runner_contract/v1.json
@@ -67,7 +67,7 @@
       "type": "object"
     },
     "RunnerJoin": {
-      "description": "The payload a runner joins the `runners` topic with.",
+      "description": "The payload a runner joins its own `runner:<runner_id>` topic with.",
       "properties": {
         "contract_version": {
           "description": "The contract version the runner was built against (semver).",

--- a/test/loopctl/api_spec/runner_contract_test.exs
+++ b/test/loopctl/api_spec/runner_contract_test.exs
@@ -51,6 +51,18 @@ defmodule Loopctl.ApiSpec.RunnerContractTest do
       refute Enum.any?(Map.keys(join), &is_binary/1)
     end
 
+    test "drops undeclared keys inside nested objects too" do
+      sample = Map.put(@sample, "padding", String.duplicate("x", 1_000))
+
+      assert {:ok, join} = RunnerContract.cast_join(Map.put(@join, "sample", sample))
+
+      assert Map.keys(join.sample) |> Enum.sort() ==
+               [:free_disk_mb, :free_ram_mb, :loadavg_1m, :sampled_at]
+
+      assert {:ok, status} = RunnerContract.cast_status(%{"sample" => sample})
+      refute Enum.any?(Map.keys(status.sample), &is_binary/1)
+    end
+
     test "accepts any minor or patch of the spoken major" do
       assert {:ok, _} = RunnerContract.cast_join(%{@join | "contract_version" => "1.9.3"})
     end

--- a/test/loopctl/api_spec/runner_contract_test.exs
+++ b/test/loopctl/api_spec/runner_contract_test.exs
@@ -1,0 +1,113 @@
+defmodule Loopctl.ApiSpec.RunnerContractTest do
+  use ExUnit.Case, async: true
+
+  alias Loopctl.ApiSpec.RunnerContract
+
+  @join %{
+    "contract_version" => "1.0.0",
+    "machine" => "minis",
+    "cores" => 16,
+    "memory_mb" => 28_000,
+    "repos" => ["mkreyman/home_care_billing"],
+    "max_sessions" => 2,
+    "in_flight" => 0,
+    "draining" => false
+  }
+
+  @sample %{
+    "sampled_at" => "2026-09-12T20:00:00Z",
+    "loadavg_1m" => 0.5,
+    "free_ram_mb" => 1_000,
+    "free_disk_mb" => 5_000
+  }
+
+  describe "the checked-in export" do
+    test "matches the declarations — run `mix loopctl.runner_contract` if this fails" do
+      path = Path.join(File.cwd!(), RunnerContract.export_path())
+      assert File.read!(path) == RunnerContract.encoded_json_schema()
+    end
+
+    test "declares every schema the contract names, and requires parent on trace events" do
+      defs = RunnerContract.json_schema()["$defs"]
+
+      for mod <- RunnerContract.schema_modules() do
+        assert Map.has_key?(defs, mod.schema().title)
+      end
+
+      assert "parent" in defs["RunnerTraceEvent"]["required"]
+      assert defs["RunnerTraceEvent"]["properties"]["parent"]["type"] == ["string", "null"]
+      assert "claim_epoch" in defs["RunnerDispatch"]["required"]
+    end
+  end
+
+  describe "cast_join/1" do
+    test "accepts a valid payload and keeps only declared fields" do
+      payload = @join |> Map.put("sample", @sample) |> Map.put("smuggled", "x")
+
+      assert {:ok, join} = RunnerContract.cast_join(payload)
+      assert join.machine == "minis"
+      assert join.sample.free_disk_mb == 5_000
+      refute Map.has_key?(join, :smuggled)
+      refute Enum.any?(Map.keys(join), &is_binary/1)
+    end
+
+    test "accepts any minor or patch of the spoken major" do
+      assert {:ok, _} = RunnerContract.cast_join(%{@join | "contract_version" => "1.9.3"})
+    end
+
+    test "refuses another major" do
+      assert {:error, {:unsupported_contract_version, "2.0.0", _}} =
+               RunnerContract.cast_join(%{@join | "contract_version" => "2.0.0"})
+
+      assert {:error, {:unsupported_contract_version, "11.0.0", _}} =
+               RunnerContract.cast_join(%{@join | "contract_version" => "11.0.0"})
+    end
+
+    test "refuses every missing required field" do
+      for field <- Map.keys(@join) do
+        assert {:error, {:invalid, _}} = RunnerContract.cast_join(Map.delete(@join, field)),
+               "expected missing #{field} to be refused"
+      end
+    end
+
+    test "refuses out-of-bound values" do
+      for {field, value} <- [
+            {"cores", 0},
+            {"max_sessions", 65},
+            {"in_flight", -1},
+            {"machine", "Mac Mini"},
+            {"repos", ["not-a-repo"]},
+            {"repos", Enum.map(1..51, &"o/r#{&1}")},
+            {"contract_version", "1.0"}
+          ] do
+        assert {:error, {:invalid, _}} = RunnerContract.cast_join(Map.put(@join, field, value)),
+               "expected #{field}=#{inspect(value)} to be refused"
+      end
+    end
+
+    test "refuses a partial health sample" do
+      assert {:error, {:invalid, _}} =
+               RunnerContract.cast_join(
+                 Map.put(@join, "sample", Map.delete(@sample, "free_disk_mb"))
+               )
+    end
+
+    test "refuses a non-object" do
+      assert {:error, {:invalid, _}} = RunnerContract.cast_join("minis")
+      assert {:error, {:invalid, _}} = RunnerContract.cast_join(nil)
+    end
+  end
+
+  describe "cast_status/1" do
+    test "accepts any subset of the status fields" do
+      assert {:ok, %{in_flight: 1}} = RunnerContract.cast_status(%{"in_flight" => 1})
+      assert {:ok, %{draining: true}} = RunnerContract.cast_status(%{"draining" => true})
+      assert {:ok, %{sample: _}} = RunnerContract.cast_status(%{"sample" => @sample})
+    end
+
+    test "refuses a status carrying no declared field" do
+      assert {:error, {:invalid, _}} = RunnerContract.cast_status(%{})
+      assert {:error, {:invalid, _}} = RunnerContract.cast_status(%{"machine" => "mac-mini"})
+    end
+  end
+end

--- a/test/loopctl/runners_test.exs
+++ b/test/loopctl/runners_test.exs
@@ -144,6 +144,37 @@ defmodule Loopctl.RunnersTest do
     end
   end
 
+  describe "the runner row follows its key" do
+    test "revoking the key through the api_keys route revokes the runner, freeing its name" do
+      tenant = fixture(:tenant)
+      {_raw, runner} = fixture(:runner, %{tenant_id: tenant.id, name: "minis"})
+      {:ok, key} = Auth.get_api_key(tenant.id, runner.api_key_id)
+      {:ok, _} = Auth.revoke_api_key(key)
+
+      assert %Runner{revoked_at: %DateTime{}} = AdminRepo.get!(Runner, runner.id)
+      assert Runners.list_runners(tenant.id) == []
+      assert {:ok, _} = Runners.enroll_runner(tenant.id, %{name: "minis"})
+    end
+
+    test "revoking an unrelated key leaves every runner active" do
+      tenant = fixture(:tenant)
+      {_raw, runner} = fixture(:runner, %{tenant_id: tenant.id})
+      {_raw_key, other} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      {:ok, _} = Auth.revoke_api_key(other)
+
+      assert is_nil(AdminRepo.get!(Runner, runner.id).revoked_at)
+    end
+
+    test "runner_key?/2 names a runner's key and nothing else, per tenant" do
+      {_raw, runner} = fixture(:runner, %{})
+      {_raw_key, plain} = fixture(:api_key, %{tenant_id: runner.tenant_id, role: :agent})
+
+      assert Runners.runner_key?(runner.tenant_id, runner.api_key_id)
+      refute Runners.runner_key?(runner.tenant_id, plain.id)
+      refute Runners.runner_key?(fixture(:tenant).id, runner.api_key_id)
+    end
+  end
+
   describe "authorized?/2" do
     test "is true for an active runner" do
       {_raw, runner} = fixture(:runner, %{})

--- a/test/loopctl/runners_test.exs
+++ b/test/loopctl/runners_test.exs
@@ -1,0 +1,214 @@
+defmodule Loopctl.RunnersTest do
+  use Loopctl.DataCase, async: true
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.AuditChain.Entry
+  alias Loopctl.Auth
+  alias Loopctl.Runners
+  alias Loopctl.Runners.Runner
+  alias Loopctl.Tenants
+
+  setup :verify_on_exit!
+
+  describe "enroll_runner/3" do
+    test "mints an :agent key bound to the machine name and records it on the audit chain" do
+      tenant = fixture(:tenant)
+
+      assert {:ok, %{runner: runner, raw_key: raw_key}} =
+               Runners.enroll_runner(tenant.id, %{name: "minis"})
+
+      assert runner.name == "minis"
+      assert runner.tenant_id == tenant.id
+      assert is_nil(runner.revoked_at)
+
+      assert {:ok, api_key} = Auth.verify_api_key(raw_key)
+      assert api_key.id == runner.api_key_id
+      assert api_key.role == :agent
+      assert api_key.tenant_id == tenant.id
+
+      assert AdminRepo.exists?(
+               from e in Entry,
+                 where:
+                   e.tenant_id == ^tenant.id and e.action == "runner_enrolled" and
+                     e.entity_id == ^runner.id
+             )
+    end
+
+    test "refuses a malformed name without minting a key" do
+      tenant = fixture(:tenant)
+
+      for bad <- ["", "Minis", "has space", "../etc", "-leading", String.duplicate("a", 64)] do
+        assert {:error, %Ecto.Changeset{} = cs} = Runners.enroll_runner(tenant.id, %{name: bad})
+        assert %{name: _} = errors_on(cs)
+      end
+
+      assert Auth.count_api_keys(tenant.id) == 0
+    end
+
+    test "refuses a second ACTIVE runner with the same name, and rolls its key back" do
+      tenant = fixture(:tenant)
+      {_raw, _runner} = fixture(:runner, %{tenant_id: tenant.id, name: "minis"})
+
+      assert {:error, %Ecto.Changeset{} = cs} = Runners.enroll_runner(tenant.id, %{name: "minis"})
+      assert "an active runner already uses this name" in errors_on(cs).name
+      assert Auth.count_api_keys(tenant.id) == 1
+    end
+
+    test "allows re-enrolling a revoked machine under its old name" do
+      tenant = fixture(:tenant)
+      {_raw, runner} = fixture(:runner, %{tenant_id: tenant.id, name: "minis"})
+      {:ok, _} = Runners.revoke_runner(tenant.id, runner.id)
+
+      assert {:ok, %{runner: again}} = Runners.enroll_runner(tenant.id, %{name: "minis"})
+      assert again.id != runner.id
+    end
+  end
+
+  describe "authenticate/1" do
+    test "resolves an enrolled runner's token" do
+      {raw, runner} = fixture(:runner, %{})
+      assert {:ok, %{runner: %Runner{id: id}, api_key: key}} = Runners.authenticate(raw)
+      assert id == runner.id
+      assert key.id == runner.api_key_id
+    end
+
+    test "refuses garbage, empty and non-binary tokens" do
+      assert {:error, :invalid_token} = Runners.authenticate("lc_not_a_key")
+      assert {:error, :invalid_token} = Runners.authenticate("")
+      assert {:error, :invalid_token} = Runners.authenticate(nil)
+    end
+
+    test "refuses a valid agent key that is not bound to a runner" do
+      tenant = fixture(:tenant)
+      {raw, _key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      assert {:error, :not_a_runner} = Runners.authenticate(raw)
+    end
+
+    test "refuses a valid key of any other role" do
+      tenant = fixture(:tenant)
+
+      for role <- [:user, :orchestrator] do
+        {raw, _key} = fixture(:api_key, %{tenant_id: tenant.id, role: role})
+        assert {:error, :not_a_runner} = Runners.authenticate(raw)
+      end
+    end
+
+    test "refuses a revoked runner at once, through the key cache" do
+      {raw, runner} = fixture(:runner, %{})
+      # Warm the positive cache entry first, so the refusal proves the cache was busted.
+      assert {:ok, _} = Runners.authenticate(raw)
+
+      {:ok, _} = Runners.revoke_runner(runner.tenant_id, runner.id)
+      assert {:error, :invalid_token} = Runners.authenticate(raw)
+    end
+
+    test "refuses a runner whose tenant is suspended" do
+      tenant = fixture(:tenant)
+      {raw, _runner} = fixture(:runner, %{tenant_id: tenant.id})
+      {:ok, _} = Tenants.suspend_tenant(tenant)
+      Auth.invalidate_key_cache_by_hashes([Auth.hash_key(raw)])
+
+      assert {:error, :tenant_inactive} = Runners.authenticate(raw)
+    end
+  end
+
+  describe "revoke_runner/3" do
+    test "revokes the row and the key, audits, and notifies the live channel" do
+      {_raw, runner} = fixture(:runner, %{})
+      :ok = Phoenix.PubSub.subscribe(Loopctl.PubSub, Runners.revocation_topic(runner.id))
+
+      assert {:ok, revoked} = Runners.revoke_runner(runner.tenant_id, runner.id)
+      assert revoked.revoked_at
+      assert_receive :runner_revoked
+
+      assert %{revoked_at: %DateTime{}} = AdminRepo.get!(Auth.ApiKey, runner.api_key_id)
+
+      assert AdminRepo.exists?(
+               from e in Entry,
+                 where: e.action == "runner_revoked" and e.entity_id == ^runner.id
+             )
+    end
+
+    test "is idempotent" do
+      {_raw, runner} = fixture(:runner, %{})
+      {:ok, first} = Runners.revoke_runner(runner.tenant_id, runner.id)
+      assert {:ok, second} = Runners.revoke_runner(runner.tenant_id, runner.id)
+      assert second.revoked_at == first.revoked_at
+    end
+
+    test "is not_found for a malformed id" do
+      tenant = fixture(:tenant)
+      assert {:error, :not_found} = Runners.revoke_runner(tenant.id, "not-a-uuid")
+    end
+  end
+
+  describe "authorized?/2" do
+    test "is true for an active runner" do
+      {_raw, runner} = fixture(:runner, %{})
+      assert Runners.authorized?(runner.tenant_id, runner.id)
+    end
+
+    test "is false once the runner is revoked" do
+      {_raw, runner} = fixture(:runner, %{})
+      {:ok, _} = Runners.revoke_runner(runner.tenant_id, runner.id)
+      refute Runners.authorized?(runner.tenant_id, runner.id)
+    end
+
+    test "is false when the key is revoked by the api_keys route, not the runner route" do
+      {_raw, runner} = fixture(:runner, %{})
+      {:ok, key} = Auth.get_api_key(runner.tenant_id, runner.api_key_id)
+      {:ok, _} = Auth.revoke_api_key(key)
+
+      refute Runners.authorized?(runner.tenant_id, runner.id)
+    end
+
+    test "is false when the key has expired" do
+      {_raw, runner} = fixture(:runner, %{})
+      past = DateTime.add(DateTime.utc_now(), -60, :second)
+
+      from(k in Auth.ApiKey, where: k.id == ^runner.api_key_id)
+      |> AdminRepo.update_all(set: [expires_at: past])
+
+      refute Runners.authorized?(runner.tenant_id, runner.id)
+    end
+
+    test "is false when the tenant is suspended" do
+      tenant = fixture(:tenant)
+      {_raw, runner} = fixture(:runner, %{tenant_id: tenant.id})
+      {:ok, _} = Tenants.suspend_tenant(tenant)
+
+      refute Runners.authorized?(tenant.id, runner.id)
+    end
+  end
+
+  describe "tenant isolation" do
+    test "tenant B can neither see, fetch, revoke nor authorize tenant A's runner" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {_raw, runner_a} = fixture(:runner, %{tenant_id: tenant_a.id, name: "minis"})
+
+      assert Runners.list_runners(tenant_b.id, include_revoked: true) == []
+      assert {:error, :not_found} = Runners.get_runner(tenant_b.id, runner_a.id)
+      assert {:error, :not_found} = Runners.revoke_runner(tenant_b.id, runner_a.id)
+      refute Runners.authorized?(tenant_b.id, runner_a.id)
+
+      assert [%Runner{id: id}] = Runners.list_runners(tenant_a.id)
+      assert id == runner_a.id
+      assert is_nil(AdminRepo.get!(Runner, runner_a.id).revoked_at)
+    end
+
+    test "two tenants may each enroll a machine of the same name" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {_raw, _a} = fixture(:runner, %{tenant_id: tenant_a.id, name: "minis"})
+
+      assert {:ok, _} = Runners.enroll_runner(tenant_b.id, %{name: "minis"})
+    end
+
+    test "each tenant's pool topic is distinct" do
+      assert Runners.pool_topic(Ecto.UUID.generate()) != Runners.pool_topic(Ecto.UUID.generate())
+    end
+  end
+end

--- a/test/loopctl/runners_test.exs
+++ b/test/loopctl/runners_test.exs
@@ -131,6 +131,20 @@ defmodule Loopctl.RunnersTest do
              )
     end
 
+    test "after a key revoke through api_keys, still audits once and tells the live channel" do
+      {_raw, runner} = fixture(:runner, %{})
+      {:ok, key} = Auth.get_api_key(runner.tenant_id, runner.api_key_id)
+      {:ok, _} = Auth.revoke_api_key(key)
+      :ok = Phoenix.PubSub.subscribe(Loopctl.PubSub, Runners.revocation_topic(runner.id))
+
+      assert {:ok, %Runner{revoked_at: %DateTime{}}} =
+               Runners.revoke_runner(runner.tenant_id, runner.id)
+
+      assert_receive :runner_revoked
+      {:ok, _} = Runners.revoke_runner(runner.tenant_id, runner.id)
+      assert revocation_entries(runner) == 1
+    end
+
     test "is idempotent" do
       {_raw, runner} = fixture(:runner, %{})
       {:ok, first} = Runners.revoke_runner(runner.tenant_id, runner.id)
@@ -173,6 +187,13 @@ defmodule Loopctl.RunnersTest do
       refute Runners.runner_key?(runner.tenant_id, plain.id)
       refute Runners.runner_key?(fixture(:tenant).id, runner.api_key_id)
     end
+  end
+
+  defp revocation_entries(runner) do
+    AdminRepo.aggregate(
+      from(e in Entry, where: e.action == "runner_revoked" and e.entity_id == ^runner.id),
+      :count
+    )
   end
 
   describe "authorized?/2" do

--- a/test/loopctl_web/controllers/runner_controller_test.exs
+++ b/test/loopctl_web/controllers/runner_controller_test.exs
@@ -1,0 +1,140 @@
+defmodule LoopctlWeb.RunnerControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  alias Loopctl.Runners
+
+  setup :verify_on_exit!
+
+  defp auth(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+  defp operator_ctx do
+    tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+    {operator_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+    %{tenant: tenant, operator_key: operator_key}
+  end
+
+  describe "POST /api/v1/runners" do
+    test "enrolls a runner and returns its token once", %{conn: conn} do
+      ctx = operator_ctx()
+
+      body =
+        conn
+        |> auth(ctx.operator_key)
+        |> post(~p"/api/v1/runners", %{"name" => "minis"})
+        |> json_response(201)
+
+      assert body["runner"]["name"] == "minis"
+      assert is_nil(body["runner"]["revoked_at"])
+      refute Map.has_key?(body["runner"], "api_key_id")
+
+      assert {:ok, %{runner: runner}} = Runners.authenticate(body["token"])
+      assert runner.id == body["runner"]["id"]
+    end
+
+    test "422 on a malformed or duplicate name", %{conn: conn} do
+      ctx = operator_ctx()
+      authed = auth(conn, ctx.operator_key)
+
+      assert json_response(post(authed, ~p"/api/v1/runners", %{"name" => "Bad Name"}), 422)
+      assert json_response(post(authed, ~p"/api/v1/runners", %{"name" => "minis"}), 201)
+      assert json_response(post(authed, ~p"/api/v1/runners", %{"name" => "minis"}), 422)
+    end
+
+    test "403 for orchestrator and agent keys", %{conn: conn} do
+      ctx = operator_ctx()
+
+      for role <- [:orchestrator, :agent] do
+        {raw, _} = fixture(:api_key, %{tenant_id: ctx.tenant.id, role: role})
+
+        assert conn
+               |> auth(raw)
+               |> post(~p"/api/v1/runners", %{"name" => "minis-#{role}"})
+               |> json_response(403)
+      end
+    end
+
+    test "403 custody_tier_required for an agent-rooted tenant, on enroll and revoke",
+         %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      {_token, runner} = fixture(:runner, %{tenant_id: tenant.id})
+      authed = auth(conn, raw)
+
+      for resp <- [
+            post(authed, ~p"/api/v1/runners", %{"name" => "minis"}),
+            delete(authed, ~p"/api/v1/runners/#{runner.id}")
+          ] do
+        assert json_response(resp, 403)["error"]["code"] == "custody_tier_required"
+      end
+
+      assert [_still_active] = Runners.list_runners(tenant.id)
+      assert json_response(get(authed, ~p"/api/v1/runners"), 200)
+    end
+
+    test "403 api_key_mint_forbidden for a dispatch-minted key", %{conn: conn} do
+      ctx = operator_ctx()
+      agent = fixture(:agent, %{tenant_id: ctx.tenant.id, agent_type: :orchestrator})
+
+      %{"api_key" => %{"raw_key" => dispatched_key}} =
+        build_conn()
+        |> auth(ctx.operator_key)
+        |> post(~p"/api/v1/dispatches", %{"role" => "user", "agent_id" => agent.id})
+        |> json_response(201)
+        |> Map.fetch!("data")
+
+      body =
+        conn
+        |> auth(dispatched_key)
+        |> post(~p"/api/v1/runners", %{"name" => "escape"})
+        |> json_response(403)
+
+      assert body["error"]["code"] == "api_key_mint_forbidden"
+      assert Runners.list_runners(ctx.tenant.id) == []
+    end
+  end
+
+  describe "GET /api/v1/runners" do
+    test "lists active runners, and revoked ones on request", %{conn: conn} do
+      ctx = operator_ctx()
+      {_raw, active} = fixture(:runner, %{tenant_id: ctx.tenant.id, name: "minis"})
+      {_raw, gone} = fixture(:runner, %{tenant_id: ctx.tenant.id, name: "blockit"})
+      {:ok, _} = Runners.revoke_runner(ctx.tenant.id, gone.id)
+
+      authed = auth(conn, ctx.operator_key)
+
+      assert [%{"id" => id}] = json_response(get(authed, ~p"/api/v1/runners"), 200)["runners"]
+      assert id == active.id
+
+      all = json_response(get(authed, ~p"/api/v1/runners?include_revoked=true"), 200)["runners"]
+      assert length(all) == 2
+    end
+  end
+
+  describe "DELETE /api/v1/runners/:id" do
+    test "revokes the runner so its token no longer authenticates", %{conn: conn} do
+      ctx = operator_ctx()
+      {raw, runner} = fixture(:runner, %{tenant_id: ctx.tenant.id})
+
+      body =
+        conn
+        |> auth(ctx.operator_key)
+        |> delete(~p"/api/v1/runners/#{runner.id}")
+        |> json_response(200)
+
+      assert body["runner"]["revoked_at"]
+      assert {:error, _} = Runners.authenticate(raw)
+    end
+
+    test "404 for another tenant's runner, which stays active", %{conn: conn} do
+      ctx = operator_ctx()
+      {raw_other, other} = fixture(:runner, %{})
+
+      assert conn
+             |> auth(ctx.operator_key)
+             |> delete(~p"/api/v1/runners/#{other.id}")
+             |> json_response(404)
+
+      assert {:ok, _} = Runners.authenticate(raw_other)
+    end
+  end
+end

--- a/test/loopctl_web/controllers/runner_controller_test.exs
+++ b/test/loopctl_web/controllers/runner_controller_test.exs
@@ -93,6 +93,22 @@ defmodule LoopctlWeb.RunnerControllerTest do
     end
   end
 
+  describe "POST /api/v1/api_keys/:id/rotate on a runner's key" do
+    test "422, and the runner keeps its one working key", %{conn: conn} do
+      ctx = operator_ctx()
+      {raw, runner} = fixture(:runner, %{tenant_id: ctx.tenant.id})
+
+      body =
+        conn
+        |> auth(ctx.operator_key)
+        |> post(~p"/api/v1/api_keys/#{runner.api_key_id}/rotate", %{})
+        |> json_response(422)
+
+      assert body["error"]["message"] =~ "belongs to a runner"
+      assert {:ok, _} = Runners.authenticate(raw)
+    end
+  end
+
   describe "GET /api/v1/runners" do
     test "lists active runners, and revoked ones on request", %{conn: conn} do
       ctx = operator_ctx()

--- a/test/loopctl_web/runner_channel_test.exs
+++ b/test/loopctl_web/runner_channel_test.exs
@@ -40,8 +40,10 @@ defmodule LoopctlWeb.RunnerChannelTest do
   defp connect_runner(token), do: connect(RunnerSocket, %{}, connect_info: connect_info(token))
 
   # Joins and waits for the channel to process :after_join (the Presence track).
+  defp topic(socket), do: "runner:" <> socket.assigns.runner.id
+
   defp join_pool(socket, machine) do
-    {:ok, reply, channel} = subscribe_and_join(socket, "runners", join_payload(machine))
+    {:ok, reply, channel} = subscribe_and_join(socket, topic(socket), join_payload(machine))
     _ = :sys.get_state(channel.channel_pid)
     {reply, channel}
   end
@@ -156,9 +158,52 @@ defmodule LoopctlWeb.RunnerChannelTest do
       {:ok, _} = Auth.revoke_api_key(key)
 
       assert {:error, %{reason: "not_authorized"}} =
-               subscribe_and_join(socket, "runners", join_payload("minis"))
+               subscribe_and_join(socket, topic(socket), join_payload("minis"))
 
       refute in_pool?(runner.tenant_id, "minis")
+    end
+
+    test "refuses a join on another runner's topic" do
+      {raw, _runner} = fixture(:runner, %{name: "minis"})
+      {_raw_other, other} = fixture(:runner, %{name: "blockit"})
+      {:ok, socket} = connect_runner(raw)
+
+      assert {:error, %{reason: "forbidden_topic"}} =
+               subscribe_and_join(socket, "runner:" <> other.id, join_payload("blockit"))
+
+      refute in_pool?(other.tenant_id, "blockit")
+    end
+
+    test "a refused unauthorized join also disconnects the socket" do
+      {raw, runner} = fixture(:runner, %{name: "minis"})
+      {:ok, socket} = connect_runner(raw)
+      @endpoint.subscribe(RunnerSocket.socket_id(runner.id))
+
+      {:ok, key} = Auth.get_api_key(runner.tenant_id, runner.api_key_id)
+      {:ok, _} = Auth.revoke_api_key(key)
+
+      assert {:error, %{reason: "not_authorized"}} =
+               subscribe_and_join(socket, topic(socket), join_payload("minis"))
+
+      assert_receive %Phoenix.Socket.Broadcast{event: "disconnect"}
+    end
+
+    test "joins are budgeted per runner BEFORE the authorization read" do
+      {raw, runner} = fixture(:runner, %{name: "minis"})
+      {:ok, socket} = connect_runner(raw)
+      join_bucket = "runner_join:" <> runner.id
+
+      Mox.stub(Loopctl.MockRateLimiter, :check_rate, fn
+        ^join_bucket, _window, limit -> {:deny, limit}
+        _bucket, _window, _limit -> {:allow, 1}
+      end)
+
+      # Revoked too: if the read ran first, the refusal would say not_authorized.
+      {:ok, key} = Auth.get_api_key(runner.tenant_id, runner.api_key_id)
+      {:ok, _} = Auth.revoke_api_key(key)
+
+      assert {:error, %{reason: "rate_limited"}} =
+               subscribe_and_join(socket, topic(socket), join_payload("minis"))
     end
 
     test "refuses a join under a machine name other than the enrolled one" do
@@ -166,7 +211,7 @@ defmodule LoopctlWeb.RunnerChannelTest do
       {:ok, socket} = connect_runner(raw)
 
       assert {:error, %{reason: "machine_mismatch", declared: "mac-mini"}} =
-               subscribe_and_join(socket, "runners", join_payload("mac-mini"))
+               subscribe_and_join(socket, topic(socket), join_payload("mac-mini"))
 
       refute in_pool?(runner.tenant_id, "mac-mini")
       refute in_pool?(runner.tenant_id, "minis")
@@ -179,7 +224,7 @@ defmodule LoopctlWeb.RunnerChannelTest do
       assert {:error, %{reason: "unsupported_contract_version", sent: "2.0.0"}} =
                subscribe_and_join(
                  socket,
-                 "runners",
+                 topic(socket),
                  join_payload("minis", %{"contract_version" => "2.0.0"})
                )
     end
@@ -189,7 +234,11 @@ defmodule LoopctlWeb.RunnerChannelTest do
       {:ok, socket} = connect_runner(raw)
 
       assert {:error, %{reason: "invalid_payload", details: details}} =
-               subscribe_and_join(socket, "runners", Map.delete(join_payload("minis"), "cores"))
+               subscribe_and_join(
+                 socket,
+                 topic(socket),
+                 Map.delete(join_payload("minis"), "cores")
+               )
 
       assert Enum.any?(details, &String.contains?(&1, "cores"))
     end

--- a/test/loopctl_web/runner_channel_test.exs
+++ b/test/loopctl_web/runner_channel_test.exs
@@ -141,6 +141,26 @@ defmodule LoopctlWeb.RunnerChannelTest do
       assert eventually(fn -> not in_pool?(runner.tenant_id, "minis") end)
     end
 
+    test "re-reads authorization on every join, so a revoked runner cannot rejoin" do
+      {raw, runner} = fixture(:runner, %{name: "minis"})
+      {:ok, socket} = connect_runner(raw)
+      {_reply, channel} = join_pool(socket, "minis")
+
+      Process.unlink(channel.channel_pid)
+      ref = leave(channel)
+      assert_reply ref, :ok
+      assert eventually(fn -> not in_pool?(runner.tenant_id, "minis") end)
+
+      # Revoked through the api_keys route: no broadcast reaches the unjoined socket.
+      {:ok, key} = Auth.get_api_key(runner.tenant_id, runner.api_key_id)
+      {:ok, _} = Auth.revoke_api_key(key)
+
+      assert {:error, %{reason: "not_authorized"}} =
+               subscribe_and_join(socket, "runners", join_payload("minis"))
+
+      refute in_pool?(runner.tenant_id, "minis")
+    end
+
     test "refuses a join under a machine name other than the enrolled one" do
       {raw, runner} = fixture(:runner, %{name: "minis"})
       {:ok, socket} = connect_runner(raw)

--- a/test/loopctl_web/runner_channel_test.exs
+++ b/test/loopctl_web/runner_channel_test.exs
@@ -1,0 +1,293 @@
+defmodule LoopctlWeb.RunnerChannelTest do
+  @moduledoc """
+  Issue #801 acceptance: a runner joins with a valid token, appears in the pool, and
+  vanishes when its process dies — with no sweeper involved — and an invalid or revoked
+  token is refused.
+  """
+
+  use LoopctlWeb.ChannelCase, async: true
+
+  alias Loopctl.ApiSpec.RunnerContract
+  alias Loopctl.Auth
+  alias Loopctl.Runners
+  alias LoopctlWeb.RunnerSocket
+
+  setup :verify_on_exit!
+
+  defp connect_info(token) do
+    %{
+      x_headers: [{RunnerSocket.token_header(), token}],
+      peer_data: %{address: {127, 0, 0, 1}, port: 40_000, ssl_cert: nil}
+    }
+  end
+
+  defp join_payload(machine, overrides \\ %{}) do
+    Map.merge(
+      %{
+        "contract_version" => RunnerContract.version(),
+        "machine" => machine,
+        "cores" => 16,
+        "memory_mb" => 28_000,
+        "repos" => ["mkreyman/home_care_billing"],
+        "max_sessions" => 2,
+        "in_flight" => 0,
+        "draining" => false
+      },
+      overrides
+    )
+  end
+
+  defp connect_runner(token), do: connect(RunnerSocket, %{}, connect_info: connect_info(token))
+
+  # Joins and waits for the channel to process :after_join (the Presence track).
+  defp join_pool(socket, machine) do
+    {:ok, reply, channel} = subscribe_and_join(socket, "runners", join_payload(machine))
+    _ = :sys.get_state(channel.channel_pid)
+    {reply, channel}
+  end
+
+  defp in_pool?(tenant_id, name), do: Map.has_key?(Runners.pool(tenant_id), name)
+
+  describe "connect" do
+    test "accepts an enrolled runner's token from the header" do
+      {raw, runner} = fixture(:runner, %{name: "minis"})
+      assert {:ok, socket} = connect_runner(raw)
+      assert socket.assigns.runner.id == runner.id
+      assert socket.assigns.tenant_id == runner.tenant_id
+      assert RunnerSocket.id(socket) == "runner_socket:" <> runner.id
+    end
+
+    test "refuses a missing, empty or invalid token" do
+      assert :error = connect(RunnerSocket, %{}, connect_info: %{x_headers: []})
+      assert :error = connect_runner("")
+      assert :error = connect_runner("lc_definitely_not_a_key")
+    end
+
+    test "ignores a token passed as a URL parameter" do
+      {raw, _runner} = fixture(:runner, %{})
+      assert :error = connect(RunnerSocket, %{"token" => raw}, connect_info: %{x_headers: []})
+    end
+
+    test "refuses two token headers rather than picking one" do
+      {raw, _runner} = fixture(:runner, %{})
+
+      info = %{
+        x_headers: [{RunnerSocket.token_header(), raw}, {RunnerSocket.token_header(), "x"}]
+      }
+
+      assert :error = connect(RunnerSocket, %{}, connect_info: info)
+    end
+
+    test "refuses a valid API key that is not enrolled as a runner" do
+      tenant = fixture(:tenant)
+      {raw, _key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      assert :error = connect_runner(raw)
+    end
+
+    test "counts the attempt against the per-IP auth bucket BEFORE resolving the token" do
+      {raw, _runner} = fixture(:runner, %{})
+      test_pid = self()
+
+      Mox.expect(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, _limit ->
+        send(test_pid, {:bucket, bucket})
+        {:allow, 1}
+      end)
+
+      assert {:ok, _socket} = connect_runner(raw)
+      assert_received {:bucket, "auth_ip:127.0.0.1"}
+    end
+
+    test "refuses a valid token once the per-IP ceiling is hit, and fails closed on a fault" do
+      {raw, _runner} = fixture(:runner, %{})
+
+      Mox.expect(Loopctl.MockRateLimiter, :check_rate, fn _b, _w, limit -> {:deny, limit} end)
+      assert :error = connect_runner(raw)
+
+      Mox.expect(Loopctl.MockRateLimiter, :check_rate, fn _b, _w, _l -> {:error, :down} end)
+      assert :error = connect_runner(raw)
+    end
+
+    test "refuses a revoked runner" do
+      {raw, runner} = fixture(:runner, %{})
+      {:ok, _} = Runners.revoke_runner(runner.tenant_id, runner.id)
+      assert :error = connect_runner(raw)
+    end
+  end
+
+  describe "join and the pool" do
+    test "a joined runner appears in its tenant's pool with its declared meta" do
+      {raw, runner} = fixture(:runner, %{name: "minis"})
+      {:ok, socket} = connect_runner(raw)
+
+      {reply, _channel} = join_pool(socket, "minis")
+      assert reply == %{contract_version: RunnerContract.version()}
+
+      assert %{"minis" => %{metas: [meta]}} = Runners.pool(runner.tenant_id)
+      assert meta.runner_id == runner.id
+      assert meta.cores == 16
+      assert meta.max_sessions == 2
+      assert meta.repos == ["mkreyman/home_care_billing"]
+    end
+
+    test "the runner vanishes from the pool when its process is killed, with no sweeper" do
+      {raw, runner} = fixture(:runner, %{name: "minis"})
+      {:ok, socket} = connect_runner(raw)
+      {_reply, channel} = join_pool(socket, "minis")
+      assert in_pool?(runner.tenant_id, "minis")
+
+      Process.unlink(channel.channel_pid)
+      Process.exit(channel.channel_pid, :kill)
+
+      assert eventually(fn -> not in_pool?(runner.tenant_id, "minis") end)
+    end
+
+    test "refuses a join under a machine name other than the enrolled one" do
+      {raw, runner} = fixture(:runner, %{name: "minis"})
+      {:ok, socket} = connect_runner(raw)
+
+      assert {:error, %{reason: "machine_mismatch", declared: "mac-mini"}} =
+               subscribe_and_join(socket, "runners", join_payload("mac-mini"))
+
+      refute in_pool?(runner.tenant_id, "mac-mini")
+      refute in_pool?(runner.tenant_id, "minis")
+    end
+
+    test "refuses a contract major version the server does not speak" do
+      {raw, _runner} = fixture(:runner, %{name: "minis"})
+      {:ok, socket} = connect_runner(raw)
+
+      assert {:error, %{reason: "unsupported_contract_version", sent: "2.0.0"}} =
+               subscribe_and_join(
+                 socket,
+                 "runners",
+                 join_payload("minis", %{"contract_version" => "2.0.0"})
+               )
+    end
+
+    test "refuses a payload that does not match the contract" do
+      {raw, _runner} = fixture(:runner, %{name: "minis"})
+      {:ok, socket} = connect_runner(raw)
+
+      assert {:error, %{reason: "invalid_payload", details: details}} =
+               subscribe_and_join(socket, "runners", Map.delete(join_payload("minis"), "cores"))
+
+      assert Enum.any?(details, &String.contains?(&1, "cores"))
+    end
+
+    test "routes no other topic, and the channel refuses one handed to it anyway" do
+      {raw, runner} = fixture(:runner, %{name: "minis"})
+      {:ok, socket} = connect_runner(raw)
+      pool_topic = Runners.pool_topic(runner.tenant_id)
+
+      assert_raise RuntimeError, ~r/no channel found/, fn ->
+        subscribe_and_join(socket, pool_topic, join_payload("minis"))
+      end
+
+      assert {:error, %{reason: "unknown_topic"}} =
+               subscribe_and_join(
+                 socket,
+                 LoopctlWeb.RunnerChannel,
+                 pool_topic,
+                 join_payload("minis")
+               )
+    end
+
+    test "a runner is invisible in another tenant's pool" do
+      {raw_a, runner_a} = fixture(:runner, %{name: "minis"})
+      tenant_b = fixture(:tenant)
+      {:ok, socket} = connect_runner(raw_a)
+      {_reply, _channel} = join_pool(socket, "minis")
+
+      assert in_pool?(runner_a.tenant_id, "minis")
+      assert Runners.pool(tenant_b.id) == %{}
+    end
+
+    test "the runner is not sent the pool" do
+      {raw, _runner} = fixture(:runner, %{name: "minis"})
+      {:ok, socket} = connect_runner(raw)
+      {_reply, _channel} = join_pool(socket, "minis")
+
+      refute_push "presence_state", _
+      refute_push "presence_diff", _
+    end
+  end
+
+  describe "status" do
+    setup do
+      {raw, runner} = fixture(:runner, %{name: "minis"})
+      {:ok, socket} = connect_runner(raw)
+      {_reply, channel} = join_pool(socket, "minis")
+      %{runner: runner, channel: channel}
+    end
+
+    test "updates the runner's meta in the pool", %{runner: runner, channel: channel} do
+      ref = push(channel, "status", %{"in_flight" => 1, "draining" => true})
+      assert_reply ref, :ok
+
+      assert %{"minis" => %{metas: [meta]}} =
+               eventually(fn ->
+                 pool = Runners.pool(runner.tenant_id)
+                 match?(%{"minis" => %{metas: [%{in_flight: 1}]}}, pool) && pool
+               end)
+
+      assert meta.draining == true
+      assert meta.cores == 16
+    end
+
+    test "refuses an update inside the minimum interval", %{channel: channel} do
+      ref = push(channel, "status", %{"in_flight" => 1})
+      assert_reply ref, :ok
+
+      ref = push(channel, "status", %{"in_flight" => 2})
+      assert_reply ref, :error, %{reason: "rate_limited"}
+    end
+
+    test "refuses a status with no known field", %{channel: channel} do
+      ref = push(channel, "status", %{"bogus" => 1})
+      assert_reply ref, :error, %{reason: "invalid_payload"}
+    end
+
+    test "refuses an unknown event", %{channel: channel} do
+      ref = push(channel, "dispatch", %{})
+      assert_reply ref, :error, %{reason: "unknown_event"}
+    end
+  end
+
+  describe "revocation of a connected runner" do
+    setup do
+      {raw, runner} = fixture(:runner, %{name: "minis"})
+      {:ok, socket} = connect_runner(raw)
+      {_reply, channel} = join_pool(socket, "minis")
+      Process.unlink(channel.channel_pid)
+      @endpoint.subscribe(RunnerSocket.socket_id(runner.id))
+      %{runner: runner, channel: channel}
+    end
+
+    test "revoke_runner disconnects the socket and empties the pool", %{runner: runner} do
+      {:ok, _} = Runners.revoke_runner(runner.tenant_id, runner.id)
+
+      assert_receive %Phoenix.Socket.Broadcast{event: "disconnect"}
+      assert eventually(fn -> not in_pool?(runner.tenant_id, "minis") end)
+    end
+
+    test "the periodic recheck catches a key revoked through the api_keys route",
+         %{runner: runner, channel: channel} do
+      {:ok, key} = Auth.get_api_key(runner.tenant_id, runner.api_key_id)
+      {:ok, _} = Auth.revoke_api_key(key)
+
+      send(channel.channel_pid, :recheck)
+
+      assert_receive %Phoenix.Socket.Broadcast{event: "disconnect"}
+      assert eventually(fn -> not in_pool?(runner.tenant_id, "minis") end)
+    end
+
+    test "the periodic recheck leaves an authorized runner connected",
+         %{runner: runner, channel: channel} do
+      send(channel.channel_pid, :recheck)
+      _ = :sys.get_state(channel.channel_pid)
+
+      refute_received %Phoenix.Socket.Broadcast{event: "disconnect"}
+      assert in_pool?(runner.tenant_id, "minis")
+    end
+  end
+end

--- a/test/loopctl_web/runner_client_ip_test.exs
+++ b/test/loopctl_web/runner_client_ip_test.exs
@@ -1,0 +1,89 @@
+defmodule LoopctlWeb.RunnerClientIpTest do
+  @moduledoc """
+  The runner socket is dispatched before the endpoint's plugs run, so its connect
+  throttle must get the trusted client IP from `LoopctlWeb.RunnerClientIp`, which wraps
+  the endpoint's `call/2`. These tests go through the real endpoint, so they fail if the
+  wrap is not ahead of socket dispatch.
+  """
+
+  use LoopctlWeb.ConnCase, async: true
+
+  alias LoopctlWeb.RunnerClientIp
+
+  setup :verify_on_exit!
+
+  defp capture_bucket do
+    test_pid = self()
+
+    Mox.expect(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, _limit ->
+      send(test_pid, {:bucket, bucket})
+      {:allow, 1}
+    end)
+  end
+
+  defp socket_request(conn, headers) do
+    headers
+    |> Enum.reduce(conn, fn {k, v}, acc -> put_req_header(acc, k, v) end)
+    |> put_req_header("x-loopctl-runner-token", "lc_not_a_runner")
+    |> get("/runner/socket/websocket?vsn=2.0.0")
+  end
+
+  describe "through the endpoint" do
+    test "the connect throttle is keyed on fly-client-ip, not on a spoofed header", %{conn: conn} do
+      capture_bucket()
+
+      conn =
+        socket_request(conn, [
+          {"fly-client-ip", "203.0.113.7"},
+          {RunnerClientIp.header(), "9.9.9.9"}
+        ])
+
+      assert conn.status == 403
+      assert_received {:bucket, "auth_ip:203.0.113.7"}
+    end
+
+    test "a spoofed header alone never reaches the throttle", %{conn: conn} do
+      capture_bucket()
+
+      conn = socket_request(conn, [{RunnerClientIp.header(), "9.9.9.9"}])
+
+      assert conn.status == 403
+      assert_received {:bucket, bucket}
+      refute bucket == "auth_ip:9.9.9.9"
+    end
+  end
+
+  describe "stamp/1" do
+    test "replaces every inbound copy on a runner-socket path" do
+      conn =
+        Plug.Test.conn(:get, "/runner/socket/websocket")
+        |> Map.update!(:req_headers, fn h ->
+          [
+            {"fly-client-ip", "203.0.113.7"},
+            {"x-loopctl-client-ip", "1.1.1.1"},
+            {"x-loopctl-client-ip", "2.2.2.2"} | h
+          ]
+        end)
+        |> RunnerClientIp.stamp()
+
+      assert Plug.Conn.get_req_header(conn, "x-loopctl-client-ip") == ["203.0.113.7"]
+    end
+
+    test "strips a spoofed copy and writes nothing when no client resolves" do
+      conn =
+        Plug.Test.conn(:get, "/runner/socket/websocket")
+        |> Plug.Conn.put_req_header("x-loopctl-client-ip", "1.1.1.1")
+        |> RunnerClientIp.stamp()
+
+      assert Plug.Conn.get_req_header(conn, "x-loopctl-client-ip") == []
+    end
+
+    test "leaves every other path untouched" do
+      conn =
+        Plug.Test.conn(:get, "/api/v1/projects")
+        |> Plug.Conn.put_req_header("fly-client-ip", "203.0.113.7")
+
+      assert RunnerClientIp.stamp(conn) == conn
+    end
+  end
+end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -1,0 +1,56 @@
+defmodule LoopctlWeb.ChannelCase do
+  @moduledoc """
+  The test case for Phoenix channel tests (issue #801, the runner channel).
+
+  Same sandbox, Mox and default-stub setup as `LoopctlWeb.ConnCase`, with
+  `Phoenix.ChannelTest` imported instead of `Phoenix.ConnTest`. Channel processes started
+  by `connect/3` and `subscribe_and_join/3` inherit the test's `$callers`, so their DB
+  calls run on the test's sandbox connection under `async: true`.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      @endpoint LoopctlWeb.Endpoint
+
+      import Phoenix.ChannelTest
+      import LoopctlWeb.ChannelCase
+      import Loopctl.Fixtures
+      import Mox
+    end
+  end
+
+  setup tags do
+    Loopctl.DataCase.setup_sandbox(tags)
+    Mox.set_mox_from_context(tags)
+    Loopctl.DataCase.stub_all_defaults()
+    :ok
+  end
+
+  @doc """
+  Polls `fun` until it returns a truthy value or `timeout_ms` elapses, and returns the
+  last value. For state that converges asynchronously, like a Presence entry removed
+  when its tracked process exits.
+  """
+  @spec eventually((-> term()), non_neg_integer()) :: term()
+  def eventually(fun, timeout_ms \\ 1_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_eventually(fun, deadline)
+  end
+
+  defp do_eventually(fun, deadline) do
+    case fun.() do
+      falsy when falsy in [nil, false] ->
+        if System.monotonic_time(:millisecond) < deadline do
+          Process.sleep(10)
+          do_eventually(fun, deadline)
+        else
+          falsy
+        end
+
+      truthy ->
+        truthy
+    end
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -1716,6 +1716,25 @@ defmodule Loopctl.Fixtures do
     end
   end
 
+  # An enrolled runner (issue #801). Returns `{raw_token, runner}` so a test can connect
+  # the runner socket with the token. Auto-creates the tenant when none is given.
+  def fixture(:runner, attrs) do
+    attrs = Enum.into(attrs, %{})
+
+    tenant_id =
+      case Map.get(attrs, :tenant_id) do
+        nil -> fixture(:tenant).id
+        tid -> tid
+      end
+
+    name = Map.get(attrs, :name, "runner-#{System.unique_integer([:positive])}")
+
+    {:ok, %{runner: runner, raw_key: raw_key}} =
+      Loopctl.Runners.enroll_runner(tenant_id, %{name: name})
+
+    {raw_key, runner}
+  end
+
   def fixture(:api_key, attrs) do
     attrs = Enum.into(attrs, %{})
     role = Map.get(attrs, :role, :user)


### PR DESCRIPTION
Closes #801. Part of the agent delivery loop epic (#800), design §2 and §7.

A runner joins with a valid token, appears in its tenant's pool, and vanishes when its process dies with no sweeper. An invalid or revoked token is refused. The contract is versioned and checked in as JSON Schema for `mkreyman/loopctl-runner` to vendor.

## What it adds

- **Runner contract** — `Loopctl.ApiSpec.RunnerContract`, beside `api_spec/schemas.ex`. One declaration per message: `RunnerJoin`, `RunnerStatus`, `RunnerSample`, `RunnerDispatch` (declared, emitted from #803) and `RunnerTraceEvent` (`parent` required, nullable only for the root). The same OpenApiSpex schemas validate inbound payloads and are exported by `mix loopctl.runner_contract` to `priv/runner_contract/v1.json`. A test fails when the export drifts from the declarations. Semver: a join is refused unless the major matches, and unknown fields are dropped at every depth rather than refused, so minors stay additive.
- **Registry** — a `runners` table (RLS enabled) binding one `api_keys` row to one machine name. `POST/GET/DELETE /api/v1/runners`, `role: :user`. Enrollment mints a credential, so it carries the same lineage ceiling as `POST /api/v1/api_keys` (`RequireUnlineagedCaller`). Enroll and revoke go on the audit chain.
- **Socket** — `/runner/socket`, websocket only. The token is read from the `x-loopctl-runner-token` header and never from the URL.
- **Presence** — `Loopctl.Runners.Presence`, tracked against the channel process.

## Decisions a reviewer should check

1. **The credential is an ordinary `api_keys` row (role `:agent`) plus a binding row, not a new token type.** The design says join must resolve the key and tenant through loopctl's existing functions. `Runners.authenticate/1` calls `Auth.verify_api_key/1`, which is what `ResolveApiKey` calls, so the revocation cache, expiry and tenant suspension apply unchanged. A key with no active runner row cannot open the socket. It is also a working REST agent key. That grants nothing new, because every enrolled machine already holds agent and orchestrator keys for its sessions.
2. **Topics are never shared across tenants.** A runner joins its own topic, `runner:<runner_id>`, and a join on another runner's topic is refused. The design's single `"runners"` topic would carry any broadcast, including a future `dispatch`, to every tenant's machines. The Presence set is `runners:<tenant_id>`, and runners never receive it. Joins are budgeted per runner (30 a minute, fail-closed) before the authorization read, and a join refused as unauthorized disconnects the socket.
3. **What `connect/3` re-applies from the HTTP pipeline, and what it doesn't.** It applies the `AuthPathThrottle` per-IP fail-closed gate, same bucket and config, counted before the token is resolved. Socket dispatch runs ahead of every endpoint plug, so `ClientIp` has not run yet, and `connect_info` cannot see `fly-client-ip`. `LoopctlWeb.RunnerClientIp` wraps the endpoint's `call/2` (`@before_compile`) and, on runner-socket paths only, replaces any client-supplied `x-loopctl-client-ip` with the address `RemoteIp` resolves. A test through the real endpoint pins the bucket to `fly-client-ip`. It applies `ResolveApiKey`'s resolution and suspended-tenant refusal. It does not apply `SetTenant`: a channel is a separate long-lived process, and every context call passes `tenant_id` explicitly. It does not apply the witness header or `CheckCustodyHalt` either, because nothing on the socket reads the chain or performs a custody operation. **#803 must add the halt check to dispatch.** That is written in `RunnerSocket`'s moduledoc.
4. **Revocation reaches a live socket in two ways.** `DELETE /api/v1/runners/:id` revokes the row and key in one transaction and busts the key cache after commit. It then broadcasts to the channel, which disconnects the socket, not just the channel, so the runner can't rejoin on the same connection. Any other revocation (`DELETE /api/v1/api_keys/:id`, expiry, tenant suspension) is caught by a 30-second `authorized?/2` recheck, and by the same read on every join, so leaving and rejoining cannot outrun it. `revoke_runner` locks the api key row and then the runner row (`FOR UPDATE`). That is the order the api_keys revoke path and its trigger take them in, so the two paths cannot deadlock, and concurrent revokes write one `revoked_at` and one audit entry. That lock is verified by reading the code, not by a test: the SQL sandbox serializes every task onto one connection, and a concurrency test there passed with the lock removed (mutate.sh exit 1), so it was deleted rather than kept as a check that cannot fail. A trigger revokes the runner row whenever its key's `revoked_at` is set, so the registry never lists a machine whose credential is gone. `POST /api_keys/:id/rotate` refuses a runner's key with 422, because rotation is revoke plus re-enroll.
5. **Enroll and revoke are human-anchored** (`RequireHumanAnchor`, new `TierCapabilities` surface `runner_pool`). A runner executes dispatched sessions as its machine's user, so admitting one is an execution root, and an agent-rooted tenant may not admit one for itself. The default-deny guard test would have refused the route anyway. Listing stays open.
6. **Machine binding.** A join whose `machine` is not the enrolled name is refused, so a token enrolled for `minis` cannot appear in the pool as `mac-mini`.

## Known limit, carried from design §7

Presence converges only within a cluster. loopctl runs single-node, and `DNS_CLUSTER_QUERY` is unset. If Fly starts a second machine, a runner tracked on node A is invisible on node B. `Loopctl.ClusterReadiness` already warns about that state. The design says to settle this before build-order step 6, which is where the pool starts being read for placement. Nothing reads it yet.

## Falsifiability

Every rule below was broken on purpose with `~/workspace/claude-config/bin/mutate.sh`, and its test went red. Exit 0 means the check failed under the mutation. The wiring was mutated as well as the mechanisms: the throttle call, the subscribe, the broadcast, the recheck call, the tenant topic on `track`, and both plugs.

| case | file | mutation | check | exit |
|---|---|---|---|---|
| throttle-wiring | runner_socket.ex | remove the throttle/1 call from connect | runner_channel_test | 0 |
| runner-binding | runners.ex | a key with no runner row resolves to a runner | runner_channel_test + runners_test | 0 |
| machine-name | runner_channel.ex | any declared machine name accepted | runner_channel_test | 0 |
| tenant-scoped-track | runner_channel.ex | Presence.track on literal "runners" | runner_channel_test | 0 |
| revoke-notifies-channel | runners.ex | drop the revocation broadcast | runner_channel_test | 0 |
| channel-subscribes | runner_channel.ex | drop the revocation subscribe | runner_channel_test | 0 |
| recheck-wiring | runner_channel.ex | recheck skips authorized?/2 | runner_channel_test | 0 |
| authorized-key-revoked | runners.ex | authorized?/2 ignores key revoked_at | runners_test + runner_channel_test | 0 |
| authorized-tenant-active | runners.ex | authorized?/2 ignores tenant status | runners_test | 0 |
| cache-bust-after-revoke | runners.ex | no key-cache bust after revoke | runners_test | 0 |
| tenant-active-at-connect | runners.ex | suspended tenant passes authenticate | runners_test | 0 |
| contract-major | runner_contract.ex | any major accepted | runner_contract_test + runner_channel_test | 0 |
| export-drift | runner_contract.ex | schema changed without re-export | runner_contract_test | 0 |
| unlineaged-plug | runner_controller.ex | RequireUnlineagedCaller removed | runner_controller_test | 0 |
| user-role-plug | runner_controller.ex | role: :user lowered to :agent | runner_controller_test | 0 |
| status-rate-limit | runner_channel.ex | status interval never refuses | runner_channel_test | 0 |
| human-anchor-on-revoke | runner_controller.ex | RequireHumanAnchor only on :create | runner_controller_test | 0 |
| join-authorized | runner_channel.ex | join skips authorized?/2 | runner_channel_test | 0 |
| endpoint-wrap | endpoint.ex | @before_compile RunnerClientIp removed | runner_client_ip_test | 0 |
| socket-reads-stamp | runner_socket.ex | throttle keyed on TCP peer, not the stamp | runner_client_ip_test | 0 |
| stamp-strips | runner_client_ip.ex | client-supplied header kept | runner_client_ip_test | 0 |
| rotate-refusal | api_key_controller.ex | runner key rotation allowed | runner_controller_test | 0 |
| nested-strip | runner_contract.ex | nested unknown keys kept | runner_contract_test | 0 |
| join-budget | runner_channel.ex | join skips the per-runner budget | runner_channel_test | 0 |
| refused-join-disconnects | runner_channel.ex | no disconnect on not_authorized | runner_channel_test | 0 |
| own-topic-only | runner_channel.ex | any runner: topic joinable | runner_channel_test | 0 |
| audit-once | runners.ex | revocation audited on every call | runners_test | 0 |
| trigger-path-revoke | runners.ex | already-revoked row errors instead of notifying | runners_test | 0 |
| row-lock | runners.ex | FOR UPDATE removed | runners_test | **1 — not testable under the sandbox, see decision 4** |

Invocation shape: `mutate.sh --quiet <file> --old '<text>' --new '<broken>' -- mix test <files>`; the full script is reproducible from the case list above.


## Review gate

The review gate is still running on this PR.
