### PR TITLE
Two delivery-loop gates: request-shaped Gate A and effect-shaped Gate B, pure and fail-closed (#802)

### DIFF
--- a/lib/loopctl/delivery_gates.ex
+++ b/lib/loopctl/delivery_gates.ex
@@ -1,0 +1,68 @@
+defmodule Loopctl.DeliveryGates do
+  @moduledoc """
+  The two gates of the agent delivery loop. Pure: no I/O, no database, no model call, and no
+  application environment read inside a gate. Everything a gate decides on is an argument.
+
+  They are two gates and not one "escalation", because they answer different questions and
+  fire at very different rates. Collapsing them into one path-based predicate was measured
+  to escalate 54% of ordinary changes — the outcome both exist to prevent.
+
+  ## Gate A — "Mark decides" (`gate_a/1`)
+
+  Request-shaped. Reads only the triage trio's verdicts: it escalates when the request
+  contradicts an existing story, KB decision or behaviour, inverts or removes behaviour a
+  previous story deliberately added, changes a workflow rather than fixing a defect, or when
+  the three agents' verdicts disagree. No file path enters it. Self-reported confidence is
+  recorded and never gates. Its rate is reported with `gate_a_rate/1`; a rate resembling the
+  collapsed predicate's is a design failure, not a tuning question.
+
+  ## Gate B — "a human confirms" (`gate_b/3`, `judge_proof/3`)
+
+  Effect-shaped. Asks whether the change can cause an irreversible external effect, from the
+  paths it touches and the size of the diff. An effect path means the change proves its
+  effect against a fixed fixture set (`judge_proof/3`): the output must change exactly
+  where intended and nowhere else, and the fixtures must cover every code the repository
+  uses. A human path, the size bound, or any failure to evaluate means a human confirms. A
+  failed proof routes to Gate A.
+
+  ## Both run twice
+
+  At triage, over the trio's predicted touches, to decide whether to dispatch. Again as a
+  merge precondition, over the real `gh pr diff --name-only` and diffstat. Nothing binds an
+  implementing session to its story's prediction, so only the second run gates a merge.
+
+  ## Fail closed
+
+  Gate B's trigger data is configuration, never source (`parse_triggers/2`). A missing,
+  empty, misparsed or checksum-mismatched document is an error, never an empty trigger set,
+  and every gate evaluation handed anything but a valid parse escalates unconditionally,
+  naming why. So do an unknown repository, a configured pattern that no longer matches any
+  file in the repository, and malformed input to either gate.
+
+  ## Agents may only add an escalation
+
+  A property of the wiring, not a rule agents follow. Gate B computes its own triggers and
+  ORs the agents' escalations onto them; it never reads an agent's negative, and no argument
+  can remove a computed trigger. Gate A's inputs ARE agent judgements, so there the property
+  is that any one agent escalating, contradicting, or disagreeing is enough.
+  """
+
+  alias Loopctl.DeliveryGates.GateA
+  alias Loopctl.DeliveryGates.GateB
+  alias Loopctl.DeliveryGates.Triggers
+
+  @doc "See `Loopctl.DeliveryGates.Triggers.parse/2`."
+  defdelegate parse_triggers(binary, expected_sha256_hex), to: Triggers, as: :parse
+
+  @doc "See `Loopctl.DeliveryGates.GateA.evaluate/1`."
+  defdelegate gate_a(trio_outputs), to: GateA, as: :evaluate
+
+  @doc "See `Loopctl.DeliveryGates.GateA.rate/1`."
+  defdelegate gate_a_rate(results), to: GateA, as: :rate
+
+  @doc "See `Loopctl.DeliveryGates.GateB.evaluate/3`."
+  defdelegate gate_b(phase, input, triggers), to: GateB, as: :evaluate
+
+  @doc "See `Loopctl.DeliveryGates.GateB.judge_proof/3`."
+  defdelegate judge_proof(intent, fixture_results, coverage), to: GateB
+end

--- a/lib/loopctl/delivery_gates.ex
+++ b/lib/loopctl/delivery_gates.ex
@@ -28,7 +28,9 @@ defmodule Loopctl.DeliveryGates do
   ## Both run twice
 
   At triage, over the trio's predicted touches, to decide whether to dispatch. Again as a
-  merge precondition, over the real `gh pr diff --name-only` and diffstat. Nothing binds an
+  merge precondition, over the real diff from `git diff --name-status -M -z base...head` —
+  every added, modified and DELETED path, plus both names of every rename — and the real
+  diffstat. Never `gh pr diff --name-only`: it prints only a rename's new name. Nothing binds an
   implementing session to its story's prediction, so only the second run gates a merge.
 
   ## Fail closed

--- a/lib/loopctl/delivery_gates.ex
+++ b/lib/loopctl/delivery_gates.ex
@@ -16,11 +16,11 @@ defmodule Loopctl.DeliveryGates do
   recorded and never gates. Its rate is reported with `gate_a_rate/1`; a rate resembling the
   collapsed predicate's is a design failure, not a tuning question.
 
-  ## Gate B — "a human confirms" (`gate_b/3`, `judge_proof/3`)
+  ## Gate B — "a human confirms" (`gate_b/3`, `judge_proof/4`)
 
   Effect-shaped. Asks whether the change can cause an irreversible external effect, from the
   paths it touches and the size of the diff. An effect path means the change proves its
-  effect against a fixed fixture set (`judge_proof/3`): the output must change exactly
+  effect against a fixed fixture set (`judge_proof/4`): the output must change exactly
   where intended and nowhere else, and the fixtures must cover every code the repository
   uses. A human path, the size bound, or any failure to evaluate means a human confirms. A
   failed proof routes to Gate A.
@@ -63,6 +63,6 @@ defmodule Loopctl.DeliveryGates do
   @doc "See `Loopctl.DeliveryGates.GateB.evaluate/3`."
   defdelegate gate_b(phase, input, triggers), to: GateB, as: :evaluate
 
-  @doc "See `Loopctl.DeliveryGates.GateB.judge_proof/3`."
-  defdelegate judge_proof(intent, fixture_results, coverage), to: GateB
+  @doc "See `Loopctl.DeliveryGates.GateB.judge_proof/4`."
+  defdelegate judge_proof(intent, fixture_set, fixture_results, coverage), to: GateB
 end

--- a/lib/loopctl/delivery_gates/gate_a.ex
+++ b/lib/loopctl/delivery_gates/gate_a.ex
@@ -1,0 +1,229 @@
+defmodule Loopctl.DeliveryGates.GateA do
+  @moduledoc """
+  Gate A — "Mark decides". Request-shaped, and meant to be rare.
+
+  Its only input is the triage trio's output: three independently prompted agents' verdicts
+  on the REQUEST. It reads no file path and has no path configuration, by design — an
+  uncontested defect in a sensitive part of the code is not a decision for a human; whether
+  the change can cause an irreversible effect is Gate B's question, answered from the diff.
+
+  It escalates when:
+
+  - there are not exactly three outputs, or any output is malformed (fail closed)
+  - the three `verdict`s disagree — three separate judgements that do not agree are a far
+    better signal than any one agent's confidence
+  - any agent's verdict is `"escalate"`
+  - any agent reports a non-empty `contradicts` (an existing story, KB decision, or code
+    behaviour the request conflicts with)
+  - any agent's `escalation_reasons` carries one of the gating reason codes below
+
+  `confidence` is RECORDED on the result and never consulted by the decision.
+
+  ## Gating reason codes
+
+  The trio contract emits these strings in `escalation_reasons`. Any other code is a SOFT
+  signal: recorded on the result and never gating, until its measured rate earns it a place
+  here.
+
+  - `"inverts_or_removes_deliberate_behaviour"` — the request inverts or removes behaviour a
+    previous story deliberately added
+  - `"workflow_change_not_defect_fix"` — the request changes a workflow rather than fixing a
+    defect
+
+  ## Output contract read
+
+  Each output is the decoded JSON object (string keys) the trio emits:
+
+      %{"verdict" => "story" | "escalate" | "reject",
+        "escalation_reasons" => [String.t()],
+        "contradicts" => [%{"kind" => "story" | "kb" | "code", "ref" => String.t(), "why" => String.t()}],
+        "confidence" => number in 0.0..1.0}
+
+  All four keys are required. `story` is not read here.
+  """
+
+  alias Loopctl.DeliveryGates.GateA.Result
+
+  @inverts_deliberate_behaviour "inverts_or_removes_deliberate_behaviour"
+  @workflow_change "workflow_change_not_defect_fix"
+
+  @gating_codes %{
+    @inverts_deliberate_behaviour => :inverts_deliberate_behaviour,
+    @workflow_change => :workflow_change
+  }
+
+  @verdicts %{"story" => :story, "escalate" => :escalate, "reject" => :reject}
+  @contradiction_kinds ~w(story kb code)
+  @trio_size 3
+
+  @doc "The escalation reason codes that gate, as the trio contract spells them."
+  @spec gating_reason_codes() :: [String.t()]
+  def gating_reason_codes, do: Map.keys(@gating_codes)
+
+  @doc """
+  Evaluates the trio's outputs. Anything other than a list of exactly three well-formed
+  outputs escalates.
+  """
+  @spec evaluate(term()) :: Result.t()
+  def evaluate(outputs) when is_list(outputs) and length(outputs) == @trio_size do
+    parsed = outputs |> Enum.with_index() |> Enum.map(&parse_output/1)
+    valid = for {:ok, index, output} <- parsed, do: {index, output}
+
+    reasons =
+      malformed_reasons(parsed) ++
+        disagreement_reasons(valid) ++
+        Enum.flat_map(valid, &agent_reasons/1)
+
+    build(reasons, valid, parsed)
+  end
+
+  def evaluate(outputs) do
+    size = if is_list(outputs), do: length(outputs), else: :not_a_list
+
+    %Result{
+      decision: :escalate,
+      verdict: nil,
+      reasons: [{:trio_size, size}],
+      confidences: [],
+      soft_signals: []
+    }
+  end
+
+  @doc """
+  The measured escalation rate over a set of results.
+
+  `by_reason` counts RESULTS carrying at least one reason of each kind, so one output
+  contradicting two stories counts once. `rate` is `nil` for an empty set: no
+  measurement is not a zero rate.
+  """
+  @spec rate([Result.t()]) :: %{
+          total: non_neg_integer(),
+          escalated: non_neg_integer(),
+          rate: float() | nil,
+          by_reason: %{atom() => pos_integer()}
+        }
+  def rate(results) when is_list(results) do
+    escalated = Enum.filter(results, fn %Result{decision: decision} -> decision == :escalate end)
+    total = length(results)
+
+    by_reason =
+      escalated
+      |> Enum.flat_map(fn %Result{reasons: reasons} ->
+        reasons |> Enum.map(&elem(&1, 0)) |> Enum.uniq()
+      end)
+      |> Enum.frequencies()
+
+    %{
+      total: total,
+      escalated: length(escalated),
+      rate: if(total == 0, do: nil, else: length(escalated) / total),
+      by_reason: by_reason
+    }
+  end
+
+  defp build(reasons, valid, parsed) do
+    decision = if reasons == [], do: :proceed, else: :escalate
+
+    verdict =
+      case {decision, valid} do
+        {:proceed, [{_index, %{verdict: verdict}} | _rest]} -> verdict
+        _ -> nil
+      end
+
+    soft_signals =
+      for {index, %{codes: codes}} <- valid,
+          code <- codes,
+          not Map.has_key?(@gating_codes, code),
+          do: {index, code}
+
+    %Result{
+      decision: decision,
+      verdict: verdict,
+      reasons: reasons,
+      confidences: Enum.map(parsed, &confidence/1),
+      soft_signals: soft_signals
+    }
+  end
+
+  defp confidence({:ok, _index, %{confidence: confidence}}), do: confidence
+  defp confidence({:error, _reason}), do: nil
+
+  defp malformed_reasons(parsed), do: for({:error, reason} <- parsed, do: reason)
+
+  defp disagreement_reasons(valid) do
+    verdicts = Enum.map(valid, fn {_index, %{verdict: verdict}} -> verdict end)
+
+    if verdicts |> Enum.uniq() |> length() > 1,
+      do: [{:verdict_disagreement, verdicts}],
+      else: []
+  end
+
+  defp agent_reasons({index, output}) do
+    escalated = if output.verdict == :escalate, do: [{:agent_escalated, index}], else: []
+
+    contradicted =
+      if output.contradicts == [], do: [], else: [{:contradiction, index, output.contradicts}]
+
+    gating =
+      for code <- Enum.uniq(output.codes),
+          Map.has_key?(@gating_codes, code),
+          do: {Map.fetch!(@gating_codes, code), index}
+
+    escalated ++ contradicted ++ gating
+  end
+
+  defp parse_output({output, index}) when is_map(output) do
+    with {:ok, verdict} <- field(output, "verdict", &verdict/1),
+         {:ok, codes} <- field(output, "escalation_reasons", &codes/1),
+         {:ok, contradicts} <- field(output, "contradicts", &contradicts/1),
+         {:ok, confidence} <- field(output, "confidence", &confidence_value/1) do
+      {:ok, index,
+       %{verdict: verdict, codes: codes, contradicts: contradicts, confidence: confidence}}
+    else
+      {:error, detail} -> {:error, {:malformed_output, index, detail}}
+    end
+  end
+
+  defp parse_output({_output, index}), do: {:error, {:malformed_output, index, :not_a_map}}
+
+  defp field(output, key, validate) do
+    case Map.fetch(output, key) do
+      {:ok, value} -> validate.(value)
+      :error -> {:error, {:missing, key}}
+    end
+  end
+
+  defp verdict(value) do
+    case Map.fetch(@verdicts, value) do
+      {:ok, verdict} -> {:ok, verdict}
+      :error -> {:error, {:invalid, "verdict"}}
+    end
+  end
+
+  defp codes(value) when is_list(value) do
+    if Enum.all?(value, &is_binary/1),
+      do: {:ok, value},
+      else: {:error, {:invalid, "escalation_reasons"}}
+  end
+
+  defp codes(_value), do: {:error, {:invalid, "escalation_reasons"}}
+
+  defp contradicts(value) when is_list(value) do
+    if Enum.all?(value, &contradiction?/1),
+      do: {:ok, value},
+      else: {:error, {:invalid, "contradicts"}}
+  end
+
+  defp contradicts(_value), do: {:error, {:invalid, "contradicts"}}
+
+  defp contradiction?(%{"kind" => kind, "ref" => ref, "why" => why})
+       when kind in @contradiction_kinds and is_binary(ref) and is_binary(why),
+       do: true
+
+  defp contradiction?(_value), do: false
+
+  defp confidence_value(value) when is_number(value) and value >= 0 and value <= 1,
+    do: {:ok, value}
+
+  defp confidence_value(_value), do: {:error, {:invalid, "confidence"}}
+end

--- a/lib/loopctl/delivery_gates/gate_a/result.ex
+++ b/lib/loopctl/delivery_gates/gate_a/result.ex
@@ -1,0 +1,26 @@
+defmodule Loopctl.DeliveryGates.GateA.Result do
+  @moduledoc """
+  One Gate A evaluation.
+
+  - `decision` — `:proceed` or `:escalate`
+  - `verdict` — the trio's unanimous verdict (`:story` or `:reject`) when `decision` is
+    `:proceed`, otherwise `nil`
+  - `reasons` — why it escalated; every reason is a tuple whose FIRST element names its kind,
+    which is what `Loopctl.DeliveryGates.GateA.rate/1` counts by
+  - `confidences` — each agent's self-reported confidence in output order, `nil` for an
+    output too malformed to read one from. Recorded for ranking; it never gates
+  - `soft_signals` — `{output_index, code}` for every escalation reason code that does NOT
+    gate. Logged so a soft trigger's rate can be measured before anyone lets it gate
+  """
+
+  @enforce_keys [:decision, :verdict, :reasons, :confidences, :soft_signals]
+  defstruct [:decision, :verdict, :reasons, :confidences, :soft_signals]
+
+  @type t :: %__MODULE__{
+          decision: :proceed | :escalate,
+          verdict: :story | :reject | nil,
+          reasons: [tuple()],
+          confidences: [number() | nil],
+          soft_signals: [{non_neg_integer(), String.t()}]
+        }
+end

--- a/lib/loopctl/delivery_gates/gate_b.ex
+++ b/lib/loopctl/delivery_gates/gate_b.ex
@@ -12,23 +12,31 @@ defmodule Loopctl.DeliveryGates.GateB do
     evaluate at all: no or bad configuration, an unknown repository, a stale trigger, missing
     or malformed input. Also any escalation an agent signalled
   - `:prove_effect` — an effect path was touched. The change must prove its effect with
-    `judge_proof/3` before it merges
+    `judge_proof/4` before it merges
   - `:clear` — none of the above
 
   ## Run twice
 
   `evaluate(:triage, ...)` runs over the story's PREDICTED touches and decides only whether
-  to dispatch. `evaluate(:merge, ...)` runs over the real `gh pr diff --name-only` plus the
-  real diffstat, applies the size bound, and is the one that gates. Only the `:merge` result
+  to dispatch. `evaluate(:merge, ...)` runs over the real diff — every added, modified and
+  DELETED path (a deletion under a guarded path is a change to it), plus both names of every
+  rename — and the real diffstat, applies the size bound, and is the one that gates. Only the `:merge` result
   carries `merge_precondition?: true`.
 
   ## Input
 
       %{repo: "owner/repo",
-        files: [String.t()],               # predicted touches at :triage, real diff at :merge
+        files: [String.t()],               # predicted touches at :triage; at :merge every
+                                           # added, modified, deleted and renamed-to path
+        renames: [{old, new}],             # required at :merge (may be []), optional at :triage
         repo_files: [String.t()],          # the target repo's `git ls-files`
         diffstat: %{files: n, changed_lines: n},   # required at :merge, ignored at :triage
         agent_escalations: [term()]}       # optional
+
+  Derive `files` and `renames` together from `git diff --name-status -M -z base...head`
+  (or the REST `files[].previous_filename`), NOT from `gh pr diff --name-only`: that prints
+  only the new name of a rename, and its parser misreads a path containing " b/". Pass
+  unquoted paths (`-z` or `-c core.quotePath=false`); a quoted one escalates.
 
   ## Agents may only ADD an escalation
 
@@ -121,18 +129,61 @@ defmodule Loopctl.DeliveryGates.GateB do
          :ok <- input_map(input),
          {:ok, repo_triggers} <- repo_triggers(triggers, Map.get(input, :repo)) do
       files = Map.get(input, :files)
+      {rename_reasons, renamed_from} = renames(phase, input)
+      touched = touched(files, renamed_from)
 
       reasons =
         stale_trigger_reasons(repo_triggers, Map.get(input, :repo_files)) ++
           file_reasons(files) ++
-          human_path_reasons(repo_triggers, files) ++
+          rename_reasons ++
+          human_path_reasons(repo_triggers, touched) ++
           limit_reasons(phase, repo_triggers, files, Map.get(input, :diffstat))
 
-      {reasons, matches(repo_triggers.effect_paths, files)}
+      {reasons, matches(repo_triggers.effect_paths, touched)}
     else
       {:escalate, reason} -> {[reason], []}
     end
   end
+
+  # The paths a trigger is matched against: `files` (added, modified, deleted and renamed-to
+  # paths) plus the OLD name of every rename. `gh pr diff --name-only` prints only the new name, so a file
+  # moved OUT of a guarded path would otherwise read as touching nothing guarded.
+  defp touched(files, renamed_from) when is_list(files), do: Enum.uniq(files ++ renamed_from)
+  defp touched(_files, renamed_from), do: renamed_from
+
+  # At :merge the caller must state the renames, even as `[]`: an absent list is
+  # indistinguishable from a caller that never asked git for them. At :triage a prediction
+  # has no renames to state, so absence adds nothing there.
+  defp renames(phase, input) do
+    case {phase, Map.fetch(input, :renames)} do
+      {:merge, :error} -> {[:missing_renames], []}
+      {:triage, :error} -> {[], []}
+      {_phase, {:ok, renames}} -> rename_pairs(renames, Map.get(input, :files))
+    end
+  end
+
+  # A rename's NEW name must also be in `files`. The two lists have to come from one diff of
+  # one range; a caller that built them from different commands or refs would otherwise pass
+  # renames computed against the wrong range, and miss the real old name of a moved file.
+  defp rename_pairs(renames, files) when is_list(renames) do
+    if Enum.all?(renames, &rename_pair?/1) do
+      listed = if is_list(files), do: files, else: []
+      olds = Enum.map(renames, &elem(&1, 0))
+
+      reasons =
+        for({old, _new} <- renames, not valid_path?(old), do: {:invalid_path, old}) ++
+          for {_old, new} <- renames, new not in listed, do: {:rename_not_in_files, new}
+
+      {reasons, olds}
+    else
+      {[{:invalid_renames, renames}], []}
+    end
+  end
+
+  defp rename_pairs(renames, _files), do: {[{:invalid_renames, renames}], []}
+
+  defp rename_pair?({old, new}) when is_binary(old) and is_binary(new), do: true
+  defp rename_pair?(_pair), do: false
 
   defp phase(phase) when phase in @phases, do: :ok
   defp phase(phase), do: {:escalate, {:invalid_phase, phase}}
@@ -212,8 +263,6 @@ defmodule Loopctl.DeliveryGates.GateB do
   defp matches(globs, files) when is_list(files) do
     for file <- files, glob <- globs, Glob.match?(glob, file), do: {file, glob.source}
   end
-
-  defp matches(_globs, _files), do: []
 
   # A path as git prints it UNQUOTED: relative, no empty, `.` or `..` segment. Anything else
   # cannot be trusted to match the way the configuration author read it. That includes git's

--- a/lib/loopctl/delivery_gates/gate_b.ex
+++ b/lib/loopctl/delivery_gates/gate_b.ex
@@ -1,0 +1,278 @@
+defmodule Loopctl.DeliveryGates.GateB do
+  @moduledoc """
+  Gate B — "a human confirms". Effect-shaped and mechanical.
+
+  It asks one question of a change: can it cause an irreversible external effect? A revert
+  does not un-submit a claim file, so reversibility of the EFFECT, not of the diff, is what
+  licenses a change to merge without a human.
+
+  ## Outcomes, in precedence order
+
+  - `:human` — a human path was touched, the size bound was exceeded, or the gate could not
+    evaluate at all: no or bad configuration, an unknown repository, a stale trigger, missing
+    or malformed input. Also any escalation an agent signalled
+  - `:prove_effect` — an effect path was touched. The change must prove its effect with
+    `judge_proof/3` before it merges
+  - `:clear` — none of the above
+
+  ## Run twice
+
+  `evaluate(:triage, ...)` runs over the story's PREDICTED touches and decides only whether
+  to dispatch. `evaluate(:merge, ...)` runs over the real `gh pr diff --name-only` plus the
+  real diffstat, applies the size bound, and is the one that gates. Only the `:merge` result
+  carries `merge_precondition?: true`.
+
+  ## Input
+
+      %{repo: "owner/repo",
+        files: [String.t()],               # predicted touches at :triage, real diff at :merge
+        repo_files: [String.t()],          # the target repo's `git ls-files`
+        diffstat: %{files: n, changed_lines: n},   # required at :merge, ignored at :triage
+        agent_escalations: [term()]}       # optional
+
+  ## Agents may only ADD an escalation
+
+  That is a property of this function's wiring, not a rule agents follow. The triggers are
+  computed here from the paths and the configuration, and `agent_escalations` is OR-ed onto
+  them: every element is an escalation, whatever it says, and an empty or absent list adds
+  nothing. There is no input that removes a computed trigger, and nothing reads an agent's
+  negative.
+
+  ## Stale triggers
+
+  loopctl holds no checkout of the target repository, so the repository's file list is an
+  input. Every configured pattern must match at least one of `repo_files`. A pattern that
+  matches nothing means the configuration has drifted from the repository — a rename
+  silently unguarded a trigger — and that escalates, naming the pattern.
+  """
+
+  alias Loopctl.DeliveryGates.GateB.ProofResult
+  alias Loopctl.DeliveryGates.GateB.Result
+  alias Loopctl.DeliveryGates.Glob
+  alias Loopctl.DeliveryGates.RepoTriggers
+  alias Loopctl.DeliveryGates.Triggers
+
+  @phases [:triage, :merge]
+
+  @type phase :: :triage | :merge
+
+  @doc """
+  Evaluates a change. `triggers` is the RETURN VALUE of
+  `Loopctl.DeliveryGates.Triggers.parse/2`, passed through untouched: `{:ok, triggers}`
+  evaluates, and `{:error, reason}`, `nil` or anything else is a `:human` result naming the
+  configuration failure.
+  """
+  @spec evaluate(term(), term(), term()) :: Result.t()
+  def evaluate(phase, input, triggers) do
+    {computed, effect_matches} = computed_triggers(phase, input, triggers)
+    reasons = computed ++ agent_escalations(input)
+
+    outcome =
+      cond do
+        reasons != [] -> :human
+        effect_matches != [] -> :prove_effect
+        true -> :clear
+      end
+
+    %Result{
+      phase: phase,
+      outcome: outcome,
+      merge_precondition?: phase == :merge,
+      reasons: reasons,
+      effect_matches: effect_matches
+    }
+  end
+
+  @doc """
+  Judges an effect proof: the fixture set regenerated against the change, compared with the
+  baseline.
+
+  - `intent` — `{:changes, [fixture_id, ...]}` (non-empty) or `:no_output_change`
+  - `fixture_results` — `%{fixture_id => :changed | :unchanged}`, non-empty
+  - `coverage` — `%{required: [code, ...], covered: [code, ...]}`: the service codes,
+    modifiers and programs present in the repository, and those the fixtures exercise
+
+  It passes only when the set of changed fixtures EQUALS the intended set — both halves. An
+  intended fixture that did not change (or did not run) fails, because "nothing changed" is
+  not a pass for a change meant to alter output; an unintended fixture that changed fails.
+  Every required code must be covered, because a golden-file oracle only sees changes to
+  what the fixtures exercise and a path no fixture reaches regresses silently.
+
+  A failure routes to Gate A.
+  """
+  @spec judge_proof(term(), term(), term()) :: ProofResult.t()
+  def judge_proof(intent, fixture_results, coverage) do
+    case intent_failures(intent, fixture_results) ++ coverage_failures(coverage) do
+      [] -> %ProofResult{verdict: :pass, failures: [], route: nil}
+      failures -> %ProofResult{verdict: :fail, failures: failures, route: :gate_a}
+    end
+  end
+
+  # -- evaluate ---------------------------------------------------------------------------
+
+  defp computed_triggers(phase, input, triggers) do
+    with :ok <- phase(phase),
+         :ok <- input_map(input),
+         {:ok, repo_triggers} <- repo_triggers(triggers, Map.get(input, :repo)) do
+      files = Map.get(input, :files)
+
+      reasons =
+        stale_trigger_reasons(repo_triggers, Map.get(input, :repo_files)) ++
+          file_reasons(files) ++
+          human_path_reasons(repo_triggers, files) ++
+          limit_reasons(phase, repo_triggers, files, Map.get(input, :diffstat))
+
+      {reasons, matches(repo_triggers.effect_paths, files)}
+    else
+      {:escalate, reason} -> {[reason], []}
+    end
+  end
+
+  defp phase(phase) when phase in @phases, do: :ok
+  defp phase(phase), do: {:escalate, {:invalid_phase, phase}}
+
+  defp input_map(input) when is_map(input), do: :ok
+  defp input_map(_input), do: {:escalate, :invalid_input}
+
+  defp repo_triggers({:ok, %Triggers{} = triggers}, repo) do
+    case Triggers.fetch_repo(triggers, repo) do
+      {:ok, %RepoTriggers{} = repo_triggers} -> usable(repo_triggers)
+      :error -> {:escalate, {:unknown_repo, repo}}
+    end
+  end
+
+  defp repo_triggers({:error, reason}, _repo), do: {:escalate, {:config_error, reason}}
+  defp repo_triggers(nil, _repo), do: {:escalate, {:config_error, :not_loaded}}
+  defp repo_triggers(_other, _repo), do: {:escalate, {:config_error, :unrecognised}}
+
+  # `parse/2` never builds an empty trigger set, but a struct can be built by hand. Checked
+  # again here so that no path, however the value was made, turns into "no triggers".
+  defp usable(%RepoTriggers{effect_paths: [_ | _], human_paths: [_ | _]} = repo_triggers)
+       when is_integer(repo_triggers.max_files) and repo_triggers.max_files > 0 and
+              is_integer(repo_triggers.max_changed_lines) and repo_triggers.max_changed_lines > 0,
+       do: {:ok, repo_triggers}
+
+  defp usable(_repo_triggers), do: {:escalate, {:config_error, :empty_trigger_set}}
+
+  defp stale_trigger_reasons(repo_triggers, [_ | _] = repo_files) do
+    if Enum.all?(repo_files, &is_binary/1) do
+      for glob <- repo_triggers.effect_paths ++ repo_triggers.human_paths,
+          not Enum.any?(repo_files, &Glob.match?(glob, &1)),
+          do: {:stale_trigger, glob.source}
+    else
+      [:invalid_repo_files]
+    end
+  end
+
+  defp stale_trigger_reasons(_repo_triggers, _repo_files), do: [:missing_repo_files]
+
+  defp file_reasons([_ | _] = files) do
+    for file <- files, not valid_path?(file), do: {:invalid_path, file}
+  end
+
+  defp file_reasons([]), do: [:no_files]
+  defp file_reasons(_files), do: [:missing_files]
+
+  defp human_path_reasons(repo_triggers, files) do
+    for {file, pattern} <- matches(repo_triggers.human_paths, files),
+        do: {:human_path, file, pattern}
+  end
+
+  defp limit_reasons(:merge, repo_triggers, files, %{files: file_count, changed_lines: lines})
+       when is_integer(file_count) and file_count >= 0 and is_integer(lines) and lines >= 0 do
+    listed = if is_list(files), do: files |> Enum.uniq() |> length(), else: 0
+    count = max(file_count, listed)
+
+    files_reason =
+      if count > repo_triggers.max_files,
+        do: [{:max_files_exceeded, count, repo_triggers.max_files}],
+        else: []
+
+    lines_reason =
+      if lines > repo_triggers.max_changed_lines,
+        do: [{:max_changed_lines_exceeded, lines, repo_triggers.max_changed_lines}],
+        else: []
+
+    files_reason ++ lines_reason
+  end
+
+  defp limit_reasons(:merge, _repo_triggers, _files, nil), do: [:missing_diffstat]
+
+  defp limit_reasons(:merge, _repo_triggers, _files, diffstat),
+    do: [{:invalid_diffstat, diffstat}]
+
+  defp limit_reasons(:triage, _repo_triggers, _files, _diffstat), do: []
+
+  defp matches(globs, files) when is_list(files) do
+    for file <- files, glob <- globs, Glob.match?(glob, file), do: {file, glob.source}
+  end
+
+  defp matches(_globs, _files), do: []
+
+  # A path git would print: relative, no empty, `.` or `..` segment. Anything else cannot be
+  # trusted to match the way the configuration author read it.
+  defp valid_path?(path) when is_binary(path) and path != "" do
+    String.valid?(path) and not String.contains?(path, <<0>>) and
+      path |> String.split("/") |> Enum.all?(&(&1 not in ["", ".", ".."]))
+  end
+
+  defp valid_path?(_path), do: false
+
+  # The OR. Every element is an escalation; there is no element that removes one.
+  defp agent_escalations(%{agent_escalations: escalations}) when is_list(escalations) do
+    Enum.map(escalations, &{:agent_escalation, &1})
+  end
+
+  defp agent_escalations(%{agent_escalations: nil}), do: []
+
+  defp agent_escalations(%{agent_escalations: escalations}),
+    do: [{:invalid_agent_escalations, escalations}]
+
+  defp agent_escalations(_input), do: []
+
+  # -- judge_proof ------------------------------------------------------------------------
+
+  defp intent_failures(intent, fixture_results) do
+    with {:ok, intended} <- intended_fixtures(intent),
+         {:ok, results} <- fixture_results(fixture_results) do
+      not_run = Enum.reject(intended, &Map.has_key?(results, &1))
+      unchanged = Enum.filter(intended, &(Map.get(results, &1) == :unchanged))
+
+      unintended =
+        for {id, :changed} <- results, id not in intended, do: id
+
+      failure(:intended_fixture_not_run, not_run) ++
+        failure(:intended_fixture_unchanged, unchanged) ++
+        failure(:unintended_fixture_changed, unintended)
+    else
+      {:error, failure} -> [failure]
+    end
+  end
+
+  defp intended_fixtures({:changes, [_ | _] = ids} = intent) do
+    if Enum.all?(ids, &is_binary/1),
+      do: {:ok, Enum.uniq(ids)},
+      else: {:error, {:invalid_intent, intent}}
+  end
+
+  defp intended_fixtures(:no_output_change), do: {:ok, []}
+  defp intended_fixtures(intent), do: {:error, {:invalid_intent, intent}}
+
+  defp fixture_results(results) when is_map(results) and map_size(results) > 0 do
+    if Enum.all?(results, fn {id, state} -> is_binary(id) and state in [:changed, :unchanged] end),
+       do: {:ok, results},
+       else: {:error, {:invalid_fixture_results, results}}
+  end
+
+  defp fixture_results(results), do: {:error, {:invalid_fixture_results, results}}
+
+  defp coverage_failures(%{required: [_ | _] = required, covered: covered})
+       when is_list(covered) do
+    failure(:uncovered_codes, Enum.uniq(required) -- covered)
+  end
+
+  defp coverage_failures(coverage), do: [{:invalid_coverage, coverage}]
+
+  defp failure(_kind, []), do: []
+  defp failure(kind, items), do: [{kind, Enum.sort(items)}]
+end

--- a/lib/loopctl/delivery_gates/gate_b.ex
+++ b/lib/loopctl/delivery_gates/gate_b.ex
@@ -88,21 +88,27 @@ defmodule Loopctl.DeliveryGates.GateB do
   baseline.
 
   - `intent` — `{:changes, [fixture_id, ...]}` (non-empty) or `:no_output_change`
-  - `fixture_results` — `%{fixture_id => :changed | :unchanged}`, non-empty
+  - `fixture_set` — the ids of the FIXED fixture set, non-empty: every fixture the baseline
+    holds. Without it "empty everywhere else" could only be checked over the fixtures that
+    happened to report, and a fixture that silently did not run would hide its own change.
+  - `fixture_results` — `%{fixture_id => :changed | :unchanged}`, one entry per fixture in
+    the set and none outside it
   - `coverage` — `%{required: [code, ...], covered: [code, ...]}`: the service codes,
     modifiers and programs present in the repository, and those the fixtures exercise
 
   It passes only when the set of changed fixtures EQUALS the intended set — both halves. An
-  intended fixture that did not change (or did not run) fails, because "nothing changed" is
-  not a pass for a change meant to alter output; an unintended fixture that changed fails.
+  intended fixture that did not change fails, because "nothing changed" is not a pass for a
+  change meant to alter output; an unintended fixture that changed fails. A fixture in the
+  set with no result, a result for a fixture outside the set, and an intended fixture that is
+  not in the set all fail.
   Every required code must be covered, because a golden-file oracle only sees changes to
   what the fixtures exercise and a path no fixture reaches regresses silently.
 
   A failure routes to Gate A.
   """
-  @spec judge_proof(term(), term(), term()) :: ProofResult.t()
-  def judge_proof(intent, fixture_results, coverage) do
-    case intent_failures(intent, fixture_results) ++ coverage_failures(coverage) do
+  @spec judge_proof(term(), term(), term(), term()) :: ProofResult.t()
+  def judge_proof(intent, fixture_set, fixture_results, coverage) do
+    case intent_failures(intent, fixture_set, fixture_results) ++ coverage_failures(coverage) do
       [] -> %ProofResult{verdict: :pass, failures: [], route: nil}
       failures -> %ProofResult{verdict: :fail, failures: failures, route: :gate_a}
     end
@@ -209,10 +215,15 @@ defmodule Loopctl.DeliveryGates.GateB do
 
   defp matches(_globs, _files), do: []
 
-  # A path git would print: relative, no empty, `.` or `..` segment. Anything else cannot be
-  # trusted to match the way the configuration author read it.
+  # A path as git prints it UNQUOTED: relative, no empty, `.` or `..` segment. Anything else
+  # cannot be trusted to match the way the configuration author read it. That includes git's
+  # own quoted form: under the default `core.quotePath`, a name with non-ASCII or special
+  # bytes comes back as `"priv/rates/tarifa_a\303\261o.csv"`, and the leading quote means no
+  # anchored pattern ever matches it — a change to that file would read as touching nothing.
+  # Callers should pass `-z` or `-c core.quotePath=false`; a quoted path escalates.
   defp valid_path?(path) when is_binary(path) and path != "" do
-    String.valid?(path) and not String.contains?(path, <<0>>) and
+    String.valid?(path) and not String.contains?(path, [<<0>>, "\""]) and
+      not String.contains?(path, "\\") and
       path |> String.split("/") |> Enum.all?(&(&1 not in ["", ".", ".."]))
   end
 
@@ -232,22 +243,35 @@ defmodule Loopctl.DeliveryGates.GateB do
 
   # -- judge_proof ------------------------------------------------------------------------
 
-  defp intent_failures(intent, fixture_results) do
+  defp intent_failures(intent, fixture_set, fixture_results) do
     with {:ok, intended} <- intended_fixtures(intent),
+         {:ok, set} <- fixture_set(fixture_set),
          {:ok, results} <- fixture_results(fixture_results) do
-      not_run = Enum.reject(intended, &Map.has_key?(results, &1))
+      outside_set = Enum.reject(intended, &(&1 in set))
+      not_run = Enum.reject(set, &Map.has_key?(results, &1))
+      unexpected = results |> Map.keys() |> Enum.reject(&(&1 in set))
       unchanged = Enum.filter(intended, &(Map.get(results, &1) == :unchanged))
 
       unintended =
         for {id, :changed} <- results, id not in intended, do: id
 
-      failure(:intended_fixture_not_run, not_run) ++
+      failure(:intended_fixture_not_in_set, outside_set) ++
+        failure(:fixture_not_run, not_run) ++
+        failure(:unexpected_fixture, unexpected) ++
         failure(:intended_fixture_unchanged, unchanged) ++
         failure(:unintended_fixture_changed, unintended)
     else
       {:error, failure} -> [failure]
     end
   end
+
+  defp fixture_set([_ | _] = ids) do
+    if Enum.all?(ids, &is_binary/1),
+      do: {:ok, Enum.uniq(ids)},
+      else: {:error, {:invalid_fixture_set, ids}}
+  end
+
+  defp fixture_set(ids), do: {:error, {:invalid_fixture_set, ids}}
 
   defp intended_fixtures({:changes, [_ | _] = ids} = intent) do
     if Enum.all?(ids, &is_binary/1),

--- a/lib/loopctl/delivery_gates/gate_b/proof_result.ex
+++ b/lib/loopctl/delivery_gates/gate_b/proof_result.ex
@@ -1,0 +1,19 @@
+defmodule Loopctl.DeliveryGates.GateB.ProofResult do
+  @moduledoc """
+  The judgement of a change's effect proof (`Loopctl.DeliveryGates.GateB.judge_proof/3`).
+
+  - `verdict` — `:pass` or `:fail`
+  - `failures` — every reason it failed, all of them rather than the first
+  - `route` — `:gate_a` on a failure, `nil` on a pass. A failed proof is never retried into a
+    pass by the loop; it goes to the human decision
+  """
+
+  @enforce_keys [:verdict, :failures, :route]
+  defstruct [:verdict, :failures, :route]
+
+  @type t :: %__MODULE__{
+          verdict: :pass | :fail,
+          failures: [tuple()],
+          route: :gate_a | nil
+        }
+end

--- a/lib/loopctl/delivery_gates/gate_b/proof_result.ex
+++ b/lib/loopctl/delivery_gates/gate_b/proof_result.ex
@@ -1,6 +1,6 @@
 defmodule Loopctl.DeliveryGates.GateB.ProofResult do
   @moduledoc """
-  The judgement of a change's effect proof (`Loopctl.DeliveryGates.GateB.judge_proof/3`).
+  The judgement of a change's effect proof (`Loopctl.DeliveryGates.GateB.judge_proof/4`).
 
   - `verdict` — `:pass` or `:fail`
   - `failures` — every reason it failed, all of them rather than the first

--- a/lib/loopctl/delivery_gates/gate_b/result.ex
+++ b/lib/loopctl/delivery_gates/gate_b/result.ex
@@ -1,0 +1,25 @@
+defmodule Loopctl.DeliveryGates.GateB.Result do
+  @moduledoc """
+  One Gate B evaluation.
+
+  - `phase` — `:triage` (over the story's predicted touches) or `:merge` (over the real diff)
+  - `outcome` — `:human`, `:prove_effect` or `:clear`, in that precedence
+  - `merge_precondition?` — `true` only for the `:merge` run. The `:triage` result decides
+    whether to dispatch at all and is NEVER a merge precondition: it certifies a
+    prediction, and nothing binds the implementing session to that prediction
+  - `reasons` — every reason the outcome is `:human`; empty otherwise
+  - `effect_matches` — `{file, pattern}` for every effect path touched, recorded whatever the
+    outcome, so a `:human` result still says what the proof would have had to cover
+  """
+
+  @enforce_keys [:phase, :outcome, :merge_precondition?, :reasons, :effect_matches]
+  defstruct [:phase, :outcome, :merge_precondition?, :reasons, :effect_matches]
+
+  @type t :: %__MODULE__{
+          phase: term(),
+          outcome: :clear | :prove_effect | :human,
+          merge_precondition?: boolean(),
+          reasons: [tuple() | atom()],
+          effect_matches: [{String.t(), String.t()}]
+        }
+end

--- a/lib/loopctl/delivery_gates/glob.ex
+++ b/lib/loopctl/delivery_gates/glob.ex
@@ -1,0 +1,70 @@
+defmodule Loopctl.DeliveryGates.Glob do
+  @moduledoc """
+  The path matcher behind Gate B's triggers, compiled once and matched many times.
+
+  Semantics, and nothing else:
+
+  - `**` matches any run of characters INCLUDING `/`
+  - `*` matches any run of characters EXCEPT `/`
+  - `?` matches exactly one character that is not `/`
+  - every other character is literal (so `.`, `[`, `{` carry no meaning)
+
+  Matching is anchored at both ends and case-sensitive, because `git ls-files` output is.
+
+  Two refinements, both of which only ever make a pattern match MORE paths, never fewer:
+
+  - `/**/` also matches a single `/`, so `lib/**/data_migrations/**` catches
+    `lib/data_migrations/x.ex` as well as `lib/app/data_migrations/x.ex`
+  - a leading `**/` also matches nothing, so `**/runtime.exs` catches a root-level
+    `runtime.exs`
+
+  Read literally, `**` = "any characters" would require the slashes on both sides of it to
+  be present. A trigger is a guard, and a pattern that silently misses the shallowest
+  instance of what it names is a leak; widening is the fail-closed direction.
+  """
+
+  @enforce_keys [:source, :regex]
+  defstruct [:source, :regex]
+
+  @type t :: %__MODULE__{source: String.t(), regex: Regex.t()}
+
+  # Order matters: the longer, more specific tokens must be tried before `**` and `*`.
+  @token ~r{/\*\*/|\A\*\*/|\*\*|\*|\?}
+
+  @doc """
+  Compiles a pattern. A non-binary, empty, or non-UTF-8 pattern is `{:error, :invalid_pattern}`.
+  """
+  @spec compile(term()) :: {:ok, t()} | {:error, :invalid_pattern}
+  def compile(pattern) when is_binary(pattern) and pattern != "" do
+    if String.valid?(pattern) do
+      body =
+        @token
+        |> Regex.split(pattern, include_captures: true, trim: true)
+        |> Enum.map_join(&fragment/1)
+
+      # `s` so `**` crosses a newline in a path too; `u` so `?` is one codepoint, not one byte.
+      {:ok, %__MODULE__{source: pattern, regex: Regex.compile!("\\A" <> body <> "\\z", "su")}}
+    else
+      {:error, :invalid_pattern}
+    end
+  end
+
+  def compile(_pattern), do: {:error, :invalid_pattern}
+
+  @doc """
+  Whether `path` matches the compiled pattern. A non-binary path never matches.
+  """
+  @spec match?(t(), term()) :: boolean()
+  def match?(%__MODULE__{regex: regex}, path) when is_binary(path) do
+    String.valid?(path) and Regex.match?(regex, path)
+  end
+
+  def match?(%__MODULE__{}, _path), do: false
+
+  defp fragment("/**/"), do: "(?:/|/.*/)"
+  defp fragment("**/"), do: "(?:.*/)?"
+  defp fragment("**"), do: ".*"
+  defp fragment("*"), do: "[^/]*"
+  defp fragment("?"), do: "[^/]"
+  defp fragment(literal), do: Regex.escape(literal)
+end

--- a/lib/loopctl/delivery_gates/repo_triggers.ex
+++ b/lib/loopctl/delivery_gates/repo_triggers.ex
@@ -1,0 +1,24 @@
+defmodule Loopctl.DeliveryGates.RepoTriggers do
+  @moduledoc """
+  One target repository's Gate B triggers, as produced by `Loopctl.DeliveryGates.Triggers.parse/2`.
+
+  - `effect_paths` — changes that can cause an irreversible external effect. Touching one
+    makes the change PROVE its effect before it merges.
+  - `human_paths` — changes with no output signature to prove (access-control pipelines,
+    auth plugs, data migrations). Touching one means a human confirms.
+  - `max_files` / `max_changed_lines` — the size bound, applied only at the merge run,
+    because only a real diff has a size.
+  """
+
+  alias Loopctl.DeliveryGates.Glob
+
+  @enforce_keys [:effect_paths, :human_paths, :max_files, :max_changed_lines]
+  defstruct [:effect_paths, :human_paths, :max_files, :max_changed_lines]
+
+  @type t :: %__MODULE__{
+          effect_paths: [Glob.t()],
+          human_paths: [Glob.t()],
+          max_files: pos_integer(),
+          max_changed_lines: pos_integer()
+        }
+end

--- a/lib/loopctl/delivery_gates/triggers.ex
+++ b/lib/loopctl/delivery_gates/triggers.ex
@@ -1,0 +1,197 @@
+defmodule Loopctl.DeliveryGates.Triggers do
+  @moduledoc """
+  Parses and verifies the Gate B trigger configuration.
+
+  The trigger DATA is configuration, never source: loopctl is public, and the list is a map
+  of which paths skip human review. This module receives the document as a binary together
+  with the SHA-256 the operator pinned for it, and either returns a fully validated trigger
+  set or an error. It never returns a partial or empty one.
+
+  ## Document shape
+
+      {
+        "version": 1,
+        "repos": {
+          "owner/repo": {
+            "effect_paths": ["priv/rates/**", "lib/app/payments/**"],
+            "human_paths": ["lib/app_web/router.ex", "lib/**/data_migrations/**"],
+            "limits": {"max_files": 12, "max_changed_lines": 1000}
+          }
+        }
+      }
+
+  Every key is required, no other key is accepted, both pattern lists must be non-empty,
+  and both limits must be positive integers. An unknown key is an error rather than
+  something to ignore, because a misspelled `"efect_paths"` beside a correct one would
+  otherwise be a trigger list nobody reads.
+
+  The checksum is verified against the raw bytes BEFORE the document is decoded, so a
+  document that does not match what the operator pinned is never interpreted at all.
+  """
+
+  alias Loopctl.DeliveryGates.Glob
+  alias Loopctl.DeliveryGates.RepoTriggers
+
+  @supported_versions [1]
+  @top_keys ~w(version repos)
+  @repo_keys ~w(effect_paths human_paths limits)
+  @limit_keys ~w(max_files max_changed_lines)
+  @repo_name ~r{\A[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\z}
+  @sha256_hex ~r/\A[0-9a-f]{64}\z/
+
+  @enforce_keys [:version, :sha256, :repos]
+  defstruct [:version, :sha256, :repos]
+
+  @type t :: %__MODULE__{
+          version: pos_integer(),
+          sha256: String.t(),
+          repos: %{String.t() => RepoTriggers.t()}
+        }
+
+  @type key_path :: [String.t()]
+
+  @type error ::
+          :missing_config
+          | :invalid_checksum_format
+          | :checksum_mismatch
+          | :invalid_json
+          | {:unsupported_version, term()}
+          | {:not_an_object, key_path()}
+          | {:missing_key, key_path()}
+          | {:unknown_key, key_path()}
+          | {:empty_repos, key_path()}
+          | {:invalid_repo_name, String.t()}
+          | {:empty_patterns, key_path()}
+          | {:invalid_patterns, key_path()}
+          | {:invalid_pattern, key_path(), term()}
+          | {:invalid_limit, key_path()}
+
+  @doc """
+  Verifies `binary` against `expected_sha256_hex` and parses it.
+
+  `nil` or an empty binary is `{:error, :missing_config}`. The expected checksum is
+  64 hex characters, case-insensitive.
+  """
+  @spec parse(term(), term()) :: {:ok, t()} | {:error, error()}
+  def parse(binary, expected_sha256_hex) do
+    with :ok <- present(binary),
+         {:ok, expected} <- normalize_checksum(expected_sha256_hex),
+         :ok <- verify_checksum(binary, expected),
+         {:ok, doc} <- decode(binary),
+         :ok <- exact_keys(doc, @top_keys, []),
+         {:ok, version} <- version(doc["version"]),
+         {:ok, repos} <- repos(doc["repos"]) do
+      {:ok, %__MODULE__{version: version, sha256: expected, repos: repos}}
+    end
+  end
+
+  @doc """
+  The triggers for one repository, or `:error` when the configuration does not name it.
+  """
+  @spec fetch_repo(t(), term()) :: {:ok, RepoTriggers.t()} | :error
+  def fetch_repo(%__MODULE__{repos: repos}, repo) when is_binary(repo), do: Map.fetch(repos, repo)
+  def fetch_repo(%__MODULE__{}, _repo), do: :error
+
+  defp present(binary) when is_binary(binary) and binary != "", do: :ok
+  defp present(_binary), do: {:error, :missing_config}
+
+  defp normalize_checksum(hex) when is_binary(hex) do
+    hex = String.downcase(hex)
+    if Regex.match?(@sha256_hex, hex), do: {:ok, hex}, else: {:error, :invalid_checksum_format}
+  end
+
+  defp normalize_checksum(_hex), do: {:error, :invalid_checksum_format}
+
+  defp verify_checksum(binary, expected) do
+    actual = :sha256 |> :crypto.hash(binary) |> Base.encode16(case: :lower)
+    if actual == expected, do: :ok, else: {:error, :checksum_mismatch}
+  end
+
+  defp decode(binary) do
+    case Jason.decode(binary) do
+      {:ok, doc} -> {:ok, doc}
+      {:error, _reason} -> {:error, :invalid_json}
+    end
+  end
+
+  defp exact_keys(map, keys, path) when is_map(map) do
+    present = Map.keys(map)
+
+    cond do
+      missing = Enum.find(keys, &(&1 not in present)) ->
+        {:error, {:missing_key, path ++ [missing]}}
+
+      unknown = Enum.find(present, &(&1 not in keys)) ->
+        {:error, {:unknown_key, path ++ [unknown]}}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp exact_keys(_value, _keys, path), do: {:error, {:not_an_object, path}}
+
+  defp version(v) when is_integer(v) and v in @supported_versions, do: {:ok, v}
+  defp version(v), do: {:error, {:unsupported_version, v}}
+
+  defp repos(repos) when is_map(repos) and map_size(repos) == 0,
+    do: {:error, {:empty_repos, ["repos"]}}
+
+  defp repos(repos) when is_map(repos) do
+    repos
+    |> Enum.sort()
+    |> Enum.reduce_while({:ok, %{}}, fn {name, entry}, {:ok, acc} ->
+      case repo(name, entry) do
+        {:ok, triggers} -> {:cont, {:ok, Map.put(acc, name, triggers)}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp repos(_repos), do: {:error, {:not_an_object, ["repos"]}}
+
+  defp repo(name, entry) do
+    path = ["repos", name]
+
+    with :ok <- repo_name(name),
+         :ok <- exact_keys(entry, @repo_keys, path),
+         {:ok, effect} <- patterns(entry["effect_paths"], path ++ ["effect_paths"]),
+         {:ok, human} <- patterns(entry["human_paths"], path ++ ["human_paths"]),
+         :ok <- exact_keys(entry["limits"], @limit_keys, path ++ ["limits"]),
+         {:ok, max_files} <- limit(entry["limits"]["max_files"], path ++ ["limits", "max_files"]),
+         {:ok, max_lines} <-
+           limit(entry["limits"]["max_changed_lines"], path ++ ["limits", "max_changed_lines"]) do
+      {:ok,
+       %RepoTriggers{
+         effect_paths: effect,
+         human_paths: human,
+         max_files: max_files,
+         max_changed_lines: max_lines
+       }}
+    end
+  end
+
+  defp repo_name(name) do
+    if Regex.match?(@repo_name, name), do: :ok, else: {:error, {:invalid_repo_name, name}}
+  end
+
+  defp patterns([], path), do: {:error, {:empty_patterns, path}}
+
+  defp patterns(list, path) when is_list(list) do
+    Enum.reduce_while(list, {:ok, []}, fn pattern, {:ok, acc} ->
+      case Glob.compile(pattern) do
+        {:ok, glob} -> {:cont, {:ok, [glob | acc]}}
+        {:error, :invalid_pattern} -> {:halt, {:error, {:invalid_pattern, path, pattern}}}
+      end
+    end)
+    |> case do
+      {:ok, globs} -> {:ok, Enum.reverse(globs)}
+      error -> error
+    end
+  end
+
+  defp patterns(_value, path), do: {:error, {:invalid_patterns, path}}
+
+  defp limit(value, _path) when is_integer(value) and value > 0, do: {:ok, value}
+  defp limit(_value, path), do: {:error, {:invalid_limit, path}}
+end

--- a/test/loopctl/delivery_gates/gate_a_test.exs
+++ b/test/loopctl/delivery_gates/gate_a_test.exs
@@ -1,0 +1,221 @@
+defmodule Loopctl.DeliveryGates.GateATest do
+  use ExUnit.Case, async: true
+
+  import Loopctl.Fixtures
+
+  alias Loopctl.DeliveryGates
+  alias Loopctl.DeliveryGates.GateA
+  alias Loopctl.DeliveryGates.GateA.Result
+
+  defp trio(overrides \\ [%{}, %{}, %{}]) do
+    Enum.map(overrides, &build(:trio_output, &1))
+  end
+
+  defp kinds(%Result{reasons: reasons}), do: Enum.map(reasons, &elem(&1, 0))
+
+  describe "proceeds" do
+    test "on three uncontested story verdicts" do
+      assert %Result{decision: :proceed, verdict: :story, reasons: []} = GateA.evaluate(trio())
+    end
+
+    test "on three unanimous reject verdicts" do
+      outputs = trio(List.duplicate(%{"verdict" => "reject"}, 3))
+      assert %Result{decision: :proceed, verdict: :reject, reasons: []} = GateA.evaluate(outputs)
+    end
+
+    test "through the facade" do
+      assert %Result{decision: :proceed} = DeliveryGates.gate_a(trio())
+    end
+
+    test "on a soft escalation reason code, which is recorded and does not gate" do
+      outputs = trio([%{"escalation_reasons" => ["touches_claims_path"]}, %{}, %{}])
+
+      assert %Result{decision: :proceed, soft_signals: [{0, "touches_claims_path"}]} =
+               GateA.evaluate(outputs)
+    end
+  end
+
+  describe "confidence is recorded and never gates" do
+    test "zero confidence on every agent still proceeds" do
+      outputs = trio(List.duplicate(%{"confidence" => 0.0}, 3))
+
+      assert %Result{decision: :proceed, confidences: [+0.0, +0.0, +0.0]} =
+               GateA.evaluate(outputs)
+    end
+
+    test "full confidence does not clear an escalation" do
+      outputs =
+        trio([%{"confidence" => 1}, %{"confidence" => 1, "verdict" => "escalate"}, %{}])
+
+      assert %Result{decision: :escalate, confidences: [1, 1, 0.8]} = GateA.evaluate(outputs)
+    end
+  end
+
+  describe "escalates on the trio's shape (fail closed)" do
+    test "fewer or more than three outputs" do
+      assert %Result{decision: :escalate, reasons: [{:trio_size, 2}]} =
+               GateA.evaluate(trio([%{}, %{}]))
+
+      assert %Result{decision: :escalate, reasons: [{:trio_size, 4}]} =
+               GateA.evaluate(trio([%{}, %{}, %{}, %{}]))
+
+      assert %Result{decision: :escalate, reasons: [{:trio_size, 0}]} = GateA.evaluate([])
+    end
+
+    test "not a list" do
+      assert %Result{decision: :escalate, reasons: [{:trio_size, :not_a_list}]} =
+               GateA.evaluate(nil)
+
+      assert %Result{decision: :escalate} = GateA.evaluate(%{"verdict" => "story"})
+    end
+
+    test "an output that is not a map" do
+      assert %Result{decision: :escalate, reasons: [{:malformed_output, 1, :not_a_map}]} =
+               GateA.evaluate([build(:trio_output), "story", build(:trio_output)])
+    end
+
+    test "a missing required key" do
+      for key <- ~w(verdict escalation_reasons contradicts confidence) do
+        outputs = [Map.delete(build(:trio_output), key), build(:trio_output), build(:trio_output)]
+
+        assert %Result{decision: :escalate, reasons: [{:malformed_output, 0, {:missing, ^key}}]} =
+                 GateA.evaluate(outputs)
+      end
+    end
+
+    test "an invalid value for each required key" do
+      cases = [
+        {"verdict", "approve"},
+        {"verdict", nil},
+        {"escalation_reasons", "workflow_change_not_defect_fix"},
+        {"escalation_reasons", [:atom]},
+        {"contradicts", nil},
+        {"contradicts", [%{"kind" => "rumour", "ref" => "x", "why" => "y"}]},
+        {"contradicts", [%{"kind" => "story", "ref" => "x"}]},
+        {"confidence", 1.5},
+        {"confidence", -0.1},
+        {"confidence", "0.9"}
+      ]
+
+      for {key, value} <- cases do
+        outputs = trio([%{}, %{}, %{key => value}])
+
+        assert %Result{
+                 decision: :escalate,
+                 reasons: [{:malformed_output, 2, {:invalid, ^key}}],
+                 confidences: [0.8, 0.8, nil]
+               } = GateA.evaluate(outputs),
+               "expected #{key} = #{inspect(value)} to be malformed"
+      end
+    end
+  end
+
+  describe "escalates on the request" do
+    test "when the verdicts disagree" do
+      outputs = trio([%{}, %{"verdict" => "reject"}, %{}])
+
+      assert %Result{
+               decision: :escalate,
+               verdict: nil,
+               reasons: [{:verdict_disagreement, [:story, :reject, :story]}]
+             } = GateA.evaluate(outputs)
+    end
+
+    test "when any one agent's verdict is escalate" do
+      for index <- 0..2 do
+        overrides = List.replace_at([%{}, %{}, %{}], index, %{"verdict" => "escalate"})
+        result = GateA.evaluate(trio(overrides))
+
+        assert result.decision == :escalate
+        assert {:agent_escalated, index} in result.reasons
+      end
+    end
+
+    test "when all three agree to escalate" do
+      outputs = trio(List.duplicate(%{"verdict" => "escalate"}, 3))
+      result = GateA.evaluate(outputs)
+
+      assert result.decision == :escalate
+      assert result.verdict == nil
+      assert kinds(result) == [:agent_escalated, :agent_escalated, :agent_escalated]
+    end
+
+    test "when any agent reports a contradiction, even with a story verdict" do
+      contradiction = %{"kind" => "kb", "ref" => "decision-123", "why" => "reverses it"}
+      outputs = trio([%{}, %{}, %{"contradicts" => [contradiction]}])
+
+      assert %Result{decision: :escalate, reasons: [{:contradiction, 2, [^contradiction]}]} =
+               GateA.evaluate(outputs)
+    end
+
+    test "on each contradiction kind" do
+      for kind <- ~w(story kb code) do
+        outputs =
+          trio([%{"contradicts" => [%{"kind" => kind, "ref" => "r", "why" => "w"}]}, %{}, %{}])
+
+        assert %Result{decision: :escalate} = GateA.evaluate(outputs)
+      end
+    end
+
+    test "when a reason says the request inverts or removes deliberately-added behaviour" do
+      outputs =
+        trio([%{}, %{"escalation_reasons" => ["inverts_or_removes_deliberate_behaviour"]}, %{}])
+
+      assert %Result{decision: :escalate, reasons: [{:inverts_deliberate_behaviour, 1}]} =
+               GateA.evaluate(outputs)
+    end
+
+    test "when a reason says the request is a workflow change rather than a defect fix" do
+      outputs = trio([%{"escalation_reasons" => ["workflow_change_not_defect_fix"]}, %{}, %{}])
+
+      assert %Result{decision: :escalate, reasons: [{:workflow_change, 0}]} =
+               GateA.evaluate(outputs)
+    end
+
+    test "the gating codes are the documented contract strings" do
+      assert Enum.sort(GateA.gating_reason_codes()) ==
+               ["inverts_or_removes_deliberate_behaviour", "workflow_change_not_defect_fix"]
+    end
+
+    test "a malformed output and a valid disagreement are both reported" do
+      outputs = [build(:trio_output), :garbage, build(:trio_output, %{"verdict" => "reject"})]
+      result = GateA.evaluate(outputs)
+
+      assert result.decision == :escalate
+      assert kinds(result) == [:malformed_output, :verdict_disagreement]
+    end
+  end
+
+  test "reads no file path: identical requests with different predicted touches decide the same" do
+    a = trio([%{"story" => %{"touches" => ["lib/app/payments/submit.ex"]}}, %{}, %{}])
+    b = trio([%{"story" => %{"touches" => ["README.md"]}}, %{}, %{}])
+
+    assert GateA.evaluate(a) == GateA.evaluate(b)
+  end
+
+  describe "rate/1" do
+    test "reports escalated over total, and counts each reason kind once per result" do
+      contradiction = %{"kind" => "story", "ref" => "US-1", "why" => "w"}
+
+      results = [
+        GateA.evaluate(trio()),
+        GateA.evaluate(trio()),
+        GateA.evaluate(
+          trio([%{"contradicts" => [contradiction]}, %{"contradicts" => [contradiction]}, %{}])
+        ),
+        GateA.evaluate(trio([%{"verdict" => "reject"}, %{}, %{}]))
+      ]
+
+      assert DeliveryGates.gate_a_rate(results) == %{
+               total: 4,
+               escalated: 2,
+               rate: 0.5,
+               by_reason: %{contradiction: 1, verdict_disagreement: 1}
+             }
+    end
+
+    test "an empty set has no rate rather than a zero rate" do
+      assert GateA.rate([]) == %{total: 0, escalated: 0, rate: nil, by_reason: %{}}
+    end
+  end
+end

--- a/test/loopctl/delivery_gates/gate_b_test.exs
+++ b/test/loopctl/delivery_gates/gate_b_test.exs
@@ -1,0 +1,357 @@
+defmodule Loopctl.DeliveryGates.GateBTest do
+  use ExUnit.Case, async: true
+
+  import Loopctl.Fixtures
+
+  alias Loopctl.DeliveryGates
+  alias Loopctl.DeliveryGates.GateB
+  alias Loopctl.DeliveryGates.GateB.Result
+  alias Loopctl.DeliveryGates.Glob
+  alias Loopctl.DeliveryGates.RepoTriggers
+  alias Loopctl.DeliveryGates.Triggers
+
+  @repo "acme/claims-app"
+
+  defp sha256(binary), do: :sha256 |> :crypto.hash(binary) |> Base.encode16(case: :lower)
+
+  defp triggers(config \\ build(:delivery_gates_config)) do
+    binary = Jason.encode!(config)
+    Triggers.parse(binary, sha256(binary))
+  end
+
+  defp input(attrs \\ %{}), do: build(:gate_b_input, attrs)
+
+  defp evaluate(phase, attrs \\ %{}, triggers \\ triggers()) do
+    GateB.evaluate(phase, input(attrs), triggers)
+  end
+
+  describe ":clear" do
+    test "an unguarded change within limits, in both phases" do
+      for phase <- [:triage, :merge] do
+        assert %Result{phase: ^phase, outcome: :clear, reasons: [], effect_matches: []} =
+                 evaluate(phase)
+      end
+    end
+
+    test "through the facade" do
+      assert %Result{outcome: :clear} = DeliveryGates.gate_b(:merge, input(), triggers())
+    end
+  end
+
+  describe "only the merge run is a merge precondition" do
+    test "triage results never are, whatever their outcome" do
+      refute evaluate(:triage).merge_precondition?
+      refute evaluate(:triage, %{files: ["lib/app_web/router.ex"]}).merge_precondition?
+    end
+
+    test "merge results always are" do
+      assert evaluate(:merge).merge_precondition?
+      assert evaluate(:merge, %{files: ["lib/app_web/router.ex"]}).merge_precondition?
+    end
+  end
+
+  describe ":prove_effect" do
+    test "each effect path, in both phases" do
+      for {file, pattern} <- [
+            {"priv/rates/2026.csv", "priv/rates/**"},
+            {"lib/app/payments/submit.ex", "lib/app/payments/**"},
+            {"config/runtime.exs", "config/runtime.exs"}
+          ],
+          phase <- [:triage, :merge] do
+        assert %Result{outcome: :prove_effect, reasons: [], effect_matches: [{^file, ^pattern}]} =
+                 evaluate(phase, %{files: ["lib/app/accounts/user.ex", file]})
+      end
+    end
+
+    test "a one-line data edit with no code touched" do
+      result =
+        evaluate(:merge, %{
+          files: ["priv/rates/2026.csv"],
+          diffstat: %{files: 1, changed_lines: 2}
+        })
+
+      assert result.outcome == :prove_effect
+    end
+
+    test "a new file under an effect path that is not yet in the repository" do
+      assert %Result{outcome: :prove_effect} =
+               evaluate(:triage, %{files: ["lib/app/payments/refund.ex"]})
+    end
+  end
+
+  describe ":human" do
+    test "each human path, in both phases" do
+      for {file, pattern} <- [
+            {"lib/app_web/router.ex", "lib/app_web/router.ex"},
+            {"lib/app/data_migrations/backfill_rates.ex", "lib/**/data_migrations/**"},
+            {"lib/data_migrations/new_one.ex", "lib/**/data_migrations/**"}
+          ],
+          phase <- [:triage, :merge] do
+        assert %Result{outcome: :human, reasons: [{:human_path, ^file, ^pattern}]} =
+                 evaluate(phase, %{files: [file]})
+      end
+    end
+
+    test "beats :prove_effect, and still records the effect matches" do
+      result = evaluate(:merge, %{files: ["priv/rates/2026.csv", "lib/app_web/router.ex"]})
+
+      assert result.outcome == :human
+      assert result.reasons == [{:human_path, "lib/app_web/router.ex", "lib/app_web/router.ex"}]
+      assert result.effect_matches == [{"priv/rates/2026.csv", "priv/rates/**"}]
+    end
+
+    test "a path that is not one git would print" do
+      for bad <- [
+            "/lib/app.ex",
+            "./lib/app.ex",
+            "lib/../lib/app_web/router.ex",
+            "lib//x.ex",
+            "",
+            nil
+          ] do
+        result = evaluate(:triage, %{files: [bad]})
+        assert result.outcome == :human
+        assert {:invalid_path, bad} in result.reasons
+      end
+    end
+
+    test "no files, or files that are not a list" do
+      assert %Result{outcome: :human, reasons: [:no_files]} = evaluate(:triage, %{files: []})
+
+      assert %Result{outcome: :human, reasons: [:missing_files]} =
+               GateB.evaluate(:triage, Map.delete(input(), :files), triggers())
+
+      assert %Result{outcome: :human, reasons: [:missing_files]} =
+               evaluate(:merge, %{files: "lib/app.ex"})
+    end
+
+    test "an input that is not a map, or a phase that is not :triage or :merge" do
+      assert %Result{outcome: :human, reasons: [:invalid_input]} =
+               GateB.evaluate(:merge, [files: []], triggers())
+
+      assert %Result{
+               outcome: :human,
+               reasons: [{:invalid_phase, :deploy}],
+               merge_precondition?: false
+             } =
+               evaluate(:deploy)
+    end
+  end
+
+  describe "size limits apply at :merge only" do
+    test "exactly at the limits is within them" do
+      files = for n <- 1..12, do: "lib/app/accounts/f#{n}.ex"
+
+      assert %Result{outcome: :clear} =
+               evaluate(:merge, %{files: files, diffstat: %{files: 12, changed_lines: 1000}})
+    end
+
+    test "one file over max_files" do
+      files = for n <- 1..13, do: "lib/app/accounts/f#{n}.ex"
+
+      assert %Result{outcome: :human, reasons: [{:max_files_exceeded, 13, 12}]} =
+               evaluate(:merge, %{files: files, diffstat: %{files: 13, changed_lines: 10}})
+    end
+
+    test "a diffstat file count over the limit, even if the name list is short" do
+      assert %Result{outcome: :human, reasons: [{:max_files_exceeded, 40, 12}]} =
+               evaluate(:merge, %{diffstat: %{files: 40, changed_lines: 10}})
+    end
+
+    test "a name list over the limit, even if the diffstat undercounts" do
+      files = for n <- 1..13, do: "lib/app/accounts/f#{n}.ex"
+
+      assert %Result{outcome: :human, reasons: [{:max_files_exceeded, 13, 12}]} =
+               evaluate(:merge, %{files: files, diffstat: %{files: 1, changed_lines: 10}})
+    end
+
+    test "one line over max_changed_lines" do
+      assert %Result{outcome: :human, reasons: [{:max_changed_lines_exceeded, 1001, 1000}]} =
+               evaluate(:merge, %{diffstat: %{files: 1, changed_lines: 1001}})
+    end
+
+    test "the size limits beat :prove_effect" do
+      assert %Result{outcome: :human} =
+               evaluate(:merge, %{
+                 files: ["priv/rates/2026.csv"],
+                 diffstat: %{files: 1, changed_lines: 5000}
+               })
+    end
+
+    test "are not applied at :triage" do
+      files = for n <- 1..40, do: "lib/app/accounts/f#{n}.ex"
+
+      assert %Result{outcome: :clear} =
+               evaluate(:triage, %{files: files, diffstat: %{files: 40, changed_lines: 99_999}})
+    end
+
+    test "a missing diffstat at :merge escalates; at :triage it is not needed" do
+      assert %Result{outcome: :human, reasons: [:missing_diffstat]} =
+               GateB.evaluate(:merge, Map.delete(input(), :diffstat), triggers())
+
+      assert %Result{outcome: :clear} =
+               GateB.evaluate(:triage, Map.delete(input(), :diffstat), triggers())
+    end
+
+    test "a malformed diffstat at :merge escalates" do
+      for bad <- [
+            %{files: 1},
+            %{files: -1, changed_lines: 1},
+            %{files: 1, changed_lines: "10"},
+            7
+          ] do
+        assert %Result{outcome: :human, reasons: [{:invalid_diffstat, ^bad}]} =
+                 evaluate(:merge, %{diffstat: bad})
+      end
+    end
+  end
+
+  describe "fails closed on configuration" do
+    test "no configuration loaded" do
+      assert %Result{outcome: :human, reasons: [{:config_error, :not_loaded}]} =
+               evaluate(:merge, %{}, nil)
+    end
+
+    test "every parse error, passed through untouched" do
+      binary = Jason.encode!(build(:delivery_gates_config))
+
+      for parsed <- [
+            Triggers.parse(nil, sha256(binary)),
+            Triggers.parse(binary, String.duplicate("0", 64)),
+            Triggers.parse("{", sha256("{")),
+            triggers(build(:delivery_gates_config, %{"version" => 99}))
+          ] do
+        assert {:error, reason} = parsed
+
+        assert %Result{outcome: :human, reasons: [{:config_error, ^reason}]} =
+                 evaluate(:merge, %{}, parsed)
+      end
+    end
+
+    test "a value that is not a parse result, including a bare struct" do
+      {:ok, parsed} = triggers()
+
+      for other <- [parsed, :ok, {:ok, %{}}, %{}] do
+        assert %Result{outcome: :human, reasons: [{:config_error, :unrecognised}]} =
+                 evaluate(:merge, %{}, other)
+      end
+    end
+
+    test "a hand-built trigger set with an empty pattern list is never read as no triggers" do
+      {:ok, glob} = Glob.compile("lib/app_web/router.ex")
+
+      for repo_triggers <- [
+            %RepoTriggers{
+              effect_paths: [],
+              human_paths: [glob],
+              max_files: 12,
+              max_changed_lines: 1000
+            },
+            %RepoTriggers{
+              effect_paths: [glob],
+              human_paths: [],
+              max_files: 12,
+              max_changed_lines: 1000
+            },
+            %RepoTriggers{
+              effect_paths: [glob],
+              human_paths: [glob],
+              max_files: 0,
+              max_changed_lines: 1000
+            },
+            %RepoTriggers{
+              effect_paths: [glob],
+              human_paths: [glob],
+              max_files: 12,
+              max_changed_lines: nil
+            }
+          ] do
+        forged = {:ok, %Triggers{version: 1, sha256: "", repos: %{@repo => repo_triggers}}}
+
+        assert %Result{outcome: :human, reasons: [{:config_error, :empty_trigger_set}]} =
+                 evaluate(:merge, %{}, forged)
+      end
+    end
+
+    test "an unknown repository" do
+      assert %Result{outcome: :human, reasons: [{:unknown_repo, "acme/other"}]} =
+               evaluate(:merge, %{repo: "acme/other"})
+
+      assert %Result{outcome: :human, reasons: [{:unknown_repo, nil}]} =
+               GateB.evaluate(:merge, Map.delete(input(), :repo), triggers())
+    end
+  end
+
+  describe "stale triggers" do
+    test "a configured pattern that matches no file in the repository escalates, naming it" do
+      repo_files = input().repo_files -- ["lib/app_web/router.ex"]
+
+      assert %Result{outcome: :human, reasons: [{:stale_trigger, "lib/app_web/router.ex"}]} =
+               evaluate(:triage, %{repo_files: repo_files})
+    end
+
+    test "a renamed effect directory escalates even when the change touches nothing" do
+      repo_files =
+        Enum.map(input().repo_files, &String.replace(&1, "priv/rates/", "priv/fee_rates/"))
+
+      assert %Result{outcome: :human, reasons: [{:stale_trigger, "priv/rates/**"}]} =
+               evaluate(:merge, %{repo_files: repo_files})
+    end
+
+    test "missing, empty, or malformed repo_files escalates" do
+      assert %Result{outcome: :human, reasons: [:missing_repo_files]} =
+               GateB.evaluate(:merge, Map.delete(input(), :repo_files), triggers())
+
+      assert %Result{outcome: :human, reasons: [:missing_repo_files]} =
+               evaluate(:merge, %{repo_files: []})
+
+      assert %Result{outcome: :human, reasons: [:invalid_repo_files]} =
+               evaluate(:merge, %{repo_files: ["README.md", nil]})
+    end
+  end
+
+  describe "agents may only add an escalation" do
+    test "an agent escalation turns a :clear change into :human" do
+      assert %Result{outcome: :human, reasons: [{:agent_escalation, "suspects rate change"}]} =
+               evaluate(:triage, %{agent_escalations: ["suspects rate change"]})
+    end
+
+    test "every element counts as an escalation, including ones that read as negatives" do
+      for negative <- [false, nil, "no escalation needed", %{"escalate" => false}] do
+        assert %Result{outcome: :human, reasons: [{:agent_escalation, ^negative}]} =
+                 evaluate(:merge, %{agent_escalations: [negative]})
+      end
+    end
+
+    test "an empty or absent agent list, or an agent's all-clear, cannot clear a computed trigger" do
+      computed = [
+        {%{files: ["lib/app_web/router.ex"]}, :human},
+        {%{files: ["priv/rates/2026.csv"]}, :prove_effect},
+        {%{diffstat: %{files: 1, changed_lines: 5000}}, :human}
+      ]
+
+      agent_all_clear = [
+        %{agent_escalations: []},
+        %{agent_escalations: nil},
+        %{agent_escalations: [], agent_verdict: "no escalation needed", escalate: false},
+        %{agent_escalations: [], override: :clear, suppress: [:human_path]}
+      ]
+
+      for {change, expected} <- computed, all_clear <- agent_all_clear do
+        assert %Result{outcome: ^expected} = evaluate(:merge, Map.merge(change, all_clear))
+      end
+    end
+
+    test "agent escalations are added even when the configuration failed" do
+      result = evaluate(:merge, %{agent_escalations: ["x"]}, nil)
+      assert result.reasons == [{:config_error, :not_loaded}, {:agent_escalation, "x"}]
+    end
+
+    test "agent escalations that are not a list escalate rather than being ignored" do
+      for bad <- [false, "none", %{}] do
+        assert %Result{outcome: :human, reasons: [{:invalid_agent_escalations, ^bad}]} =
+                 evaluate(:merge, %{agent_escalations: bad})
+      end
+    end
+  end
+end

--- a/test/loopctl/delivery_gates/gate_b_test.exs
+++ b/test/loopctl/delivery_gates/gate_b_test.exs
@@ -106,6 +106,8 @@ defmodule Loopctl.DeliveryGates.GateBTest do
             "./lib/app.ex",
             "lib/../lib/app_web/router.ex",
             "lib//x.ex",
+            ~S("priv/rates/tarifa_a\303\261o.csv"),
+            ~S(lib/app/payments/r\303\251sum\303\251.ex),
             "",
             nil
           ] do

--- a/test/loopctl/delivery_gates/gate_b_test.exs
+++ b/test/loopctl/delivery_gates/gate_b_test.exs
@@ -140,6 +140,76 @@ defmodule Loopctl.DeliveryGates.GateBTest do
     end
   end
 
+  describe "renames: both sides are matched" do
+    test "moving a file OUT of a human path escalates, though its new name is unguarded" do
+      result =
+        evaluate(:merge, %{
+          files: ["lib/app/backfill_rates.ex"],
+          renames: [{"lib/app/data_migrations/backfill_rates.ex", "lib/app/backfill_rates.ex"}]
+        })
+
+      assert result.outcome == :human
+
+      assert {:human_path, "lib/app/data_migrations/backfill_rates.ex",
+              "lib/**/data_migrations/**"} in result.reasons
+    end
+
+    test "moving a file out of an effect path needs the proof" do
+      result =
+        evaluate(:merge, %{
+          files: ["archive/2026.csv"],
+          renames: [{"priv/rates/2026.csv", "archive/2026.csv"}]
+        })
+
+      assert result.outcome == :prove_effect
+      assert {"priv/rates/2026.csv", "priv/rates/**"} in result.effect_matches
+    end
+
+    test "an unstated rename list at :merge escalates; at :triage it adds nothing" do
+      merge = GateB.evaluate(:merge, Map.delete(input(), :renames), triggers())
+      assert merge.outcome == :human
+      assert :missing_renames in merge.reasons
+
+      assert %Result{outcome: :clear} =
+               GateB.evaluate(:triage, Map.delete(input(), :renames), triggers())
+    end
+
+    test "a malformed rename list, or an invalid old path, escalates" do
+      for bad <- [nil, "a->b", [{"a"}], [{:a, "b"}], [["a", "b"]]] do
+        result = evaluate(:merge, %{renames: bad})
+        assert result.outcome == :human
+        assert {:invalid_renames, bad} in result.reasons
+      end
+
+      result =
+        evaluate(:merge, %{
+          files: ["x.csv"],
+          renames: [{~S("priv/rates/a\303\261o.csv"), "x.csv"}]
+        })
+
+      assert result.outcome == :human
+      assert Enum.any?(result.reasons, &match?({:invalid_path, _}, &1))
+    end
+  end
+
+  describe "renames and files come from one diff" do
+    test "a rename whose new name is missing from files escalates" do
+      result =
+        evaluate(:merge, %{
+          files: ["lib/app/accounts/user.ex"],
+          renames: [{"lib/app/old_name.ex", "lib/app/new_name.ex"}]
+        })
+
+      assert result.outcome == :human
+      assert {:rename_not_in_files, "lib/app/new_name.ex"} in result.reasons
+    end
+
+    test "a deleted guarded path listed in files escalates" do
+      result = evaluate(:merge, %{files: ["lib/app/data_migrations/backfill_rates.ex"]})
+      assert result.outcome == :human
+    end
+  end
+
   describe "size limits apply at :merge only" do
     test "exactly at the limits is within them" do
       files = for n <- 1..12, do: "lib/app/accounts/f#{n}.ex"

--- a/test/loopctl/delivery_gates/glob_test.exs
+++ b/test/loopctl/delivery_gates/glob_test.exs
@@ -1,0 +1,109 @@
+defmodule Loopctl.DeliveryGates.GlobTest do
+  use ExUnit.Case, async: true
+
+  alias Loopctl.DeliveryGates.Glob
+
+  defp matches?(pattern, path) do
+    {:ok, glob} = Glob.compile(pattern)
+    Glob.match?(glob, path)
+  end
+
+  describe "compile/1" do
+    test "rejects a pattern that is not a non-empty UTF-8 binary" do
+      assert Glob.compile("") == {:error, :invalid_pattern}
+      assert Glob.compile(nil) == {:error, :invalid_pattern}
+      assert Glob.compile(:atom) == {:error, :invalid_pattern}
+      assert Glob.compile(<<0xFF, 0xFE>>) == {:error, :invalid_pattern}
+    end
+
+    test "keeps the source pattern for reporting" do
+      assert {:ok, %Glob{source: "priv/rates/**"}} = Glob.compile("priv/rates/**")
+    end
+  end
+
+  describe "**" do
+    test "matches across directory separators" do
+      assert matches?("priv/rates/**", "priv/rates/2026.csv")
+      assert matches?("priv/rates/**", "priv/rates/nested/deep/2026.csv")
+    end
+
+    test "requires the literal prefix" do
+      refute matches?("priv/rates/**", "priv/rates")
+      refute matches?("priv/rates/**", "priv/ratesheet.csv")
+      refute matches?("priv/rates/**", "other/priv/rates/2026.csv")
+    end
+
+    test "embedded in a segment" do
+      assert matches?("lib/**.ex", "lib/app/payments/submit.ex")
+      refute matches?("lib/**.ex", "lib/app/payments/submit.exs")
+    end
+
+    test "/**/ matches zero or more intermediate directories" do
+      assert matches?("lib/**/data_migrations/**", "lib/app/data_migrations/x.ex")
+      assert matches?("lib/**/data_migrations/**", "lib/a/b/c/data_migrations/x.ex")
+      assert matches?("lib/**/data_migrations/**", "lib/data_migrations/x.ex")
+      refute matches?("lib/**/data_migrations/**", "lib/app/data_migrationsx/x.ex")
+      refute matches?("lib/**/data_migrations/**", "libdata_migrations/x.ex")
+    end
+
+    test "a leading **/ matches at the root too" do
+      assert matches?("**/runtime.exs", "runtime.exs")
+      assert matches?("**/runtime.exs", "config/runtime.exs")
+      refute matches?("**/runtime.exs", "config/xruntime.exs")
+    end
+
+    test "crosses a newline in a path" do
+      assert matches?("priv/**", "priv/odd\nname.csv")
+    end
+  end
+
+  describe "*" do
+    test "matches within one segment only" do
+      assert matches?("lib/app_web/plugs/*auth*", "lib/app_web/plugs/require_auth.ex")
+      assert matches?("lib/*.ex", "lib/app.ex")
+      refute matches?("lib/*.ex", "lib/app/payments.ex")
+    end
+
+    test "matches the empty string" do
+      assert matches?("lib/app*.ex", "lib/app.ex")
+    end
+  end
+
+  describe "?" do
+    test "matches exactly one non-slash character" do
+      assert matches?("priv/rates/202?.csv", "priv/rates/2026.csv")
+      refute matches?("priv/rates/202?.csv", "priv/rates/202.csv")
+      refute matches?("priv/rates/202?.csv", "priv/rates/20266.csv")
+      refute matches?("a?b", "a/b")
+    end
+
+    test "matches one codepoint, not one byte" do
+      assert matches?("docs/?.md", "docs/é.md")
+    end
+  end
+
+  describe "literals" do
+    test "regex metacharacters carry no meaning" do
+      assert matches?("lib/app.ex", "lib/app.ex")
+      refute matches?("lib/app.ex", "lib/appXex")
+      assert matches?("a[b].{c}+(d)|$^", "a[b].{c}+(d)|$^")
+      refute matches?("a[b]", "ab")
+    end
+
+    test "is anchored at both ends" do
+      refute matches?("config/runtime.exs", "config/runtime.exs.bak")
+      refute matches?("config/runtime.exs", "x/config/runtime.exs")
+    end
+
+    test "is case-sensitive" do
+      refute matches?("lib/app_web/router.ex", "lib/App_web/router.ex")
+    end
+  end
+
+  test "a non-binary path never matches" do
+    {:ok, glob} = Glob.compile("**")
+    refute Glob.match?(glob, nil)
+    refute Glob.match?(glob, :path)
+    refute Glob.match?(glob, <<0xFF>>)
+  end
+end

--- a/test/loopctl/delivery_gates/judge_proof_test.exs
+++ b/test/loopctl/delivery_gates/judge_proof_test.exs
@@ -1,0 +1,153 @@
+defmodule Loopctl.DeliveryGates.JudgeProofTest do
+  use ExUnit.Case, async: true
+
+  alias Loopctl.DeliveryGates
+  alias Loopctl.DeliveryGates.GateB
+  alias Loopctl.DeliveryGates.GateB.ProofResult
+
+  @covered %{required: ["T1019", "U2", "HCBS"], covered: ["HCBS", "T1019", "U2", "S5125"]}
+
+  defp pass?(%ProofResult{verdict: :pass, failures: [], route: nil}), do: true
+  defp pass?(%ProofResult{}), do: false
+
+  describe "passes" do
+    test "when exactly the intended fixtures changed" do
+      results = %{"f-rate" => :changed, "f-mod" => :changed, "f-other" => :unchanged}
+      assert pass?(GateB.judge_proof({:changes, ["f-rate", "f-mod"]}, results, @covered))
+    end
+
+    test "when no output change was intended and none happened" do
+      results = %{"f-rate" => :unchanged, "f-other" => :unchanged}
+      assert pass?(GateB.judge_proof(:no_output_change, results, @covered))
+    end
+
+    test "through the facade" do
+      assert pass?(
+               DeliveryGates.judge_proof({:changes, ["a"]}, %{"a" => :changed}, %{
+                 required: ["X"],
+                 covered: ["X"]
+               })
+             )
+    end
+  end
+
+  describe "fails on the intended half, and routes to Gate A" do
+    test "an intended fixture that did not change: nothing changed is not a pass" do
+      results = %{"f-rate" => :unchanged, "f-other" => :unchanged}
+
+      assert %ProofResult{
+               verdict: :fail,
+               route: :gate_a,
+               failures: [{:intended_fixture_unchanged, ["f-rate"]}]
+             } = GateB.judge_proof({:changes, ["f-rate"]}, results, @covered)
+    end
+
+    test "one of several intended fixtures did not change" do
+      results = %{"f-a" => :changed, "f-b" => :unchanged}
+
+      assert %ProofResult{verdict: :fail, failures: [{:intended_fixture_unchanged, ["f-b"]}]} =
+               GateB.judge_proof({:changes, ["f-a", "f-b"]}, results, @covered)
+    end
+
+    test "an intended fixture that did not run" do
+      results = %{"f-other" => :unchanged}
+
+      assert %ProofResult{verdict: :fail, failures: [{:intended_fixture_not_run, ["f-rate"]}]} =
+               GateB.judge_proof({:changes, ["f-rate"]}, results, @covered)
+    end
+  end
+
+  describe "fails on the unintended half, and routes to Gate A" do
+    test "a fixture changed that was not intended" do
+      results = %{"f-rate" => :changed, "f-other" => :changed}
+
+      assert %ProofResult{
+               verdict: :fail,
+               route: :gate_a,
+               failures: [{:unintended_fixture_changed, ["f-other"]}]
+             } = GateB.judge_proof({:changes, ["f-rate"]}, results, @covered)
+    end
+
+    test "any change when no output change was intended" do
+      results = %{"f-rate" => :unchanged, "f-other" => :changed}
+
+      assert %ProofResult{verdict: :fail, failures: [{:unintended_fixture_changed, ["f-other"]}]} =
+               GateB.judge_proof(:no_output_change, results, @covered)
+    end
+
+    test "both halves at once are both reported" do
+      results = %{"f-rate" => :unchanged, "f-other" => :changed}
+
+      assert %ProofResult{
+               verdict: :fail,
+               failures: [
+                 {:intended_fixture_unchanged, ["f-rate"]},
+                 {:unintended_fixture_changed, ["f-other"]}
+               ]
+             } = GateB.judge_proof({:changes, ["f-rate"]}, results, @covered)
+    end
+  end
+
+  describe "fixture coverage" do
+    test "a required code no fixture exercises fails, naming the uncovered codes" do
+      coverage = %{required: ["T1019", "U2", "H0038", "HX"], covered: ["T1019", "U2"]}
+
+      assert %ProofResult{
+               verdict: :fail,
+               route: :gate_a,
+               failures: [{:uncovered_codes, ["H0038", "HX"]}]
+             } =
+               GateB.judge_proof(:no_output_change, %{"f" => :unchanged}, coverage)
+    end
+
+    test "fails even when the fixture diff is exactly as intended" do
+      coverage = %{required: ["NEW1"], covered: []}
+
+      assert %ProofResult{verdict: :fail, failures: [{:uncovered_codes, ["NEW1"]}]} =
+               GateB.judge_proof({:changes, ["f"]}, %{"f" => :changed}, coverage)
+    end
+
+    test "malformed or empty coverage fails" do
+      for bad <- [
+            nil,
+            %{},
+            %{required: [], covered: []},
+            %{required: ["X"]},
+            %{required: "X", covered: ["X"]}
+          ] do
+        assert %ProofResult{verdict: :fail, failures: [{:invalid_coverage, ^bad}]} =
+                 GateB.judge_proof(:no_output_change, %{"f" => :unchanged}, bad)
+      end
+    end
+  end
+
+  describe "fails closed on malformed input" do
+    test "an intent that is neither {:changes, non-empty ids} nor :no_output_change" do
+      for bad <- [
+            nil,
+            :changes,
+            {:changes, []},
+            {:changes, "f"},
+            {:changes, [:f]},
+            {:no_output_change}
+          ] do
+        assert %ProofResult{verdict: :fail, route: :gate_a, failures: [{:invalid_intent, ^bad}]} =
+                 GateB.judge_proof(bad, %{"f" => :changed}, @covered)
+      end
+    end
+
+    test "fixture results that are empty, not a map, or carry another state" do
+      for bad <- [
+            %{},
+            nil,
+            [{"f", :changed}],
+            %{"f" => :different},
+            %{"f" => true},
+            %{f: :changed}
+          ] do
+        assert %ProofResult{verdict: :fail, failures: [{:invalid_fixture_results, ^bad}]} =
+                 GateB.judge_proof(:no_output_change, bad, @covered)
+      end
+    end
+  end
+end

--- a/test/loopctl/delivery_gates/judge_proof_test.exs
+++ b/test/loopctl/delivery_gates/judge_proof_test.exs
@@ -13,17 +13,25 @@ defmodule Loopctl.DeliveryGates.JudgeProofTest do
   describe "passes" do
     test "when exactly the intended fixtures changed" do
       results = %{"f-rate" => :changed, "f-mod" => :changed, "f-other" => :unchanged}
-      assert pass?(GateB.judge_proof({:changes, ["f-rate", "f-mod"]}, results, @covered))
+
+      assert pass?(
+               GateB.judge_proof(
+                 {:changes, ["f-rate", "f-mod"]},
+                 Map.keys(results),
+                 results,
+                 @covered
+               )
+             )
     end
 
     test "when no output change was intended and none happened" do
       results = %{"f-rate" => :unchanged, "f-other" => :unchanged}
-      assert pass?(GateB.judge_proof(:no_output_change, results, @covered))
+      assert pass?(GateB.judge_proof(:no_output_change, Map.keys(results), results, @covered))
     end
 
     test "through the facade" do
       assert pass?(
-               DeliveryGates.judge_proof({:changes, ["a"]}, %{"a" => :changed}, %{
+               DeliveryGates.judge_proof({:changes, ["a"]}, ["a"], %{"a" => :changed}, %{
                  required: ["X"],
                  covered: ["X"]
                })
@@ -39,21 +47,21 @@ defmodule Loopctl.DeliveryGates.JudgeProofTest do
                verdict: :fail,
                route: :gate_a,
                failures: [{:intended_fixture_unchanged, ["f-rate"]}]
-             } = GateB.judge_proof({:changes, ["f-rate"]}, results, @covered)
+             } = GateB.judge_proof({:changes, ["f-rate"]}, Map.keys(results), results, @covered)
     end
 
     test "one of several intended fixtures did not change" do
       results = %{"f-a" => :changed, "f-b" => :unchanged}
 
       assert %ProofResult{verdict: :fail, failures: [{:intended_fixture_unchanged, ["f-b"]}]} =
-               GateB.judge_proof({:changes, ["f-a", "f-b"]}, results, @covered)
+               GateB.judge_proof({:changes, ["f-a", "f-b"]}, Map.keys(results), results, @covered)
     end
 
     test "an intended fixture that did not run" do
       results = %{"f-other" => :unchanged}
 
-      assert %ProofResult{verdict: :fail, failures: [{:intended_fixture_not_run, ["f-rate"]}]} =
-               GateB.judge_proof({:changes, ["f-rate"]}, results, @covered)
+      assert %ProofResult{verdict: :fail, failures: [{:fixture_not_run, ["f-rate"]}]} =
+               GateB.judge_proof({:changes, ["f-rate"]}, ["f-rate", "f-other"], results, @covered)
     end
   end
 
@@ -65,14 +73,14 @@ defmodule Loopctl.DeliveryGates.JudgeProofTest do
                verdict: :fail,
                route: :gate_a,
                failures: [{:unintended_fixture_changed, ["f-other"]}]
-             } = GateB.judge_proof({:changes, ["f-rate"]}, results, @covered)
+             } = GateB.judge_proof({:changes, ["f-rate"]}, Map.keys(results), results, @covered)
     end
 
     test "any change when no output change was intended" do
       results = %{"f-rate" => :unchanged, "f-other" => :changed}
 
       assert %ProofResult{verdict: :fail, failures: [{:unintended_fixture_changed, ["f-other"]}]} =
-               GateB.judge_proof(:no_output_change, results, @covered)
+               GateB.judge_proof(:no_output_change, Map.keys(results), results, @covered)
     end
 
     test "both halves at once are both reported" do
@@ -84,7 +92,60 @@ defmodule Loopctl.DeliveryGates.JudgeProofTest do
                  {:intended_fixture_unchanged, ["f-rate"]},
                  {:unintended_fixture_changed, ["f-other"]}
                ]
-             } = GateB.judge_proof({:changes, ["f-rate"]}, results, @covered)
+             } = GateB.judge_proof({:changes, ["f-rate"]}, Map.keys(results), results, @covered)
+    end
+  end
+
+  describe "nowhere else means the whole fixed set" do
+    test "a fixture in the set with no result fails, even when every reported one is as intended" do
+      results = %{"f-rate" => :changed}
+
+      assert %ProofResult{
+               verdict: :fail,
+               route: :gate_a,
+               failures: [{:fixture_not_run, ["f-mod", "f-other"]}]
+             } =
+               GateB.judge_proof(
+                 {:changes, ["f-rate"]},
+                 ["f-rate", "f-mod", "f-other"],
+                 results,
+                 @covered
+               )
+    end
+
+    test "no output change over a partial report of a larger set fails" do
+      set = Enum.map(1..50, &"f#{&1}")
+
+      assert %ProofResult{verdict: :fail, failures: [{:fixture_not_run, not_run}]} =
+               GateB.judge_proof(:no_output_change, set, %{"f1" => :unchanged}, @covered)
+
+      assert length(not_run) == 49
+    end
+
+    test "a result for a fixture outside the set fails" do
+      results = %{"f-rate" => :changed, "f-stray" => :unchanged}
+
+      assert %ProofResult{verdict: :fail, failures: [{:unexpected_fixture, ["f-stray"]}]} =
+               GateB.judge_proof({:changes, ["f-rate"]}, ["f-rate"], results, @covered)
+    end
+
+    test "an intended fixture that is not in the set fails" do
+      assert %ProofResult{verdict: :fail, failures: failures} =
+               GateB.judge_proof(
+                 {:changes, ["f-new"]},
+                 ["f-rate"],
+                 %{"f-rate" => :unchanged},
+                 @covered
+               )
+
+      assert {:intended_fixture_not_in_set, ["f-new"]} in failures
+    end
+
+    test "an empty, missing or non-string fixture set fails" do
+      for bad <- [[], nil, "f", [:f]] do
+        assert %ProofResult{verdict: :fail, failures: [{:invalid_fixture_set, ^bad}]} =
+                 GateB.judge_proof(:no_output_change, bad, %{"f" => :unchanged}, @covered)
+      end
     end
   end
 
@@ -97,14 +158,14 @@ defmodule Loopctl.DeliveryGates.JudgeProofTest do
                route: :gate_a,
                failures: [{:uncovered_codes, ["H0038", "HX"]}]
              } =
-               GateB.judge_proof(:no_output_change, %{"f" => :unchanged}, coverage)
+               GateB.judge_proof(:no_output_change, ["f"], %{"f" => :unchanged}, coverage)
     end
 
     test "fails even when the fixture diff is exactly as intended" do
       coverage = %{required: ["NEW1"], covered: []}
 
       assert %ProofResult{verdict: :fail, failures: [{:uncovered_codes, ["NEW1"]}]} =
-               GateB.judge_proof({:changes, ["f"]}, %{"f" => :changed}, coverage)
+               GateB.judge_proof({:changes, ["f"]}, ["f"], %{"f" => :changed}, coverage)
     end
 
     test "malformed or empty coverage fails" do
@@ -116,7 +177,7 @@ defmodule Loopctl.DeliveryGates.JudgeProofTest do
             %{required: "X", covered: ["X"]}
           ] do
         assert %ProofResult{verdict: :fail, failures: [{:invalid_coverage, ^bad}]} =
-                 GateB.judge_proof(:no_output_change, %{"f" => :unchanged}, bad)
+                 GateB.judge_proof(:no_output_change, ["f"], %{"f" => :unchanged}, bad)
       end
     end
   end
@@ -132,7 +193,7 @@ defmodule Loopctl.DeliveryGates.JudgeProofTest do
             {:no_output_change}
           ] do
         assert %ProofResult{verdict: :fail, route: :gate_a, failures: [{:invalid_intent, ^bad}]} =
-                 GateB.judge_proof(bad, %{"f" => :changed}, @covered)
+                 GateB.judge_proof(bad, ["f"], %{"f" => :changed}, @covered)
       end
     end
 
@@ -146,7 +207,7 @@ defmodule Loopctl.DeliveryGates.JudgeProofTest do
             %{f: :changed}
           ] do
         assert %ProofResult{verdict: :fail, failures: [{:invalid_fixture_results, ^bad}]} =
-                 GateB.judge_proof(:no_output_change, bad, @covered)
+                 GateB.judge_proof(:no_output_change, ["f"], bad, @covered)
       end
     end
   end

--- a/test/loopctl/delivery_gates/triggers_test.exs
+++ b/test/loopctl/delivery_gates/triggers_test.exs
@@ -1,0 +1,202 @@
+defmodule Loopctl.DeliveryGates.TriggersTest do
+  use ExUnit.Case, async: true
+
+  import Loopctl.Fixtures
+
+  alias Loopctl.DeliveryGates.Glob
+  alias Loopctl.DeliveryGates.RepoTriggers
+  alias Loopctl.DeliveryGates.Triggers
+
+  @repo "acme/claims-app"
+
+  defp sha256(binary), do: :sha256 |> :crypto.hash(binary) |> Base.encode16(case: :lower)
+
+  defp parse_doc(doc) do
+    binary = Jason.encode!(doc)
+    Triggers.parse(binary, sha256(binary))
+  end
+
+  defp put_repo_key(key, value) do
+    config = build(:delivery_gates_config)
+    put_in(config, ["repos", @repo, key], value)
+  end
+
+  describe "a valid document" do
+    test "parses into compiled triggers for each repository" do
+      binary = Jason.encode!(build(:delivery_gates_config))
+      assert {:ok, %Triggers{} = triggers} = Triggers.parse(binary, sha256(binary))
+
+      assert triggers.version == 1
+      assert triggers.sha256 == sha256(binary)
+
+      assert {:ok, %RepoTriggers{} = repo} = Triggers.fetch_repo(triggers, @repo)
+
+      assert Enum.map(repo.effect_paths, & &1.source) ==
+               ["priv/rates/**", "lib/app/payments/**", "config/runtime.exs"]
+
+      assert Enum.map(repo.human_paths, & &1.source) ==
+               ["lib/app_web/router.ex", "lib/**/data_migrations/**"]
+
+      assert Enum.all?(repo.effect_paths ++ repo.human_paths, &match?(%Glob{}, &1))
+      assert repo.max_files == 12
+      assert repo.max_changed_lines == 1000
+    end
+
+    test "accepts the expected checksum in upper case" do
+      binary = Jason.encode!(build(:delivery_gates_config))
+      assert {:ok, %Triggers{}} = Triggers.parse(binary, String.upcase(sha256(binary)))
+    end
+
+    test "fetch_repo/2 is :error for a repository the document does not name" do
+      {:ok, triggers} = parse_doc(build(:delivery_gates_config))
+      assert Triggers.fetch_repo(triggers, "acme/other") == :error
+      assert Triggers.fetch_repo(triggers, nil) == :error
+    end
+  end
+
+  describe "fails closed on a missing or unverifiable document" do
+    test "nil or empty binary" do
+      assert Triggers.parse(nil, String.duplicate("a", 64)) == {:error, :missing_config}
+      assert Triggers.parse("", sha256("")) == {:error, :missing_config}
+    end
+
+    test "a missing or malformed expected checksum" do
+      binary = Jason.encode!(build(:delivery_gates_config))
+      assert Triggers.parse(binary, nil) == {:error, :invalid_checksum_format}
+      assert Triggers.parse(binary, "") == {:error, :invalid_checksum_format}
+      assert Triggers.parse(binary, "abc") == {:error, :invalid_checksum_format}
+
+      assert Triggers.parse(binary, String.duplicate("g", 64)) ==
+               {:error, :invalid_checksum_format}
+    end
+
+    test "a checksum that does not match the bytes" do
+      binary = Jason.encode!(build(:delivery_gates_config))
+      other = Jason.encode!(build(:delivery_gates_config, %{"version" => 2}))
+      assert Triggers.parse(binary, sha256(other)) == {:error, :checksum_mismatch}
+    end
+
+    test "a one-byte change to a pinned document is a mismatch, before it is decoded" do
+      binary = Jason.encode!(build(:delivery_gates_config))
+      pinned = sha256(binary)
+      tampered = String.replace(binary, "priv/rates/**", "priv/ratez/**")
+      assert tampered != binary
+      assert Triggers.parse(tampered, pinned) == {:error, :checksum_mismatch}
+    end
+
+    test "invalid JSON, even with a matching checksum" do
+      binary = "{\"version\": 1, \"repos\": "
+      assert Triggers.parse(binary, sha256(binary)) == {:error, :invalid_json}
+    end
+
+    test "a document that is not a JSON object" do
+      assert parse_doc([]) == {:error, {:not_an_object, []}}
+      assert parse_doc("text") == {:error, {:not_an_object, []}}
+    end
+  end
+
+  describe "fails closed on a malformed document" do
+    test "unknown or unsupported version" do
+      assert parse_doc(build(:delivery_gates_config, %{"version" => 2})) ==
+               {:error, {:unsupported_version, 2}}
+
+      assert parse_doc(build(:delivery_gates_config, %{"version" => "1"})) ==
+               {:error, {:unsupported_version, "1"}}
+
+      assert parse_doc(build(:delivery_gates_config, %{"version" => nil})) ==
+               {:error, {:unsupported_version, nil}}
+    end
+
+    test "missing top-level keys" do
+      assert parse_doc(Map.delete(build(:delivery_gates_config), "version")) ==
+               {:error, {:missing_key, ["version"]}}
+
+      assert parse_doc(Map.delete(build(:delivery_gates_config), "repos")) ==
+               {:error, {:missing_key, ["repos"]}}
+    end
+
+    test "unknown top-level key" do
+      assert parse_doc(build(:delivery_gates_config, %{"extra" => true})) ==
+               {:error, {:unknown_key, ["extra"]}}
+    end
+
+    test "empty or non-object repos" do
+      assert parse_doc(build(:delivery_gates_config, %{"repos" => %{}})) ==
+               {:error, {:empty_repos, ["repos"]}}
+
+      assert parse_doc(build(:delivery_gates_config, %{"repos" => []})) ==
+               {:error, {:not_an_object, ["repos"]}}
+    end
+
+    test "a repository key that is not owner/repo" do
+      entry = get_in(build(:delivery_gates_config), ["repos", @repo])
+
+      assert parse_doc(build(:delivery_gates_config, %{"repos" => %{"claims-app" => entry}})) ==
+               {:error, {:invalid_repo_name, "claims-app"}}
+    end
+
+    test "a missing key in a repository entry" do
+      for key <- ~w(effect_paths human_paths limits) do
+        config = build(:delivery_gates_config)
+        {_, config} = pop_in(config, ["repos", @repo, key])
+        assert parse_doc(config) == {:error, {:missing_key, ["repos", @repo, key]}}
+      end
+    end
+
+    test "an unknown key in a repository entry, such as a misspelling" do
+      assert parse_doc(put_repo_key("efect_paths", ["x/**"])) ==
+               {:error, {:unknown_key, ["repos", @repo, "efect_paths"]}}
+    end
+
+    test "an empty pattern list" do
+      assert parse_doc(put_repo_key("effect_paths", [])) ==
+               {:error, {:empty_patterns, ["repos", @repo, "effect_paths"]}}
+
+      assert parse_doc(put_repo_key("human_paths", [])) ==
+               {:error, {:empty_patterns, ["repos", @repo, "human_paths"]}}
+    end
+
+    test "a pattern list that is not a list" do
+      assert parse_doc(put_repo_key("effect_paths", "priv/rates/**")) ==
+               {:error, {:invalid_patterns, ["repos", @repo, "effect_paths"]}}
+    end
+
+    test "an invalid pattern inside a list" do
+      assert parse_doc(put_repo_key("human_paths", ["lib/app_web/router.ex", ""])) ==
+               {:error, {:invalid_pattern, ["repos", @repo, "human_paths"], ""}}
+
+      assert parse_doc(put_repo_key("effect_paths", [42])) ==
+               {:error, {:invalid_pattern, ["repos", @repo, "effect_paths"], 42}}
+    end
+
+    test "limits that are missing, unknown, or not positive integers" do
+      assert parse_doc(put_repo_key("limits", %{"max_files" => 12})) ==
+               {:error, {:missing_key, ["repos", @repo, "limits", "max_changed_lines"]}}
+
+      assert parse_doc(
+               put_repo_key("limits", %{"max_files" => 12, "max_changed_lines" => 1, "x" => 1})
+             ) == {:error, {:unknown_key, ["repos", @repo, "limits", "x"]}}
+
+      assert parse_doc(put_repo_key("limits", 12)) ==
+               {:error, {:not_an_object, ["repos", @repo, "limits"]}}
+
+      for bad <- [0, -1, 1.5, "12", nil] do
+        assert parse_doc(put_repo_key("limits", %{"max_files" => bad, "max_changed_lines" => 1})) ==
+                 {:error, {:invalid_limit, ["repos", @repo, "limits", "max_files"]}}
+
+        assert parse_doc(put_repo_key("limits", %{"max_files" => 1, "max_changed_lines" => bad})) ==
+                 {:error, {:invalid_limit, ["repos", @repo, "limits", "max_changed_lines"]}}
+      end
+    end
+
+    test "one bad repository fails the whole document" do
+      config = build(:delivery_gates_config)
+      good = get_in(config, ["repos", @repo])
+      bad = Map.put(good, "effect_paths", [])
+      config = put_in(config, ["repos"], %{@repo => good, "acme/zz-broken" => bad})
+
+      assert parse_doc(config) ==
+               {:error, {:empty_patterns, ["repos", "acme/zz-broken", "effect_paths"]}}
+    end
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -673,6 +673,62 @@ defmodule Loopctl.Fixtures do
     )
   end
 
+  # Delivery gates (#802). SYNTHETIC trigger data only: loopctl is public and the real
+  # target repositories' trigger lists are configuration, never source.
+
+  # The decoded trigger configuration document, string keys, one repository.
+  # `Jason.encode!/1` it and pin its SHA-256 to feed `Triggers.parse/2`.
+  def build(:delivery_gates_config, attrs) do
+    Map.merge(
+      %{
+        "version" => 1,
+        "repos" => %{
+          "acme/claims-app" => %{
+            "effect_paths" => ["priv/rates/**", "lib/app/payments/**", "config/runtime.exs"],
+            "human_paths" => ["lib/app_web/router.ex", "lib/**/data_migrations/**"],
+            "limits" => %{"max_files" => 12, "max_changed_lines" => 1000}
+          }
+        }
+      },
+      Enum.into(attrs, %{})
+    )
+  end
+
+  # A Gate B input for the repository above that touches nothing guarded.
+  def build(:gate_b_input, attrs) do
+    Map.merge(
+      %{
+        repo: "acme/claims-app",
+        files: ["lib/app/accounts/user.ex"],
+        repo_files: [
+          "README.md",
+          "config/runtime.exs",
+          "lib/app/accounts/user.ex",
+          "lib/app/data_migrations/backfill_rates.ex",
+          "lib/app/payments/submit.ex",
+          "lib/app_web/router.ex",
+          "priv/rates/2026.csv"
+        ],
+        diffstat: %{files: 1, changed_lines: 10}
+      },
+      Enum.into(attrs, %{})
+    )
+  end
+
+  # One triage agent's output, as the trio contract emits it: an uncontested story.
+  def build(:trio_output, attrs) do
+    Map.merge(
+      %{
+        "verdict" => "story",
+        "story" => %{"title" => "Fix the monthly total rounding"},
+        "escalation_reasons" => [],
+        "contradicts" => [],
+        "confidence" => 0.8
+      },
+      Enum.into(attrs, %{})
+    )
+  end
+
   @doc """
   Inserts a record into the database, auto-creating any required dependencies.
   Returns the inserted struct.

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -700,6 +700,7 @@ defmodule Loopctl.Fixtures do
       %{
         repo: "acme/claims-app",
         files: ["lib/app/accounts/user.ex"],
+        renames: [],
         repo_files: [
           "README.md",
           "config/runtime.exs",


### PR DESCRIPTION
Closes #802

**Review gate: still running.** This PR opens on the first green commit, and the review runs alongside CI.

Adds `Loopctl.DeliveryGates`, a pure module that implements design section 5 of the agent delivery loop. It does no I/O, touches no database, calls no model and reads no application env inside a gate. Gate A and Gate B are separate functions with separate tests.

## Gate A: "Mark decides" (`gate_a/1`, `gate_a_rate/1`)

Request-shaped. Its only input is the triage trio's three output objects, and it reads no file path. It escalates when:
- the trio is not exactly three outputs, or any output is malformed. All four contract keys are required (`verdict`, `escalation_reasons`, `contradicts`, `confidence`) and each is type-checked, so this fails closed.
- the three verdicts disagree.
- any agent's verdict is `escalate`.
- any agent reports a non-empty `contradicts`.
- any agent's `escalation_reasons` carries a gating code. There are two: `inverts_or_removes_deliberate_behaviour` and `workflow_change_not_defect_fix`. `GateA.gating_reason_codes/0` exposes them for the trio contract (#803).

Confidence is recorded on the result and never gates. Any other reason code is recorded in `soft_signals` and does not gate, so each soft trigger's rate can be measured before it is allowed to gate. `rate/1` reports escalated/total plus a count per reason kind, and returns `nil` for an empty set.

## Gate B: "a human confirms" (`gate_b/3`, `judge_proof/4`)

Effect-shaped. Precedence is `:human` > `:prove_effect` > `:clear`.
- `:human`: a human path was touched, the size bound was exceeded, the configuration is missing or bad, the repo is unknown, a trigger is stale, the input is missing or malformed, or an agent sent any escalation.
- `:prove_effect`: an effect path was touched. The matched `{file, pattern}` pairs are recorded even when the outcome is `:human`.

**Run twice.** `:triage` runs over the predicted touches and only decides whether to dispatch. `:merge` runs over the real `gh pr diff --name-only` and diffstat, and it is the only phase that applies `max_files` / `max_changed_lines`. Only the merge result has `merge_precondition?: true`. A missing diffstat at `:merge` escalates. The file count used for the limit is the larger of the listed names and the diffstat count.

**Agents may only add an escalation.** This is a wiring property. Triggers are computed from the paths and the config, and `agent_escalations` is OR-ed onto them. Every element counts as an escalation, including `false` and "no escalation needed". An empty or absent list adds nothing, and a non-list escalates. No input key can remove a computed trigger.

**Stale triggers.** loopctl has no checkout of the target repo, so the caller passes `repo_files` (the output of `git ls-files`). Any configured pattern that matches none of those files escalates as `{:stale_trigger, pattern}`. Missing or empty `repo_files` also escalates.

**`judge_proof(intent, fixture_set, fixture_results, coverage)`** passes only when the set of changed fixtures equals the intended set exactly, in both directions, over the WHOLE fixed fixture set:
- an intended fixture that stayed unchanged fails.
- an unintended fixture that changed fails.
- a fixture in the set with no result, a result for a fixture outside the set, and an intended fixture not in the set all fail. Without the set, "empty everywhere else" could only be checked over the fixtures that happened to report (review round 1).

**Renames are matched on both sides.** `gh pr diff --name-only` prints only a rename's new name, so a file moved OUT of a human or effect path read as touching nothing guarded (review round 2). The gate now matches the old name of every rename too. At `:merge` the caller must state `renames: [{old, new}]`, which may be `[]`; an absent list escalates as `:missing_renames`. Old paths are validated like new ones, and a rename whose new name is not in `files` escalates as `{:rename_not_in_files, new}`, so lists built from different ranges are caught (review round 3). `files` must include deleted paths. Derive `files` and `renames` together from `git diff --name-status -M -z base...head`, not `gh pr diff --name-only`.

**Paths in git's quoted form escalate.** Under the default `core.quotePath`, git prints a non-ASCII name as `"priv/rates/tarifa_a\303\261o.csv"`, which no anchored pattern matches, so such a change read as touching nothing (review round 1). A leading quote or a backslash escape is now `{:invalid_path, path}`. Callers should pass `-z` or `-c core.quotePath=false`.

Every required code must also be covered. Malformed intent, results or coverage fails, and so does an empty `required` list. A failure returns `route: :gate_a`.

## Trigger configuration (fail closed)

`parse_triggers(binary, expected_sha256_hex)` checks the SHA-256 against the raw bytes before it decodes anything. It then requires this exact shape: every key present, no unknown keys, both pattern lists non-empty, positive integer limits, `owner/repo` repo keys, and `version: 1`.

```json
{"version": 1,
 "repos": {"owner/repo": {"effect_paths": ["..."], "human_paths": ["..."],
                          "limits": {"max_files": 12, "max_changed_lines": 1000}}}}
```

The only accepted trigger input is `{:ok, %Triggers{}}` exactly as `parse/2` returns it. `{:error, _}`, `nil`, a bare struct or anything else gives `:human` with `{:config_error, _}`. `usable/1` also rejects a hand-built `RepoTriggers` that has an empty list or a bad limit. No code path turns bad config into an empty trigger set.

Glob semantics:
- `**` matches any characters, including `/`.
- `*` matches any characters except `/`.
- `?` matches one character that is not `/`.
- Everything else is literal. Matching is anchored and case-sensitive.

Two refinements make patterns match more paths, never fewer. `/**/` also matches a single `/`, so `lib/**/data_migrations/**` catches `lib/data_migrations/x.ex`. A leading `**/` also matches at the repo root. Read literally, `**` would miss the shallowest instance of what a trigger names.

Tests use only synthetic trigger data (`acme/claims-app`, `priv/rates/**`, `lib/app/payments/**`). No target repo's real paths appear anywhere in this repo.

**No new env var and no CHANGELOG entry.** Loading the config document and its pinned checksum from the environment belongs to the caller, which is #803's job. Nothing here is operator-facing yet.

## Falsifiability: every rule mutated with bin/mutate.sh

Every mutation below was run as `~/workspace/claude-config/bin/mutate.sh <file> --old '<working>' --new '<broken>' --quiet --timeout 300 -- mix test <test file>`, with the baseline enforced. All 64 exited **0**, meaning the test went red under the mutation. Cases marked *wiring* break the call site or the branch that decides whether a mechanism runs at all, not the mechanism itself.

| id | file -> test | mutation | exit |
|---|---|---|---|
| T1 | triggers.ex -> triggers_test | checksum compare replaced by `if true` | 0 |
| T2 | triggers.ex -> triggers_test | empty binary accepted | 0 |
| T3 | triggers.ex -> triggers_test | empty pattern list returns `{:ok, []}` | 0 |
| T4 | triggers.ex -> triggers_test | unknown-key detection disabled | 0 |
| T5 | triggers.ex -> triggers_test | any positive version accepted | 0 |
| T6 | triggers.ex -> triggers_test | limit 0 accepted | 0 |
| T7 | triggers.ex -> triggers_test | checksum format check disabled | 0 |
| B1 | gate_b.ex -> gate_b_test | *wiring*: `{:error, _}` config yields an empty trigger set | 0 |
| B2 | gate_b.ex -> gate_b_test | *wiring*: nil config yields an empty trigger set | 0 |
| B3 | gate_b.ex -> gate_b_test | *wiring*: unrecognised config yields an empty trigger set | 0 |
| B4 | gate_b.ex -> gate_b_test | unknown repo yields an empty trigger set | 0 |
| B5 | gate_b.ex -> gate_b_test | hand-built empty trigger set accepted | 0 |
| B6 | gate_b.ex -> gate_b_test | *wiring*: agent escalations not OR-ed in | 0 |
| B7 | gate_b.ex -> gate_b_test | *wiring*: an empty agent list clears computed triggers | 0 |
| B8 | gate_b.ex -> gate_b_test | `false`/`nil` read as an agent's negative | 0 |
| B9 | gate_b.ex -> gate_b_test | non-list agent escalations ignored | 0 |
| B10 | gate_b.ex -> gate_b_test | precedence swapped (`:prove_effect` before `:human`) | 0 |
| B11 | gate_b.ex -> gate_b_test | *wiring*: effect matches dropped | 0 |
| B12 | gate_b.ex -> gate_b_test | *wiring*: human-path reasons dropped | 0 |
| B13 | gate_b.ex -> gate_b_test | `merge_precondition?` always true | 0 |
| B14 | gate_b.ex -> gate_b_test | *wiring*: size limits never applied at `:merge` | 0 |
| B15 | gate_b.ex -> gate_b_test | *wiring*: size limits applied at `:triage` | 0 |
| B16 | gate_b.ex -> gate_b_test | max_files boundary `>` changed to `>=` | 0 |
| B17 | gate_b.ex -> gate_b_test | max_files effectively disabled (x10) | 0 |
| B18 | gate_b.ex -> gate_b_test | file count taken from the diffstat only | 0 |
| B19 | gate_b.ex -> gate_b_test | max_changed_lines boundary `>` changed to `>=` | 0 |
| B20 | gate_b.ex -> gate_b_test | max_changed_lines effectively disabled (x10) | 0 |
| B21 | gate_b.ex -> gate_b_test | missing diffstat at `:merge` ignored | 0 |
| B22 | gate_b.ex -> gate_b_test | *wiring*: stale-trigger check not called | 0 |
| B23 | gate_b.ex -> gate_b_test | stale-trigger mechanism never fires | 0 |
| B24 | gate_b.ex -> gate_b_test | missing repo_files ignored | 0 |
| B25 | gate_b.ex -> gate_b_test | empty file list ignored | 0 |
| B26 | gate_b.ex -> gate_b_test | `.`/`..` path segments accepted | 0 |
| B27 | gate_b.ex -> gate_b_test | *wiring*: path validation not called | 0 |
| P1 | gate_b.ex -> judge_proof_test | intended-but-unchanged half removed | 0 |
| P2 | gate_b.ex -> judge_proof_test | intended-but-not-run removed | 0 |
| P3 | gate_b.ex -> judge_proof_test | unintended-changed half removed | 0 |
| P4 | gate_b.ex -> judge_proof_test | *wiring*: coverage not checked | 0 |
| P5 | gate_b.ex -> judge_proof_test | uncovered codes never reported | 0 |
| P6 | gate_b.ex -> judge_proof_test | empty required list accepted | 0 |
| P7 | gate_b.ex -> judge_proof_test | failure route `nil` instead of `:gate_a` | 0 |
| P8 | gate_b.ex -> judge_proof_test | `{:changes, []}` accepted | 0 |
| P9 | gate_b.ex -> judge_proof_test | empty fixture results accepted | 0 |
| A1 | gate_a.ex -> gate_a_test | a trio of 2+ accepted | 0 |
| A2 | gate_a.ex -> gate_a_test | disagreement detection needs 3 distinct verdicts | 0 |
| A3 | gate_a.ex -> gate_a_test | agent `escalate` verdict ignored | 0 |
| A4 | gate_a.ex -> gate_a_test | contradictions ignored | 0 |
| A5 | gate_a.ex -> gate_a_test | gating reason codes never match | 0 |
| A6 | gate_a.ex -> gate_a_test | *wiring*: per-agent reasons not collected | 0 |
| A7 | gate_a.ex -> gate_a_test | *wiring*: malformed outputs not reported | 0 |
| A8 | gate_a.ex -> gate_a_test | confidence < 0.5 made to gate | 0 |
| A9 | gate_a.ex -> gate_a_test | confidence > 1 accepted | 0 |
| A10 | gate_a.ex -> gate_a_test | empty-set rate 0.0 instead of nil | 0 |
| A11 | gate_a.ex -> gate_a_test | per-result reason dedup removed | 0 |
| A12 | gate_a.ex -> gate_a_test | contradiction kind unchecked | 0 |
| G1 | glob.ex -> glob_test | `*` crosses `/` | 0 |
| G2 | glob.ex -> glob_test | `?` matches `/` | 0 |
| G3 | glob.ex -> glob_test | literals not regex-escaped | 0 |
| G4 | glob.ex -> glob_test | anchoring removed | 0 |
| G5 | glob.ex -> glob_test | `/**/` requires an intermediate dir | 0 |
| G6 | glob.ex -> glob_test | leading `**/` requires a dir | 0 |
| G7 | glob.ex -> glob_test | dotall flag removed | 0 |
| G8 | glob.ex -> glob_test | unicode flag removed | 0 |
| G9 | glob.ex -> glob_test | `**` stops at `/` | 0 |
| R1 | gate_b.ex -> judge_proof_test | not-run checked over intended only, not the whole set | 0 |
| R2 | gate_b.ex -> judge_proof_test | result outside the set ignored | 0 |
| R3 | gate_b.ex -> judge_proof_test | intended fixture outside the set ignored | 0 |
| R4 | gate_b.ex -> gate_b_test | git-quoted path accepted | 0 |
| R5 | gate_b.ex -> gate_b_test | human paths matched over new names only | 0 |
| R6 | gate_b.ex -> gate_b_test | effect paths matched over new names only | 0 |
| R7 | gate_b.ex -> gate_b_test | renames not required at :merge | 0 |
| R8 | gate_b.ex -> gate_b_test | rename old path not validated | 0 |
| R9 | gate_b.ex -> gate_b_test | rename reasons dropped | 0 |
| R10 | gate_b.ex -> gate_b_test | rename new name not checked against files | 0 |

## Not in this PR

The first correction comment on #802 asked for an allowlist-first predicate, where any change of unrecognised shape escalates and CI fails on an unclassified top-level module. Design section 5 is authoritative and does not include that, so Gate B stays denylist-shaped: effect paths plus human paths plus the size bound, backed by the stale-trigger guard. If the allowlist is still wanted, it needs a decision against the design.


## Review

Three `/code-review high` rounds. Round 1 found 2 issues, round 2 found 3 (two of them left behind by round 1's fix), and round 3 found 3 (doc and caller-wiring gaps in round 2's rename fix). All are fixed, and round 3 was the last.
